### PR TITLE
action spec adds the execution selector field, and the pipeline selects the executor according to the field

### DIFF
--- a/apistructs/extention.go
+++ b/apistructs/extention.go
@@ -240,6 +240,12 @@ type ActionSpec struct {
 	OutputsFromParams []OutputsFromParams   `json:"outputsFromParams" yaml:"outputsFromParams"`
 	Loop              *PipelineTaskLoop     `json:"loop" yaml:"loop"`
 	Priority          *PipelineTaskPriority `json:"priority" yaml:"priority"`
+	Executor          *ActionExecutor       `json:"executor" yaml:"executor"`
+}
+
+type ActionExecutor struct {
+	Kind string `json:"kind" yaml:"kind"`
+	Name string `json:"name" yaml:"name"`
 }
 
 type ActionMatchOutputType string


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:

The apitest task will use the apitest executor when it is executed, but version 1.0 should use the schduler executor, version 2.0 only use the apitest executor, so the executor selection field is added to the action spec, and subsequent actions can choose the executor by themselves

action spec add field like: 
```yaml
executor:
  executorKind: "APITEST"
  executorName: "api-test"
```
