### PR TITLE
remove 'if exists' in alter table specs

### DIFF
--- a/pkg/database/sqlparser/ddlreverser/reverser.go
+++ b/pkg/database/sqlparser/ddlreverser/reverser.go
@@ -201,7 +201,6 @@ func ReverseAlterWithCompares(compares *ast.CreateTableStmt, alter *ast.AlterTab
 			}
 
 			var reverseSpec ast.AlterTableSpec
-			reverseSpec.IfNotExists = true
 			reverseSpec.Tp = ast.AlterTableAddConstraint
 
 			for _, constraint := range compares.Constraints {
@@ -357,7 +356,6 @@ func ReverseDropIndexStmtWithCompares(compares *ast.CreateTableStmt, drop *ast.D
 	}
 
 	var spec ast.AlterTableSpec
-	spec.IfNotExists = true
 	spec.Tp = ast.AlterTableAddConstraint
 
 	for _, constraint := range compares.Constraints {

--- a/pkg/database/sqlparser/ddlreverser/reverser.go
+++ b/pkg/database/sqlparser/ddlreverser/reverser.go
@@ -216,9 +216,9 @@ func ReverseAlterWithCompares(compares *ast.CreateTableStmt, alter *ast.AlterTab
 			}
 
 		// spec syntax:
-		// MODIFY [ColumnKeywordOpt] [IfExists] {ColumnDef} [ColumnPosition]
+		// MODIFY [ColumnKeywordOpt] {ColumnDef} [ColumnPosition]
 		//
-		// CHANGE [ColumnKeywordOpt] [IfExists] {ColumnName} {ColumnDef} [ColumnPosition]
+		// CHANGE [ColumnKeywordOpt] {ColumnName} {ColumnDef} [ColumnPosition]
 		//
 		// note: the renaming of columns by AlterTableChangeColumn is not considered here,
 		// because column renaming is not compliant and will be filtered out in ErdaMySQLLint.
@@ -236,7 +236,6 @@ func ReverseAlterWithCompares(compares *ast.CreateTableStmt, alter *ast.AlterTab
 		case ast.AlterTableModifyColumn, ast.AlterTableChangeColumn, ast.AlterTableAlterColumn:
 			var reverseSpec ast.AlterTableSpec
 			reverseSpec.Tp = ast.AlterTableChangeColumn
-			reverseSpec.IfExists = true
 			reverseSpec.OldColumnName = spec.NewColumns[0].Name // 此处不考虑列被重命名的情况
 			for _, col := range compares.Cols {
 				if reverseSpec.OldColumnName.String() == col.Name.String() {
@@ -255,7 +254,6 @@ func ReverseAlterWithCompares(compares *ast.CreateTableStmt, alter *ast.AlterTab
 		case ast.AlterTableRenameColumn:
 			var reverseSpec ast.AlterTableSpec
 			reverseSpec.Tp = ast.AlterTableRenameColumn
-			reverseSpec.IfExists = true
 			reverseSpec.NewColumnName = spec.OldColumnName
 			reverseSpec.OldColumnName = spec.NewColumnName
 			restorer.Specs = append(restorer.Specs, &reverseSpec)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:
the SQL spec option 'if exists'/'if not exists' is only supported by MariaDB, so remove it.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @johnlanni 

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
