### PR TITLE
add pipeline event url

### DIFF
--- a/modules/dop/services/cdp/cdp.go
+++ b/modules/dop/services/cdp/cdp.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/dop/conf"
 )
 
 // CDP pipeline 结构体
@@ -165,9 +166,13 @@ func (cdp *CDP) CdpNotifyProcess(pipelineEvent *apistructs.PipelineInstanceEvent
 			params := map[string]string{
 				"pipelineID":     strconv.FormatUint(pipelineData.PipelineID, 10),
 				"notifyItemName": notifyItem.DisplayName,
+				"appID":          strconv.FormatUint(pipelineDetail.ApplicationID, 10),
 				"appName":        pipelineDetail.ApplicationName,
+				"projectID":      strconv.FormatUint(pipelineDetail.ProjectID, 10),
 				"projectName":    pipelineDetail.ProjectName,
+				"orgName":        pipelineDetail.OrgName,
 				"branch":         pipelineDetail.Branch,
+				"uiPublicURL":    conf.UIPublicURL(),
 			}
 			//失败情况尝输出错误日志
 			if notifyItem.Name == "pipeline_failed" {

--- a/pkg/erda-configs/i18n/notify_item.yml
+++ b/pkg/erda-configs/i18n/notify_item.yml
@@ -78,13 +78,13 @@ zh-CN:
     - 信息：{{message}}
   notify.pipeline.pipeline_success: 流水线运行成功
   notify.pipeline.pipeline_success.markdown_template: |-
-    ### {{projectName}}/{{appName}} 流水线{{pipelineID}}运行成功
+    ### {{projectName}}/{{appName}} 流水线 {{pipelineID}} 运行成功 {{uiPublicURL}}/{{orgName}}/dop/projects/{{projectID}}/apps/{{appID}}/pipeline?pipelineID={{pipelineID}}
   notify.pipeline.pipeline_running: 流水线开始运行
   notify.pipeline.pipeline_running.markdown_template: |-
     ### {{projectName}}/{{appName}} 流水线{{pipelineID}}开始运行
   notify.pipeline.pipeline_failed: 流水线运行失败
   notify.pipeline.pipeline_failed.markdown_template: |-
-    ### {{projectName}}/{{appName}} 流水线{{pipelineID}}运行失败
+    ### {{projectName}}/{{appName}} 流水线 {{pipelineID}} 运行失败 {{uiPublicURL}}/{{orgName}}/dop/projects/{{projectID}}/apps/{{appID}}/pipeline?pipelineID={{pipelineID}}
     {{failedDetail}}
   notify.issue.issue_create: 创建任务事件
   notify.issue.issue_create.markdown_template: "事件【{{issue_title}}】{{content}}"


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

kind feature


#### What this PR does / why we need it:

You can directly click on the url in the Dingding group to enter the pipeline page

#### Which issue(s) this PR fixes:

https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/requirement?id=65866&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&type=requirement

old:

<img width="358" alt="屏幕快照 2021-07-28 下午5 19 50" src="https://user-images.githubusercontent.com/32703277/127297727-708fda41-df71-4c16-aff8-c1191429ba24.png">

now:

<img width="364" alt="屏幕快照 2021-07-28 下午5 19 42" src="https://user-images.githubusercontent.com/32703277/127297754-37fab0d5-f3ef-40a3-8628-d8f0d087b6b5.png">


