### PR TITLE
autotest configs order by update time

### DIFF
--- a/apistructs/autotest.go
+++ b/apistructs/autotest.go
@@ -160,6 +160,18 @@ type AutoTestGlobalConfig struct {
 	UIConfig  *AutoTestUIConfig  `json:"uiConfig,omitempty"`
 }
 
+type SortByUpdateTimeAutoTestGlobalConfigs []AutoTestGlobalConfig
+
+func (p SortByUpdateTimeAutoTestGlobalConfigs) Len() int {
+	return len(p)
+}
+func (p SortByUpdateTimeAutoTestGlobalConfigs) Less(i, j int) bool {
+	return p[i].UpdatedAt.After(p[j].UpdatedAt)
+}
+func (p SortByUpdateTimeAutoTestGlobalConfigs) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
 func (cfg AutoTestGlobalConfig) GetUserIDs() []string {
 	return strutil.DedupSlice([]string{cfg.CreatorID, cfg.UpdaterID}, true)
 }

--- a/modules/dop/services/autotest/global_config.go
+++ b/modules/dop/services/autotest/global_config.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	cmspb "github.com/erda-project/erda-proto-go/core/pipeline/cms/pb"
@@ -135,7 +136,7 @@ func (svc *Service) parseGlobalConfigFromCmsNs(ns string) (*apistructs.AutoTestG
 		case CmsCfgKeyUpdatedAt:
 			var updatedAt time.Time
 			if err := json.Unmarshal([]byte(cfg.Value), &updatedAt); err == nil {
-				result.CreatedAt = updatedAt
+				result.UpdatedAt = updatedAt
 			}
 		case CmsCfgKeyAPIGlobalConfig:
 			var apiConfig apistructs.AutoTestAPIConfig
@@ -332,15 +333,17 @@ func (svc *Service) ListGlobalConfigs(req apistructs.AutoTestGlobalConfigListReq
 		return nil, apierrors.ErrListAutoTestGlobalConfigs.InternalError(err)
 	}
 
-	var results []apistructs.AutoTestGlobalConfig
+	var sortResult apistructs.SortByUpdateTimeAutoTestGlobalConfigs
 
 	for _, ns := range namespaces.Data {
 		cfg, err := svc.parseGlobalConfigFromCmsNs(ns.Ns)
 		if err != nil {
 			return nil, apierrors.ErrListAutoTestGlobalConfigs.InternalError(err)
 		}
-		results = append(results, *cfg)
+		sortResult = append(sortResult, *cfg)
 	}
+	// sort by update time
+	sort.Sort(sortResult)
 
-	return results, nil
+	return sortResult, nil
 }

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
@@ -195,8 +195,11 @@ func GenLoopProps(loop *apistructs.PipelineTaskLoop) (loopFp []apistructs.FormPr
 	maxTimes := apistructs.FormPropItem{
 		Label:     "最大循环次数",
 		Component: "inputNumber",
-		Key:       GroupLoop + "." + "strategy.max_times",
-		Group:     GroupLoop,
+		ComponentProps: map[string]interface{}{
+			"precision": 0,
+		},
+		Key:   GroupLoop + "." + "strategy.max_times",
+		Group: GroupLoop,
 	}
 	declineRatio := apistructs.FormPropItem{
 		Label:     "衰退比例",
@@ -208,9 +211,12 @@ func GenLoopProps(loop *apistructs.PipelineTaskLoop) (loopFp []apistructs.FormPr
 	declineLimit := apistructs.FormPropItem{
 		Label:     "衰退最大值(秒)",
 		Component: "inputNumber",
-		Key:       GroupLoop + "." + "strategy.decline_limit_sec",
-		Group:     GroupLoop,
-		LabelTip:  "循环最大间隔时间",
+		ComponentProps: map[string]interface{}{
+			"precision": 0,
+		},
+		Key:      GroupLoop + "." + "strategy.decline_limit_sec",
+		Group:    GroupLoop,
+		LabelTip: "循环最大间隔时间",
 	}
 	interval := apistructs.FormPropItem{
 		Label:     "起始间隔(秒)",


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
The original parameter configuration of the automated test is not sorted. When there are too many, the previously created ones will always be in the front.


erda-issue: [erda-issue](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=72042&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=431&type=BUG)

need cherry-pick release/1.2
