### PR TITLE
optimize runtime endpoint gc

### DIFF
--- a/modules/hepa/gateway/service/gateway_openapi_service.go
+++ b/modules/hepa/gateway/service/gateway_openapi_service.go
@@ -803,6 +803,7 @@ func (impl GatewayOpenapiServiceImpl) TryClearRuntimePackage(runtimeService *orm
 	if pack != nil {
 		apis, err := packApiSession.SelectByAny(&orm.GatewayPackageApi{
 			PackageId: pack.Id,
+			Origin:    string(gw.FROM_CUSTOM),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:
if there is no api from custom origin in the endpoint， then the endpoint need be recycled.



