### PR TITLE
contribution: add guide doc for auto-cherry-pick

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,7 @@ Once we've discussed your changes and you've got your code ready, make sure that
 * Includes tests for new functionality.
 * References the original issue in description, e.g. "Resolves #123".
 * Has a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## How to cherry pick a merged PR?
+
+See [cherry-pick.md](./docs/guides/dev/cherry-pick.md).

--- a/docs/guides/dev/cherry-pick.md
+++ b/docs/guides/dev/cherry-pick.md
@@ -1,0 +1,28 @@
+# Overview
+
+This document explains how cherry picks are managed on release branches within all erda-projects repositories.
+
+A common use case for cherry picks is backporting PRs from master to release branches.
+
+## Initiate a Cherry Pick
+
+- Open your **MERGED** PR page on browser
+
+- Add a comment
+
+  This example applies a master branch PR to the release/1.0:
+  ```
+  /cherry-pick release/1.0
+  ```
+
+  Tips:
+  If you comment to an **UNMERGED** PR, erda-bot will auto append a commit to tell you: cherry-pick to an unmerged PR is
+  forbidden.
+
+## Searching for Cherry Picks
+
+Filter by labels: `auto-cherry-pick`
+
+Examples:
+
+- [Erda auto-cherry-pick](https://github.com/erda-project/erda/pulls?q=is%3Apr+label%3Aauto-cherry-pick)


### PR DESCRIPTION
#### What type of this PR

/kind documentation

#### What this PR does / why we need it:

Add guide doc for (automated) cherry-pick.

You can use PR comment `/cherry-pick release/1.0` to created a cherry-pick PR automaticlly.
