### PR TITLE
bugfix: fix generate schema example error

### DIFF
--- a/bundle/gen_example_test.go
+++ b/bundle/gen_example_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package bundle_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"gopkg.in/yaml.v3"
+
+	"github.com/erda-project/erda/bundle"
+)
+
+const schemaA = `description: ""
+example:
+  str: Example
+properties:
+  str:
+    example: Example
+    type: string
+    x-dice-name: str
+    x-dice-required: true
+required:
+  - str
+type: object`
+
+const schemaAExample = `{
+  "str": "Example"
+}`
+
+func TestGenExample(t *testing.T) {
+	s := openapi3.NewSchema()
+	if err := yaml.Unmarshal([]byte(schemaA), s); err != nil {
+		t.Fatalf("failed to yaml.Unmarshal schemaA: %v", err)
+	}
+	bundle.GenExample(s)
+
+	t.Log("GenExample:", s.Example)
+	if example, ok := s.Example.(string); !ok {
+		t.Fatal("s.Example was not converted to string")
+	} else if example != schemaAExample {
+		t.Fatal("s.Example was converted wrong")
+	}
+
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature


#### What this PR does / why we need it:
Previously, when the example was generated, if the user customized the example, it was returned directly. It did not take into account that the example from the user was not a string. Now it is changed to that, if the user customizes the example, it will be converted into an escaped string.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @your-reviewer

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
