### PR TITLE
Support to get Action from git, in order to debug Action quickly 

### DIFF
--- a/modules/dicehub/service/extension/extension.go
+++ b/modules/dicehub/service/extension/extension.go
@@ -16,6 +16,7 @@ package extension
 import (
 	"errors"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver"
 	"github.com/jinzhu/gorm"
@@ -88,27 +89,49 @@ func (i *Extension) Create(req *apistructs.ExtensionCreateRequest) (*apistructs.
 
 // SearchExtensions 批量查询扩展
 func (i *Extension) SearchExtensions(req apistructs.ExtensionSearchRequest) (map[string]*apistructs.ExtensionVersion, error) {
-	result := map[string]*apistructs.ExtensionVersion{}
+	result := struct {
+		mp map[string]*apistructs.ExtensionVersion
+		sync.RWMutex
+	}{mp: make(map[string]*apistructs.ExtensionVersion)}
+	var wg sync.WaitGroup
+	wg.Add(len(req.Extensions))
 	for _, fullName := range req.Extensions {
-		splits := strings.Split(fullName, "@")
-		name := splits[0]
-		version := ""
-		if len(splits) > 1 {
-			version = splits[1]
-		}
-		if version == "" {
-			extVersion, _ := i.GetExtensionDefaultVersion(name, req.YamlFormat)
-			result[fullName] = extVersion
-		} else {
-			extensionVersion, err := i.GetExtensionVersion(name, version, req.YamlFormat)
-			if err != nil {
-				result[fullName] = nil
-			} else {
-				result[fullName] = extensionVersion
+		go func(fnm string) {
+			defer wg.Done()
+			splits := strings.SplitN(fnm, "@", 2)
+			name := splits[0]
+			version := ""
+			if len(splits) > 1 {
+				version = splits[1]
 			}
-		}
+			if version == "" {
+				extVersion, _ := i.GetExtensionDefaultVersion(name, req.YamlFormat)
+				result.Lock()
+				result.mp[fnm] = extVersion
+				result.Unlock()
+			} else if strings.HasPrefix(version, "https://") || strings.HasPrefix(version, "http://") {
+				extensionVersion, err := i.GetExtensionByGit(name, version, "spec.yml", "dice.yml", "README.md")
+				result.Lock()
+				if err != nil {
+					result.mp[fnm] = nil
+				} else {
+					result.mp[fnm] = extensionVersion
+				}
+				result.Unlock()
+			} else {
+				extensionVersion, err := i.GetExtensionVersion(name, version, req.YamlFormat)
+				result.Lock()
+				if err != nil {
+					result.mp[fnm] = nil
+				} else {
+					result.mp[fnm] = extensionVersion
+				}
+				result.Unlock()
+			}
+		}(fullName)
 	}
-	return result, nil
+	wg.Wait()
+	return result.mp, nil
 }
 
 // QueryExtensions 查询Extension列表

--- a/modules/dicehub/service/extension/git.go
+++ b/modules/dicehub/service/extension/git.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package extension
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func (i *Extension) GetExtensionByGit(name, d string, file ...string) (*apistructs.ExtensionVersion, error) {
+	files, err := getGitFileContents(d, file...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &apistructs.ExtensionVersion{
+		Name:      name,
+		Version:   "1.0",
+		Type:      "action",
+		Spec:      files[0],
+		Dice:      files[1],
+		Swagger:   "",
+		Readme:    files[2],
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		IsDefault: false,
+		Public:    true,
+	}, nil
+}
+
+func getGitFileContents(d string, file ...string) ([]string, error) {
+	var resp []string
+	// dirName is a random string
+	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	// git init
+	command := exec.Command("sh", "-c", "git init")
+	command.Dir = dir
+	err = command.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// git remote
+	remoteCmd := "git remote add -f origin " + d
+	command = exec.Command("sh", "-c", remoteCmd)
+	command.Dir = dir
+	err = command.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// set git config
+	command = exec.Command("sh", "-c", "git config core.sparsecheckout true")
+	command.Dir = dir
+	err = command.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// set sparse-checkout
+	for _, v := range file {
+		echoCmd := "echo " + v + " >> .git/info/sparse-checkout"
+		command = exec.Command("sh", "-c", echoCmd)
+		command.Dir = dir
+		err = command.Run()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// git pull
+	command = exec.Command("sh", "-c", "git pull origin master")
+	command.Dir = dir
+	err = command.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	// read .yml
+	for _, v := range file {
+		f, err := os.Open(dir + "/" + v)
+		if err != nil {
+			resp = append(resp, "")
+			continue
+		}
+		str, err := ioutil.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+		f.Close()
+		resp = append(resp, string(str))
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

Modified the code of the DiceHub module

Support to get pipeline-action from git
Support to concurrent query extension 

pipeline get  pipeline-action definition form erda-action project before. In order to debug pipeline-action ,support get it form git

because get pipeline-action form git need a lot of time. Support concurrent query. Call the interface once for about 5 seconds