### PR TITLE
openapi oauth2 disallowed token request without accessTokenExpiredIn param

### DIFF
--- a/apistructs/openapi.go
+++ b/apistructs/openapi.go
@@ -24,7 +24,7 @@ type OpenapiOAuth2Token struct {
 }
 
 type OpenapiOAuth2TokenPayload struct {
-	AccessTokenExpiredIn string            `json:"accessTokenExpiredIn"` // such as "300ms", "-1.5h" or "2h45m". "0" means it doesn't expire.
+	AccessTokenExpiredIn string            `json:"accessTokenExpiredIn"` // such as "300ms", "-1.5h" or "2h45m". "0" means it doesn't expire. Empty string is not allowed.
 	AllowAccessAllAPIs   bool              `json:"allowAccessAllApIs,omitempty"`
 	AccessibleAPIs       []AccessibleAPI   `json:"accessibleAPIs,omitempty"`
 	Metadata             map[string]string `json:"metadata,omitempty"`

--- a/modules/openapi/oauth2/jwt.go
+++ b/modules/openapi/oauth2/jwt.go
@@ -75,7 +75,9 @@ func (a *JWTAccessGenerate) Token(data *oauth2.GenerateBasic, isGenRefresh bool)
 	}
 
 	// expire_in
-	if payload.AccessTokenExpiredIn != "" {
+	if payload.AccessTokenExpiredIn == "" {
+		return "", "", fmt.Errorf("no accessTokenExpiredIn is not allowed")
+	} else {
 		expiredIn, err := time.ParseDuration(payload.AccessTokenExpiredIn)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to parse accessTokenExpiredIn from request body, err: %v", err)

--- a/modules/openapi/oauth2/jwt.go
+++ b/modules/openapi/oauth2/jwt.go
@@ -76,7 +76,7 @@ func (a *JWTAccessGenerate) Token(data *oauth2.GenerateBasic, isGenRefresh bool)
 
 	// expire_in
 	if payload.AccessTokenExpiredIn == "" {
-		return "", "", fmt.Errorf("no accessTokenExpiredIn is not allowed")
+		return "", "", fmt.Errorf("accessTokenExpiredIn is required")
 	} else {
 		expiredIn, err := time.ParseDuration(payload.AccessTokenExpiredIn)
 		if err != nil {

--- a/modules/openapi/oauth2/server.go
+++ b/modules/openapi/oauth2/server.go
@@ -58,6 +58,7 @@ func NewOAuth2Server() *OAuth2Server {
 	// logger
 	srv.SetInternalErrorHandler(func(err error) (re *errors.Response) {
 		logrus.Errorf("oauth2 server internal err: %v", err)
+		re = &errors.Response{Error: err}
 		return
 	})
 	srv.SetResponseErrorHandler(func(re *errors.Response) {


### PR DESCRIPTION
#### What type of this PR

feature

#### What this PR does / why we need it:

Openapi oauth2 disallowed token request without accessTokenExpiredIn param.
Client must set expected accessTokenExpiredIn explicitly.
All related clients have been adjusted.