### PR TITLE
if end status don`t calculate status

### DIFF
--- a/modules/pipeline/pipengine/reconciler/listen.go
+++ b/modules/pipeline/pipengine/reconciler/listen.go
@@ -144,6 +144,10 @@ func (r *Reconciler) updateStatusAfterReconcile(ctx context.Context, pipelineID 
 
 	p := pipelineWithTasks.Pipeline
 	tasks := pipelineWithTasks.Tasks
+	// if status is end status like stopByUser, should return immediately
+	if p.Status.IsEndStatus() {
+		return nil
+	}
 
 	// calculate pipeline status by tasks
 	calcPStatus := statusutil.CalculatePipelineStatusV2(tasks)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
if status is end status like stopByUser, should return immediately


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=204383&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=431&type=BUG)