### PR TITLE
queue manager handle runningPipeline correctly when reload into queue

### DIFF
--- a/modules/pipeline/pipengine/reconciler/queuemanage/queue/add_pipeline.go
+++ b/modules/pipeline/pipengine/reconciler/queuemanage/queue/add_pipeline.go
@@ -53,10 +53,14 @@ func (q *defaultQueue) AddPipelineIntoQueue(p *spec.Pipeline, doneCh chan struct
 	//   else add to pending queue.
 	if p.Status.AfterPipelineQueue() {
 		q.eq.ProcessingQueue().Add(priorityqueue.NewItem(itemKey, priority, *createdTime))
+		go func() {
+			doneCh <- struct{}{}
+			close(doneCh)
+		}()
 	} else {
 		q.eq.Add(itemKey, priority, *createdTime)
+		q.doneChanByPipelineID[p.ID] = doneCh
 	}
-	q.doneChanByPipelineID[p.ID] = doneCh
 
 	go func() {
 		q.rangeAtOnceCh <- true


### PR DESCRIPTION
#### What type of this PR

bug

#### What this PR does / why we need it:

Before fix, workflow in running status won't be reconciled when pipeline component reload because no done signal sent to channel.

Now, workflow will be added into processing queue and send done signal to continue reconcile directly.