### PR TITLE
hotfix: httpserver remove promxp to fix compile error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.426
 	github.com/davecgh/go-spew v1.1.1
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/erda-project/erda-infra v0.0.0-20210310022010-dfb20478842b
 	github.com/getkin/kin-openapi v0.49.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
@@ -19,12 +20,13 @@ require (
 	github.com/magiconair/properties v1.8.4
 	github.com/otiai10/copy v1.5.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.9.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/sony/sonyflake v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/valyala/fasttemplate v1.2.1 // indirect
+	golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/stretchr/testify.v1 v1.2.2
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
@@ -22,8 +21,6 @@ import (
 	"github.com/erda-project/erda/pkg/strutil"
 	"github.com/erda-project/erda/pkg/uuid"
 )
-
-var RequestHistogram prometheus.Histogram
 
 const (
 	readTimeout       = 60 * time.Second
@@ -121,7 +118,6 @@ func (s *Server) internal(handler func(context.Context, *http.Request, map[strin
 		ctx, cancel := context.WithCancel(pctx)
 		defer func() {
 			cancel()
-			RequestHistogram.Observe(time.Since(start).Seconds())
 			logrus.Debugf("finished handle request %s %s (took %v)", r.Method, r.URL.String(), time.Since(start))
 		}()
 		ctx = context.WithValue(ctx, ResponseWriter, w)
@@ -191,7 +187,6 @@ func (s *Server) internalWriterHandler(handler func(context.Context, http.Respon
 		ctx, cancel := context.WithCancel(pctx)
 		defer func() {
 			cancel()
-			RequestHistogram.Observe(time.Since(start).Seconds())
 			logrus.Debugf("finished handle request %s %s (took %v)", r.Method, r.URL.String(), time.Since(start))
 		}()
 


### PR DESCRIPTION
httpserver remove promxp to fix compile error.

after `telemetry/promxp` opensourced, then add it again.