### PR TITLE
Feature/cluster create adjust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,11 @@ copyright:
 	go run tools/gotools/copyright/main.go
 
 # docker image
-build-image:
+build-image: prepare
 	./build/scripts/docker_image.sh ${MODULE_PATH} build
 push-image:
 	./build/scripts/docker_image.sh ${MODULE_PATH} push
-build-push-image:
+build-push-image: prepare
 	./build/scripts/docker_image.sh ${MODULE_PATH} build-push
 
 build-push-all:

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -5,6 +5,7 @@ FROM ${BASE_DOCKER_IMAGE} as build
 RUN mkdir -p "$GOPATH/src/github.com/erda-project/erda/"
 COPY . "$GOPATH/src/github.com/erda-project/erda/"
 WORKDIR "$GOPATH/src/github.com/erda-project/erda/"
+ENV GOPROXY https://goproxy.cn/,direct
 
 ARG CONFIG_PATH
 ARG MODULE_PATH

--- a/modules/cmp/dbclient/models.go
+++ b/modules/cmp/dbclient/models.go
@@ -54,10 +54,15 @@ type StatusType string
 
 const (
 	StatusTypeSuccess    StatusType = "success"
+	StatusTypeSuccessed  StatusType = "successed"
 	StatusTypeFailed     StatusType = "failed"
 	StatusTypeProcessing StatusType = "processing"
 	StatusTypeUnknown    StatusType = "unknown"
 )
+
+func (s StatusType) String() string {
+	return string(s)
+}
 
 type Record struct {
 	dbengine.BaseModel

--- a/modules/cmp/dbclient/records.go
+++ b/modules/cmp/dbclient/records.go
@@ -85,7 +85,7 @@ func (r *recordsReader) ByUserIDs(userids ...string) *recordsReader {
 }
 
 func (r *recordsReader) ByCreateTime(beforeNSecs int) *recordsReader {
-	r.conditions = append(r.conditions, fmt.Sprintf("created_at < now() - interval %d second", beforeNSecs))
+	r.conditions = append(r.conditions, fmt.Sprintf("created_at > now() - interval %d second", beforeNSecs))
 	return r
 }
 

--- a/modules/cmp/endpoints/endpoints.go
+++ b/modules/cmp/endpoints/endpoints.go
@@ -68,6 +68,10 @@ func New(db *dbclient.DBClient, js jsonstore.JsonStore, cachedJS jsonstore.JsonS
 	return e
 }
 
+func (e *Endpoints) GetCluster() *clusters.Clusters {
+	return e.clusters
+}
+
 // WithBundle With bundle
 func WithBundle(bdl *bundle.Bundle) Option {
 	return func(e *Endpoints) {

--- a/modules/cmp/services/kubernetes/kubernetes.go
+++ b/modules/cmp/services/kubernetes/kubernetes.go
@@ -87,6 +87,8 @@ func (k *Kubernetes) UpdateClient(clusterName string) error {
 }
 
 func (k *Kubernetes) RemoveClient(clusterName string) {
+	k.Lock()
+	defer k.Unlock()
 	delete(k.clients, clusterName)
 }
 


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature
adjust cluster create logic

#### What this PR does / why we need it:
Previous, cluster added in pipeline action through internal cmdb url;
But now, internal erda service namespaces is not fixed, so it's not convient to call from action.
Now, cmp will monitor cluster create pipeline, get created cluster metainfo from pipeline result and import cluster in erda.

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @luobily 

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
