### PR TITLE
bugfix pipeline send running events lost info

### DIFF
--- a/modules/pipeline/pipengine/reconciler/listen.go
+++ b/modules/pipeline/pipengine/reconciler/listen.go
@@ -120,12 +120,8 @@ func (r *Reconciler) reconcileAgain(pipelineID uint64) {
 func (r *Reconciler) updateStatusBeforeReconcile(p spec.Pipeline) error {
 	if !p.Status.IsRunningStatus() {
 		oldStatus := p.Status
-		if err := r.updatePipelineStatus(&spec.Pipeline{
-			PipelineBase: spec.PipelineBase{
-				ID:     p.ID,
-				Status: apistructs.PipelineStatusRunning,
-			},
-		}); err != nil {
+		p.Status = apistructs.PipelineStatusRunning
+		if err := r.updatePipelineStatus(&p); err != nil {
 			return err
 		}
 		rlog.PInfof(p.ID, "update pipeline status (%s -> %s)", oldStatus, apistructs.PipelineStatusRunning)


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
The events sent when the pipeline is updated to the running state are missing information, which will cause the FDP service to report an error

erda-issue: [erda-issue](https://erda-org.erda.cloud/erda/dop/projects/387/issues/bug?id=204419&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=467&type=BUG)