### PR TITLE
fix(pipeline): action if expression handle unexpected panic

### DIFF
--- a/pkg/expression/expression_reconcile.go
+++ b/pkg/expression/expression_reconcile.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/Knetic/govaluate.v3"
 
 	"github.com/erda-project/erda/pkg/mock"
@@ -59,7 +60,18 @@ type ExpressionExecSign struct {
 	Condition string
 }
 
-func Reconcile(condition string) ExpressionExecSign {
+func Reconcile(condition string) (sign ExpressionExecSign) {
+
+	// panic handler
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.Errorf("pkg.expression: invalid condition: %s, panic: %v", condition, r)
+			sign = ExpressionExecSign{
+				Sign: TaskJumpOver,
+				Err:  fmt.Errorf("expression %q exec failed, action skip", condition),
+			}
+		}
+	}()
 
 	// 表达式为空，不跳过
 	if condition == "" {

--- a/pkg/expression/expression_reconcile_test.go
+++ b/pkg/expression/expression_reconcile_test.go
@@ -57,3 +57,32 @@ func Test_expression(t *testing.T) {
 		}
 	}
 }
+
+func TestReconcile(t *testing.T) {
+	type args struct {
+		condition string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantSign SignType
+	}{
+		{
+			name:     "invalid aa",
+			args:     args{condition: "aa"},
+			wantSign: TaskJumpOver,
+		},
+		{
+			name:     "1 != 2",
+			args:     args{condition: "1 != 2"},
+			wantSign: TaskNotJumpOver,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotSign := Reconcile(tt.args.condition); gotSign.Sign != tt.wantSign {
+				t.Errorf("Reconcile() = %v, want %v", gotSign, tt.wantSign)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

bug

#### What this PR does / why we need it:

It will be unexpected panic from lib if action IF expression is invalid, such as `aa`, `bb`.