### PR TITLE
erda.yml declare global PIPELINE_ADDR for discover multi-port random-detect

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -12,6 +12,7 @@ envs:
   ETCDCTL_API: "3"
   MONITOR_ADDR: monitor:7096
   COLLECTOR_ADDR: collector:7076
+  PIPELINE_ADDR: pipeline:3081
 services:
   action-runner-scheduler:
     cmd: "/app/action-runner-scheduler"


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

discover detect use gprc port as PIPELINE_ADDR, so bundle invoke get malformed response.