### PR TITLE
pipeline apitest use json oneline instead of strutil string

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/envconf.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/apitest/logic/envconf.go
@@ -15,7 +15,7 @@ package logic
 
 import (
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/strutil"
+	"github.com/erda-project/erda/pkg/jsonparse"
 )
 
 type EnvConfig struct {
@@ -66,7 +66,7 @@ type APIParam struct {
 func (p APIParam) convert() apistructs.APIParam {
 	return apistructs.APIParam{
 		Key:   p.Key,
-		Value: strutil.String(p.Value),
+		Value: jsonparse.JsonOneLine(p.Value),
 		Desc:  p.Desc,
 	}
 }
@@ -80,7 +80,7 @@ type APIHeader struct {
 func (h APIHeader) convert() apistructs.APIHeader {
 	return apistructs.APIHeader{
 		Key:   h.Key,
-		Value: strutil.String(h.Value),
+		Value: jsonparse.JsonOneLine(h.Value),
 		Desc:  h.Desc,
 	}
 }
@@ -95,6 +95,6 @@ func (a APIAssert) convert() apistructs.APIAssert {
 	return apistructs.APIAssert{
 		Arg:      a.Arg,
 		Operator: a.Operator,
-		Value:    strutil.String(a.Value),
+		Value:    jsonparse.JsonOneLine(a.Value),
 	}
 }

--- a/pkg/jsonparse/parse_test.go
+++ b/pkg/jsonparse/parse_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package jsonparse
+
+import (
+	"math"
+	"testing"
+)
+
+func TestJsonOneLine(t *testing.T) {
+	tests := []struct {
+		name string
+		i    interface{}
+		want string
+	}{
+		{name: "int", i: 1, want: "1"},
+		{name: "int8 min", i: int8(math.MinInt8), want: "-128"},
+		{name: "int8 max", i: int8(math.MaxInt8), want: "127"},
+		{name: "int32 min", i: int32(math.MinInt32), want: "-2147483648"},
+		{name: "int32 max", i: int32(math.MaxInt32), want: "2147483647"},
+		{name: "int64 min", i: int64(math.MinInt64), want: "-9223372036854775808"},
+		{name: "int64 max", i: int64(math.MaxInt64), want: "9223372036854775807"},
+		{name: "uint", i: uint(1), want: "1"},
+		{name: "uint8 max", i: uint8(math.MaxUint8), want: "255"},
+		{name: "uint32 max", i: uint32(math.MaxUint32), want: "4294967295"},
+		{name: "uint64 max", i: uint64(math.MaxUint64), want: "18446744073709551615"},
+		{name: "float64", i: float64(132455555555555.1), want: "132455555555555.1"},
+		{name: "[]byte", i: []byte{'a', 'b'}, want: "ab"},
+		{name: "string", i: "ab", want: "ab"},
+		{name: "json", i: "[{\"aaa\":111}]", want: "[{\"aaa\":111}]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JsonOneLine(tt.i); got != tt.want {
+				t.Errorf("JsonOneLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
use jsonOnline instead of strutil string compatible json type param, header, assert

