### PR TITLE
hotfix: cmdb disable file permission check for multi-domain temporarily

### DIFF
--- a/modules/cmdb/conf/conf.go
+++ b/modules/cmdb/conf/conf.go
@@ -79,6 +79,9 @@ type Conf struct {
 	FileMaxUploadSizeStr string `env:"FILE_MAX_UPLOAD_SIZE" default:"300MB"` // 文件上传限制大小，默认 300MB
 	FileMaxUploadSize    datasize.ByteSize
 
+	// disable file download permission validate temporarily for multi-domain
+	DisableFileDownloadPermissionValidate bool `env:"DISABLE_FILE_DOWNLOAD_PERMISSION_VALIDATE" default:"false"`
+
 	// fs
 	// 修改该值的话，注意同步修改 dice.yml 中 '<%$.Storage.MountPoint%>/dice/cmdb/files:/files:rw' 容器内挂载点的值
 	StorageMountPointInContainer string `env:"STORAGE_MOUNT_POINT_IN_CONTAINER" default:"/files"`
@@ -446,6 +449,11 @@ func ProjectStatsCacheCron() string {
 // FileMaxUploadSize 返回 文件上传的大小限制.
 func FileMaxUploadSize() datasize.ByteSize {
 	return cfg.FileMaxUploadSize
+}
+
+// DisableFileDownloadPermissionValidate return switch for file download permission check.
+func DisableFileDownloadPermissionValidate() bool {
+	return cfg.DisableFileDownloadPermissionValidate
 }
 
 // StorageMountPointInContainer 返回 files 在容器内的挂载点.

--- a/modules/cmdb/endpoints/file.go
+++ b/modules/cmdb/endpoints/file.go
@@ -160,7 +160,7 @@ func (e *Endpoints) DownloadFile(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	// 校验用户登录
-	if file.Extra.IsPublic == false {
+	if !file.Extra.IsPublic && !conf.DisableFileDownloadPermissionValidate() {
 		_, err = user.GetIdentityInfo(r)
 		if err != nil {
 			return apierrors.ErrDownloadFile.NotLogin()


### PR DESCRIPTION
#### What type of this PR

bug

#### What this PR does / why we need it:

cmdb disable file permission check for multi-domain temporarily