### PR TITLE
release/1.2 support push extension no need Admin account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,11 @@ copyright:
 
 # docker image
 build-image: prepare
-	./build/scripts/docker_image.sh ${MODULE_PATH} build
+	./build/scripts/docker_image.sh ${MODULE_PATH} build ${EXTENSION_ZIP_ADDRS}
 push-image:
 	./build/scripts/docker_image.sh ${MODULE_PATH} push
 build-push-image: prepare
-	./build/scripts/docker_image.sh ${MODULE_PATH} build-push
+	./build/scripts/docker_image.sh ${MODULE_PATH} build-push ${EXTENSION_ZIP_ADDRS}
 
 build-push-all:
 	MAKE_BUILD_CMD=build-all ./build/scripts/docker_image.sh / build-push

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -6,8 +6,12 @@ RUN mkdir -p "$GOPATH/src/github.com/erda-project/erda/"
 COPY . "$GOPATH/src/github.com/erda-project/erda/"
 WORKDIR "$GOPATH/src/github.com/erda-project/erda/"
 
-ARG CONFIG_PATH
 ARG MODULE_PATH
+ARG EXTENSION_ZIP_ADDRS
+RUN mkdir -p /tmp/dicehub-extension
+RUN if [ ${MODULE_PATH} = dicehub ] ; then ./build/scripts/dicehub/extension-push.sh "${EXTENSION_ZIP_ADDRS}" ; fi
+
+ARG CONFIG_PATH
 ARG DOCKER_IMAGE
 ARG MAKE_BUILD_CMD
 RUN --mount=type=cache,target=/root/.cache/go-build\
@@ -33,6 +37,9 @@ COPY --from=build "$GOPATH/src/github.com/erda-project/erda/bin/${APP_NAME}" "/a
 COPY --from=build "$GOPATH/src/github.com/erda-project/erda/conf/${CONFIG_PATH}" "/app/conf/${CONFIG_PATH}"
 COPY --from=build "$GOPATH/src/github.com/erda-project/erda/pkg/erda-configs" "/app/erda-configs"
 COPY --from=build "$GOPATH/src/github.com/erda-project/erda/conf/common" "/app/conf/common"
+
+# use for dicehub
+COPY --from=build "/tmp/dicehub-extension" "/app/dicehub-extension"
 
 # use for gittar
 COPY --from=build "/go/src/github.com/erda-project/erda/build/dockerfiles/gittar-resource/.gitconfig" "/root/.gitconfig"

--- a/build/scripts/dicehub/extension-push.sh
+++ b/build/scripts/dicehub/extension-push.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+string=$*
+array=(${string//,/ })
+
+for param in ${array[@]}
+do
+    wget $param -O extension$count.zip
+    unzip extension$count.zip -d /tmp/dicehub-extension
+    count=$[$count+1]
+done

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -24,6 +24,7 @@ if [ -z "$1" ]; then
 fi
 MODULE_PATH=$1
 ACTION=$2
+EXTENSION_ZIP_ADDRS=$3
 
 # cd to root directory
 cd $(git rev-parse --show-toplevel)
@@ -128,6 +129,7 @@ build_image()  {
         --build-arg "DOCKER_IMAGE=${DOCKER_IMAGE}" \
         --build-arg "BASE_DOCKER_IMAGE=${BASE_DOCKER_IMAGE}" \
         --build-arg "MAKE_BUILD_CMD=${MAKE_BUILD_CMD}" \
+        --build-arg "EXTENSION_ZIP_ADDRS=${EXTENSION_ZIP_ADDRS}" \
         -f "${DOCKERFILE}" .
 }
 

--- a/modules/dicehub/dbclient/extention.go
+++ b/modules/dicehub/dbclient/extention.go
@@ -225,3 +225,12 @@ func (client *DBClient) GetExtensionVersionCount(name string) (int64, error) {
 		Count(&count).Error
 	return count, err
 }
+
+func (client *DBClient) QueryAllExtensions() ([]ExtensionVersion, error) {
+	var result []ExtensionVersion
+	err := client.Model(&ExtensionVersion{}).Find(&result).Error
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/modules/dicehub/endpoints/endpoints.go
+++ b/modules/dicehub/endpoints/endpoints.go
@@ -105,6 +105,11 @@ func (e *Endpoints) Release() *release.Release {
 	return e.release
 }
 
+// Extension 获取 extension service
+func (e *Endpoints) Extension() *extension.Extension {
+	return e.extension
+}
+
 // Routes 返回 endpoints 的所有 endpoint 方法，也就是 route.
 func (e *Endpoints) Routes() []httpserver.Endpoint {
 	return []httpserver.Endpoint{

--- a/modules/dicehub/initialize.go
+++ b/modules/dicehub/initialize.go
@@ -49,6 +49,9 @@ func Initialize(p *provider) error {
 		return err
 	}
 
+	// extension init
+	go InitExtension(ep.Extension())
+
 	// 启动 release 定时清理任务
 	if err := ReleaseGC(ep.Release()); err != nil {
 		return err
@@ -77,6 +80,14 @@ func ReleaseGC(rl *release.Release) error {
 		recycle.ImageGCCron(rl, etcdStore.GetClient())
 	}
 	return nil
+}
+
+func InitExtension(ex *extension.Extension) {
+	err := ex.InitExtension("/app/extension")
+	if err != nil {
+		panic(err)
+	}
+	logrus.Infoln("End init extension")
 }
 
 // 初始化 Endpoints

--- a/modules/dicehub/service/extension/action.go
+++ b/modules/dicehub/service/extension/action.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package extension
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+type Repo struct {
+	// addr workPath
+	addr string
+	// versions ExtensionVersion dir path
+	versions []string
+}
+
+// Version is a version of an Extension
+type Version struct {
+	Name    string
+	Dirname string
+
+	Spec          *apistructs.Spec // structure of spec.yml
+	SpecContent   []byte           // content of spec.yml
+	DiceContent   []byte           // content of dice.yml
+	ReadmeContent []byte           // content of readme.md
+
+	SwaggerContent []byte // content of swagger.yml
+}
+
+func (s *Extension) InitExtension(addr string) error {
+	logrus.Infoln("Start init extension")
+
+	// get all extensionVersion in repo
+	repo := LoadExtensions(addr)
+
+	// get all extensions existed
+	allActionVersions, err := s.db.QueryAllExtensions()
+	if err != nil {
+		if !gorm.IsRecordNotFoundError(err) {
+			return err
+		}
+	}
+
+	// extensionVersionMap key:ExtensionName value:ExtensionVersion
+	// one extension can have version more then 1
+	extensionVersionMap := make(map[string][]string)
+
+	// extensionTypeMap key:ExtensionName value:ExtensionType
+	extensionTypeMap := make(map[string][]string)
+
+	// add all actionVersions to map
+	for _, v := range allActionVersions {
+		version := extensionVersionMap[v.Name]
+		version = append(version, v.Version)
+		extensionVersionMap[v.Name] = version
+
+		specData := apistructs.Spec{}
+		err = yaml.Unmarshal([]byte(v.Spec), &specData)
+		if err != nil {
+			return err
+		}
+
+		extensionType := extensionTypeMap[v.Name]
+		extensionType = append(extensionType, specData.Type)
+		extensionTypeMap[v.Name] = extensionType
+
+	}
+
+	// push all actionVersions
+	for _, v := range repo.versions {
+		name, version, err := s.RunExtensionsPush(v, extensionVersionMap, extensionTypeMap)
+		if err == nil {
+			logrus.Infoln("extension create success, name: ", name, ", version: ", version)
+		} else {
+			logrus.Infoln("extension create false, name: ", name, ", version: ", version, " err: ", err)
+		}
+	}
+	return nil
+}
+
+// RunExtensionsPush push extensions
+func (s *Extension) RunExtensionsPush(dir string, extensionVersionMap, extensionTypeMap map[string][]string) (string, string, error) {
+	version, err := NewVersion(dir)
+	if err != nil {
+		return "", "", err
+	}
+
+	specData := version.Spec
+
+	// if extension is existed, return
+	versionNow := extensionVersionMap[specData.Name]
+	typeNow := extensionTypeMap[specData.Name]
+	needCreate := true
+	for i, version := range versionNow {
+		if version == specData.Version && typeNow[i] == specData.Type {
+			needCreate = false
+			break
+		}
+	}
+	if !needCreate {
+		return "", "", errors.New("extension is existed")
+	}
+
+	var request = &apistructs.ExtensionVersionCreateRequest{
+		Name:        specData.Name,
+		Version:     specData.Version,
+		SpecYml:     string(version.SpecContent),
+		DiceYml:     string(version.DiceContent),
+		SwaggerYml:  string(version.SwaggerContent),
+		Readme:      string(version.ReadmeContent),
+		Public:      specData.Public,
+		ForceUpdate: false,
+		All:         false,
+		IsDefault:   specData.IsDefault,
+	}
+
+	_, err = s.CreateExtensionVersion(request)
+	if err != nil {
+		return "", "", err
+	}
+
+	return request.Name, request.Version, err
+}
+
+func NewVersion(dirname string) (*Version, error) {
+	fileInfos, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to ReadDir")
+	}
+
+	var version = Version{
+		Name:           filepath.Base(dirname),
+		Dirname:        dirname,
+		Spec:           new(apistructs.Spec),
+		SpecContent:    nil,
+		DiceContent:    nil,
+		ReadmeContent:  nil,
+		SwaggerContent: nil,
+	}
+	for _, fileInfo := range fileInfos {
+		if fileInfo.IsDir() {
+			continue
+		}
+		switch {
+		case strings.EqualFold(fileInfo.Name(), "spec.yml") || strings.EqualFold(fileInfo.Name(), "spec.yaml"):
+			version.SpecContent, err = ioutil.ReadFile(filepath.Join(dirname, fileInfo.Name()))
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to ReadFile")
+			}
+			if err = yaml.Unmarshal(version.SpecContent, version.Spec); err != nil {
+				return nil, errors.Wrap(err, "failed to parse "+fileInfo.Name())
+			}
+
+		case strings.EqualFold(fileInfo.Name(), "dice.yml") || strings.EqualFold(fileInfo.Name(), "dice.yaml"):
+			version.DiceContent, _ = ioutil.ReadFile(filepath.Join(dirname, fileInfo.Name()))
+
+		case strings.EqualFold(fileInfo.Name(), "readme.md") || strings.EqualFold(fileInfo.Name(), "readme.markdown"):
+			version.ReadmeContent, _ = ioutil.ReadFile(filepath.Join(dirname, fileInfo.Name()))
+
+		case strings.EqualFold(fileInfo.Name(), "swagger.json") || strings.EqualFold(fileInfo.Name(), "swagger.yml") ||
+			strings.EqualFold(fileInfo.Name(), "swagger.yaml"):
+			version.SwaggerContent, _ = ioutil.ReadFile(filepath.Join(dirname, fileInfo.Name()))
+		}
+	}
+
+	if version.Spec == nil || len(version.SpecContent) == 0 {
+		return nil, errors.Errorf("spec file not found in %s", dirname)
+	}
+
+	return &version, nil
+}
+
+// LoadExtensions loads all extensions from the repo (contains all versions below)
+func LoadExtensions(addr string) *Repo {
+	repo := &Repo{
+		addr: addr,
+	}
+	repo.locate(repo.addr, 0)
+	return repo
+}
+
+// locate Recursively traverse folders
+func (repo *Repo) locate(dirname string, deep int) {
+	infos, ok := isThereSpecFile(dirname)
+	if ok {
+		repo.versions = append(repo.versions, dirname)
+		return
+	}
+
+	for _, cur := range infos {
+		// only find path /repoName/actions/actionsName
+		if deep == 1 && (cur.Name() != "actions" || !cur.IsDir()) {
+			continue
+		}
+		repo.locate(filepath.Join(dirname, cur.Name()), deep+1)
+	}
+}
+
+// isThereSpecFile  check is there have spec.yml
+func isThereSpecFile(dirname string) ([]os.FileInfo, bool) {
+	var dirs []os.FileInfo
+	infos, err := ioutil.ReadDir(dirname)
+	if err != nil {
+		return nil, false
+	}
+	for _, file := range infos {
+		if file.IsDir() {
+			dirs = append(dirs, file)
+			continue
+		}
+		if strings.EqualFold(file.Name(), "spec.yml") || strings.EqualFold(file.Name(), "spec.yaml") {
+			return nil, true
+		}
+	}
+	return dirs, false
+}

--- a/modules/dicehub/service/extension/extension.action_test.go
+++ b/modules/dicehub/service/extension/extension.action_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package extension
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/alecthomas/assert"
+)
+
+func Test_action_isThereSpecFile(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	_, v := isThereSpecFile(dir)
+	assert.Equal(t, v, false)
+
+	os.Create(path.Join(dir, "spec.yaml"))
+	assert.NoError(t, err)
+	_, v = isThereSpecFile(dir)
+	assert.Equal(t, v, true)
+}
+
+func Test_action_LoadExtensions(t *testing.T) {
+	dir := path.Join(os.TempDir(), "extension")
+	dir1 := path.Join(dir, "test1", "actions", "one")
+	dir2 := path.Join(dir, "test2", "actions", "two")
+
+	err := os.MkdirAll(dir1, os.ModePerm)
+	assert.NoError(t, err)
+	err = os.MkdirAll(dir2, os.ModePerm)
+	assert.NoError(t, err)
+	defer func() {
+		err := os.RemoveAll(dir)
+		assert.NoError(t, err)
+	}()
+
+	f, err := os.Create(path.Join(dir1, "spec.yaml"))
+	assert.NoError(t, err)
+	specYml := `name: api-publish
+version: "1.0"
+type: action`
+	_, err = f.Write([]byte(specYml))
+	assert.NoError(t, err)
+
+	tests := &Repo{
+		addr:     dir,
+		versions: []string{dir1},
+	}
+
+	r := LoadExtensions(dir)
+	assert.Equal(t, tests, r)
+}


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

Before, push extension need admin permission
Therefore, open source users who want to push extensions need to create an admin account first.
To solve this problem, allow users to push extensions from external repositories

When packaging the image, download the external code, and every time the “dicehub” is started, new actions will be created according to the action in the external repositories

if want to push extension in erda-addons and erda-actions, you can use it to build docker image.
make build-push-image MODULE_PATH=dicehub EXTENSION_ZIP_ADDRS="https://github.com/erda-project/erda-actions/archive/refs/heads/master.zip"

The original PR is based on the extension provider, release/1.2 does not have an extension provider yet, so this pr was created for release/1.2
original PR: https://github.com/erda-project/erda/pull/1449