### PR TITLE
chngc set cluster_name in filter rule but invalidate

### DIFF
--- a/modules/monitor/alert/alert-apis/adapt/alert_convert.go
+++ b/modules/monitor/alert/alert-apis/adapt/alert_convert.go
@@ -14,6 +14,7 @@
 package adapt
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -314,6 +315,15 @@ func (e *AlertExpression) ToModel(orgName string, alert *Alert, rule *AlertRule)
 		value, ok := filterMap["value"]
 		if !ok {
 			continue
+		}
+		if tag == clusterNameTag || tag == applicationIdTag {
+			v, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("assert cluster_name or application_id is failed")
+			}
+			if !strings.HasPrefix(v, "$") {
+				continue
+			}
 		}
 		if attr, ok := attributes[tag]; ok {
 			val, err := formatOperatorValue(opType, utils.StringType, attr)

--- a/modules/monitor/alert/alert-apis/adapt/customize.go
+++ b/modules/monitor/alert/alert-apis/adapt/customize.go
@@ -271,6 +271,8 @@ const (
 	customizeAlertTypeMicroService = "micro_service_customize"
 	applicationIdTag               = "application_id"
 	applicationIdValue             = "$application_id"
+	clusterNameTag                 = "cluster_name"
+	clusterNameValue               = "$cluster_name"
 )
 
 // CustomizeAlerts .
@@ -382,7 +384,9 @@ func (a *Adapt) CustomizeAlertDetail(id uint64) (*CustomizeAlertDetail, error) {
 			if filter.Tag == applicationIdTag && filter.Value == applicationIdValue {
 				continue
 			}
-
+			if filter.Tag == clusterNameTag && filter.Value.(string) == clusterNameValue {
+				continue
+			}
 			if alert.AlertType == customizeAlertTypeMicroService && a.microServiceFilterTags[filter.Tag] {
 				continue
 			}

--- a/modules/monitor/alert/alert-apis/org-custom-apis.go
+++ b/modules/monitor/alert/alert-apis/org-custom-apis.go
@@ -152,7 +152,7 @@ func (p *provider) createOrgCustomizeAlert(r *http.Request, alert *adapt.Customi
 		ruleMetric := metricMap[rule.Metric]
 		labels := ruleMetric.Labels
 		scope := labels["metric_scope"]
-		scopeId := labels["metric_scope_id"]
+		scopeId := org.Name
 
 		if err := p.checkMetricMeta(rule, metricMap[rule.Metric]); err != nil {
 			return api.Errors.InvalidParameter(err)
@@ -172,6 +172,11 @@ func (p *provider) createOrgCustomizeAlert(r *http.Request, alert *adapt.Customi
 				Value:    scopeId,
 			})
 		}
+		rule.Filters = append(rule.Filters, &adapt.CustomizeAlertRuleFilter{
+			Tag:      "cluster_name",
+			Operator: "in",
+			Value:    "$cluster_name",
+		})
 	}
 	if err := p.checkCustomizeAlert(alert); err != nil {
 		return api.Errors.InvalidParameter(err)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
chngc set cluster_name in filter rule but invalidate

#### Specified Reviewers:
/assign @liuhaoyang 


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      chngc set cluster_name does not take effect when it exists in custom filter rules        |
| 🇨🇳 中文    |       中国金币设置cluster_name在自定义过滤规则中存在时不生效       |
