### PR TITLE
create alert rule is failed

### DIFF
--- a/modules/core/monitor/alert/alert-apis/adapt/alert_convert.go
+++ b/modules/core/monitor/alert/alert-apis/adapt/alert_convert.go
@@ -14,7 +14,6 @@
 package adapt
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -468,11 +467,10 @@ func ToDBAlertExpressionModel(e *pb.AlertExpression, orgName string, alert *pb.A
 		}
 		if tag == ClusterName || tag == ApplicationId {
 			v, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("assert cluster_name or application_id is failed")
-			}
-			if !strings.HasPrefix(v, "$") {
-				continue
+			if ok {
+				if !strings.HasPrefix(v, "$") {
+					continue
+				}
 			}
 		}
 		if attr, ok := attributes[tag]; ok {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:

#### Specified Reviewers:
/assign @liuhaoyang 

#### ChangeLog
| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Use system built-in rules to create an alarm report assert cluster_name or application_is is failed        |
| 🇨🇳 中文    |        使用系统内置规则创建告警报assert cluster_name or application_is is failed      |

