### PR TITLE
pipeline loop task generate params add current task status, because loop is before update current task db storage status

### DIFF
--- a/modules/pipeline/pexpr/pexpr_params/task_params.go
+++ b/modules/pipeline/pexpr/pexpr_params/task_params.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/pvolumes"
 	"github.com/erda-project/erda/modules/pipeline/spec"
 	"github.com/erda-project/erda/pkg/loop"
@@ -36,7 +37,7 @@ import (
 // - 内置变量
 //   - pipeline_status
 //   - task_status
-func GenerateParamsFromTask(pipelineID uint64, taskID uint64) map[string]string {
+func GenerateParamsFromTask(pipelineID uint64, taskID uint64, taskStatus apistructs.PipelineStatus) map[string]string {
 	// get data from db
 	var (
 		p           *spec.Pipeline
@@ -53,6 +54,8 @@ func GenerateParamsFromTask(pipelineID uint64, taskID uint64) map[string]string 
 		tasks = pWithTasks.Tasks
 		for _, task := range tasks {
 			if task.ID == taskID {
+				// because loop is before update current task db storage status
+				task.Status = taskStatus
 				currentTask = task
 				break
 			}

--- a/modules/pipeline/pipengine/reconciler/taskrun/task_loop.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/task_loop.go
@@ -51,7 +51,7 @@ func (tr *TaskRun) handleTaskLoop() error {
 		loopOpt.Strategy = &apistructs.PipelineTaskDefaultLoopStrategy
 	}
 	// Determine whether the exit conditions are still not met
-	params := pexpr_params.GenerateParamsFromTask(tr.P.ID, tr.Task.ID)
+	params := pexpr_params.GenerateParamsFromTask(tr.P.ID, tr.Task.ID, tr.Task.Status)
 	result, err := pexpr.Eval(expr, params)
 	if err != nil {
 		return fmt.Errorf("loop break expr %s evaluate failed, err: %v", expr, err)


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:
```yaml
version: "1.1"
stages:
  - stage:
      - custom-script:
          alias: custom-script
          image: centos:7
          commands:
            - echo "hello world"
          loop:
            break: task_status == 'Success'
            strategy:
              max_times: 5
              decline_ratio: 2
              decline_limit_sec: 60
              interval_sec: 5
```
The loop judges that the current task cannot be obtained is a successful state. The above task execution will be executed 5 times. The reason is that the loop execution is before the storage, so the current task state needs to be passed for judgment.


