### PR TITLE
Remove deprecated org prefix in org dto domain

### DIFF
--- a/modules/core-services/endpoints/organization.go
+++ b/modules/core-services/endpoints/organization.go
@@ -477,9 +477,9 @@ func (e *Endpoints) convertToOrgDTO(org model.Org, domains ...string) apistructs
 	if len(domainAndPort) > 1 {
 		port = domainAndPort[1]
 	}
-	concatDomain := conf.RootDomain()
+	concatDomain := conf.UIDomain()
 	if port != "" {
-		concatDomain = strutil.Concat(conf.RootDomain(), ":", port)
+		concatDomain = strutil.Concat(conf.UIDomain(), ":", port)
 	}
 
 	orgDto := apistructs.OrgDTO{

--- a/modules/core-services/endpoints/organization.go
+++ b/modules/core-services/endpoints/organization.go
@@ -477,9 +477,9 @@ func (e *Endpoints) convertToOrgDTO(org model.Org, domains ...string) apistructs
 	if len(domainAndPort) > 1 {
 		port = domainAndPort[1]
 	}
-	concatDomain := strutil.Concat(strutil.ToLower(org.Name), "-org.", conf.RootDomain())
+	concatDomain := conf.RootDomain()
 	if port != "" {
-		concatDomain = strutil.Concat(strutil.ToLower(org.Name), "-org.", conf.RootDomain(), ":", port)
+		concatDomain = strutil.Concat(conf.RootDomain(), ":", port)
 	}
 
 	orgDto := apistructs.OrgDTO{


### PR DESCRIPTION
#### What type of this PR
feature

#### What this PR does / why we need it:
Remove deprecated org prefix in org dto domain

#### Specified Reviewers:

/assign @Effet @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Remove organization prefix in domain of official website redirect link  |
| 🇨🇳 中文    | 官网跳转erda.cloud链接域名移除组织前缀   |

