### PR TITLE
Modified the problem that the pipeline cannot be triggered when on merge

### DIFF
--- a/modules/dop/endpoints/pipeline.go
+++ b/modules/dop/endpoints/pipeline.go
@@ -644,7 +644,6 @@ func (e *Endpoints) checkrunCreate(ctx context.Context, r *http.Request, vars ma
 
 		if diceworkspace.IsRefPatternMatch(gitEvent.Content.TargetBranch, pipelineYml.Spec().On.Merge.Branches) {
 			exist = true
-			break
 		}
 
 		if !exist {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug

#### What this PR does / why we need it:

The pipeline cannot be triggered when merging, and it is found that there is a problem with the code logic, and it breaks directly when it matches the branch.

Test link:[Test](https://erda.dev.terminus.io/terminus/dop/projects/2/apps/142)
Steps:
1. Create a new master branch
2. Create a develop branch based on the master branch
3. Create a pipeline.yml file in the develop branch and add on merge
4. Create a merge request from develop to master
Results of the test:
![image](https://user-images.githubusercontent.com/32703277/129327413-5de00699-1e5d-47d5-9e47-3461efb26c10.png)
