### PR TITLE
bugfix: optimize on deploy continuous processing when interrupted

### DIFF
--- a/modules/msp/resource/deploy/handlers/handler.go
+++ b/modules/msp/resource/deploy/handlers/handler.go
@@ -259,14 +259,19 @@ func (h *DefaultDeployHandler) CheckIfNeedTmcInstance(req *ResourceDeployRequest
 		return nil, false, err
 	}
 
-	if instance == nil {
+	// we only care about the RUNNING one
+	isValid := func(ins *db.Instance) bool {
+		return instance != nil && instance.Status == TmcInstanceStatusRunning
+	}
+
+	if !isValid(instance) {
 		instance, err = h.InstanceDb.GetByEngineAndVersionAndAz(resourceInfo.TmcVersion.Engine, resourceInfo.TmcVersion.Version, req.Az)
 		if err != nil {
 			return nil, false, err
 		}
 	}
 
-	return instance, instance == nil, nil
+	return instance, !isValid(instance), nil
 }
 
 func (h *DefaultDeployHandler) GetClusterConfig(az string) (map[string]string, error) {
@@ -495,6 +500,12 @@ func (h *DefaultDeployHandler) CheckIfNeedTmcInstanceTenant(req *ResourceDeployR
 	tenant, err := h.TenantDb.GetByID(req.Uuid)
 	if err != nil {
 		return nil, need, err
+	}
+
+	// if tenant already marked deleted, the caller(orchestrator) should use new uuid for next request
+	// we return error here if the same failed id came again
+	if tenant != nil && tenant.IsDeleted == "Y" {
+		return nil, need, fmt.Errorf("tenant id not valid")
 	}
 
 	return tenant, need && tenant == nil, nil

--- a/modules/msp/resource/deploy/handlers/handler.go
+++ b/modules/msp/resource/deploy/handlers/handler.go
@@ -505,7 +505,7 @@ func (h *DefaultDeployHandler) CheckIfNeedTmcInstanceTenant(req *ResourceDeployR
 	// if tenant already marked deleted, the caller(orchestrator) should use new uuid for next request
 	// we return error here if the same failed id came again
 	if tenant != nil && tenant.IsDeleted == "Y" {
-		return nil, need, fmt.Errorf("tenant id not valid")
+		return tenant, need, fmt.Errorf("tenant id not valid")
 	}
 
 	return tenant, need && tenant == nil, nil

--- a/modules/msp/resource/utils/nacos_client.go
+++ b/modules/msp/resource/utils/nacos_client.go
@@ -46,7 +46,7 @@ func (c *NacosClient) Login() (string, error) {
 		return "", err
 	}
 	if !resp.IsOK() {
-		return "", fmt.Errorf("response code error")
+		return "", fmt.Errorf("nacos login response code error[%d], body:%s", resp.StatusCode(), string(resp.Body()))
 	}
 	accessToken, ok := result["accessToken"]
 	if !ok {
@@ -77,7 +77,7 @@ func (c *NacosClient) GetNamespaceId(namespaceName string) (string, error) {
 		return "", err
 	}
 	if !resp.IsOK() {
-		return "", fmt.Errorf("response code error")
+		return "", fmt.Errorf("nacos get namespaceid response code error[%d], body:%s", resp.StatusCode(), string(resp.Body()))
 	}
 
 	for _, namespace := range result.Data {
@@ -102,7 +102,7 @@ func (c *NacosClient) CreateNamespace(namespaceName string) (string, error) {
 		return "", err
 	}
 	if !resp.IsOK() {
-		return "", fmt.Errorf("response code error")
+		return "", fmt.Errorf("nacos create namespace response code error[%d], body:%s", resp.StatusCode(), string(resp.Body()))
 	}
 
 	return c.GetNamespaceId(namespaceName)
@@ -120,7 +120,7 @@ func (c *NacosClient) SaveConfig(tenantName string, groupName string, dataId str
 		return err
 	}
 	if !resp.IsOK() {
-		return fmt.Errorf("response code error")
+		return fmt.Errorf("nacos save config response code error[%d], body:%s", resp.StatusCode(), string(resp.Body()))
 	}
 	return nil
 }
@@ -137,7 +137,7 @@ func (c *NacosClient) DeleteConfig(tenantName string, groupName string) error {
 		return err
 	}
 	if !resp.IsOK() {
-		return fmt.Errorf("response code error")
+		return fmt.Errorf("nacos delete config response code error[%d], body:%s", resp.StatusCode(), string(resp.Body()))
 	}
 
 	return nil


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### Why we need this PR
in cases msp service may shutdown when deploy is processing, thus may lead the tmcinstance stay at INIT status which should not be reused in next deploy request, so filter it. same reason for the instance_tenant.

#### Specified Reviewers:

/assign @liuhaoyang 

#### Need cherry-pick to release versions?
/cherry-pick release/1.1