### PR TITLE
fix: scheduler maybe register empty address to eventbox

### DIFF
--- a/modules/eventbox/webhook/builtin.go
+++ b/modules/eventbox/webhook/builtin.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/discover"
 )
 
 // 如果不存在相同名字的 webhook 则创建
@@ -47,19 +46,7 @@ func createIfNotExist(impl *WebHookImpl, req *CreateHookRequest) error {
 
 // MakeSureBuiltinHooks 创建默认 webhook (如果不存在)
 func MakeSureBuiltinHooks(impl *WebHookImpl) error {
-	hooks := []CreateHookRequest{
-		{
-			Name:   "scheduler-clusterhook",
-			Events: []string{"cluster"},
-			URL:    fmt.Sprintf("http://%s/clusterhook", discover.Scheduler()),
-			Active: true,
-			HookLocation: apistructs.HookLocation{
-				Org:         "-1",
-				Project:     "-1",
-				Application: "-1",
-			},
-		},
-	}
+	hooks := make([]CreateHookRequest, 0)
 
 	for i := range hooks {
 		if err := createIfNotExist(impl, &hooks[i]); err != nil {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
1. remove eventbox buildin scheduler webhook
2. add scheduler register cluster event webohook

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     scheduler maybe register empty address to eventbox         |
| 🇨🇳 中文    |     修复 Erda 部署时，scheduler webhook 注册到 eventbox 中为空的情况         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
