### PR TITLE
Put selected users at the top of issue filter list

### DIFF
--- a/modules/openapi/component-protocol/scenarios/issue-manage/components/issueFilter/state_conditions.go
+++ b/modules/openapi/component-protocol/scenarios/issue-manage/components/issueFilter/state_conditions.go
@@ -15,6 +15,7 @@ package issueFilter
 
 import (
 	"github.com/erda-project/erda/modules/openapi/component-protocol/components/filter"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 type FrontendConditionProps []filter.PropCondition
@@ -65,6 +66,9 @@ func (f *ComponentFilter) SetStateConditionProps() ([]filter.PropCondition, erro
 				onceProjectMemberQueried = true
 			}
 			cond.Options = onceProjectMemberOptions
+			if userIDs := f.State.FrontendConditionValues.CreatorIDs; userIDs != nil {
+				cond.Options = reorderMemberOption(onceProjectMemberOptions, userIDs)
+			}
 
 		case PropConditionKeyAssigneeIDs:
 			if !onceProjectMemberQueried {
@@ -76,6 +80,9 @@ func (f *ComponentFilter) SetStateConditionProps() ([]filter.PropCondition, erro
 				onceProjectMemberQueried = true
 			}
 			cond.Options = onceProjectMemberOptions
+			if userIDs := f.State.FrontendConditionValues.AssigneeIDs; userIDs != nil {
+				cond.Options = reorderMemberOption(onceProjectMemberOptions, userIDs)
+			}
 
 		case PropConditionKeyOwnerIDs:
 			if f.InParams.FrontendFixedIssueType == "TASK" || f.InParams.FrontendFixedIssueType == "REQUIREMENT" {
@@ -91,6 +98,9 @@ func (f *ComponentFilter) SetStateConditionProps() ([]filter.PropCondition, erro
 				onceProjectMemberQueried = true
 			}
 			cond.Options = onceProjectMemberOptions
+			if userIDs := f.State.FrontendConditionValues.OwnerIDs; userIDs != nil {
+				cond.Options = reorderMemberOption(onceProjectMemberOptions, userIDs)
+			}
 
 		case PropConditionKeyBugStages:
 			if f.InParams.FrontendFixedIssueType == "REQUIREMENT" || f.InParams.FrontendFixedIssueType == "ALL" {
@@ -115,4 +125,17 @@ func (f *ComponentFilter) SetStateConditionProps() ([]filter.PropCondition, erro
 	}
 
 	return newConditions, nil
+}
+
+func reorderMemberOption(options []filter.PropConditionOption, userIDs []string) []filter.PropConditionOption {
+	var selected []filter.PropConditionOption
+	var result []filter.PropConditionOption
+	for _, option := range options {
+		if strutil.Exist(userIDs, option.Value.(string)) {
+			selected = append(selected, option)
+		} else {
+			result = append(result, option)
+		}
+	}
+	return append(selected, result...)
 }

--- a/modules/openapi/component-protocol/scenarios/issue-manage/components/issueFilter/state_conditions_test.go
+++ b/modules/openapi/component-protocol/scenarios/issue-manage/components/issueFilter/state_conditions_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package issueFilter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/erda-project/erda/modules/openapi/component-protocol/components/filter"
+)
+
+func Test_reorderMemberOption(t *testing.T) {
+	type args struct {
+		options []filter.PropConditionOption
+		userIDs []string
+	}
+
+	options := []filter.PropConditionOption{
+		{Value: "1"},
+		{Value: "2"},
+		{Value: "3"},
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []filter.PropConditionOption
+	}{
+		{
+			name: "reorder single item",
+			args: args{
+				options: options,
+				userIDs: []string{
+					"2",
+				},
+			},
+			want: []filter.PropConditionOption{
+				{Value: "2"},
+				{Value: "1"},
+				{Value: "3"},
+			},
+		},
+		{
+			name: "reorder mutliple items",
+			args: args{
+				options: options,
+				userIDs: []string{
+					"2",
+					"3",
+				},
+			},
+			want: []filter.PropConditionOption{
+				{Value: "2"},
+				{Value: "3"},
+				{Value: "1"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reorderMemberOption(tt.args.options, tt.args.userIDs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("reorderMemberOption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR
feature


#### What this PR does / why we need it:
Put selected users at the top of issue filter list, make it easy to select/unselect.

#### Specified Reviewers:

/assign @Effet @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Put selected users at the top of issue management filter list  |
| 🇨🇳 中文    |   事项协同里已选择的用户放在过滤器列表最前面     |

