### PR TITLE
Dockerfile install qa required commands

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -17,9 +17,10 @@ RUN tar -zcvf ./bin/scripts.tar.gz ./modules/ops/scripts/
 ARG BASE_DOCKER_IMAGE
 FROM ${BASE_DOCKER_IMAGE}
 
-RUN apk add --no-cache jq && \
+RUN apk add --no-cache jq py3-pip && \
     apk add --update nodejs nodejs-npm && \
-    npm i -g jackson-converter@1.0.10
+    npm i -g jackson-converter@1.0.10 && \
+    pip3 install dicttoxml xmindparser
 
 WORKDIR /app
 


### PR DESCRIPTION
#### What type of this PR

bug

#### What this PR does / why we need it:

Dockerfile install QA required commands, such as xmindparser, dicttoxml.
QA testcases import will use these commands.
