### PR TITLE
Manual testset's query detail support return ancestors info

### DIFF
--- a/apistructs/testset.go
+++ b/apistructs/testset.go
@@ -35,12 +35,18 @@ type TestSet struct {
 	UpdaterID string `json:"updaterID"`
 }
 
+type TestSetWithAncestors struct {
+	TestSet
+	// ancestors
+	Ancestors []TestSet `json:"ancestors,omitempty"`
+}
+
 type TestSetGetRequest struct {
 	ID uint64 `json:"id"`
 }
 type TestSetGetResponse struct {
 	Header
-	Data *TestSet `json:"data"`
+	Data *TestSetWithAncestors `json:"data"`
 }
 
 // TestSetCreateRequest POST /api/testsets 创建测试集

--- a/modules/qa/endpoints/testset.go
+++ b/modules/qa/endpoints/testset.go
@@ -73,7 +73,19 @@ func (e *Endpoints) GetTestSet(ctx context.Context, r *http.Request, vars map[st
 		return errorresp.ErrResp(err)
 	}
 
-	return httpserver.OkResp(ts, strutil.DedupSlice([]string{ts.CreatorID, ts.UpdaterID}))
+	tsWithAncestors := apistructs.TestSetWithAncestors{TestSet: *ts}
+
+	// get ancestors
+	withAncestors, _ := strconv.ParseBool(r.URL.Query().Get("withAncestors"))
+	if withAncestors {
+		ancestors, err := e.testset.FindAncestors(testSetID)
+		if err != nil {
+			return errorresp.ErrResp(err)
+		}
+		tsWithAncestors.Ancestors = ancestors
+	}
+
+	return httpserver.OkResp(tsWithAncestors, strutil.DedupSlice([]string{ts.CreatorID, ts.UpdaterID}))
 }
 
 // ListTestSets 获取测试集列表


### PR DESCRIPTION
#### What type of this PR

feature

#### What this PR does / why we need it:

Manual testSet's query detail return with ancestors info, so frontend can locate this testSet in the whole testSet tree.