### PR TITLE
fix table audit_history error

### DIFF
--- a/.erda/migrations/cmdb/20210721-fixAuditHistory.sql
+++ b/.erda/migrations/cmdb/20210721-fixAuditHistory.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dice_audit_history ADD COLUMN `fdp_project_id` varchar(128) DEFAULT "" NOT NULL COMMENT 'fdp project id';
+ALTER TABLE dice_audit MODIFY COLUMN `fdp_project_id` varchar(128) DEFAULT "" NOT NULL COMMENT 'fdp project id';

--- a/.erda/migrations/cmdb/20210721-fixAuditHistory.sql
+++ b/.erda/migrations/cmdb/20210721-fixAuditHistory.sql
@@ -1,2 +1,4 @@
 ALTER TABLE dice_audit_history ADD COLUMN `fdp_project_id` varchar(128) DEFAULT "" NOT NULL COMMENT 'fdp project id';
+
+UPDATE dice_audit SET `fdp_project_id` = "" WHERE `fdp_project_id` IS NULL;
 ALTER TABLE dice_audit MODIFY COLUMN `fdp_project_id` varchar(128) DEFAULT "" NOT NULL COMMENT 'fdp project id';


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
If the fields of table `dice_audit_history` and table `dice_audit` are inconsistent, the audit archive will fail

#### Specified Reviewers:

/assign @Effet 

