### PR TITLE
fix: cancel line character limit of commit's and compare's response

### DIFF
--- a/modules/gittar/pkg/gitmodule/repo_diff.go
+++ b/modules/gittar/pkg/gitmodule/repo_diff.go
@@ -63,6 +63,11 @@ func NewDefaultDiffOptions() *DiffOptions {
 	}
 }
 
+func (d *DiffOptions) SetShowAll(showAll bool) *DiffOptions {
+	d.ShowAll = showAll
+	return d
+}
+
 // DiffLine represents a line in diff.
 type DiffLine struct {
 	OldLineNo int          `json:"oldLineNo"`
@@ -179,7 +184,7 @@ func (repo *Repository) GetDiffFile(newCommit *Commit, oldCommit *Commit, oldPat
 }
 
 func (repo *Repository) GetDiff(newCommit *Commit, oldCommit *Commit) (*Diff, error) {
-	return repo.GetDiffWithOptions(newCommit, oldCommit, NewDefaultDiffOptions())
+	return repo.GetDiffWithOptions(newCommit, oldCommit, NewDefaultDiffOptions().SetShowAll(true))
 }
 
 func (repo *Repository) GetDiffWithOptions(newCommit *Commit, oldCommit *Commit, diffOptions *DiffOptions) (*Diff, error) {


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
fix: cancel line character limit of commit's and compare's response

#### Which issue(s) this PR fixes:
https://erda-org.erda.cloud/erda/workBench/projects/387/issues/all?id=63802&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMTI2MSJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=429&type=BUG
#### Specified Reviewers:
/assign @sfwn 

