### PR TITLE
replace step value should use stepIDAssociationMap instead of sceneID…

### DIFF
--- a/modules/dop/services/autotest_v2/space_data.go
+++ b/modules/dop/services/autotest_v2/space_data.go
@@ -602,7 +602,7 @@ func (a *AutoTestSpaceData) CopySceneSteps() error {
 	for oldSceneID, steps := range a.Steps {
 		var head uint64
 		for _, each := range steps {
-			each.Value = replacePreStepValue(each.Value, a.sceneIDAssociationMap)
+			each.Value = replacePreStepValue(each.Value, a.stepIDAssociationMap)
 
 			newStep := &dao.AutoTestSceneStep{
 				Type:      each.Type,
@@ -623,7 +623,7 @@ func (a *AutoTestSpaceData) CopySceneSteps() error {
 			pHead := newStep.ID
 
 			for _, pv := range each.Children {
-				pv.Value = replacePreStepValue(pv.Value, a.sceneIDAssociationMap)
+				pv.Value = replacePreStepValue(pv.Value, a.stepIDAssociationMap)
 
 				newPStep := &dao.AutoTestSceneStep{
 					Type:      pv.Type,


### PR DESCRIPTION
…AssociationMap

#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
replace step value should use stepIDAssociationMap when copy step

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/workBench/projects/387/issues/all?id=58510&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=429&type=BUG)
