### PR TITLE
set charset utf8mb4 and set collation utf8mb4_unicode_ci if url is null

### DIFF
--- a/modules/pipeline/dbclient/dbclient.go
+++ b/modules/pipeline/dbclient/dbclient.go
@@ -93,8 +93,7 @@ func New() (*Client, error) {
 		return nil, errors.Wrap(err, "failed to get mysql configuration from env")
 	}
 
-	engine, err := xorm.NewEngine("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8&parseTime=True&loc=Local",
-		cfg.Username, cfg.Password, cfg.Host, cfg.Port, cfg.Database))
+	engine, err := xorm.NewEngine("mysql", cfg.url())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to connect to mysql server")
 	}
@@ -119,6 +118,7 @@ func New() (*Client, error) {
 }
 
 type clientConfig struct {
+	URL             string        `env:"MYSQL_URL" envDefault:""`
 	Host            string        `env:"MYSQL_HOST" envDefault:"127.0.0.1"`
 	Port            int           `env:"MYSQL_PORT" envDefault:"3306"`
 	Username        string        `env:"MYSQL_USERNAME" envDefault:"root"`
@@ -129,4 +129,14 @@ type clientConfig struct {
 	ConnMaxLifetime time.Duration `env:"MYSQL_CONNMAXLIFETIME" envDefault:"10s"`
 	LogLevel        string        `env:"MYSQL_LOG_LEVEL" envDefault:"INFO"`
 	ShowSQL         bool          `env:"MYSQL_SHOW_SQL" envDefault:"false"`
+	PROPERTIES      string        `env:"MYSQL_PROPERTIES" envDefault:"charset=utf8mb4&collation=utf8mb4_unicode_ci&parseTime=True&loc=Local"`
+}
+
+// url judge env mysql_url whether is null
+func (cfg *clientConfig) url() string {
+	if cfg.URL != "" {
+		return cfg.URL
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s",
+		cfg.Username, cfg.Password, cfg.Host, cfg.Port, cfg.Database, cfg.PROPERTIES)
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
set charset=utf8mb4&collation=utf8mb4_unicode_ci when connect to mysql if env: mysql_url is null

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/workBench/projects/387/issues/all?id=201276&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=429&type=BUG)

