### PR TITLE
Pipeline queue manager acquire read lock before read pipelineCaches

### DIFF
--- a/modules/pipeline/pipengine/reconciler/queuemanage/queue/range_pending_queue.go
+++ b/modules/pipeline/pipengine/reconciler/queuemanage/queue/range_pending_queue.go
@@ -82,7 +82,10 @@ func (q *defaultQueue) RangePendingQueue() {
 		}
 
 		// queue validate
+		// it will cause `concurrent map read and map write` panic if `pipeline_caches` is not locked.
+		q.lock.RLock()
 		validateResult := q.validatePipeline(p)
+		q.lock.RUnlock()
 		if !validateResult.Success {
 			q.emitEvent(p, PendingQueueValidate, validateResult.Reason, events.EventLevelWarning)
 			// stopRange if queue is strict mode


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

Pipeline queue manager acquire read lock before read pipelineCaches.
Otherwise, it will cause `concurrent map read and map write` panic.