### PR TITLE
modify the uc-adaptor's provider name

### DIFF
--- a/modules/uc-adaptor/provider.go
+++ b/modules/uc-adaptor/provider.go
@@ -19,13 +19,13 @@ import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 )
 
-const serviceSoldier = "ucAdaptor"
+const serviceUCAdaptor = "uc-adaptor"
 
 type provider struct{}
 
-func init() { servicehub.RegisterProvider(serviceSoldier, &provider{}) }
+func init() { servicehub.RegisterProvider(serviceUCAdaptor, &provider{}) }
 
-func (p *provider) Service() []string                 { return []string{serviceSoldier} }
+func (p *provider) Service() []string                 { return []string{serviceUCAdaptor} }
 func (p *provider) Dependencies() []string            { return []string{} }
 func (p *provider) Init(ctx servicehub.Context) error { return nil }
 func (p *provider) Run(ctx context.Context) error     { return Initialize() }


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
uc-adaptor's provider name is wrong, it caused him to fail to boot
![image](https://user-images.githubusercontent.com/35135086/117533999-29b47100-b022-11eb-88e2-a9f98f7509b8.png)


#### Specified Reivewers:
/assgin @sfwn 

