### PR TITLE
Pipeline add `pipeline_in_queue_precheck_before_pop` type of aop tunepoint

### DIFF
--- a/modules/pipeline/aop/aoptypes/tunepoint.go
+++ b/modules/pipeline/aop/aoptypes/tunepoint.go
@@ -25,8 +25,9 @@ const (
 type TuneTrigger string
 
 const (
-	TuneTriggerPipelineBeforeExec TuneTrigger = "pipeline_before_exec"
-	TuneTriggerPipelineAfterExec  TuneTrigger = "pipeline_after_exec"
+	TuneTriggerPipelineBeforeExec               TuneTrigger = "pipeline_before_exec"
+	TuneTriggerPipelineInQueuePrecheckBeforePop TuneTrigger = "pipeline_in_queue_precheck_before_pop"
+	TuneTriggerPipelineAfterExec                TuneTrigger = "pipeline_after_exec"
 
 	TuneTriggerTaskBeforeExec    TuneTrigger = "task_before_exec"
 	TuneTriggerTaskAfterExec     TuneTrigger = "task_after_exec"

--- a/modules/pipeline/aop/plugins/pipeline/plugins/precheck_before_pop/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/plugins/precheck_before_pop/plugin.go
@@ -1,0 +1,32 @@
+//  Copyright (c) 2021 Terminus, Inc.
+//
+//  This program is free software: you can use, redistribute, and/or modify
+//  it under the terms of the GNU Affero General Public License, version 3
+//  or later ("AGPL"), as published by the Free Software Foundation.
+//
+//  This program is distributed in the hope that it will be useful, but WITHOUT
+//  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package precheck_before_pop
+
+import (
+	"github.com/erda-project/erda/modules/pipeline/aop/aoptypes"
+)
+
+type Plugin struct {
+	aoptypes.PipelineBaseTunePoint
+}
+
+func New() *Plugin { return &Plugin{} }
+
+func (p *Plugin) Name() string { return "queue" }
+func (p *Plugin) Handle(ctx aoptypes.TuneContext) error {
+
+	// TODO invoke fdp dependency check
+
+	return nil
+}

--- a/modules/pipeline/aop/plugins/pipeline/tunechain.go
+++ b/modules/pipeline/aop/plugins/pipeline/tunechain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/apitest_report"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/basic"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/echo"
+	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/precheck_before_pop"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/project"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/scene_after"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/pipeline/plugins/scene_before"
@@ -25,13 +26,17 @@ import (
 
 // TuneTriggerChains 保存流水线所有触发时机下的调用链
 var TuneTriggerChains = map[aoptypes.TuneTrigger]aoptypes.TuneChain{
-	// pipeline 执行前
+	// pipeline before exec
 	aoptypes.TuneTriggerPipelineBeforeExec: []aoptypes.TunePoint{
 		echo.New(),
 		project.New(),
 		scene_before.New(),
 	},
-	// pipeline 执行后
+	// pipeline in queue precheck before pop
+	aoptypes.TuneTriggerPipelineInQueuePrecheckBeforePop: []aoptypes.TunePoint{
+		precheck_before_pop.New(),
+	},
+	// pipeline after exec
 	aoptypes.TuneTriggerPipelineAfterExec: []aoptypes.TunePoint{
 		echo.New(),
 		basic.New(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
#TODO: Add Tips
-->

#### What type of PR is this?

feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flaked
/kind regression
-->

#### What this PR does / why we need it:

Pipeline add `pipeline_in_queue_precheck_before_pop` type of aop tunepoint.

Pipeline dependency logic will be added here.

Related doc: https://www.yuque.com/erda-project/design/sdvvwl

