### PR TITLE
Fix: don't update pipeline status and emit event when p_i re-enter queue

### DIFF
--- a/modules/pipeline/pipengine/reconciler/queuemanage/manager/pipeline.go
+++ b/modules/pipeline/pipengine/reconciler/queuemanage/manager/pipeline.go
@@ -125,6 +125,11 @@ func (mgr *defaultManager) ensureQueryPipelineQueueDetail(p *spec.Pipeline) *api
 		}
 
 		// update pipeline status to Queue
+		if p.Status == apistructs.PipelineStatusQueue || p.Status.AfterPipelineQueue() {
+			// no need update, already at queue or later status
+			return true, nil
+		}
+		// do update status and emit event
 		if err := mgr.dbClient.UpdatePipelineBaseStatus(p.ID, apistructs.PipelineStatusQueue); err != nil {
 			err = fmt.Errorf("failed to update pipeline status to Queue, err: %v", err)
 			rlog.PErrorf(p.ID, err.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
#TODO: Add Tips
-->

#### What type of PR is this?

bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flaked
/kind regression
-->

#### What this PR does / why we need it:

Before fix, when pipeline service restart, instance which status is "Running" will re-enter queue, 'rollback' to "Queue" and re-emit p_i changed event.