### PR TITLE
hotfix: autotest add missing kvs when create global configs

### DIFF
--- a/modules/dop/services/autotest/global_config.go
+++ b/modules/dop/services/autotest/global_config.go
@@ -275,7 +275,7 @@ func (svc *Service) createOrUpdatePipelineCmsGlobalConfigs(cfg *apistructs.AutoT
 	if _, err := svc.cms.UpdateCmsNsConfigs(utils.WithInternalClientContext(context.Background()), &cmspb.CmsNsConfigsUpdateRequest{
 		Ns:             cfg.Ns,
 		PipelineSource: apistructs.PipelineSourceAutoTest.String(),
-		KVs:            nil,
+		KVs:            kvs,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

autotest add missing kvs when create global configs