### PR TITLE
dice.yml support tow different ways to expose ports

### DIFF
--- a/modules/orchestrator/services/deployment/deployment_context.go
+++ b/modules/orchestrator/services/deployment/deployment_context.go
@@ -328,20 +328,26 @@ func (fsm *DeployFSMContext) continuePhasePreService() error {
 	}
 	fsm.d.Log(`prepare default domain...`)
 	// TODO: create default domain should be one phase
+	var expose bool
 	for name, serv := range fsm.Spec.Services {
-		if len(serv.Expose) == 0 {
-			// not an endpoint
-			continue
+		// serv.Expose will abandoned, serv.Ports.Expose is recommended
+		for _, svcPort := range serv.Ports {
+			if svcPort.Expose {
+				expose = true
+				break
+			}
 		}
-		rootDomains := strings.Split(fsm.Cluster.WildcardDomain, ",")
-		if len(rootDomains) < 1 {
-			return errors.Errorf("domain not exist, cluster %s", fsm.Cluster.Name)
-		}
-		rootDomain := rootDomains[0]
-		if _, err := fsm.db.GetDefaultDomainOrCreate(fsm.Runtime.ID, name,
-			// TODO: default domain format should be refactored
-			fmt.Sprintf("%s-%s-%d-app.%s", name, strings.ToLower(fsm.Runtime.Workspace), fsm.Runtime.ID, rootDomain)); err != nil {
-			return err
+		if len(serv.Expose) != 0 || expose {
+			rootDomains := strings.Split(fsm.Cluster.WildcardDomain, ",")
+			if len(rootDomains) < 1 {
+				return errors.Errorf("domain not exist, cluster %s", fsm.Cluster.Name)
+			}
+			rootDomain := rootDomains[0]
+			if _, err := fsm.db.GetDefaultDomainOrCreate(fsm.Runtime.ID, name,
+				// TODO: default domain format should be refactored
+				fmt.Sprintf("%s-%s-%d-app.%s", name, strings.ToLower(fsm.Runtime.Workspace), fsm.Runtime.ID, rootDomain)); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/modules/orchestrator/services/runtime/runtime.go
+++ b/modules/orchestrator/services/runtime/runtime.go
@@ -1516,7 +1516,15 @@ func (r *Runtime) Get(userID user.ID, orgID uint64, idOrName string, appID strin
 	// TODO: no diceJson and no overlay, we just read dice from releaseId
 	for k, v := range dice.Services {
 		var expose []string
-		if len(v.Expose) != 0 {
+		var svcPortExpose bool
+		// serv.Expose will abandoned, serv.Ports.Expose is recommended
+		for _, svcPort := range v.Ports {
+			if svcPort.Expose {
+				svcPortExpose = true
+			}
+		}
+
+		if len(v.Expose) != 0 || svcPortExpose {
 			expose = domainMap[k]
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
dice.yml support tow different ways to expose ports. (services.Expose and services.Ports.Expose)

#### Specified Reivewers:
@johnlanni @Effet 

