### PR TITLE
modify GetTaskExecutor func

### DIFF
--- a/modules/pipeline/endpoints/clusterinfo.go
+++ b/modules/pipeline/endpoints/clusterinfo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor"
 	"github.com/erda-project/erda/pkg/http/httpserver"
 )
 
@@ -38,4 +39,8 @@ func (e *Endpoints) clusterHook(ctx context.Context, r *http.Request, vars map[s
 		return httpserver.ErrResp(http.StatusBadRequest, "", errStr)
 	}
 	return httpserver.OkResp(nil)
+}
+
+func (e *Endpoints) executorInfo(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+	return httpserver.OkResp(executor.GetExecutorInfo())
 }

--- a/modules/pipeline/endpoints/endpoints.go
+++ b/modules/pipeline/endpoints/endpoints.go
@@ -241,5 +241,8 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 
 		// cluster info
 		{Path: clusterinfo.ClusterHookApiPath, Method: http.MethodPost, Handler: e.clusterHook},
+
+		// executor info, only for internal check executor and cluster info
+		{Path: "/api/pipeline-executors/actions/query", Method: http.MethodGet, Handler: e.executorInfo},
 	}
 }

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
@@ -89,35 +89,44 @@ func (s *Sched) Name() types.Name {
 	return s.name
 }
 
-func (s *Sched) GetTaskExecutor(executorType string, clusterName string, task *spec.PipelineTask) (tasktypes.TaskExecutor, error) {
+// GetTaskExecutor return bool, task exectuor, error, bool means should it be dispatch to scheduler
+func (s *Sched) GetTaskExecutor(executorType string, clusterName string, task *spec.PipelineTask) (bool, tasktypes.TaskExecutor, error) {
 	var executorName string
-	// TODO judge executor type and cluster name
-	switch executorType {
-	case "flink":
-		executorName = "flink"
-	case "spark":
-		executorName = "spark"
-	default:
-		executorName = "k8sjob"
-	}
-	if value, ok := task.Extra.Action.Params["bigDataConf"]; ok {
-		spec := apistructs.BigdataSpec{}
-		if err := json.Unmarshal([]byte(value.(string)), &spec); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal task bigDataConf")
-		}
-		if spec.FlinkConf != nil {
-			executorName = "k8sflink"
-		}
-		if spec.SparkConf != nil {
-			executorName = "k8sspark"
-		}
-	}
-	name := fmt.Sprintf("%sfor%s", clusterName, executorName)
-	taskExecutor, err := s.taskManager.Get(tasktypes.Name(name))
+	cluster, err := s.taskManager.GetCluster(clusterName)
 	if err != nil {
-		return nil, err
+		return false, nil, err
 	}
-	return taskExecutor, nil
+	switch cluster.Type {
+	case apistructs.DCOS:
+		return true, nil, nil
+	case apistructs.EDAS:
+		return true, nil, nil
+	case apistructs.K8S:
+		if executorType == "flink" || executorType == "spark" {
+			return false, nil, errors.Errorf("k8s cluster don`t support executor type: %s", executorType)
+		}
+		executorName = "k8sjob"
+		if value, ok := task.Extra.Action.Params["bigDataConf"]; ok {
+			spec := apistructs.BigdataSpec{}
+			if err := json.Unmarshal([]byte(value.(string)), &spec); err != nil {
+				return false, nil, fmt.Errorf("failed to unmarshal task bigDataConf")
+			}
+			if spec.FlinkConf != nil {
+				executorName = "k8sflink"
+			}
+			if spec.SparkConf != nil {
+				executorName = "k8sspark"
+			}
+		}
+		name := fmt.Sprintf("%sfor%s", clusterName, executorName)
+		taskExecutor, err := s.taskManager.Get(tasktypes.Name(name))
+		if err != nil {
+			return false, nil, err
+		}
+		return false, taskExecutor, nil
+	default:
+		return false, nil, errors.Errorf("invalid cluster type: %s", cluster.Type)
+	}
 }
 
 func validateAction(action *spec.PipelineTask) error {
@@ -187,8 +196,13 @@ func (s *Sched) Create(ctx context.Context, action *spec.PipelineTask) (data int
 	}
 
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute create", taskExecutor.Name())
 		return nil, nil
 	}
 
@@ -253,8 +267,13 @@ func (s *Sched) Start(ctx context.Context, action *spec.PipelineTask) (data inte
 	}
 
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute start", taskExecutor.Name())
 		return taskExecutor.Create(ctx, action)
 	}
 
@@ -302,8 +321,13 @@ func (s *Sched) Status(ctx context.Context, action *spec.PipelineTask) (desc api
 
 	var result apistructs.StatusDesc
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return apistructs.PipelineStatusDesc{}, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute status", taskExecutor.Name())
 		result, err = taskExecutor.Status(ctx, action)
 		if err != nil {
 			return apistructs.PipelineStatusDesc{}, err
@@ -348,8 +372,13 @@ func (s *Sched) Cancel(ctx context.Context, action *spec.PipelineTask) (data int
 	}
 
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute cancel", taskExecutor.Name())
 		return taskExecutor.Remove(ctx, action)
 	}
 	var body bytes.Buffer
@@ -381,8 +410,13 @@ func (s *Sched) Remove(ctx context.Context, action *spec.PipelineTask) (data int
 	}
 
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute remove", taskExecutor.Name())
 		return taskExecutor.Remove(ctx, action)
 	}
 
@@ -423,8 +457,13 @@ func (s *Sched) BatchDelete(ctx context.Context, actions []*spec.PipelineTask) (
 	}
 
 	var taskExecutor tasktypes.TaskExecutor
-	taskExecutor, _ = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
-	if taskExecutor != nil {
+	var shouldDispatch bool
+	shouldDispatch, taskExecutor, err = s.GetTaskExecutor(action.Type, action.Extra.ClusterName, action)
+	if err != nil {
+		return nil, err
+	}
+	if !shouldDispatch {
+		logrus.Infof("task executor %s execute batch delete", taskExecutor.Name())
 		return taskExecutor.BatchDelete(ctx, actions)
 	}
 
@@ -527,8 +566,8 @@ func respBodyDecodeErr(statusCode int, respBody string, err error) error {
 }
 
 func printActionInfo(action *spec.PipelineTask) string {
-	return fmt.Sprintf("pipelineID: %d, id: %d, name: %s, namespace: %s, schedulerJobID: %s",
-		action.PipelineID, action.ID, action.Name, action.Extra.Namespace, task_uuid.MakeJobID(action))
+	return fmt.Sprintf("pipelineID: %d, id: %d, name: %s, namespace: %s, schedulerJobID: %s, clusterName: %s",
+		action.PipelineID, action.ID, action.Name, action.Extra.Namespace, task_uuid.MakeJobID(action), action.Extra.ClusterName)
 }
 
 // isJobIdempotent

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -437,7 +437,7 @@ func (pre *prepare) makeTaskRun() (needRetry bool, err error) {
 		if !ok {
 			return false, fmt.Errorf("failed to createJobVolume, err: invalid task executor kind")
 		}
-		schedPlugin, err := schedExecutor.GetTaskExecutor(task.Type, p.ClusterName, task)
+		_, schedPlugin, err := schedExecutor.GetTaskExecutor(task.Type, p.ClusterName, task)
 		if err != nil {
 			return false, fmt.Errorf("failed to createJobVolume, err: can not get k8s executor")
 		}


### PR DESCRIPTION
add internal endpoint for get executor info

#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
modify GetTaskExecutor func, if cluster`type is k8s, don`t dispatch to scheduler
add internal endpotint for query executor info
add some logs

#### Which issue(s) this PR fixes:
