### PR TITLE
fix action component protocol

### DIFF
--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
@@ -447,6 +447,10 @@ func (a *ComponentAction) Render(ctx context.Context, c *apistructs.Component, s
 		return fmt.Errorf("failed to Unmarshal actionData:%+v, err:%v", actionDataJson, err)
 	}
 
+	if action.Type == "" {
+		action.Type = scenario.ScenarioKey
+	}
+
 	doFunc := actionTypeRender[action.Type]
 	if doFunc == nil {
 		return nil


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

kind bug


#### What this PR does / why we need it:

Modified the problem that the componentized protocol cannot be executed when creating a new action node

pre:
<img width="554" alt="C458544C-1B12-4BD2-8C72-DF068150796F" src="https://user-images.githubusercontent.com/32703277/127429810-e4bef038-65b4-4060-9df0-63d18c93e7e3.png">

now:
<img width="551" alt="D703DB8F-D06D-4FF4-A016-0EE2A62EEAD7" src="https://user-images.githubusercontent.com/32703277/127429837-40fdbecb-1f43-4ef8-ad28-ad4601552059.png">
