### PR TITLE
Fixed possible null exception of ElasticSearch bucket

### DIFF
--- a/modules/monitor/core/metrics/metricq/es-tsql/influxql/query.go
+++ b/modules/monitor/core/metrics/metricq/es-tsql/influxql/query.go
@@ -261,6 +261,10 @@ func (q *Query) parseDimensionsAggsData(rs *tsql.ResultSet, aggs elastic.Aggrega
 			}
 		}
 	} else if histogram, ok := aggs.Histogram("histogram"); ok {
+		bucketsCount := len(histogram.Buckets)
+		if bucketsCount > 0 && histogram.Buckets[bucketsCount-1].DocCount == 0 {
+			histogram.Buckets = histogram.Buckets[:bucketsCount-1]
+		}
 		for _, bucket := range histogram.Buckets {
 			err := q.parseDimensionsAggsData(rs, bucket.Aggregations, append(buckets, bucket))
 			if err != nil {


### PR DESCRIPTION
#### What type of this PR
Fixed an issue where interval may be empty if bucket is an integral divisor of the timestamp difference.

example:

```sql
      SELECT max(cpu_usage_active::field)
      FROM  host_summary
      GROUP BY time(10m);
```

Here is the DSL of influxql converted.

```json
{
	"aggregations": {
		"histogram": {
			"aggregations": {
				"687cf45294c71d1f": {
					"max": {
						"field": "fields.cpu_usage_active"
					}
				}
			},
			"histogram": {
				"extended_bounds": {
					"max": 1622021455605479000,
					"min": 1622017855605479000
				},
				"field": "timestamp",
				"interval": 600000000000,
				"min_doc_count": 0,
				"offset": 1622017855605479000
			}
		}
	},
	"query": {
		"bool": {
			"filter": {
				"range": {
					"timestamp": {
						"from": 1622017855605479000,
						"include_lower": true,
						"include_upper": true,
						"to": 1622021455605479000
					}
				}
			}
		}
	},
	"size": 0
}
```

the result 

```json
  "took": 2,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": 697,
    "max_score": 0,
    "hits": []
  },
  "aggregations": {
    "histogram": {
      "buckets": [
        {
          "key": 1622012506164996000,
          "doc_count": 169,
          "f806016e28788176": {
            "values": {
              "70.777": 47.048367252868125
            }
          }
        },
        {
          "key": 1622013406164996000,
          "doc_count": 179,
          "f806016e28788176": {
            "values": {
              "70.777": 38.66210676367953
            }
          }
        },
        {
          "key": 1622014306164996000,
          "doc_count": 178,
          "f806016e28788176": {
            "values": {
              "70.777": 41.84140599648707
            }
          }
        },
        {
          "key": 1622015206164996000,
          "doc_count": 171,
          "f806016e28788176": {
            "values": {
              "70.777": 44.50996088633486
            }
          }
        },
        {
          "key": 1622016106164996000, //aggregation start time was equal to endtime.
          "doc_count": 0,
          "f806016e28788176": {
            "values": {
              "70.777": "NaN"
            }
          }
        }
      ]
    }
  }
}
```

Add one of the following kinds:
/kind bug


#### Specified Reviewers:
/assign @recallsong @liuhaoyang 

