### PR TITLE
pipeline events show order

### DIFF
--- a/modules/pipeline/dbclient/op_pipeline_event.go
+++ b/modules/pipeline/dbclient/op_pipeline_event.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/erda-project/erda/apistructs"
@@ -65,52 +66,16 @@ func (client *Client) AppendPipelineEvent(pipelineID uint64, newEvents []*apistr
 	session := client.NewSession(ops...)
 	defer session.Close()
 
-	// get latest events
+	// get events
 	report, events, err := client.GetPipelineEvents(pipelineID, ops...)
 	if err != nil {
 		return err
 	}
-	// merge all events
-	events = append(events, newEvents...)
-	// group events by event detail
-	group := make(map[string][]*apistructs.PipelineEvent)
-	for _, event := range events {
-		key := makeEventGroupKey(event)
-		group[key] = append(group[key], event)
-	}
-	mergedGroup := make(map[string]*apistructs.PipelineEvent)
-	for key, ses := range group {
-		newSe := *ses[0]
-		for i, se := range ses {
-			if i == 0 {
-				continue
-			}
-			if !se.FirstTimestamp.IsZero() && se.FirstTimestamp.Before(newSe.FirstTimestamp) {
-				newSe.FirstTimestamp = se.FirstTimestamp
-			}
-			if se.LastTimestamp.After(newSe.LastTimestamp) {
-				newSe.LastTimestamp = se.LastTimestamp
-			}
-			newSe.Count++
-		}
-		// set default
-		now := time.Now()
-		if newSe.FirstTimestamp.IsZero() {
-			newSe.FirstTimestamp = now
-		}
-		if newSe.LastTimestamp.IsZero() {
-			newSe.FirstTimestamp = now
-		}
-		// add to merged group
-		mergedGroup[key] = &newSe
-	}
-	// order message by firstTimestamp
-	var ordered orderedEvents
-	for _, g := range mergedGroup {
-		ordered = append(ordered, g)
-	}
-	sort.Sort(ordered)
-	if len(ordered) == 0 {
+
+	// get order events
+	ordered := makeOrderEvents(events, newEvents)
+
+	if len(ordered) <= 0 {
 		return nil
 	}
 
@@ -129,10 +94,78 @@ func (client *Client) AppendPipelineEvent(pipelineID uint64, newEvents []*apistr
 	return client.UpdatePipelineReport(report, ops...)
 }
 
+func getLastEvent(ordered orderedEvents) *apistructs.PipelineEvent {
+	if ordered != nil {
+		sort.Sort(ordered)
+		return ordered[len(ordered)-1]
+	}
+	return nil
+}
+
 type orderedEvents []*apistructs.PipelineEvent
 
+func makeOrderEvents(events []*apistructs.PipelineEvent, newEvents []*apistructs.PipelineEvent) orderedEvents {
+	// order events
+	var ordered orderedEvents
+	for _, g := range events {
+		ordered = append(ordered, g)
+	}
+
+	// new events order, if event not have time to add time
+	var newEventOrder orderedEvents
+	now := time.Now()
+	for index, g := range newEvents {
+		if g.FirstTimestamp.IsZero() {
+			g.FirstTimestamp = now.Add(time.Duration(index) * time.Millisecond)
+		}
+		if g.LastTimestamp.IsZero() {
+			g.FirstTimestamp = now.Add(time.Duration(index) * time.Millisecond)
+		}
+		newEventOrder = append(newEventOrder, g)
+	}
+	sort.Sort(newEventOrder)
+
+	// get before last events
+	lastEvent := getLastEvent(ordered)
+	for _, ev := range newEventOrder {
+		// if lastEvent was empty, mean ordered was empty
+		// lastEvent assignment this events
+		if lastEvent == nil {
+			ordered = append(ordered, ev)
+			lastEvent = ev
+			continue
+		}
+
+		// get last events key and this events key
+		lastEventKey := makeEventGroupKey(lastEvent)
+		thsEventKey := makeEventGroupKey(ev)
+
+		// same like
+		if strings.EqualFold(lastEventKey, thsEventKey) {
+			// compare time and exchange
+			if !ev.FirstTimestamp.IsZero() && ev.FirstTimestamp.Before(lastEvent.FirstTimestamp) {
+				lastEvent.FirstTimestamp = ev.FirstTimestamp
+			}
+			if ev.LastTimestamp.After(lastEvent.LastTimestamp) {
+				lastEvent.LastTimestamp = ev.LastTimestamp
+			}
+			// count++
+			// lastEvent not change
+			lastEvent.Count++
+			continue
+		} else {
+			// not like,
+			// append this events to orders
+			// lastEvent assignment this events
+			ordered = append(ordered, ev)
+			lastEvent = ev
+		}
+	}
+	return ordered
+}
+
 func (o orderedEvents) Len() int           { return len(o) }
-func (o orderedEvents) Less(i, j int) bool { return o[i].FirstTimestamp.Before(o[j].FirstTimestamp) }
+func (o orderedEvents) Less(i, j int) bool { return o[i].LastTimestamp.Before(o[j].LastTimestamp) }
 func (o orderedEvents) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }
 
 func makeEventGroupKey(se *apistructs.PipelineEvent) string {

--- a/modules/pipeline/dbclient/op_pipeline_event_test.go
+++ b/modules/pipeline/dbclient/op_pipeline_event_test.go
@@ -1,0 +1,818 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dbclient
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func Test_makeOrderEvents(t *testing.T) {
+	var nowTime = time.Now()
+	type args struct {
+		events    []*apistructs.PipelineEvent
+		newEvents []*apistructs.PipelineEvent
+	}
+	tests := []struct {
+		name string
+		args args
+		want orderedEvents
+	}{
+		{
+			name: "empty events add one newEvents",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(20 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "empty events add two differ newEvents",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(20 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "empty events add two same newEvents",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          2,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "empty events add three no order lastTimestamp newEvents",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(10 * time.Second),
+						LastTimestamp:  nowTime.Add(30 * time.Second),
+						Count:          1,
+						Type:           "type1",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(20 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(10 * time.Second),
+					LastTimestamp:  nowTime.Add(30 * time.Second),
+					Count:          1,
+					Type:           "type1",
+				},
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "empty events add three order lastTimestamp newEvents",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(10 * time.Second),
+						LastTimestamp:  nowTime.Add(30 * time.Second),
+						Count:          1,
+						Type:           "type1",
+					},
+					{
+						Reason:  "reason2",
+						Message: "message2",
+						Source: apistructs.PipelineEventSource{
+							Component: "component2",
+							Host:      "host2",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type2",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(20 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(10 * time.Second),
+					LastTimestamp:  nowTime.Add(30 * time.Second),
+					Count:          1,
+					Type:           "type1",
+				},
+				{
+					Reason:  "reason2",
+					Message: "message2",
+					Source: apistructs.PipelineEventSource{
+						Component: "component2",
+						Host:      "host2",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          1,
+					Type:           "type2",
+				},
+			},
+		},
+		{
+			name: "empty events add three no order lastTimestamp newEvents，two events count++",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(30 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(10 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type1",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(30 * time.Second),
+					Count:          2,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(10 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          1,
+					Type:           "type1",
+				},
+			},
+		},
+		{
+			name: "empty events add three no order lastTimestamp newEvents，three events count++",
+			args: args{
+				events: nil,
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(20 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(30 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(10 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          3,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "events add in order",
+			args: args{
+				events: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          3,
+						Type:           "type",
+					},
+				},
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(50 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          3,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(50 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "events first add counts",
+			args: args{
+				events: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          3,
+						Type:           "type",
+					},
+				},
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(60 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(50 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(50 * time.Second),
+					Count:          4,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(60 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+		{
+			name: "events first add counts three add counts",
+			args: args{
+				events: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          3,
+						Type:           "type",
+					},
+				},
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(60 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(-30 * time.Second),
+						LastTimestamp:  nowTime.Add(80 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason2",
+						Message: "message2",
+						Source: apistructs.PipelineEventSource{
+							Component: "component2",
+							Host:      "host2",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(90 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(50 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(50 * time.Second),
+					Count:          4,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(-30 * time.Second),
+					LastTimestamp:  nowTime.Add(80 * time.Second),
+					Count:          2,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason2",
+					Message: "message2",
+					Source: apistructs.PipelineEventSource{
+						Component: "component2",
+						Host:      "host2",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(90 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+
+		{
+			name: "sort events and add events",
+			args: args{
+				events: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason",
+						Message: "message",
+						Source: apistructs.PipelineEventSource{
+							Component: "component",
+							Host:      "host",
+						},
+						FirstTimestamp: nowTime.Add(-20 * time.Second),
+						LastTimestamp:  nowTime.Add(40 * time.Second),
+						Count:          3,
+						Type:           "type",
+					},
+					{
+						Reason:  "reason1",
+						Message: "message1",
+						Source: apistructs.PipelineEventSource{
+							Component: "component1",
+							Host:      "host1",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(30 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+				newEvents: []*apistructs.PipelineEvent{
+					{
+						Reason:  "reason2",
+						Message: "message2",
+						Source: apistructs.PipelineEventSource{
+							Component: "component2",
+							Host:      "host2",
+						},
+						FirstTimestamp: nowTime.Add(20 * time.Second),
+						LastTimestamp:  nowTime.Add(90 * time.Second),
+						Count:          1,
+						Type:           "type",
+					},
+				},
+			},
+			want: orderedEvents{
+				{
+					Reason:  "reason1",
+					Message: "message1",
+					Source: apistructs.PipelineEventSource{
+						Component: "component1",
+						Host:      "host1",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(30 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason",
+					Message: "message",
+					Source: apistructs.PipelineEventSource{
+						Component: "component",
+						Host:      "host",
+					},
+					FirstTimestamp: nowTime.Add(-20 * time.Second),
+					LastTimestamp:  nowTime.Add(40 * time.Second),
+					Count:          3,
+					Type:           "type",
+				},
+				{
+					Reason:  "reason2",
+					Message: "message2",
+					Source: apistructs.PipelineEventSource{
+						Component: "component2",
+						Host:      "host2",
+					},
+					FirstTimestamp: nowTime.Add(20 * time.Second),
+					LastTimestamp:  nowTime.Add(90 * time.Second),
+					Count:          1,
+					Type:           "type",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := makeOrderEvents(tt.args.events, tt.args.newEvents); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("makeOrderEvents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:
The order of the records of the pipeline events is modified. The original count number and the order of the records is not correct, events should be able to express the order instead of just counting.

erda-issue: [erda-issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=200490&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)
