### PR TITLE
feat: ignore boilerplate for coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -34,3 +34,9 @@ coverage:
 
 github_checks:
   annotations: true
+
+ignore:
+  # ignore the boilerplate code
+  - "modules/*/conf"
+  - "modules/*/dbclient"
+  - "modules/*/dao"


### PR DESCRIPTION
ignore boilerplate code for coverage, like
- conf
- dbclient
- dao

@sfwn 