### PR TITLE
bugfix: query tenantgroup exclude is_deleted

### DIFF
--- a/modules/monitor/common/db/instance_tenant.go
+++ b/modules/monitor/common/db/instance_tenant.go
@@ -30,6 +30,7 @@ func (db *InstanceTenantDb) QueryTkByTenantGroup(tenantGroup string) (string, er
 		Select("*").
 		Where("tenant_group = ?", tenantGroup).
 		Where("engine = ?", "monitor").
+		Where("is_deleted = ?", "N").
 		Find(&tenantInfo).
 		Order("create_time", false).
 		Limit(1).


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
query tenantgroup exclude deleted ones.


#### Specified Reviewers:
/assign @liuhaoyang @Counterflowwind 


#### Need cherry-pick to release versions?
/cherry-pick release/1.1