### PR TITLE
apitest recognize Set-Cookie header and set cookie to latter apis

### DIFF
--- a/modules/pipeline/aop/plugins/task/plugins/autotest_cookie_keep_after/plugin.go
+++ b/modules/pipeline/aop/plugins/task/plugins/autotest_cookie_keep_after/plugin.go
@@ -16,13 +16,13 @@ package autotest_cookie_keep_after
 import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/aop/aoptypes"
+	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 const taskType = "api-test"
-const cookieMetafileName = "api_set_cookies"
+const metaKeySetCookie = "api_set_cookie"
 const AutotestApiGlobalConfig = "AUTOTEST_API_GLOBAL_CONFIG"
 const ReportTypeAutotestSetCookie = "autotest_set_cookie"
-const CookieJar = "cookieJar"
 
 type Plugin struct {
 	aoptypes.TaskBaseTunePoint
@@ -43,14 +43,14 @@ func (p *Plugin) Handle(ctx *aoptypes.TuneContext) error {
 	if metadata == nil {
 		return nil
 	}
-	var cookieJar string
+	var setCookieJSON string
 	for _, field := range metadata {
-		if field.Name == cookieMetafileName {
-			cookieJar = field.Value
+		if field.Name == metaKeySetCookie {
+			setCookieJSON = field.Value
 			break
 		}
 	}
-	if len(cookieJar) <= 0 {
+	if setCookieJSON == "" {
 		return nil
 	}
 
@@ -63,7 +63,7 @@ func (p *Plugin) Handle(ctx *aoptypes.TuneContext) error {
 		PipelineID: ctx.SDK.Pipeline.ID,
 		Type:       ReportTypeAutotestSetCookie,
 		Meta: map[string]interface{}{
-			CookieJar: cookieJar,
+			apitestsv2.HeaderSetCookie: setCookieJSON,
 		},
 	})
 	return err

--- a/modules/pipeline/aop/plugins/task/plugins/autotest_cookie_keep_before/plugin.go
+++ b/modules/pipeline/aop/plugins/task/plugins/autotest_cookie_keep_before/plugin.go
@@ -15,12 +15,15 @@ package autotest_cookie_keep_before
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/aop/aoptypes"
 	"github.com/erda-project/erda/modules/pipeline/aop/plugins/task/plugins/autotest_cookie_keep_after"
+	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/rlog"
+	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 const taskType = "api-test"
@@ -44,45 +47,58 @@ func (p *Plugin) Handle(ctx *aoptypes.TuneContext) error {
 	// will only fetch the latest one
 	reportSets, err := ctx.SDK.Report.GetPipelineReportSet(ctx.SDK.Pipeline.ID, autotest_cookie_keep_after.ReportTypeAutotestSetCookie)
 	if err != nil {
+		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get pipeline reports, err: %", err)
 		return err
 	}
-	var cookieJar string
+	var setCookieJSON string
 	for _, v := range reportSets.Reports {
-		if v.Meta == nil || v.Meta[autotest_cookie_keep_after.CookieJar] == nil {
+		if v.Meta == nil || v.Meta[apitestsv2.HeaderSetCookie] == nil {
 			continue
 		}
-		cookieJar = v.Meta[autotest_cookie_keep_after.CookieJar].(string)
+		setCookieJSON = v.Meta[apitestsv2.HeaderSetCookie].(string)
 		break
 	}
-
-	if len(cookieJar) <= 0 {
+	rlog.TDebugf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "setCookieJSON: %s", setCookieJSON)
+	if setCookieJSON == "" {
 		return nil
 	}
+	// parse Set-Cookie-JSON to Cookie
+	var setCookies []string
+	if err := json.Unmarshal([]byte(setCookieJSON), &setCookies); err != nil {
+		return fmt.Errorf("failed to parse Set-Cookie: %s, err: %v", setCookieJSON, err)
+	}
+	if len(setCookies) == 0 {
+		return nil
+	}
+	setCookie := setCookies[0]
 
-	logrus.Infof("autotest keep cookie： %v", cookieJar)
+	logrus.Infof("pipelineID: %d, taskID: %d, autotest keep cookie: %v", ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, setCookie)
 	// if autoTestAPIConfig is empty
 	// means not use config to run, also need to keep cookie
 	var config apistructs.AutoTestAPIConfig
-	if len(ctx.SDK.Task.Extra.PrivateEnvs[autotest_cookie_keep_after.AutotestApiGlobalConfig]) >= 0 {
-		err := json.Unmarshal([]byte(ctx.SDK.Task.Extra.PrivateEnvs[autotest_cookie_keep_after.AutotestApiGlobalConfig]), &config)
-		if err != nil {
+	if configStr, ok := ctx.SDK.Task.Extra.PrivateEnvs[autotest_cookie_keep_after.AutotestApiGlobalConfig]; ok {
+		if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+			rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to unmarshal AUTOTEST_API_GLOBAL_CONFIG, err: %v", err)
 			return err
 		}
 	}
 	if config.Header == nil {
 		config.Header = map[string]string{}
 	}
-	config.Header[autotest_cookie_keep_after.CookieJar] = cookieJar
-	configJson, err := json.Marshal(config)
+	config.Header[apitestsv2.HeaderCookie] = setCookie
+	configJson, err := json.Marshal(&config)
 	if err != nil {
+		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to marshal AUTOTEST_API_GLOBAL_CONFIG, err: %v", err)
 		return err
 	}
 	ctx.SDK.Task.Extra.PrivateEnvs[autotest_cookie_keep_after.AutotestApiGlobalConfig] = string(configJson)
 
 	err = ctx.SDK.DBClient.UpdatePipelineTaskExtra(ctx.SDK.Task.ID, ctx.SDK.Task.Extra)
 	if err != nil {
+		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to update task extra, err: %v", err)
 		return err
 	}
+	rlog.TDebugf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "AUTOTEST_API_GLOBAL_CONFIG updated")
 	return nil
 }
 

--- a/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/meta.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/meta.go
@@ -23,8 +23,10 @@ import (
 	"github.com/erda-project/erda/modules/actionagent"
 	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/spec"
+	"github.com/erda-project/erda/pkg/apitestsv2"
 	"github.com/erda-project/erda/pkg/apitestsv2/cookiejar"
 	"github.com/erda-project/erda/pkg/httpclient"
+	"github.com/erda-project/erda/pkg/jsonparse"
 )
 
 const (
@@ -36,7 +38,7 @@ const (
 	MetaKeyResult           = "result"
 	metaKeyAPIRequest       = "api_request"
 	metaKeyAPIResponse      = "api_response"
-	metaKeyAPICookies       = "api_set_cookies"
+	metaKeyAPISetCookie     = "api_set_cookie"
 	metaKeyAPIAssertSuccess = "api_assert_success" // true; false
 	metaKeyAPIAssertDetail  = "api_assert_detail"
 )
@@ -86,11 +88,10 @@ func writeMetaFile(ctx context.Context, task *spec.PipelineTask, meta *Meta) {
 	}
 	if meta.Resp != nil {
 		kvs.add(metaKeyAPIResponse, jsonOneLine(ctx, meta.Resp))
-	}
-	if meta.CookieJar != nil {
-		if meta.Resp != nil && meta.Resp.Headers != nil && meta.Resp.Headers["Set-Cookie"] != nil {
-			jar, _ := json.Marshal(meta.CookieJar)
-			kvs.add(metaKeyAPICookies, string(jar))
+		if len(meta.Resp.Headers) > 0 {
+			if headerSetCookie := meta.Resp.Headers[apitestsv2.HeaderSetCookie]; len(headerSetCookie) > 0 {
+				kvs.add(metaKeyAPISetCookie, jsonparse.JsonOneLine(headerSetCookie)) // format: []string
+			}
 		}
 	}
 	if len(meta.OutParamsResult) > 0 {

--- a/modules/pipeline/pipengine/reconciler/taskrun/teardown.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/teardown.go
@@ -29,7 +29,8 @@ func (tr *TaskRun) Teardown() {
 	defer logrus.Infof("reconciler: pipelineID: %d, task %q end tear down", tr.P.ID, tr.Task.Name)
 	defer tr.TeardownConcurrencyCount()
 	defer tr.TeardownPriorityQueue()
-	defer aop.Handle(aop.NewContextForTask(*tr.Task, *tr.P, aoptypes.TuneTriggerTaskAfterExec))
+	// handle aop synchronously, then do subsequent tasks
+	_ = aop.Handle(aop.NewContextForTask(*tr.Task, *tr.P, aoptypes.TuneTriggerTaskAfterExec))
 
 	// invalidate openapi oauth2 token
 	tokens := strutil.DedupSlice([]string{

--- a/pkg/apitestsv2/apitest.go
+++ b/pkg/apitestsv2/apitest.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/apitestsv2/cookiejar"
 	"github.com/erda-project/erda/pkg/httpclient"
 	"github.com/erda-project/erda/pkg/strutil"
 )
@@ -187,8 +186,7 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 	apiReq.Body.Content = reqBody
 
 	// use netportal
-	jar, _ := httpClient.Jar.(*cookiejar.Jar)
-	customReq, cookies, err := handleCustomNetportalRequest(&apiReq, jar, at.opt.netportalURL)
+	customReq, err := handleCustomNetportalRequest(&apiReq, at.opt.netportalURL)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -197,13 +195,10 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 	apiReq.Headers = polishHeadersForCompression(apiReq.Headers)
 
 	var buffer bytes.Buffer
-	req := httpclient.New(httpclient.WithCookieJar(httpClient.Jar), httpclient.WithCompleteRedirect()).
+	req := httpclient.New(httpclient.WithCompleteRedirect()).
 		Method(apiReq.Method, customReq.URL.Scheme+"://"+customReq.URL.Host, httpclient.NoRetry).
 		Path(customReq.URL.Path).
 		Headers(apiReq.Headers)
-	for _, cookie := range cookies {
-		req = req.Cookie(cookie)
-	}
 	httpResp, err := req.Params(apiReq.Params).
 		RawBody(bytes.NewBufferString(apiReq.Body.Content.(string))).
 		Do().Body(&buffer)

--- a/pkg/apitestsv2/header.go
+++ b/pkg/apitestsv2/header.go
@@ -16,6 +16,8 @@ package apitestsv2
 import "net/http"
 
 const headerAcceptEncoding = "Accept-Encoding"
+const HeaderSetCookie = "Set-Cookie"
+const HeaderCookie = "Cookie"
 
 // polishHeadersForCompression 优化用于压缩的 header
 func polishHeadersForCompression(headers http.Header) http.Header {

--- a/pkg/apitestsv2/netportal.go
+++ b/pkg/apitestsv2/netportal.go
@@ -18,22 +18,19 @@ import (
 	"net/http"
 
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/apitestsv2/cookiejar"
 	"github.com/erda-project/erda/pkg/customhttp"
 	"github.com/erda-project/erda/pkg/httpclientutil"
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
-func handleCustomNetportalRequest(apiReq *apistructs.APIRequestInfo, jar *cookiejar.Jar, netPortalURL string) (*http.Request, []*http.Cookie, error) {
-	var url = apiReq.URL
-
+func handleCustomNetportalRequest(apiReq *apistructs.APIRequestInfo, netPortalURL string) (*http.Request, error) {
 	if netPortalURL != "" {
 		apiReq.URL = strutil.Concat(netPortalURL, "/", httpclientutil.RmProto(apiReq.URL))
 	}
 
 	customReq, err := customhttp.NewRequest(apiReq.Method, apiReq.URL, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to handle custom netportal request, err: %v", err)
+		return nil, fmt.Errorf("failed to handle custom netportal request, err: %v", err)
 	}
 	for k, values := range customReq.Header {
 		for _, v := range values {
@@ -41,11 +38,5 @@ func handleCustomNetportalRequest(apiReq *apistructs.APIRequestInfo, jar *cookie
 		}
 	}
 
-	var cookies []*http.Cookie
-	if jar != nil {
-		request, _ := http.NewRequest(apiReq.Method, url, nil)
-		u := request.URL
-		cookies = jar.Cookies(u)
-	}
-	return customReq, cookies, nil
+	return customReq, nil
 }

--- a/pkg/apitestsv2/netportal_test.go
+++ b/pkg/apitestsv2/netportal_test.go
@@ -30,7 +30,7 @@ func Test_handleCustomNetportalRequest(t *testing.T) {
 		Method:  http.MethodGet,
 		Headers: http.Header{},
 	}
-	customReq, _, err := handleCustomNetportalRequest(&req, nil, "")
+	customReq, err := handleCustomNetportalRequest(&req, "")
 	_ = customReq
 	assert.NoError(t, err)
 	assert.NotZero(t, len(req.Headers))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
#TODO: Add Tips
-->

#### What type of PR is this?

bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flaked
/kind regression
-->

#### What this PR does / why we need it:

use `Set-Cookie` header in response instead of CookieJar, and set `Cookie` header for latter apis to simulate login.