### PR TITLE
fix: update k8sHost to short domain

### DIFF
--- a/modules/openapi/server.go
+++ b/modules/openapi/server.go
@@ -16,12 +16,9 @@ package openapi
 import (
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/erda-project/erda/modules/openapi/api"
 	"github.com/erda-project/erda/modules/openapi/conf"
 )
 
@@ -29,29 +26,6 @@ func NewServer() (*http.Server, error) {
 	s, err := NewLoginServer()
 	if err != nil {
 		return nil, err
-	}
-	customNs := conf.CustomNamespace()
-	if customNs != "" {
-		if customNs == "local" {
-			for i := range api.API {
-				oldHost := api.API[i].K8SHost
-				localHost := strings.Replace(oldHost, ".default.svc.cluster.local", "", -1)
-				componentName := strings.ToUpper(strings.Split(localHost, ":")[0]) + "_ADDR"
-				componentAddr := os.Getenv(componentName)
-				if componentAddr != "" {
-					l := strings.Split(componentAddr, ":")
-					api.API[i].K8SHost = l[0]
-					port, _ := strconv.ParseInt(l[1], 10, 64)
-					api.API[i].Port = int(port)
-				} else {
-					api.API[i].K8SHost = localHost
-				}
-			}
-		} else {
-			for i := range api.API {
-				api.API[i].K8SHost = strings.Replace(api.API[i].K8SHost, ".default.", "."+customNs+".", -1)
-			}
-		}
 	}
 
 	srv := &http.Server{

--- a/modules/pkg/innerdomain/innerdomain.go
+++ b/modules/pkg/innerdomain/innerdomain.go
@@ -40,7 +40,6 @@ package innerdomain
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -249,13 +248,7 @@ func (a *domaininfoLegacy) k8s() (string, error) {
 	if a.servicegroupName != "" || a.servicegroupNamespace != "" {
 		return "", ErrNoLegacyK8SAddr
 	}
-	ns := namespaceForDice
-	customns := os.Getenv("CUSTOM_NAMESPACE")
-	if customns != "" {
-		ns = customns
-	}
-	components := []string{a.serviceName, ns, k8sSuffix}
-	return strutil.Join(components, "."), nil
+	return a.serviceName, nil
 }
 
 func (a *domaininfoLegacy) marathon() (string, error) {


### PR DESCRIPTION
#### What type of this PR
/kind polish

#### What this PR does / why we need it:
fix: update k8sHost to short domain and remove the CUSTOM_NAMESPACE=local env of openapi

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @sfwn 

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
