### PR TITLE
set default content when creating yml file

### DIFF
--- a/modules/gittar-adaptor/service/filetree/filetree.go
+++ b/modules/gittar-adaptor/service/filetree/filetree.go
@@ -518,9 +518,11 @@ func (svc *GittarFileTree) CreateFileTreeNode(req apistructs.UnifiedFileTreeNode
 		request.Branch = branch
 		request.Actions = []apistructs.EditActionItem{}
 		request.Message = "add " + node.Name
+		// set default yml content
 		action := apistructs.EditActionItem{
 			Action:   "add",
 			PathType: gittarEntryBlobType,
+			Content:  "version: \"1.1\"\nstages: []\n",
 		}
 
 		// 假如长度为4，那就是应用的根目录下，就只能创建pipeline.yml文件了


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
set default content when creating yml file,otherwise pipeline-yml-graph will report an error for parse null yml content

