### PR TITLE
update(edas): return error when application list is zero

### DIFF
--- a/modules/openapi/api/generate/generate_doc.go
+++ b/modules/openapi/api/generate/generate_doc.go
@@ -24,7 +24,6 @@ import (
 	"github.com/erda-project/erda/pkg/swagger/oas3"
 )
 
-
 func generateDoc(onlyOpenapi bool, resultfile string) {
 	var (
 		apisM     = make(map[string][]*apis.ApiSpec)
@@ -56,7 +55,7 @@ func generateDoc(onlyOpenapi bool, resultfile string) {
 
 func writeSwagger(filename, title string, v3 *openapi3.Swagger) error {
 	filename = filepath.Base(filename)
-	filename = strings.TrimSuffix(filename, filepath.Ext(filename))+".yml"
+	filename = strings.TrimSuffix(filename, filepath.Ext(filename)) + ".yml"
 	filename = title + "-" + filename
 
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)

--- a/modules/scheduler/executor/plugins/edas/edas.go
+++ b/modules/scheduler/executor/plugins/edas/edas.go
@@ -1136,6 +1136,11 @@ func (e *EDAS) getAppID(name string) (string, error) {
 		return "", errors.Errorf("failed to list app, edasCode: %d, message: %s", resp.Code, resp.Message)
 	}
 
+	if len(resp.ApplicationList.Application) == 0 {
+		errMsg := fmt.Sprintf("[EDAS] application list count is 0")
+		logrus.Errorf(errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
 	for _, app := range resp.ApplicationList.Application {
 		if name == app.Name {
 			logrus.Infof("[EDAS] Successfully to get app id: %s, name: %s", app.AppId, name)


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
- update(edas): return error when application list is zero

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |update(edas): return error when application list is zero |
| 🇨🇳 中文    | 为 edas 获取列表时，若列表数量为空，则直接报错返回|


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
