### PR TITLE
fix client_header_timeout in ingress annotations

### DIFF
--- a/modules/hepa/apipolicy/policies/proxy/dto.go
+++ b/modules/hepa/apipolicy/policies/proxy/dto.go
@@ -23,6 +23,7 @@ const (
 	ANNOTATION_REQ_LIMIT          = "nginx.ingress.kubernetes.io/proxy-body-size"
 	ANNOTATION_PROXY_REQ_TIMEOUT  = "nginx.ingress.kubernetes.io/proxy-send-timeout"
 	ANNOTATION_PROXY_RESP_TIMEOUT = "nginx.ingress.kubernetes.io/proxy-read-timeout"
+	ANNOTATION_SERVER_SNIPPET     = "nginx.ingress.kubernetes.io/server-snippet"
 	ANNOTATION_SSL_REDIRECT       = "nginx.ingress.kubernetes.io/ssl-redirect"
 )
 

--- a/modules/hepa/apipolicy/policies/proxy/policy.go
+++ b/modules/hepa/apipolicy/policies/proxy/policy.go
@@ -109,11 +109,12 @@ func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interfa
 	annotation[ANNOTATION_PROXY_REQ_TIMEOUT] = &reqTimeout
 	respTimeout := fmt.Sprintf("%d", policyDto.ProxyRespTimeout)
 	annotation[ANNOTATION_PROXY_RESP_TIMEOUT] = &respTimeout
+	clientHeaderTimeout := fmt.Sprintf("client_header_timeout %ds;", policyDto.ClientReqTimeout)
+	annotation[ANNOTATION_SERVER_SNIPPET] = &clientHeaderTimeout
 	snippet := fmt.Sprintf(`
-client_header_timeout %ds;
 client_body_timeout %ds;
 send_timeout %ds;
-`, policyDto.ClientReqTimeout, policyDto.ClientReqTimeout, policyDto.ClientRespTimeout)
+`, policyDto.ClientReqTimeout, policyDto.ClientRespTimeout)
 	res.IngressAnnotation = &apipolicy.IngressAnnotation{
 		LocationSnippet: &snippet,
 		Annotation:      annotation,


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
this nginx directive `client_header_timeout` is not allowed in location snippet.


