### PR TITLE
delete dicehub yml extension_menu

### DIFF
--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -23,7 +23,7 @@ erda.core.dicehub.release:
   gc_switch: "${RELEASE_GC_SWITCH:true}"
 
 erda.core.dicehub.extension:
-  extension_menu: ${EXTENSION_MENU:{"":""}}
+#  extension_menu: ${EXTENSION_MENU:{"":""}}
 
 mysql:
   host: "${MYSQL_HOST:localhost}"


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

delete  EXTENSION_MENU in dicehub provider.
it is useless now
