### PR TITLE
feature(dicehub): extension spec parse supportedVersions field from `supportedErdaVersions` tag

### DIFF
--- a/apistructs/extention.go
+++ b/apistructs/extention.go
@@ -62,7 +62,7 @@ type Spec struct {
 	Desc              string            `json:"desc" yaml:"desc"`
 	Labels            map[string]string `json:"labels" yaml:"labels"`
 	LogoUrl           string            `json:"logoUrl" yaml:"logoUrl"`
-	SupportedVersions []string          `json:"supportedVersions" yaml:"supportedVersions"`
+	SupportedVersions []string          `json:"supportedErdaVersions" yaml:"supportedErdaVersions"`
 	Public            bool              `json:"public" yaml:"public"`
 	IsDefault         bool              `json:"isDefault" yaml:"isDefault"`
 }


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

Erda Version 1.1 is lower than old Dice Version like 3.21. So cli push ext will delete ext needed.

Add new field `supportedErdaVersions` in spec.yml and version from erda 1.0 to distinguish dice version.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/workBench/projects/387/issues/all?id=65286&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=429&type=TASK)

#### Specified Reviewers:

/assign @Effet 

#### Need cherry-pick to release versions?

No. Just for 1.1.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
