### PR TITLE
update cluster-agent/cluster-dailer resource request

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -68,7 +68,7 @@ services:
         port: 9527
         protocol: TCP
     resources:
-      cpu: ${request_cpu:0.5}
+      cpu: ${request_cpu:1}
       max_cpu: 1
       mem: ${request_mem:2048}
       max_mem: 2048
@@ -87,7 +87,7 @@ services:
       - "${nfs_root:/netdata}/dice-ops/dice-config/certificates/etcd-client.pem:/certs/etcd-client.pem:ro"
       - "${nfs_root:/netdata}/dice-ops/dice-config/certificates/etcd-client-key.pem:/certs/etcd-client-key.pem:ro"
     resources:
-      cpu: ${request_cpu:0.1}
+      cpu: ${request_cpu:0.2}
       max_cpu: 0.2
       mem: ${request_mem:128}
       max_mem: 256
@@ -176,10 +176,10 @@ services:
     envs:
       DEBUG: "false"
     resources:
-      cpu: ${request_cpu:0.5}
-      max_cpu: 0.5
-      mem: ${request_mem:512}
-      max_mem: 512
+      cpu: ${request_cpu:2}
+      max_cpu: 2
+      mem: ${request_mem:2048}
+      max_mem: 2048
       network:
         mode: "container"
     deployments:
@@ -195,10 +195,10 @@ services:
     envs:
       DEBUG: "false"
     resources:
-      cpu: ${request_cpu:0.1}
-      max_cpu: 0.5
-      mem: ${request_mem:512}
-      max_mem: 512
+      cpu: ${request_cpu:1}
+      max_cpu: 1
+      mem: ${request_mem:1024}
+      max_mem: 1024
       network:
         mode: "container"
     deployments:
@@ -583,7 +583,7 @@ services:
       CMDB_GROUP: "spot_cmdb_group2"
       DEBUG: "false"
     resources:
-      cpu: ${request_cpu:0.3}
+      cpu: ${request_cpu:1}
       max_cpu: 1
       mem: ${request_mem:2048}
       max_mem: 2048


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature


#### What this PR does / why we need it:
The default value of `cpu` should be equal to `max_cpu`(which does not work in erda but works in erda operator).
We use resource oversold to set a  less `request cpu` in erda.