### PR TITLE
fix(scheduler): the error name spelling mistake when creating PVC on Kubernetes

### DIFF
--- a/modules/scheduler/executor/plugins/k8sjob/job.go
+++ b/modules/scheduler/executor/plugins/k8sjob/job.go
@@ -926,7 +926,9 @@ func (k *k8sJob) CreatePVCIfNotExists(pvc *corev1.PersistentVolumeClaim) error {
 		}
 		_, createErr := k.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 		if createErr != nil {
-			return errors.Errorf("failed to create pvc, name: %s, (%v)", pvc.Name, err)
+			if !strings.Contains(createErr.Error(), "already exist") {
+				return errors.Errorf("failed to create pvc, name: %s, (%v)", pvc.Name, createErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
#TODO: Add Tips
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

#### What this PR does / why we need it:

Fix the error name spelling mistake when creating PVC on Kubernetes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #