### PR TITLE
k8sjob query status use jobName

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
@@ -108,8 +108,8 @@ func (k *K8sJob) Status(ctx context.Context, action *spec.PipelineTask) (desc ap
 		job     *batchv1.Job
 		jobPods *corev1.PodList
 	)
-	jobName := strutil.Concat(action.Extra.Namespace, ".", action.Extra.UUID)
-	job, err = k.client.ClientSet.BatchV1().Jobs(action.Extra.Namespace).Get(ctx, task_uuid.MakeJobID(action), metav1.GetOptions{})
+	jobName := strutil.Concat(action.Extra.Namespace, ".", task_uuid.MakeJobID(action))
+	job, err = k.client.ClientSet.BatchV1().Jobs(action.Extra.Namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			desc.Status = apistructs.StatusNotFoundInCluster


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
k8sjob executor status use jobName

#### Which issue(s) this PR fixes:
