### PR TITLE
add autotest-plan openapi

### DIFF
--- a/modules/openapi/api/apis/testplatform/autotest/autotests_scene_set_list.go
+++ b/modules/openapi/api/apis/testplatform/autotest/autotests_scene_set_list.go
@@ -16,20 +16,17 @@ package autotest
 import (
 	"net/http"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/openapi/api/apis"
 )
 
-var GLOBAL_CONFIG_LIST = apis.ApiSpec{
-	Path:         "/api/autotests/global-configs",
-	BackendPath:  "/api/autotests/global-configs",
-	Host:         "dop.marathon.l4lb.thisdcos.directory:9527",
-	Scheme:       "http",
-	Method:       http.MethodGet,
-	CheckLogin:   true,
-	CheckToken:   true,
-	IsOpenAPI:    true,
-	RequestType:  apistructs.AutoTestGlobalConfigListRequest{},
-	ResponseType: apistructs.AutoTestGlobalConfigListResponse{},
-	Doc:          "查询自动化测试全局配置列表",
+var AUTOTESTS_SCENE_SET_LIST = apis.ApiSpec{
+	Path:        "/api/autotests/scenesets",
+	BackendPath: "/api/autotests/scenesets",
+	Host:        "dop.marathon.l4lb.thisdcos.directory:9527",
+	Scheme:      "http",
+	Method:      http.MethodGet,
+	CheckLogin:  true,
+	CheckToken:  true,
+	IsOpenAPI:   true,
+	Doc:         "自动化测试场景集列表",
 }

--- a/modules/openapi/api/apis/testplatform/autotest/autotests_scenes_execute.go
+++ b/modules/openapi/api/apis/testplatform/autotest/autotests_scenes_execute.go
@@ -26,5 +26,7 @@ var AUTOTESTS_SCENES_EXECUTE = apis.ApiSpec{
 	Scheme:      "http",
 	Method:      http.MethodPost,
 	CheckLogin:  true,
+	CheckToken:  true,
+	IsOpenAPI:   true,
 	Doc:         "自动化测试场景执行",
 }

--- a/modules/openapi/api/apis/testplatform/autotest/autotests_scenes_list.go
+++ b/modules/openapi/api/apis/testplatform/autotest/autotests_scenes_list.go
@@ -16,20 +16,17 @@ package autotest
 import (
 	"net/http"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/openapi/api/apis"
 )
 
-var GLOBAL_CONFIG_LIST = apis.ApiSpec{
-	Path:         "/api/autotests/global-configs",
-	BackendPath:  "/api/autotests/global-configs",
-	Host:         "dop.marathon.l4lb.thisdcos.directory:9527",
-	Scheme:       "http",
-	Method:       http.MethodGet,
-	CheckLogin:   true,
-	CheckToken:   true,
-	IsOpenAPI:    true,
-	RequestType:  apistructs.AutoTestGlobalConfigListRequest{},
-	ResponseType: apistructs.AutoTestGlobalConfigListResponse{},
-	Doc:          "查询自动化测试全局配置列表",
+var AUTOTESTS_SCENES_LIST = apis.ApiSpec{
+	Path:        "/api/autotests/scenes",
+	BackendPath: "/api/autotests/scenes",
+	Host:        "dop.marathon.l4lb.thisdcos.directory:9527",
+	Scheme:      "http",
+	Method:      http.MethodGet,
+	CheckLogin:  true,
+	CheckToken:  true,
+	IsOpenAPI:   true,
+	Doc:         "自动化测试场景列表",
 }

--- a/modules/openapi/api/apis/testplatform/testplan/autotest_space_list.go
+++ b/modules/openapi/api/apis/testplatform/testplan/autotest_space_list.go
@@ -11,25 +11,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package autotest
+package testplan
 
 import (
-	"net/http"
-
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/openapi/api/apis"
 )
 
-var GLOBAL_CONFIG_LIST = apis.ApiSpec{
-	Path:         "/api/autotests/global-configs",
-	BackendPath:  "/api/autotests/global-configs",
+var QA_AUTOTEST_SPACE_LIST = apis.ApiSpec{
+	Path:         "/api/autotests/spaces",
+	BackendPath:  "/api/autotests/spaces",
 	Host:         "dop.marathon.l4lb.thisdcos.directory:9527",
 	Scheme:       "http",
-	Method:       http.MethodGet,
+	Method:       "GET",
 	CheckLogin:   true,
 	CheckToken:   true,
+	ResponseType: apistructs.AutoTestSpaceList{},
 	IsOpenAPI:    true,
-	RequestType:  apistructs.AutoTestGlobalConfigListRequest{},
-	ResponseType: apistructs.AutoTestGlobalConfigListResponse{},
-	Doc:          "查询自动化测试全局配置列表",
+	Doc:          "summary: 获取获取autotest-space列表",
 }

--- a/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_create.go
+++ b/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_create.go
@@ -11,25 +11,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-package autotest
+package testplan
 
 import (
 	"net/http"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/openapi/api/apis"
 )
 
-var GLOBAL_CONFIG_LIST = apis.ApiSpec{
-	Path:         "/api/autotests/global-configs",
-	BackendPath:  "/api/autotests/global-configs",
-	Host:         "dop.marathon.l4lb.thisdcos.directory:9527",
-	Scheme:       "http",
-	Method:       http.MethodGet,
-	CheckLogin:   true,
-	CheckToken:   true,
-	IsOpenAPI:    true,
-	RequestType:  apistructs.AutoTestGlobalConfigListRequest{},
-	ResponseType: apistructs.AutoTestGlobalConfigListResponse{},
-	Doc:          "查询自动化测试全局配置列表",
+var AUTOTESTS_TESTPLAN_CREATE = apis.ApiSpec{
+	Path:           "/api/autotests/testplans",
+	BackendPath:    "/api/autotests/testplans",
+	Host:           "dop.marathon.l4lb.thisdcos.directory:9527",
+	Scheme:         "http",
+	Method:         http.MethodPost,
+	CheckLogin:     true,
+	CheckBasicAuth: true,
+	Doc:            "创建自动化测试计划",
 }

--- a/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_execute.go
+++ b/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_execute.go
@@ -27,5 +27,7 @@ var AUTOTESTS_TESTPLAN_EXECUTE = apis.ApiSpec{
 	Method:         http.MethodPost,
 	CheckLogin:     true,
 	CheckBasicAuth: true,
+	CheckToken:     true,
+	IsOpenAPI:      true,
 	Doc:            "自动化测试计划执行",
 }

--- a/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_paging.go
+++ b/modules/openapi/api/apis/testplatform/testplan/autotests_testplan_paging.go
@@ -24,8 +24,10 @@ var AUTOTESTS_TESTPLAN_PAGING = apis.ApiSpec{
 	BackendPath:    "/api/autotests/testplans",
 	Host:           "dop.marathon.l4lb.thisdcos.directory:9527",
 	Scheme:         "http",
-	Method:         http.MethodPost,
+	Method:         http.MethodGet,
 	CheckLogin:     true,
 	CheckBasicAuth: true,
+	CheckToken:     true,
+	IsOpenAPI:      true,
 	Doc:            "自动化测试计划列表",
 }


### PR DESCRIPTION
(cherry picked from commit 2ba8a5de64b2c3d1fd3ef2c572cf13e8a4ae1e36)

#### What type of this PR

Add one of the following kinds:

kind feature


#### What this PR does / why we need it:

These openapis are needed to run auto test plan actions
