### PR TITLE
fix PipelineLink url

### DIFF
--- a/bundle/pipeline.go
+++ b/bundle/pipeline.go
@@ -184,7 +184,7 @@ func (b *Bundle) RunPipeline(req apistructs.PipelineRunRequest) error {
 		return apierrors.ErrInvoke.InternalError(err)
 	}
 	if !httpResp.IsOK() || !runResp.Success {
-		return toAPIError(httpResp.StatusCode(), runResp.Error)
+		return toAPIError(httpResp.StatusCode(), runResp.Error).SetCtx(runResp.Error.Ctx)
 	}
 	return nil
 }

--- a/modules/dop/endpoints/getpipelinelink_test.go
+++ b/modules/dop/endpoints/getpipelinelink_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package endpoints
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/dop/services/apierrors"
+)
+
+func TestGetPipelineLink(t *testing.T) {
+	type args struct {
+		p      apistructs.PipelineDTO
+		ctxMap map[string]interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test_empty",
+			args: args{
+				p: apistructs.PipelineDTO{
+					OrgName:       "terminus",
+					ProjectID:     123,
+					ApplicationID: 123123,
+				},
+				ctxMap: map[string]interface{}{
+					apierrors.ErrParallelRunPipeline.Error(): fmt.Sprintf("%d", 777777),
+				},
+			},
+			want:    "/terminus/dop/projects/123/apps/123123/pipeline?pipelineID=777777",
+			wantErr: false,
+		},
+		{
+			name: "test_empty",
+			args: args{
+				p: apistructs.PipelineDTO{
+					OrgName:       "t2erminus",
+					ProjectID:     123,
+					ApplicationID: 123123,
+				},
+				ctxMap: map[string]interface{}{
+					apierrors.ErrParallelRunPipeline.Error(): fmt.Sprintf("%d", 66666),
+				},
+			},
+			want:    "/t2erminus/dop/projects/123/apps/123123/pipeline?pipelineID=66666",
+			wantErr: false,
+		},
+		{
+			name: "test_empty",
+			args: args{
+				p: apistructs.PipelineDTO{
+					OrgName:       "terminus",
+					ProjectID:     13,
+					ApplicationID: 123123,
+				},
+				ctxMap: map[string]interface{}{
+					apierrors.ErrParallelRunPipeline.Error(): fmt.Sprintf("%d", 777777),
+				},
+			},
+			want:    "/terminus/dop/projects/13/apps/123123/pipeline?pipelineID=777777",
+			wantErr: false,
+		},
+		{
+			name: "test_empty",
+			args: args{
+				p: apistructs.PipelineDTO{
+					OrgName:       "terminus",
+					ProjectID:     1234,
+					ApplicationID: 123123,
+				},
+				ctxMap: map[string]interface{}{
+					apierrors.ErrParallelRunPipeline.Error(): fmt.Sprintf("%d", 77777),
+				},
+			},
+			want:    "/terminus/dop/projects/1234/apps/123123/pipeline?pipelineID=77777",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetPipelineLink(tt.args.p, tt.args.ctxMap)
+			if got != tt.want {
+				t.Errorf("GetPipelineLink() got = %v, want %v", got, tt.want)
+			}
+			if !got1 {
+				t.Errorf("GetPipelineLink() got1 = %v, want %v", got1, true)
+			}
+		})
+	}
+}

--- a/modules/dop/services/apierrors/errors.go
+++ b/modules/dop/services/apierrors/errors.go
@@ -472,6 +472,8 @@ var (
 	ErrDeletePublisher = err("ErrDeletePublisher", "删除Publisher失败")
 	ErrGetPublisher    = err("ErrGetPublisher", "获取Publisher失败")
 	ErrListPublisher   = err("ErrListPublisher", "获取Publisher列表失败")
+
+	ErrParallelRunPipeline = err("ErrParallelRunPipeline", "已有流水线正在运行中")
 )
 
 func err(template, defaultValue string) *errorresp.APIError {

--- a/pkg/http/httpserver/errorresp/errors.go
+++ b/pkg/http/httpserver/errorresp/errors.go
@@ -31,6 +31,7 @@ type APIError struct {
 	code               string
 	msg                string
 	localeMetaMessages []MetaMessage
+	ctx                interface{}
 }
 
 // Error 错误信息
@@ -51,7 +52,12 @@ func (e *APIError) HttpCode() int {
 	return e.httpCode
 }
 
-// Option 可选参数
+// Ctx Context information
+func (e *APIError) Ctx() interface{} {
+	return e.ctx
+}
+
+// Option Optional parameters
 type Option func(*APIError)
 
 // New 新建接口错误
@@ -80,6 +86,12 @@ func WithTemplateMessage(template, defaultValue string, args ...interface{}) Opt
 func WithCode(httpCode int, code string) Option {
 	return func(a *APIError) {
 		_ = a.appendCode(httpCode, code)
+	}
+}
+
+func WithCtx(ctx interface{}) Option {
+	return func(a *APIError) {
+		a.ctx = ctx
 	}
 }
 
@@ -117,6 +129,11 @@ func (e *APIError) appendLocaleTemplate(template *i18n.Template, args ...interfa
 	return e
 }
 
+func (e *APIError) setCtx(ctx interface{}) *APIError {
+	e.ctx = ctx
+	return e
+}
+
 func (e *APIError) Render(localeResource *i18n.LocaleResource) string {
 	for _, metaMessage := range e.localeMetaMessages {
 		var template *i18n.Template
@@ -142,5 +159,11 @@ func (e *APIError) dup() *APIError {
 		code:               e.code,
 		msg:                e.msg,
 		localeMetaMessages: e.localeMetaMessages,
+		ctx:                e.ctx,
 	}
+}
+
+// SetCtx Set ctx
+func (e *APIError) SetCtx(ctx interface{}) *APIError {
+	return e.dup().setCtx(ctx)
 }

--- a/pkg/http/httpserver/errorresp/response.go
+++ b/pkg/http/httpserver/errorresp/response.go
@@ -32,6 +32,7 @@ func (e *APIError) ToResp() httpserver.Responser {
 			Err: apistructs.ErrorResponse{
 				Code: e.code,
 				Msg:  e.msg,
+				Ctx:  e.ctx,
 			},
 		},
 	}

--- a/pkg/http/httpserver/ierror/ierror.go
+++ b/pkg/http/httpserver/ierror/ierror.go
@@ -21,4 +21,5 @@ type IAPIError interface {
 	Render(locale *i18n.LocaleResource) string
 	Code() string
 	HttpCode() int
+	Ctx() interface{}
 }

--- a/pkg/http/httpserver/response.go
+++ b/pkg/http/httpserver/response.go
@@ -60,6 +60,7 @@ func (r HTTPResponse) GetLocaledResp(locale *i18n.LocaleResource) HTTPResponse {
 				Err: apistructs.ErrorResponse{
 					Code: r.Error.Code(),
 					Msg:  r.Error.Render(locale),
+					Ctx:  r.Error.Ctx(),
 				},
 			},
 		}


### PR DESCRIPTION
(cherry picked from commit 29d9fa6495b4f1413e41573b39c993530ab967ec)

#### What type of this PR
kind bug
#### What this PR does / why we need it:
When there is a task that is already being executed in the pipeline, the link error of clicking the execution prompt is wrong
![image](https://user-images.githubusercontent.com/32703277/126302815-170e3c2c-14b3-4c5c-aa25-dde8076131d1.png)
Steps to reproduce:
Corresponding to the existing branch of yml, click to create a new pipeline when executing, an error message is displayed, and the copy link cannot be opened

