### PR TITLE
fix: manage config is nil in edas executor

### DIFF
--- a/modules/scheduler/executor/plugins/k8s/k8s.go
+++ b/modules/scheduler/executor/plugins/k8s/k8s.go
@@ -279,11 +279,6 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 		return nil, err
 	}
 
-	// credential config
-	if cluster.ManageConfig == nil {
-		return nil, fmt.Errorf("cluster %s manage config is nil", clusterName)
-	}
-
 	addr, client, err := util.GetClient(clusterName, cluster.ManageConfig)
 	if err != nil {
 		logrus.Errorf("cluster %s get http client and addr error: %v", clusterName, err)

--- a/modules/scheduler/executor/util/util.go
+++ b/modules/scheduler/executor/util/util.go
@@ -247,6 +247,10 @@ func IsNotFound(err error) bool {
 
 // GetClient get http client with cluster info.
 func GetClient(clusterName string, manageConfig *apistructs.ManageConfig) (string, *httpclient.HTTPClient, error) {
+	if manageConfig == nil {
+		return "", nil, fmt.Errorf("cluster %s manage config is nil", clusterName)
+	}
+
 	inetPortal := "inet://"
 
 	hcOptions := []httpclient.OpOption{


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
fix: manage config is nil in edas executor

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily @wangyc117 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: manage config is nil in edas executor            |
| 🇨🇳 中文    |    修复 Edas 在1.2版本中变更迁移 GetClient 函数导致的 manage config nil          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
