### PR TITLE
optimize: not retry on post request to hepa

### DIFF
--- a/bundle/msp.go
+++ b/bundle/msp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle/apierrors"
 	"github.com/erda-project/erda/pkg/discover"
+	"github.com/erda-project/erda/pkg/http/httpclient"
 	"github.com/erda-project/erda/pkg/http/httputil"
 )
 
@@ -121,7 +122,7 @@ func (b *Bundle) CreateGatewayTenant(req *apistructs.GatewayTenantRequest) error
 	hc := b.hc
 
 	var resp apistructs.Header
-	r, err := hc.Post(host).
+	r, err := hc.Post(host, httpclient.NoRetry).
 		Path("/api/gateway/tenants").
 		JSONBody(req).
 		Do().

--- a/modules/msp/resource/deploy/handlers/handler.go
+++ b/modules/msp/resource/deploy/handlers/handler.go
@@ -248,6 +248,7 @@ func NewDefaultHandler(dbClient *gorm.DB, logger logs.Logger) *DefaultDeployHand
 			bundle.WithPipeline(),
 			bundle.WithMonitor(),
 			bundle.WithCollector(),
+			bundle.WithHTTPClient(httpclient.New(httpclient.WithTimeout(time.Second*10, time.Second*60))),
 		),
 		Log: logger,
 	}

--- a/modules/msp/resource/deploy/handlers/handler_test.go
+++ b/modules/msp/resource/deploy/handlers/handler_test.go
@@ -99,3 +99,10 @@ func TestMapAppend(t *testing.T) {
 		t.Error("append should be in-place")
 	}
 }
+
+func TestNewDefaultHandler(t *testing.T) {
+	instance := NewDefaultHandler(nil, nil)
+	if instance.Bdl == nil {
+		t.Errorf("DefaultHandler.Bdl should not nil")
+	}
+}


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
createtenant request to hepa, processing is slow, should increase the timeout value, and should not retry because the processing is not idempotent


#### Specified Reviewers:

/assign @johnlanni 
