### PR TITLE
ElasticSearch query engine support diff and diffps functions

### DIFF
--- a/modules/monitor/core/metrics/metricq/es-tsql/functions.go
+++ b/modules/monitor/core/metrics/metricq/es-tsql/functions.go
@@ -39,6 +39,7 @@ type Context interface {
 	Aggregations() elastic.Aggregations
 	HandleScopeAgg(scope string, aggs elastic.Aggregations, expr influxql.Expr) (interface{}, error)
 	RowNum() int64
+	AttributesCache() map[string]interface{}
 }
 
 var timeLayouts = []string{

--- a/modules/monitor/core/metrics/metricq/es-tsql/influxql/query.go
+++ b/modules/monitor/core/metrics/metricq/es-tsql/influxql/query.go
@@ -265,12 +265,27 @@ func (q *Query) parseDimensionsAggsData(rs *tsql.ResultSet, aggs elastic.Aggrega
 		if bucketsCount > 0 && histogram.Buckets[bucketsCount-1].DocCount == 0 {
 			histogram.Buckets = histogram.Buckets[:bucketsCount-1]
 		}
-		for _, bucket := range histogram.Buckets {
+		q.ctx.AttributesCache()
+		for i, bucket := range histogram.Buckets {
+			if i+1 < len(histogram.Buckets) {
+				q.ctx.attributesCache["next"] = histogram.Buckets[i+1].Aggregations
+			} else {
+				delete(q.ctx.attributesCache, "next")
+				continue
+			}
+			if i == 0 {
+				delete(q.ctx.attributesCache, "previous")
+				continue
+			} else {
+				q.ctx.attributesCache["previous"] = histogram.Buckets[i-1].Aggregations
+			}
 			err := q.parseDimensionsAggsData(rs, bucket.Aggregations, append(buckets, bucket))
 			if err != nil {
 				return err
 			}
 		}
+		delete(q.ctx.attributesCache, "next")
+		delete(q.ctx.attributesCache, "previous")
 	} else if rng, ok := aggs.Range("range"); ok {
 		for _, bucket := range rng.Buckets {
 			err := q.parseDimensionsAggsData(rs, bucket.Aggregations, append(buckets, bucket))

--- a/modules/monitor/core/metrics/metricq/es-tsql/tsql-test/main.go
+++ b/modules/monitor/core/metrics/metricq/es-tsql/tsql-test/main.go
@@ -129,10 +129,37 @@ func getSources(query tsql.Query) []string {
 }
 
 func main() {
-	err := test20()
+	err := test22()
 	if err != nil {
 		panic(err)
 	}
+}
+
+func test23() error {
+	return Query(
+		`
+		SELECT time(),round_float(avg(max::field), 2) 
+		FROM jvm_memory 
+		WHERE service_id::tag='9_feature/auto-test1_apm-demo-dubbo' 
+		GROUP BY time()
+		`, map[string]interface{}{})
+}
+
+func test22() error {
+	return Query(`
+		SELECT service_id::tag,service_name::tag,min(rx_bytes::field),round_float(diff(rx_bytes::field), 2),round_float(diffps(rx_bytes::field), 2)
+		FROM docker_container_summary
+		GROUP BY time(),service_id::tag;
+		`, map[string]interface{}{})
+}
+
+func test21() error {
+	return Query(`
+		SELECT min(rx_bytes::field),round_float(diff(rx_bytes::field), 2),round_float(diffps(rx_bytes::field), 2)
+		FROM docker_container_summary
+		WHERE service_id::tag='9_feature/auto-test1_apm-demo-dubbo'
+		GROUP BY time();
+		`, map[string]interface{}{})
 }
 
 func test20() error {


### PR DESCRIPTION
Signed-off-by: luoyu <o.sparkli@outlook.com>

#### What type of this PR

ElasticSearch query engine support some custom functions

- diff 
  Show difference value for the countervalue field, that is, the difference between the upper and lower bucket.

- diffps
  Is the rate of the countervalue field, that is, the rate of the difference between the upper and lower bucket per second.

    
![image](https://user-images.githubusercontent.com/51604064/120261939-81fe2c00-c2cb-11eb-9623-05cac73d5a4b.png)




/kind feature

#### Use
For some fields witch one use counter to calculate the difference and rate.
