### PR TITLE
fix the cluster netportal acquisition logic

### DIFF
--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -15,6 +15,7 @@ package apistructs
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/erda-project/erda/pkg/strutil"
 )
@@ -152,12 +153,12 @@ func (info ClusterInfoData) GetIstioInfo() IstioInfo {
 }
 
 func (info ClusterInfoData) GetApiServerUrl() string {
-	netportalUrl := info.Get(NETPORTAL_URL)
-	masterAddr := info.Get(MASTER_VIP_ADDR)
-	if netportalUrl == "" {
+	currentCluster := os.Getenv("DICE_CLUSTER_NAME")
+	cluster := info.Get(DICE_CLUSTER_NAME)
+	if cluster == currentCluster {
 		return masterAddr
 	} else {
-		return netportalUrl + "/" + masterAddr
+		return fmt.Sprintf("inet://%s/%s", cluster, masterAddr)
 	}
 }
 

--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -154,6 +154,7 @@ func (info ClusterInfoData) GetIstioInfo() IstioInfo {
 
 func (info ClusterInfoData) GetApiServerUrl() string {
 	currentCluster := os.Getenv("DICE_CLUSTER_NAME")
+	masterAddr := info.Get(MASTER_VIP_ADDR)
 	cluster := info.Get(DICE_CLUSTER_NAME)
 	if cluster == currentCluster {
 		return masterAddr

--- a/modules/hepa/repository/service/gateway_kong_info_service.go
+++ b/modules/hepa/repository/service/gateway_kong_info_service.go
@@ -18,8 +18,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/modules/hepa/bundle"
 	. "github.com/erda-project/erda/modules/hepa/common/vars"
 	"github.com/erda-project/erda/modules/hepa/config"
 	"github.com/erda-project/erda/modules/hepa/repository/orm"
@@ -184,11 +182,7 @@ func (impl *GatewayKongInfoServiceImpl) acquireKongAddr(netportalUrl, selfAz str
 
 func (impl *GatewayKongInfoServiceImpl) adjustKongInfo(info *orm.GatewayKongInfo) error {
 	selfAz := os.Getenv("DICE_CLUSTER_NAME")
-	clusterInfo, err := bundle.Bundle.QueryClusterInfo(info.Az)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	netportalUrl := clusterInfo.Get(apistructs.NETPORTAL_URL)
+	netportalUrl := "inet://" + info.Az
 	kongAddr, err := impl.acquireKongAddr(netportalUrl, selfAz, info)
 	if err != nil {
 		return err

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -122,7 +122,7 @@ func (pre *prepare) makeTaskRun() (needRetry bool, err error) {
 	if err != nil {
 		return true, apierrors.ErrGetCluster.InternalError(err)
 	}
-	pre.Ctx = context.WithValue(pre.Ctx, apistructs.NETPORTAL_URL, clusterInfo.Get(apistructs.NETPORTAL_URL))
+	pre.Ctx = context.WithValue(pre.Ctx, apistructs.NETPORTAL_URL, "inet://"+p.ClusterName)
 
 	// TODO 目前 initSQL 需要存储在 网盘上，暂时不能用 volume 来解
 	mountPoint := clusterInfo.MustGet(apistructs.DICE_STORAGE_MOUNTPOINT)

--- a/pkg/netportal/netportal.go
+++ b/pkg/netportal/netportal.go
@@ -17,11 +17,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/pkg/http/customhttp"
 )
@@ -34,15 +32,11 @@ func init() {
 
 // NewNetportalRequest 在NewRequest基础上增加ClusterName参数，完成netportal代理请求
 func NewNetportalRequest(clusterName, method, url string, body io.Reader) (*http.Request, error) {
-	info, err := bdl.QueryClusterInfo(clusterName)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	netportalUrl := info.Get(apistructs.NETPORTAL_URL)
-	if netportalUrl != "" {
+	currentClusterName := os.Getenv("DICE_CLUSTER_NAME")
+	if currentClusterName != clusterName {
 		url = strings.TrimPrefix(url, "http://")
 		url = strings.TrimPrefix(url, "https://")
-		url = fmt.Sprintf("%s/%s", netportalUrl, url)
+		url = fmt.Sprintf("inet://%s/%s", clusterName, url)
 	}
 	return customhttp.NewRequest(method, url, body)
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
acquire the netportal url by "inet://" + clusterName, not from scheduler api.
