### PR TITLE
Fixed the problem of extension provider reading configuration failure and incorrect interface parameter parsing

### DIFF
--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -23,7 +23,7 @@ erda.core.dicehub.release:
   gc_switch: "${RELEASE_GC_SWITCH:true}"
 
 erda.core.dicehub.extension:
-#  extension_menu: ${EXTENSION_MENU:{"":""}}
+  extension_menu: "${EXTENSION_MENU:{}}"
 
 mysql:
   host: "${MYSQL_HOST:localhost}"

--- a/modules/dicehub/extension/config.go
+++ b/modules/dicehub/extension/config.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package extension
+
+import "encoding/json"
+
+func (c *config) ConvertConfigExtensionMenu() (map[string][]string, error) {
+	var mp map[string][]string
+	err := json.Unmarshal([]byte(c.ExtensionMenu), &mp)
+	if err != nil {
+		return nil, err
+	}
+	if mp == nil {
+		mp = make(map[string][]string)
+	}
+	return mp, nil
+}

--- a/modules/dicehub/extension/config_test.go
+++ b/modules/dicehub/extension/config_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package extension
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+)
+
+func Test_ConvertConfigExtensionMenu(t *testing.T) {
+	cfg := &config{
+		ExtensionMenu: "{}",
+	}
+	test, err := cfg.ConvertConfigExtensionMenu()
+	want := map[string][]string{}
+	assert.NoError(t, err)
+	assert.Equal(t, test, want)
+
+	cfg.ExtensionMenu = "{\"流水线任务\":[\"source_code_management:代码管理\",\"build_management:构建管理\",\"deploy_management:部署管理\",\"version_management:版本管理\",\"test_management:测试管理\",\"data_management:数据治理\",\"custom_task:自定义任务\"],\"扩展服务\":[\"database:存储\",\"distributed_cooperation:分布式协作\",\"search:搜索\",\"message:消息\",\"content_management:内容管理\",\"security:安全\",\"traffic_load:流量负载\",\"monitoring&logging:监控&日志\",\"content:文本处理\",\"image_processing:图像处理\",\"document_processing:文件处理\",\"sound_processing:音频处理\",\"custom:自定义\",\"general_ability:通用能力\",\"new_retail:新零售能力\",\"srm:采供能力\",\"solution:解决方案\"]}"
+	test, err = cfg.ConvertConfigExtensionMenu()
+	want = map[string][]string{
+		"流水线任务": {
+			"source_code_management:代码管理",
+			"build_management:构建管理",
+			"deploy_management:部署管理",
+			"version_management:版本管理",
+			"test_management:测试管理",
+			"data_management:数据治理",
+			"custom_task:自定义任务",
+		},
+		"扩展服务": {
+			"database:存储",
+			"distributed_cooperation:分布式协作",
+			"search:搜索",
+			"message:消息",
+			"content_management:内容管理",
+			"security:安全",
+			"traffic_load:流量负载",
+			"monitoring&logging:监控&日志",
+			"content:文本处理",
+			"image_processing:图像处理",
+			"document_processing:文件处理",
+			"sound_processing:音频处理",
+			"custom:自定义",
+			"general_ability:通用能力",
+			"new_retail:新零售能力",
+			"srm:采供能力",
+			"solution:解决方案",
+		},
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, test, want)
+}

--- a/modules/dicehub/extension/provider_test.go
+++ b/modules/dicehub/extension/provider_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_provider(t *testing.T) {
-	pv := &provider{Cfg: &config{ExtensionMenu: nil}}
+	pv := &provider{Cfg: &config{ExtensionMenu: "{}"}}
 	pv.newExtensionService()
 	cl := &db.ExtensionConfigDB{}
 	p := &extensionService{


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:

extension provider is in module dicehub

.yml cannot read env like map[string][]string.So read it as string and unmarshal  it when provider init.

Many interface parameters were originally processed by url.QueryUnescape(), but they were omitted during refac. Now add them