### PR TITLE
bug fix if the action result value has a newline character, the result of the task will be truncated

### DIFF
--- a/modules/actionagent/callback_test.go
+++ b/modules/actionagent/callback_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
 )
 
 func TestHandleMetaFile(t *testing.T) {
@@ -41,4 +43,38 @@ name=pipeline
 	assert.Equal(t, "test metafile", cb.Metadata[2].Value)
 	assert.Equal(t, "name", cb.Metadata[3].Name)
 	assert.Equal(t, "pipeline", cb.Metadata[3].Value)
+}
+
+func TestAppendMetaFile(t *testing.T) {
+	var kvs = []struct {
+		key   string
+		value string
+	}{
+		{
+			key: "name",
+			value: `aaa
+bbb`,
+		},
+		{
+			key: "name1",
+			value: `123456
+2345667`,
+		},
+		{
+			key:   "name3",
+			value: `aaabbb`,
+		},
+	}
+
+	var fields []*apistructs.MetadataField
+	for _, value := range kvs {
+		fields = append(fields, &apistructs.MetadataField{Name: value.key, Value: value.value})
+	}
+
+	cb := Callback{}
+	cb.AppendMetadataFields(fields)
+	for index, _ := range kvs {
+		assert.Equal(t, cb.Metadata[index].Name, kvs[index].key)
+		assert.Equal(t, cb.Metadata[index].Value, kvs[index].value)
+	}
 }

--- a/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/meta.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/meta.go
@@ -16,7 +16,6 @@ package logic
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/erda-project/erda/apistructs"
@@ -73,8 +72,6 @@ func (kvs *KVs) add(k, v string) {
 func writeMetaFile(ctx context.Context, task *spec.PipelineTask, meta *Meta) {
 	log := clog(ctx)
 
-	var content string
-
 	// kvs 保证顺序
 	kvs := &KVs{}
 
@@ -104,15 +101,13 @@ func writeMetaFile(ctx context.Context, task *spec.PipelineTask, meta *Meta) {
 		}
 	}
 
+	var fields []*apistructs.MetadataField
 	for _, kv := range *kvs {
-		content = fmt.Sprintf("%s\n%s=%s\n", content, kv.k, kv.v)
+		fields = append(fields, &apistructs.MetadataField{Name: kv.k, Value: kv.v})
 	}
 
 	var cb actionagent.Callback
-	if err := cb.HandleMetaFile([]byte(content)); err != nil {
-		log.Errorf("invalid meta, err: %v", err)
-		return
-	}
+	cb.AppendMetadataFields(fields)
 	cb.PipelineID = task.PipelineID
 	cb.PipelineTaskID = task.ID
 


### PR DESCRIPTION


#### What type of this PR

bug

#### What this PR does / why we need it:

At present, the return result of the task is to intercept the contents of the file according to the newline character. In the autotest, the return value of some tasks has a newline character, which causes part of the return value to be lost.

