### PR TITLE
feature: add cluster-manager

### DIFF
--- a/apistructs/cluster.go
+++ b/apistructs/cluster.go
@@ -13,9 +13,7 @@
 
 package apistructs
 
-import (
-	"time"
-)
+import "time"
 
 // 集群类型
 const (
@@ -38,18 +36,16 @@ const (
 	ClusterStatusOffline string = "offline"
 )
 
-// token / client-cert&client-key / proxy(dialer) / inet(self-innovate)
+// token / client-cert&client-key / proxy(dialer)
 const (
 	ManageToken = "token"
 	ManageCert  = "cert"
 	ManageProxy = "proxy"
-	ManageInet  = "inet"
 )
 
 // ClusterCreateRequest 集群创建请求
 // TODO 逐步废弃 urls & settings, 统一使用config
 type ClusterCreateRequest struct {
-	OrgID           int64               `json:"orgID"`
 	Name            string              `json:"name"`
 	CloudVendor     string              `json:"cloudVendor"`
 	DisplayName     string              `json:"displayName"`
@@ -57,13 +53,19 @@ type ClusterCreateRequest struct {
 	Type            string              `json:"type"` // dcos, edas, k8s
 	Logo            string              `json:"logo"`
 	WildcardDomain  string              `json:"wildcardDomain"`
-	URLs            map[string]string   `json:"urls"`
-	Settings        map[string]string   `json:"settings"`
-	Config          map[string]string   `json:"config"` // 集群基本配置
 	SchedulerConfig *ClusterSchedConfig `json:"scheduler"`
 	OpsConfig       *OpsConfig          `json:"opsConfig"`
 	SysConfig       *Sysconf            `json:"sysConfig"`
 	ManageConfig    *ManageConfig       `json:"manageConfig"` // e.g. token, cert, proxy
+
+	// Deprecated
+	OrgID int64 `json:"orgID"`
+	// Deprecated
+	URLs map[string]string `json:"urls"`
+	// Deprecated
+	Settings map[string]string `json:"settings"`
+	// Deprecated
+	Config map[string]string `json:"config"` // 集群基本配置
 }
 
 // ClusterCreateResponse 集群创建响应
@@ -74,24 +76,33 @@ type ClusterCreateResponse struct {
 
 // ClusterUpdateRequest 集群更新请求
 type ClusterUpdateRequest struct {
-	OrgID           int                 `json:"orgID"`
 	Name            string              `json:"name"`
 	DisplayName     string              `json:"displayName"`
 	Type            string              `json:"type"`
 	Logo            string              `json:"logo"`
 	Description     string              `json:"description"`
 	WildcardDomain  string              `json:"wildcardDomain"`
-	URLs            map[string]string   `json:"urls"`
 	SchedulerConfig *ClusterSchedConfig `json:"scheduler"`
 	OpsConfig       *OpsConfig          `json:"opsConfig"`
 	SysConfig       *Sysconf            `json:"sysConfig"`
 	ManageConfig    *ManageConfig       `json:"manageConfig"`
+
+	// Deprecated
+	OrgID int `json:"orgID"`
+	// Deprecated
+	URLs map[string]string `json:"urls"`
 }
 
 // ClusterUpdateResponse 集群更新响应
 type ClusterUpdateResponse struct {
 	Header
 	Data interface{} `json:"data"`
+}
+
+// ClusterPatchRequest cluster patch request
+type ClusterPatchRequest struct {
+	Name         string        `json:"name"`
+	ManageConfig *ManageConfig `json:"manageConfig"`
 }
 
 // ClusterFetchResponse 集群详情响应
@@ -167,27 +178,33 @@ const (
 
 // ClusterInfo 集群信息
 type ClusterInfo struct {
-	ID             int                    `json:"id"`
-	OrgID          int                    `json:"orgID"`
-	Name           string                 `json:"name"`
-	DisplayName    string                 `json:"displayName"`
-	Type           string                 `json:"type"` // dcos, edas, k8s
-	CloudVendor    string                 `json:"cloudVendor"`
-	Logo           string                 `json:"logo"`
-	Description    string                 `json:"description"`
-	WildcardDomain string                 `json:"wildcardDomain"`
-	URLs           map[string]string      `json:"urls,omitempty"`
-	Settings       map[string]interface{} `json:"settings,omitempty"`
-	Config         map[string]string      `json:"config,omitempty"`
-	SchedConfig    *ClusterSchedConfig    `json:"scheduler,omitempty"`
-	OpsConfig      *OpsConfig             `json:"opsConfig,omitempty"`
+	ID             int                 `json:"id"`
+	Name           string              `json:"name"`
+	DisplayName    string              `json:"displayName"`
+	Type           string              `json:"type"` // dcos, edas, k8s
+	CloudVendor    string              `json:"cloudVendor"`
+	Logo           string              `json:"logo"`
+	Description    string              `json:"description"`
+	WildcardDomain string              `json:"wildcardDomain"`
+	SchedConfig    *ClusterSchedConfig `json:"scheduler,omitempty"`
+	OpsConfig      *OpsConfig          `json:"opsConfig,omitempty"`
+	System         *Sysconf            `json:"system,omitempty"`
+	ManageConfig   *ManageConfig       `json:"manageConfig"`
+	CreatedAt      time.Time           `json:"createdAt"`
+	UpdatedAt      time.Time           `json:"updatedAt"`
+
+	// Deprecated
+	OrgID int `json:"orgID"`
+	// Deprecated
+	URLs map[string]string `json:"urls,omitempty"`
+	// Deprecated
+	Settings map[string]interface{} `json:"settings,omitempty"`
+	// Deprecated
+	Config map[string]string `json:"config,omitempty"`
 	//Resource       *aliyun.AliyunResources `json:"resource"`  // TODO: 重构优化
-	System       *Sysconf      `json:"system,omitempty"`
-	ManageConfig *ManageConfig `json:"manageConfig"`
 	// 是否关联集群，Y: 是，N: 否
-	IsRelation string    `json:"isRelation"`
-	CreatedAt  time.Time `json:"createdAt"`
-	UpdatedAt  time.Time `json:"updatedAt"`
+	// Deprecated
+	IsRelation string `json:"isRelation"`
 }
 
 // GetClusterResponse 根据集群名称或集群ID获取集群信息

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -243,6 +243,24 @@ func WithAPIM() Option {
 	}
 }
 
+// WithClusterManager create cluster manager client with CLUSTER_MANAGER
+func WithClusterManager() Option {
+	return func(b *Bundle) {
+		k := discover.EnvClusterManager
+		v := os.Getenv(k)
+		b.urls.Put(k, v)
+	}
+}
+
+// WithECP create ecp client with CLUSTER_MANAGER
+func WithECP() Option {
+	return func(b *Bundle) {
+		k := discover.EnvECP
+		v := os.Getenv(k)
+		b.urls.Put(k, v)
+	}
+}
+
 // WithAllAvailableClients 将环境变量中所有可以拿到的客户端均注入
 func WithAllAvailableClients() Option {
 	return func(b *Bundle) {

--- a/bundle/cluster.go
+++ b/bundle/cluster.go
@@ -19,12 +19,13 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle/apierrors"
+	"github.com/erda-project/erda/pkg/http/httpserver"
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
 // GetCluster 查询集群
 func (b *Bundle) GetCluster(idOrName string) (*apistructs.ClusterInfo, error) {
-	host, err := b.urls.CMDB()
+	host, err := b.urls.ClusterManager()
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +46,7 @@ func (b *Bundle) GetCluster(idOrName string) (*apistructs.ClusterInfo, error) {
 
 // ListCluster 返回 org 下所有集群; 当 orgID == "" 时，返回所有集群.
 func (b *Bundle) ListClusters(clusterType string, orgID ...uint64) ([]apistructs.ClusterInfo, error) {
-	host, err := b.urls.CMDB()
+	host, err := b.urls.ClusterManager()
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +97,9 @@ func (b *Bundle) DeleteImageManifests(clusterIDOrName string, images []string) (
 	return &deleteResp.Data, nil
 }
 
-// UpdateCluster 更新集群信息
+// UpdateCluster update cluster
 func (b *Bundle) UpdateCluster(req apistructs.ClusterUpdateRequest, header ...http.Header) error {
-	host, err := b.urls.CMDB()
+	host, err := b.urls.ClusterManager()
 	if err != nil {
 		return err
 	}
@@ -119,5 +120,85 @@ func (b *Bundle) UpdateCluster(req apistructs.ClusterUpdateRequest, header ...ht
 	if !resp.IsOK() || !updateResp.Success {
 		return toAPIError(resp.StatusCode(), updateResp.Error)
 	}
+	return nil
+}
+
+// CreateCluster Create cluster with event
+func (b *Bundle) CreateCluster(req *apistructs.ClusterCreateRequest, header ...http.Header) error {
+	host, err := b.urls.ClusterManager()
+	if err != nil {
+		return err
+	}
+	hc := b.hc
+
+	var createResp apistructs.ClusterCreateResponse
+
+	q := hc.Post(host).Path("/api/clusters")
+	if len(header) > 0 {
+		q.Headers(header[0])
+	}
+	resp, err := q.JSONBody(req).
+		Do().
+		JSON(&createResp)
+	if err != nil {
+		return apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !createResp.Success {
+		return toAPIError(resp.StatusCode(), createResp.Error)
+	}
+	return nil
+}
+
+// PatchCluster patch cluster with event
+func (b *Bundle) PatchCluster(req *apistructs.ClusterPatchRequest, header ...http.Header) error {
+	host, err := b.urls.ClusterManager()
+	if err != nil {
+		return err
+	}
+	hc := b.hc
+
+	q := hc.Patch(host).Path("/api/clusters")
+	if len(header) > 0 {
+		q.Headers(header[0])
+	}
+
+	var httpResp httpserver.Resp
+
+	resp, err := q.JSONBody(req).Do().JSON(&httpResp)
+	if err != nil {
+		return apierrors.ErrInvoke.InternalError(err)
+	}
+
+	if !resp.IsOK() || !httpResp.Success {
+		return toAPIError(resp.StatusCode(), httpResp.Err)
+	}
+
+	return nil
+}
+
+// DeleteCluster Delete cluster with event
+func (b *Bundle) DeleteCluster(clusterName string, header ...http.Header) error {
+	host, err := b.urls.ClusterManager()
+	if err != nil {
+		return err
+	}
+	hc := b.hc
+
+	q := hc.Delete(host).Path("/api/clusters/" + clusterName)
+	if len(header) > 0 {
+		q.Headers(header[0])
+	}
+
+	var httpResp httpserver.Resp
+
+	resp, err := q.Do().JSON(&httpResp)
+	if err != nil {
+		return apierrors.ErrInvoke.InternalError(err)
+	}
+
+	if !resp.IsOK() || !httpResp.Success {
+		return toAPIError(resp.StatusCode(), httpResp.Err)
+	}
+
 	return nil
 }

--- a/bundle/ecp.go
+++ b/bundle/ecp.go
@@ -48,7 +48,7 @@ func (b *Bundle) ListEdgeApp(req *apistructs.EdgeAppListPageRequest, identify ap
 		reqParam   map[string]string
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (b *Bundle) GetEdgeApp(appID uint64, identify apistructs.Identity) (*apistr
 		httpReqRes httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (b *Bundle) CreateEdgeApp(req *apistructs.EdgeAppCreateRequest, identify ap
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (b *Bundle) UpdateEdgeApp(req *apistructs.EdgeAppUpdateRequest, appID uint6
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (b *Bundle) DeleteEdgeApp(appID int64, identify apistructs.Identity) error 
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func (b *Bundle) GetEdgeAppStatus(req *apistructs.EdgeAppStatusListRequest, iden
 		httpReqRes httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (b *Bundle) ListEdgeSite(req *apistructs.EdgeSiteListPageRequest, identify 
 		reqParam   map[string]string
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func (b *Bundle) GetEdgeSite(siteID int64, identify apistructs.Identity) (*apist
 		httpReqRes httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (b *Bundle) CreateEdgeSite(req *apistructs.EdgeSiteCreateRequest, identify 
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -457,7 +457,7 @@ func (b *Bundle) UpdateEdgeSite(req *apistructs.EdgeSiteUpdateRequest, siteID in
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,7 @@ func (b *Bundle) DeleteEdgeSite(siteID int64, identify apistructs.Identity) erro
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func (b *Bundle) ListEdgeConfigset(req *apistructs.EdgeConfigSetListPageRequest,
 		reqParam   map[string]string
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +590,7 @@ func (b *Bundle) GetEdgeConfigSet(itemID int64, identify apistructs.Identity) (*
 		httpReqRes httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +634,7 @@ func (b *Bundle) CreateEdgeConfigset(req *apistructs.EdgeConfigSetCreateRequest,
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -663,7 +663,7 @@ func (b *Bundle) UpdateEdgeConfigset(req *apistructs.EdgeConfigSetUpdateRequest,
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -692,7 +692,7 @@ func (b *Bundle) DeleteEdgeConfigset(siteID int64, identify apistructs.Identity)
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -722,7 +722,7 @@ func (b *Bundle) ListEdgeCfgSetItem(req *apistructs.EdgeCfgSetItemListPageReques
 		buffer     bytes.Buffer
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func (b *Bundle) GetEdgeCfgSetItem(itemID int64, identify apistructs.Identity) (
 		httpReqRes httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -829,7 +829,7 @@ func (b *Bundle) CreateEdgeCfgSetItem(req *apistructs.EdgeCfgSetItemCreateReques
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -858,7 +858,7 @@ func (b *Bundle) UpdateEdgeCfgSetItem(req *apistructs.EdgeCfgSetItemUpdateReques
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -887,7 +887,7 @@ func (b *Bundle) DeleteEdgeCfgSetItem(siteID int64, identify apistructs.Identity
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -1081,7 +1081,7 @@ func (b *Bundle) GetEdgeSiteInitShell(siteID int64, identify apistructs.Identity
 		buffer     bytes.Buffer
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return nil, err
 	}
@@ -1214,7 +1214,7 @@ func (b *Bundle) RestartEdgeAppSite(appID uint64, req *apistructs.EdgeAppSiteReq
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}
@@ -1243,7 +1243,7 @@ func (b *Bundle) OfflineEdgeAppSite(appID uint64, req *apistructs.EdgeAppSiteReq
 		resp httpserver.Resp
 	)
 
-	host, err := b.urls.Ops()
+	host, err := b.urls.ECP()
 	if err != nil {
 		return err
 	}

--- a/bundle/events.go
+++ b/bundle/events.go
@@ -29,11 +29,12 @@ type Sender = string
 
 // Event sender collections
 const (
-	SenderCMDB         Sender = "cmdb"
-	SenderDiceHub      Sender = "dicehub"
-	SenderScheduler    Sender = "scheduler"
-	SenderOrchestrator Sender = "orchestrator"
-	SenderCoreServices Sender = "coreServices"
+	SenderCMDB           Sender = "cmdb"
+	SenderDiceHub        Sender = "dicehub"
+	SenderScheduler      Sender = "scheduler"
+	SenderOrchestrator   Sender = "orchestrator"
+	SenderCoreServices   Sender = "coreServices"
+	SenderClusterManager Sender = "clusterManager"
 )
 
 // Event types

--- a/bundle/urls.go
+++ b/bundle/urls.go
@@ -129,6 +129,14 @@ func (u urls) DOP() (string, error) {
 	return u.getURL(discover.EnvDOP, discover.SvcDOP)
 }
 
+func (u urls) ClusterManager() (string, error) {
+	return u.getURL(discover.EnvClusterManager, discover.SvcClusterManager)
+}
+
+func (u urls) ECP() (string, error) {
+	return u.getURL(discover.EnvECP, discover.SvcECP)
+}
+
 func (u urls) getURL(k, srvName string) (string, error) {
 	v, ok := u[k]
 	if ok {

--- a/cmd/cluster-manager/main.go
+++ b/cmd/cluster-manager/main.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"github.com/erda-project/erda-infra/modcom"
+	_ "github.com/erda-project/erda/modules/cluster-manager"
+)
+
+func main() {
+	modcom.RunWithCfgDir("conf/cluster-manager", "cluster-manager")
+}

--- a/conf/cluster-manager/cluster-manager.yaml
+++ b/conf/cluster-manager/cluster-manager.yaml
@@ -1,0 +1,1 @@
+cluster-manager:

--- a/modules/cluster-manager/conf/conf.go
+++ b/modules/cluster-manager/conf/conf.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package conf
+
+type Conf struct {
+	Debug  bool   `default:"false"`
+	Listen string `default:":8080"`
+}

--- a/modules/cluster-manager/dbclient/cluster.go
+++ b/modules/cluster-manager/dbclient/cluster.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dbclient
+
+import (
+	"github.com/jinzhu/gorm"
+
+	"github.com/erda-project/erda/modules/cluster-manager/model"
+)
+
+// CreateCluster create cluster
+func (client *DBClient) CreateCluster(cluster *model.Cluster) error {
+	return client.Create(cluster).Error
+}
+
+// UpdateCluster update cluster
+func (client *DBClient) UpdateCluster(cluster *model.Cluster) error {
+	return client.Save(cluster).Error
+}
+
+// DeleteCluster delete cluster
+func (client *DBClient) DeleteCluster(clusterName string) error {
+	return client.Where("name = ?", clusterName).Delete(&model.Cluster{}).Error
+}
+
+// GetClusterByName get cluster by name
+func (client *DBClient) GetClusterByName(clusterName string) (*model.Cluster, error) {
+	var cluster model.Cluster
+	if err := client.Where("name = ?", clusterName).First(&cluster).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+// GetClusterByID get cluster by name
+func (client *DBClient) GetClusterByID(clusterID int64) (*model.Cluster, error) {
+	var cluster model.Cluster
+	if err := client.Where("id = ?", clusterID).First(&cluster).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+// ListCluster list cluster
+func (client *DBClient) ListCluster() (*[]model.Cluster, error) {
+	var clusters []model.Cluster
+	if err := client.Find(&clusters).Error; err != nil {
+		return nil, err
+	}
+	return &clusters, nil
+}
+
+// ListClusterByType list cluster filter by cluster type
+func (client *DBClient) ListClusterByType(clusterType string) (*[]model.Cluster, error) {
+	var clusters []model.Cluster
+	if clusterType != "" {
+		if err := client.Where("type = ?", clusterType).Find(&clusters).Error; err != nil {
+			return nil, err
+		}
+	}
+	return &clusters, nil
+}

--- a/modules/cluster-manager/dbclient/dbclient.go
+++ b/modules/cluster-manager/dbclient/dbclient.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dbclient
+
+import (
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+
+	"github.com/erda-project/erda/pkg/database/dbengine"
+)
+
+type DBClient struct {
+	*dbengine.DBEngine
+}
+
+func Open() *DBClient {
+	return &DBClient{DBEngine: dbengine.MustOpen()}
+}

--- a/modules/cluster-manager/endpoints/cluster.go
+++ b/modules/cluster-manager/endpoints/cluster.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/cluster-manager/services/apierrors"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/http/httpserver/errorresp"
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+// GetCluster get cluster meta info
+func (e *Endpoints) GetCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	cluster, err := e.cluster.GetCluster(vars["idOrName"])
+	if err != nil {
+		if strutil.Contains(err.Error(), "not found") {
+			return apierrors.ErrGetCluster.NotFound().ToResp(), nil
+		}
+		return apierrors.ErrGetCluster.InternalError(err).ToResp(), nil
+	}
+
+	return httpserver.OkResp(*cluster)
+}
+
+// ListCluster list all cluster
+func (e *Endpoints) ListCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	var (
+		clusters *[]apistructs.ClusterInfo
+		err      error
+	)
+
+	clusterType := r.URL.Query().Get("clusterType")
+
+	if clusterType != "" {
+		clusters, err = e.cluster.ListClusterByType(clusterType)
+	} else {
+		clusters, err = e.cluster.ListCluster()
+	}
+
+	if err != nil {
+		return apierrors.ErrListCluster.InternalError(err).ToResp(), nil
+	}
+
+	return httpserver.OkResp(clusters)
+}
+
+// CreateCluster create cluster
+func (e *Endpoints) CreateCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	var req apistructs.ClusterCreateRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return apierrors.ErrCreateCluster.InvalidParameter(err).ToResp(), nil
+	}
+	logrus.Infof("request body: %+v", req)
+
+	if err := e.cluster.CreateWithEvent(&req); err != nil {
+		return apierrors.ErrCreateCluster.InvalidParameter(err).ToResp(), nil
+	}
+
+	return httpserver.OkResp(nil)
+}
+
+// UpdateCluster update cluster
+func (e *Endpoints) UpdateCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	var req apistructs.ClusterUpdateRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return apierrors.ErrUpdateCluster.InvalidParameter(err).ToResp(), nil
+	}
+	logrus.Infof("request body: %+v", req)
+
+	if err := e.cluster.UpdateWithEvent(&req); err != nil {
+		if strutil.Contains(err.Error(), "not found") {
+			return apierrors.ErrGetCluster.NotFound().ToResp(), nil
+		}
+		return apierrors.ErrUpdateCluster.InvalidParameter(err).ToResp(), nil
+	}
+
+	return httpserver.OkResp(nil)
+}
+
+// PatchCluster patch cluster
+func (e *Endpoints) PatchCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	var req apistructs.ClusterPatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return apierrors.ErrPatchCluster.InvalidParameter(err).ToResp(), nil
+	}
+	logrus.Infof("request body: %+v", req)
+
+	if err := e.cluster.PatchWithEvent(&req); err != nil {
+		if strutil.Contains(err.Error(), "not found") {
+			return apierrors.ErrGetCluster.NotFound().ToResp(), nil
+		}
+		return apierrors.ErrPatchCluster.InvalidParameter(err).ToResp(), nil
+	}
+
+	return httpserver.OkResp(nil)
+}
+
+// DeleteCluster delete cluster
+func (e *Endpoints) DeleteCluster(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	if err := e.cluster.DeleteWithEvent(vars["clusterName"]); err != nil {
+		return errorresp.ErrResp(err)
+	}
+
+	return httpserver.OkResp(nil)
+}

--- a/modules/cluster-manager/endpoints/endpoints.go
+++ b/modules/cluster-manager/endpoints/endpoints.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package endpoints
+
+import (
+	"net/http"
+
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/cluster-manager/dbclient"
+	"github.com/erda-project/erda/modules/cluster-manager/services/cluster"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+)
+
+type Endpoints struct {
+	dbClient *dbclient.DBClient
+	cluster  *cluster.Cluster
+}
+
+type Option func(*Endpoints)
+
+func New(options ...Option) *Endpoints {
+	e := &Endpoints{}
+
+	for _, op := range options {
+		op(e)
+	}
+
+	e.cluster = cluster.New(
+		cluster.WithDBClient(e.dbClient),
+		cluster.WithBundle(bundle.New(bundle.WithEventBox())),
+	)
+
+	return e
+}
+
+func WithDBClient(db *dbclient.DBClient) Option {
+	return func(e *Endpoints) {
+		e.dbClient = db
+	}
+}
+
+// Routes Return routes
+func (e *Endpoints) Routes() []httpserver.Endpoint {
+	return []httpserver.Endpoint{
+		{Path: "/api/clusters", Method: http.MethodGet, Handler: auth(e.ListCluster)},
+		{Path: "/api/clusters/{idOrName}", Method: http.MethodGet, Handler: auth(e.GetCluster)},
+		{Path: "/api/clusters", Method: http.MethodPost, Handler: auth(e.CreateCluster)},
+		{Path: "/api/clusters", Method: http.MethodPut, Handler: auth(e.UpdateCluster)},
+		{Path: "/api/clusters/{clusterName}", Method: http.MethodDelete, Handler: auth(e.DeleteCluster)},
+		{Path: "/api/clusters", Method: http.MethodPatch, Handler: auth(e.PatchCluster)},
+	}
+}

--- a/modules/cluster-manager/endpoints/prehandle.go
+++ b/modules/cluster-manager/endpoints/prehandle.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package endpoints
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/erda-project/erda/modules/cluster-manager/services/apierrors"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/http/httputil"
+)
+
+type endpoint func(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error)
+
+func auth(f endpoint) endpoint {
+	return func(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+		// TODO: Use new auth
+		if r.Header.Get(httputil.InternalHeader) == "" {
+			return apierrors.ErrPreCheckCluster.AccessDenied().ToResp(), nil
+		}
+
+		if r.Body == nil {
+			return apierrors.ErrPreCheckCluster.MissingParameter("body").ToResp(), nil
+		}
+		return f(ctx, r, vars)
+	}
+}

--- a/modules/cluster-manager/initialize.go
+++ b/modules/cluster-manager/initialize.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cluster_manager
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda/modules/cluster-manager/conf"
+	"github.com/erda-project/erda/modules/cluster-manager/dbclient"
+	"github.com/erda-project/erda/modules/cluster-manager/endpoints"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+)
+
+func initialize(cfg *conf.Conf) error {
+	if cfg.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	ep := endpoints.New(
+		endpoints.WithDBClient(dbclient.Open()),
+	)
+
+	server := httpserver.New(cfg.Listen)
+	server.RegisterEndpoint(append(ep.Routes()))
+
+	logrus.Infof("start the service and listen on address [%s]", cfg.Listen)
+	logrus.Info("starting cluster-manager instance")
+
+	return server.ListenAndServe()
+}

--- a/modules/cluster-manager/model/model.go
+++ b/modules/cluster-manager/model/model.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package model
+
+import (
+	"time"
+)
+
+// BaseModel common info for all models
+type BaseModel struct {
+	ID        int64     `json:"id" gorm:"primary_key"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Cluster cluster model
+type Cluster struct {
+	BaseModel
+	Name            string
+	DisplayName     string
+	CloudVendor     string
+	Description     string
+	Type            string
+	Logo            string
+	WildcardDomain  string
+	SchedulerConfig string `gorm:"column:scheduler;type:text"`
+	OpsConfig       string `gorm:"column:opsconfig;type:text"`
+	ManageConfig    string `gorm:"column:manage_config;type:text"`
+	SysConfig       string `gorm:"column:sys;type:text"`
+}
+
+// TableName cluster table name
+func (Cluster) TableName() string {
+	return "co_clusters"
+}

--- a/modules/cluster-manager/provider.go
+++ b/modules/cluster-manager/provider.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cluster_manager
+
+import (
+	"context"
+
+	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda/modules/cluster-manager/conf"
+)
+
+type provider struct {
+	Cfg *conf.Conf
+}
+
+func (p *provider) Init(ctx servicehub.Context) error {
+	return initialize(p.Cfg)
+}
+
+func (p *provider) Run(ctx context.Context) error {
+	return nil
+}
+
+func init() {
+	servicehub.Register("cluster-manager", &servicehub.Spec{
+		Services:    []string{"cluster-manager"},
+		Description: "cluster manager",
+		ConfigFunc: func() interface{} {
+			return &conf.Conf{}
+		},
+		Creator: func() servicehub.Provider {
+			return &provider{}
+		},
+	})
+}

--- a/modules/cluster-manager/services/apierrors/errors.go
+++ b/modules/cluster-manager/services/apierrors/errors.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package apierrors
+
+import (
+	"github.com/erda-project/erda/pkg/http/httpserver/errorresp"
+)
+
+var (
+	ErrPreCheckCluster = err("ErrPreCheckCluster", "auth failed")
+	ErrCreateCluster   = err("ErrCreateCluster", "failed to create cluster")
+	ErrUpdateCluster   = err("ErrUpdateCluster", "failed to update cluster")
+	ErrPatchCluster    = err("ErrPatchCluster", "failed to patch cluster")
+	ErrGetCluster      = err("ErrGetCluster", "failed to get cluster")
+	ErrListCluster     = err("ErrListCluster", "failed to list cluster")
+	ErrDeleteCluster   = err("ErrDeleteCluster", "failed to delete cluster")
+)
+
+func err(template, defaultValue string) *errorresp.APIError {
+	return errorresp.New(errorresp.WithTemplateMessage(template, defaultValue))
+}

--- a/modules/cluster-manager/services/cluster/cluster.go
+++ b/modules/cluster-manager/services/cluster/cluster.go
@@ -1,0 +1,510 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/cluster-manager/dbclient"
+	"github.com/erda-project/erda/modules/cluster-manager/model"
+	"github.com/erda-project/erda/modules/cluster-manager/services/apierrors"
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+type Option func(*Cluster)
+
+// Cluster cluster
+type Cluster struct {
+	db  *dbclient.DBClient
+	bdl *bundle.Bundle
+}
+
+// New new cluster
+func New(options ...Option) *Cluster {
+	cluster := &Cluster{}
+	for _, op := range options {
+		op(cluster)
+	}
+	return cluster
+}
+
+func WithDBClient(db *dbclient.DBClient) Option {
+	return func(c *Cluster) {
+		c.db = db
+	}
+}
+
+func WithBundle(bdl *bundle.Bundle) Option {
+	return func(c *Cluster) {
+		c.bdl = bdl
+	}
+}
+
+// CreateWithEvent create cluster with event request
+func (c *Cluster) CreateWithEvent(req *apistructs.ClusterCreateRequest) error {
+	cluster, err := c.db.GetClusterByName(req.Name)
+	if err != nil {
+		return err
+	}
+	if cluster != nil {
+		return nil
+	}
+
+	if err = c.Create(req); err != nil {
+		return err
+	}
+
+	clusterInfo, err := c.GetCluster(req.Name)
+	if err != nil {
+		return err
+	}
+
+	ev := &apistructs.EventCreateRequest{
+		EventHeader: apistructs.EventHeader{
+			Event:     bundle.ClusterEvent,
+			Action:    bundle.CreateAction,
+			OrgID:     "-1",
+			ProjectID: "-1",
+			TimeStamp: time.Now().Format("2006-01-02 15:04:05"),
+		},
+		Sender:  bundle.SenderClusterManager,
+		Content: clusterInfo,
+	}
+
+	if err = c.bdl.CreateEvent(ev); err != nil {
+		logrus.Warnf("failed to send cluster create event, (%v)", err)
+		return nil
+	}
+
+	return nil
+}
+
+// Create create cluster
+func (c *Cluster) Create(req *apistructs.ClusterCreateRequest) error {
+	// validate param
+	if err := c.checkCreateParam(req); err != nil {
+		return err
+	}
+
+	if req.SysConfig != nil {
+		switch req.Type {
+		case apistructs.K8S:
+			if req.SysConfig.MainPlatform != nil {
+				req.SchedulerConfig.MasterURL = strutil.Concat("inet://", req.WildcardDomain,
+					"/insecure-kubernetes.default.svc.cluster.local")
+			} else {
+				req.SchedulerConfig.MasterURL = "http://insecure-kubernetes.default.svc.cluster.local"
+			}
+		case apistructs.DCOS:
+			if req.SysConfig.MainPlatform != nil {
+				req.SchedulerConfig.MasterURL = strutil.Concat("inet://", req.WildcardDomain, "/master.mesos")
+			} else {
+				req.SchedulerConfig.MasterURL = "http://master.mesos"
+			}
+		}
+	}
+
+	// parse json store
+	sysConfig, err := json.MarshalIndent(req.SysConfig, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	schedulerConfig, err := json.MarshalIndent(req.SchedulerConfig, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	opsConfig, err := json.MarshalIndent(req.OpsConfig, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	manageConfig, err := json.MarshalIndent(req.ManageConfig, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	cluster := &model.Cluster{
+		Name:            req.Name,
+		DisplayName:     req.DisplayName,
+		Description:     req.Description,
+		Type:            req.Type,
+		CloudVendor:     req.CloudVendor,
+		Logo:            req.Logo,
+		WildcardDomain:  req.WildcardDomain,
+		SysConfig:       string(sysConfig),
+		SchedulerConfig: string(schedulerConfig),
+		OpsConfig:       string(opsConfig),
+		ManageConfig:    string(manageConfig),
+	}
+
+	if err = c.db.CreateCluster(cluster); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateWithEvent update cluster & sender cluster update event
+func (c *Cluster) UpdateWithEvent(req *apistructs.ClusterUpdateRequest) error {
+	if err := c.Update(req); err != nil {
+		return err
+	}
+
+	cluster, err := c.GetCluster(req.Name)
+	if err != nil {
+		return err
+	}
+
+	ev := &apistructs.EventCreateRequest{
+		EventHeader: apistructs.EventHeader{
+			Event:     bundle.ClusterEvent,
+			Action:    bundle.UpdateAction,
+			OrgID:     "-1",
+			ProjectID: "-1",
+			TimeStamp: time.Now().Format("2006-01-02 15:04:05"),
+		},
+		Sender:  bundle.SenderClusterManager,
+		Content: cluster,
+	}
+
+	if err = c.bdl.CreateEvent(ev); err != nil {
+		logrus.Warnf("failed to send cluster update event, (%v)", err)
+		return nil
+	}
+
+	return nil
+}
+
+// Update update cluster
+func (c *Cluster) Update(req *apistructs.ClusterUpdateRequest) error {
+	cluster, err := c.db.GetClusterByName(req.Name)
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		return errors.Errorf("not found")
+	}
+	logrus.Infof("before updated cluster info: %+v", cluster)
+
+	cluster.DisplayName = req.DisplayName
+	if req.Type != "" {
+		cluster.Type = req.Type
+	}
+	cluster.Logo = req.Logo
+	cluster.Description = req.Description
+	if req.WildcardDomain != "" {
+		cluster.WildcardDomain = req.WildcardDomain
+	}
+
+	if req.SchedulerConfig != nil {
+		schedulerConfig, err := json.MarshalIndent(req.SchedulerConfig, "", "\t")
+		if err != nil {
+			return err
+		}
+		cluster.SchedulerConfig = string(schedulerConfig)
+	}
+	if req.OpsConfig != nil {
+		opsConfig, err := json.MarshalIndent(req.OpsConfig, "", "\t")
+		if err != nil {
+			return err
+		}
+		cluster.OpsConfig = string(opsConfig)
+	}
+	if req.SysConfig != nil {
+		var newSysConfig *apistructs.Sysconf
+		if err := json.Unmarshal([]byte(cluster.SysConfig), &newSysConfig); err != nil {
+			return err
+		}
+		// Check field which change disabled
+		if err := c.diffSysConfig(req.SysConfig, newSysConfig); err != nil {
+			return err
+		}
+		sysConfig, err := json.MarshalIndent(req.SysConfig, "", "\t")
+		if err != nil {
+			return err
+		}
+		cluster.SysConfig = string(sysConfig)
+	}
+	if req.ManageConfig != nil {
+		manageConfig, err := json.MarshalIndent(req.ManageConfig, "", "\t")
+		if err != nil {
+			return err
+		}
+		cluster.ManageConfig = string(manageConfig)
+	}
+
+	if err = c.db.UpdateCluster(cluster); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PatchWithEvent patch with event
+func (c *Cluster) PatchWithEvent(req *apistructs.ClusterPatchRequest) error {
+	cluster, err := c.db.GetClusterByName(req.Name)
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		return errors.Errorf("not found")
+	}
+
+	if req.ManageConfig == nil {
+		return nil
+	}
+
+	manageConfig, err := json.MarshalIndent(req.ManageConfig, "", "\t")
+	if err != nil {
+		return err
+	}
+	cluster.ManageConfig = string(manageConfig)
+
+	if err = c.db.UpdateCluster(cluster); err != nil {
+		return err
+	}
+
+	ev := &apistructs.EventCreateRequest{
+		EventHeader: apistructs.EventHeader{
+			Event:     bundle.ClusterEvent,
+			Action:    bundle.UpdateAction,
+			OrgID:     "-1",
+			ProjectID: "-1",
+			TimeStamp: time.Now().Format("2006-01-02 15:04:05"),
+		},
+		Sender:  bundle.SenderClusterManager,
+		Content: c.convert(cluster),
+	}
+
+	if err = c.bdl.CreateEvent(ev); err != nil {
+		logrus.Warnf("failed to send cluster update event, (%v)", err)
+		return nil
+	}
+
+	return nil
+}
+
+// DeleteWithEvent delete cluster with delete event
+func (c *Cluster) DeleteWithEvent(clusterName string) error {
+	cluster, err := c.db.GetClusterByName(clusterName)
+	if err != nil {
+		return apierrors.ErrDeleteCluster.InternalError(err)
+	}
+	if cluster == nil {
+		return errors.Errorf("not found")
+	}
+
+	logrus.Infof("deleting cluster: %+v", *cluster)
+
+	if err := c.DeleteByName(clusterName); err != nil {
+		return apierrors.ErrDeleteCluster.InternalError(err)
+	}
+
+	ev := &apistructs.EventCreateRequest{
+		EventHeader: apistructs.EventHeader{
+			Event:     bundle.ClusterEvent,
+			Action:    bundle.DeleteAction,
+			OrgID:     "-1",
+			ProjectID: "-1",
+			TimeStamp: time.Now().Format("2006-01-02 15:04:05"),
+		},
+		Sender:  bundle.SenderClusterManager,
+		Content: cluster,
+	}
+
+	if err = c.bdl.CreateEvent(ev); err != nil {
+		logrus.Warnf("[alert]failed to send cluster delete event, (%v)", err)
+	}
+
+	return nil
+}
+
+// DeleteByName delete cluster by name
+func (c *Cluster) DeleteByName(clusterName string) error {
+	return c.db.DeleteCluster(clusterName)
+}
+
+// GetCluster get cluster by name
+func (c *Cluster) GetCluster(idOrName string) (*apistructs.ClusterInfo, error) {
+	var cluster *model.Cluster
+	clusterID, err := strutil.Atoi64(idOrName)
+	if err == nil {
+		cluster, err = c.db.GetClusterByID(clusterID)
+	} else {
+		cluster, err = c.db.GetClusterByName(idOrName)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if cluster == nil {
+		return nil, errors.Errorf("not found")
+	}
+
+	return c.convert(cluster), nil
+}
+
+// ListCluster list all cluster
+func (c *Cluster) ListCluster() (*[]apistructs.ClusterInfo, error) {
+	clusters, err := c.db.ListCluster()
+	if err != nil {
+		return nil, err
+	}
+	clusterInfos := make([]apistructs.ClusterInfo, 0, len(*clusters))
+	for i := range *clusters {
+		item := c.convert(&(*clusters)[i])
+		// TODO: Deprecated at future version.
+		if item.SchedConfig != nil {
+			item.SchedConfig.AuthPassword = ""
+			item.SchedConfig.ClientCrt = ""
+			item.SchedConfig.CACrt = ""
+			item.SchedConfig.ClientKey = ""
+			if item.SchedConfig.CPUSubscribeRatio == "" {
+				item.SchedConfig.CPUSubscribeRatio = "1"
+			}
+		}
+
+		clusterInfos = append(clusterInfos, *item)
+	}
+
+	return &clusterInfos, nil
+}
+
+func (c *Cluster) ListClusterByType(clusterType string) (*[]apistructs.ClusterInfo, error) {
+	var clusterList []apistructs.ClusterInfo
+
+	clusters, err := c.db.ListClusterByType(clusterType)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterList = make([]apistructs.ClusterInfo, 0, len(*clusters))
+	// TODO: Deprecated at future version.
+	for i := range *clusters {
+		item := c.convert(&(*clusters)[i])
+		// TODO: Deprecated at future version.
+		if item.SchedConfig != nil {
+			item.SchedConfig.AuthPassword = ""
+			item.SchedConfig.ClientCrt = ""
+			item.SchedConfig.CACrt = ""
+			item.SchedConfig.ClientKey = ""
+			if item.SchedConfig.CPUSubscribeRatio == "" {
+				item.SchedConfig.CPUSubscribeRatio = "1"
+			}
+		}
+
+		clusterList = append(clusterList, *item)
+	}
+
+	return &clusterList, nil
+}
+
+// checkCreateParam check create param
+func (c *Cluster) checkCreateParam(req *apistructs.ClusterCreateRequest) error {
+	if req.Name == "" {
+		return errors.Errorf("name is empty")
+	}
+
+	switch req.Type {
+	case apistructs.DCOS, apistructs.EDAS, apistructs.K8S:
+	default:
+		return errors.Errorf("type is invalid")
+	}
+	return nil
+}
+
+func (c *Cluster) diffSysConfig(new, old *apistructs.Sysconf) error {
+	if new.Cluster.Name != old.Cluster.Name {
+		return errors.Errorf("cluster name mismatch")
+	}
+	if new.FPS.Host != old.FPS.Host {
+		return errors.Errorf("fps host mismatch")
+	}
+	if new.Platform.WildcardDomain != old.Platform.WildcardDomain {
+		return errors.Errorf("wildcard domain mismatch")
+	}
+	if new.Storage.MountPoint != old.Storage.MountPoint {
+		return errors.New("nas mount point mismatch")
+	}
+	if new.Docker.DataRoot != old.Docker.DataRoot {
+		return errors.New("docker data root mismatch")
+	}
+	newNodes := make(map[string]string, len(new.Nodes))
+	for _, node := range new.Nodes {
+		newNodes[node.IP] = node.Type
+	}
+	for _, node := range old.Nodes {
+		if _, ok := newNodes[node.IP]; !ok {
+			return errors.New("nodes info mismatch")
+		}
+	}
+	return nil
+}
+
+// convert convert cluster model to ClusterInfo
+func (c *Cluster) convert(cluster *model.Cluster) *apistructs.ClusterInfo {
+	var (
+		schedulerConfig *apistructs.ClusterSchedConfig
+		opsConfig       *apistructs.OpsConfig
+		manageConfig    *apistructs.ManageConfig
+		sysConfig       *apistructs.Sysconf
+	)
+
+	if cluster.SysConfig != "" {
+		if err := json.Unmarshal([]byte(cluster.SysConfig), &sysConfig); err != nil {
+			logrus.Warnf("failed to unmarshal, (%v)", err)
+		}
+	}
+
+	if cluster.ManageConfig != "" {
+		if err := json.Unmarshal([]byte(cluster.ManageConfig), &manageConfig); err != nil {
+			logrus.Warnf("failed to unmarshal, (%v)", err)
+		}
+	}
+
+	if cluster.SchedulerConfig != "" {
+		if err := json.Unmarshal([]byte(cluster.SchedulerConfig), &schedulerConfig); err != nil {
+			logrus.Warnf("failed to unmarshal, (%v)", err)
+		}
+	}
+	if cluster.OpsConfig != "" {
+		if err := json.Unmarshal([]byte(cluster.OpsConfig), &opsConfig); err != nil {
+			logrus.Warnf("failed to unmarshal, (%v)", err)
+		}
+	}
+
+	return &apistructs.ClusterInfo{
+		ID:             int(cluster.ID),
+		Name:           cluster.Name,
+		DisplayName:    cluster.DisplayName,
+		Description:    cluster.Description,
+		Type:           cluster.Type,
+		CloudVendor:    cluster.CloudVendor,
+		Logo:           cluster.Logo,
+		WildcardDomain: cluster.WildcardDomain,
+		SchedConfig:    schedulerConfig,
+		System:         sysConfig,
+		OpsConfig:      opsConfig,
+		ManageConfig:   manageConfig,
+		CreatedAt:      cluster.CreatedAt,
+		UpdatedAt:      cluster.UpdatedAt,
+	}
+}

--- a/pkg/discover/address.go
+++ b/pkg/discover/address.go
@@ -21,54 +21,58 @@ import (
 
 // 定义各个服务地址的环境变量配置名字.
 const (
-	EnvEventBox      = "EVENTBOX_ADDR"
-	EnvCMDB          = "CMDB_ADDR"
-	EnvScheduler     = "SCHEDULER_ADDR"
-	EnvDiceHub       = "DICEHUB_ADDR"
-	EnvSoldier       = "SOLDIER_ADDR"
-	EnvOrchestrator  = "ORCHESTRATOR_ADDR"
-	EnvAddOnPlatform = "ADDON_PLATFORM_ADDR"
-	EnvGittar        = "GITTAR_ADDR"
-	EnvGittarAdaptor = "GITTAR_ADAPTOR_ADDR"
-	EnvCollector     = "COLLECTOR_ADDR"
-	EnvMonitor       = "MONITOR_ADDR"
-	EnvPipeline      = "PIPELINE_ADDR"
-	EnvHepa          = "HEPA_ADDR"
-	EnvOps           = "OPS_ADDR"
-	EnvOpenapi       = "OPENAPI_ADDR"
-	EnvKMS           = "KMS_ADDR"
-	EnvQA            = "QA_ADDR"
-	EnvAPIM          = "APIM_ADDR"
-	EnvTMC           = "TMC_ADDR"
-	EnvUC            = "UC_ADDR"
-	EnvClusterDialer = "CLUSTER_DIALER_ADDR"
-	EnvDOP           = "DOP_ADDR"
+	EnvEventBox       = "EVENTBOX_ADDR"
+	EnvCMDB           = "CMDB_ADDR"
+	EnvScheduler      = "SCHEDULER_ADDR"
+	EnvDiceHub        = "DICEHUB_ADDR"
+	EnvSoldier        = "SOLDIER_ADDR"
+	EnvOrchestrator   = "ORCHESTRATOR_ADDR"
+	EnvAddOnPlatform  = "ADDON_PLATFORM_ADDR"
+	EnvGittar         = "GITTAR_ADDR"
+	EnvGittarAdaptor  = "GITTAR_ADAPTOR_ADDR"
+	EnvCollector      = "COLLECTOR_ADDR"
+	EnvMonitor        = "MONITOR_ADDR"
+	EnvPipeline       = "PIPELINE_ADDR"
+	EnvHepa           = "HEPA_ADDR"
+	EnvOps            = "OPS_ADDR"
+	EnvOpenapi        = "OPENAPI_ADDR"
+	EnvKMS            = "KMS_ADDR"
+	EnvQA             = "QA_ADDR"
+	EnvAPIM           = "APIM_ADDR"
+	EnvTMC            = "TMC_ADDR"
+	EnvUC             = "UC_ADDR"
+	EnvClusterDialer  = "CLUSTER_DIALER_ADDR"
+	EnvDOP            = "DOP_ADDR"
+	EnvECP            = "ECP_ADDR"
+	EnvClusterManager = "CLUSTER_MANAGER_ADDR"
 )
 
 // 定义各个服务的 k8s svc 名称
 const (
-	SvcEventBox      = "eventbox"
-	SvcCMDB          = "cmdb"
-	SvcScheduler     = "scheduler"
-	SvcDiceHub       = "dicehub"
-	SvcSoldier       = "soldier"
-	SvcOrchestrator  = "orchestrator"
-	SvcAddOnPlatform = "addon-platform"
-	SvcGittar        = "gittar"
-	SvcGittarAdaptor = "gittar-adaptor"
-	SvcCollector     = "collector"
-	SvcMonitor       = "monitor"
-	SvcPipeline      = "pipeline"
-	SvcHepa          = "hepa"
-	SvcOps           = "ops"
-	SvcOpenapi       = "openapi"
-	SvcKMS           = "addon-kms"
-	SvcQA            = "qa"
-	SvcAPIM          = "apim"
-	SvcTMC           = "tmc"
-	SvcUC            = "uc"
-	SvcClusterDialer = "cluster-dialer"
-	SvcDOP           = "dop"
+	SvcEventBox       = "eventbox"
+	SvcCMDB           = "cmdb"
+	SvcScheduler      = "scheduler"
+	SvcDiceHub        = "dicehub"
+	SvcSoldier        = "soldier"
+	SvcOrchestrator   = "orchestrator"
+	SvcAddOnPlatform  = "addon-platform"
+	SvcGittar         = "gittar"
+	SvcGittarAdaptor  = "gittar-adaptor"
+	SvcCollector      = "collector"
+	SvcMonitor        = "monitor"
+	SvcPipeline       = "pipeline"
+	SvcHepa           = "hepa"
+	SvcOps            = "ops"
+	SvcOpenapi        = "openapi"
+	SvcKMS            = "addon-kms"
+	SvcQA             = "qa"
+	SvcAPIM           = "apim"
+	SvcTMC            = "tmc"
+	SvcUC             = "uc"
+	SvcClusterDialer  = "cluster-dialer"
+	SvcDOP            = "dop"
+	SvcECP            = "ecp"
+	SvcClusterManager = "cluster-manager"
 )
 
 func EventBox() string {
@@ -157,6 +161,14 @@ func ClusterDialer() string {
 
 func DOP() string {
 	return getURL(EnvDOP, SvcDOP)
+}
+
+func ECP() string {
+	return getURL(EnvECP, SvcECP)
+}
+
+func ClusterManager() string {
+	return getURL(EnvClusterManager, SvcClusterManager)
 }
 
 func getURL(envKey, srvName string) string {

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -31,8 +31,7 @@ type K8sClient struct {
 
 // New new K8sClient with clusterName.
 func New(clusterName string) (*K8sClient, error) {
-	// TODO: Get clusterInfo from cluster manager, request cmdb for the temporary use.
-	b := bundle.New(bundle.WithCMDB())
+	b := bundle.New(bundle.WithClusterManager())
 
 	ci, err := b.GetCluster(clusterName)
 	if err != nil {


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
1. new component cluster-manager, move from cmdb
2. **_model deprecated: orgID, URLs, Settings, Config. There fields will get from configmap (dice-cluster-info)_**
3. pkg/k8sclient instead request from cmdb to cluster-manager
4. bundle support cluster manager
5. cluster-dialer support register cluster info

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @luobily 

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
