### PR TITLE
qa autotest generate and replace random value before create pipeline yml

### DIFF
--- a/modules/qa/services/autotest_v2/scene.go
+++ b/modules/qa/services/autotest_v2/scene.go
@@ -395,9 +395,12 @@ func (svc *Service) ExecuteDiceAutotestScene(req apistructs.AutotestExecuteScene
 
 	var params []apistructs.PipelineRunParam
 	for _, input := range sceneInputs {
+		// replace mock temp before create pipeline
+		// and so steps can use the same mock temp
+		replacedTemp := expression.ReplaceRandomParams(input.Temp)
 		params = append(params, apistructs.PipelineRunParam{
 			Name:  input.Name,
-			Value: input.Temp,
+			Value: replacedTemp,
 		})
 	}
 

--- a/modules/qa/services/autotest_v2/testplan_v2.go
+++ b/modules/qa/services/autotest_v2/testplan_v2.go
@@ -577,7 +577,10 @@ func (svc *Service) BatchQuerySceneSetPipelineSnippetYaml(configs []apistructs.S
 
 			var params = make(map[string]interface{})
 			for _, input := range inputs {
-				params[input.Name] = input.Value
+				// replace mock random param before return to pipeline
+				// and so steps can use the same random value
+				replacedValue := expression.ReplaceRandomParams(input.Value)
+				params[input.Name] = replacedValue
 			}
 
 			sceneJson, err := json.Marshal(v)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
qa autotest need the same mock params value in different scenes
