### PR TITLE
add a send email switch for personal message

### DIFF
--- a/apistructs/org.go
+++ b/apistructs/org.go
@@ -195,6 +195,7 @@ func (org *OrgDTO) HidePassword() {
 }
 
 type OrgConfig struct {
+	EnablePersonalMessageEmail bool   `json:"enablePersonalMessageEmail"`
 	EnableMS                   bool   `json:"enableMS"`
 	SMTPHost                   string `json:"smtpHost"`
 	SMTPUser                   string `json:"smtpUser"`

--- a/modules/core-services/endpoints/organization.go
+++ b/modules/core-services/endpoints/organization.go
@@ -494,6 +494,7 @@ func (e *Endpoints) convertToOrgDTO(org model.Org, domains ...string) apistructs
 		DisplayName: org.DisplayName,
 		Type:        org.Type,
 		Config: &apistructs.OrgConfig{
+			EnablePersonalMessageEmail: org.Config.EnablePersonalMessageEmail,
 			EnableMS:                   org.Config.EnableMS,
 			SMTPHost:                   org.Config.SMTPHost,
 			SMTPUser:                   org.Config.SMTPUser,

--- a/modules/core-services/model/organization.go
+++ b/modules/core-services/model/organization.go
@@ -50,6 +50,7 @@ type BlockoutConfig struct {
 }
 
 type OrgConfig struct {
+	EnablePersonalMessageEmail bool   `json:"enablePersonalMessageEmail"`
 	EnableMS                   bool   `json:"enableMs"`
 	SMTPHost                   string `json:"smtpHost"`
 	SMTPUser                   string `json:"smtpUser"`

--- a/modules/dop/endpoints/issue_callback.go
+++ b/modules/dop/endpoints/issue_callback.go
@@ -142,8 +142,11 @@ func (e *Endpoints) sendIssueEventToSpecificRecipient(req apistructs.IssueEvent)
 	logrus.Debugf("params of issue event is: %v", params)
 	logrus.Debugf("email addr is: %v", emailAddrs)
 
-	if err := e.bdl.CreateEmailNotify(emailTemplateName, params, org.Locale, org.ID, emailAddrs); err != nil {
-		logrus.Errorf("send personal issue %s event email err: %v", params["issueID"], err)
+	// if allowd send email for personal message
+	if org.Config.EnablePersonalMessageEmail {
+		if err := e.bdl.CreateEmailNotify(emailTemplateName, params, org.Locale, org.ID, emailAddrs); err != nil {
+			logrus.Errorf("send personal issue %s event email err: %v", params["issueID"], err)
+		}
 	}
 	if err := e.bdl.CreateMboxNotify(mboxTemplateName, params, org.Locale, org.ID, req.Content.Receivers); err != nil {
 		logrus.Errorf("send personal issue %s event mbox err: %v", params["issueID"], err)


### PR DESCRIPTION
#### What type of this PR
/kind feature


#### What this PR does / why we need it:
Too many personal messages, the mail server has a limit on the number of emails sent

#### Which issue(s) this PR fixes:
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=202091&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDQzNiJdfQ%3D%3D&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=429&type=TASK)

#### Specified Reviewers:
/assign @sfwn @Effet 

#### Need cherry-pick to release versions?
/cherry-pick release/1.1
