### PR TITLE
move dicehub to core in proto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/elastic/cloud-on-k8s v0.0.0-20210205172912-5ce0eca90c60
 	github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6
 	github.com/erda-project/erda-infra v0.0.0-20210722100357-dfb1489a28d3
-	github.com/erda-project/erda-proto-go v0.0.0-20210723104827-f1d10d4562c7
+	github.com/erda-project/erda-proto-go v0.0.0-20210726082300-2e07d1bd9d45
 	github.com/extrame/ole2 v0.0.0-20160812065207-d69429661ad7 // indirect
 	github.com/extrame/xls v0.0.1
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect

--- a/go.sum
+++ b/go.sum
@@ -434,6 +434,8 @@ github.com/erda-project/erda-infra v0.0.0-20210722100357-dfb1489a28d3 h1:4AZkA22
 github.com/erda-project/erda-infra v0.0.0-20210722100357-dfb1489a28d3/go.mod h1:L+fFQghY2po2P3H9pzwEOufDLAhL+mRRhPGdZ7vFnAw=
 github.com/erda-project/erda-proto-go v0.0.0-20210723104827-f1d10d4562c7 h1:ieuje9agkYu7XCK69jqqdN6cEdUTRWOTawzrFc0HI+I=
 github.com/erda-project/erda-proto-go v0.0.0-20210723104827-f1d10d4562c7/go.mod h1:rSETXX3nKxxIhgrVn7fKDM3mla1nNlWcPz4AkepixaU=
+github.com/erda-project/erda-proto-go v0.0.0-20210726082300-2e07d1bd9d45 h1:n0aHZGCiRFQR8Bl89JSbEdQv6BaONiD0GHRxW6+yu94=
+github.com/erda-project/erda-proto-go v0.0.0-20210726082300-2e07d1bd9d45/go.mod h1:rSETXX3nKxxIhgrVn7fKDM3mla1nNlWcPz4AkepixaU=
 github.com/erda-project/influxql v1.1.0-ex h1:NgP5+S5Qo234IVSIJ3N/egvzCNYJURfMAett3e8a9LE=
 github.com/erda-project/influxql v1.1.0-ex/go.mod h1:gHp9y86a/pxhjJ+zMjNXiQAA197Xk9wLxaz+fGG+kWk=
 github.com/erda-project/remotedialer v0.2.6-0.20210713103000-da03eb9e4b23 h1:NaKo6voQVqZM6DMBVhcTT4gjd+lr1C3zE17RROspfg0=

--- a/modules/dicehub/image/image.service.go
+++ b/modules/dicehub/image/image.service.go
@@ -19,7 +19,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/erda-project/erda-proto-go/dicehub/image/pb"
+	"github.com/erda-project/erda-proto-go/core/dicehub/image/pb"
 	"github.com/erda-project/erda/modules/dicehub/image/db"
 	"github.com/erda-project/erda/modules/dicehub/service/apierrors"
 	"github.com/erda-project/erda/pkg/common/apis"

--- a/modules/dicehub/image/image.service_test.go
+++ b/modules/dicehub/image/image.service_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
-	"github.com/erda-project/erda-proto-go/dicehub/image/pb"
+	"github.com/erda-project/erda-proto-go/core/dicehub/image/pb"
 )
 
 func Test_imageService_GetImage(t *testing.T) {

--- a/modules/dicehub/image/provider.go
+++ b/modules/dicehub/image/provider.go
@@ -19,7 +19,7 @@ import (
 	logs "github.com/erda-project/erda-infra/base/logs"
 	servicehub "github.com/erda-project/erda-infra/base/servicehub"
 	transport "github.com/erda-project/erda-infra/pkg/transport"
-	pb "github.com/erda-project/erda-proto-go/dicehub/image/pb"
+	pb "github.com/erda-project/erda-proto-go/core/dicehub/image/pb"
 	db "github.com/erda-project/erda/modules/dicehub/image/db"
 )
 


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

move provider named dicehub to corn in erda-proto
update import