### PR TITLE
Fix pipeline filetree node, add url unescape before decoding node path

### DIFF
--- a/modules/dop/endpoints/projectpipelinefiletree.go
+++ b/modules/dop/endpoints/projectpipelinefiletree.go
@@ -70,7 +70,7 @@ func (e *Endpoints) GetFileTreeNode(ctx context.Context, r *http.Request, vars m
 	}
 	inode, err := url.QueryUnescape(vars["inode"])
 	if err != nil {
-		logrus.Error(apierrors.ErrGetFileTreeNode.InvalidParameter("QueryUnescape inode"))
+		logrus.Errorf("QueryUnescape pipeline filetree inode %v failed", vars["inode"])
 		inode = vars["inode"]
 	}
 

--- a/modules/dop/endpoints/projectpipelinefiletree.go
+++ b/modules/dop/endpoints/projectpipelinefiletree.go
@@ -17,7 +17,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strconv"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/dop/services/apierrors"
@@ -65,7 +68,13 @@ func (e *Endpoints) GetFileTreeNode(ctx context.Context, r *http.Request, vars m
 	if err := e.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
 		return apierrors.ErrListFileTreeNodes.InvalidParameter(err).ToResp(), nil
 	}
-	req.Inode = vars["inode"]
+	inode, err := url.QueryUnescape(vars["inode"])
+	if err != nil {
+		logrus.Error(apierrors.ErrGetFileTreeNode.InvalidParameter("QueryUnescape inode"))
+		inode = vars["inode"]
+	}
+
+	req.Inode = inode
 	req.IdentityInfo = identityInfo
 
 	// 获取企业id


### PR DESCRIPTION
#### What type of this PR
bug

#### What this PR does / why we need it:
Fix pipeline filetree node, add url unescape before decoding node path

#### Specified Reviewers:

/assign @sfwn 

