### PR TITLE
retry reconcile task until no platform errors

### DIFF
--- a/apistructs/pipeline_task.go
+++ b/apistructs/pipeline_task.go
@@ -14,6 +14,9 @@
 package apistructs
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -48,11 +51,11 @@ type PipelineTaskExtra struct {
 }
 
 type PipelineTaskResult struct {
-	Metadata    Metadata                 `json:"metadata,omitempty"`
-	Errors      []ErrorResponse          `json:"errors,omitempty"`
-	MachineStat *PipelineTaskMachineStat `json:"machineStat,omitempty"`
-	Inspect     string                   `json:"inspect,omitempty"`
-	Events      string                   `json:"events,omitempty"`
+	Metadata    Metadata                   `json:"metadata,omitempty"`
+	Errors      []*PipelineTaskErrResponse `json:"errors,omitempty"`
+	MachineStat *PipelineTaskMachineStat   `json:"machineStat,omitempty"`
+	Inspect     string                     `json:"inspect,omitempty"`
+	Events      string                     `json:"events,omitempty"`
 }
 
 type PipelineTaskSnippetDetail struct {
@@ -134,6 +137,85 @@ type PipelineTaskLoopOptions struct {
 type PipelineTaskLoop struct {
 	Break    string        `json:"break" yaml:"break"`
 	Strategy *LoopStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty"`
+}
+
+type PipelineTaskErrResponse struct {
+	Code string             `json:"code"`
+	Msg  string             `json:"msg"`
+	Ctx  PipelineTaskErrCtx `json:"ctx"`
+}
+
+type PipelineTaskErrCtx struct {
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+	Count     uint64    `json:"count"`
+}
+
+type orderedResponses []*PipelineTaskErrResponse
+
+func (o orderedResponses) Len() int           { return len(o) }
+func (o orderedResponses) Less(i, j int) bool { return o[i].Ctx.EndTime.Before(o[j].Ctx.EndTime) }
+func (o orderedResponses) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }
+
+func (t *PipelineTaskResult) AppendError(newResponses ...*PipelineTaskErrResponse) []*PipelineTaskErrResponse {
+	if len(newResponses) == 0 {
+		return t.Errors
+	}
+	var orderd orderedResponses
+	for _, g := range t.Errors {
+		orderd = append(orderd, g)
+	}
+
+	var newResponseOrder orderedResponses
+	now := time.Now()
+	for index, g := range newResponses {
+		if g.Ctx.EndTime.IsZero() {
+			g.Ctx.EndTime = now.Add(time.Duration(index) * time.Millisecond)
+		}
+		if g.Ctx.Count == 0 {
+			g.Ctx.Count = 1
+		}
+		newResponseOrder = append(newResponseOrder, g)
+	}
+	sort.Sort(newResponseOrder)
+
+	var lastResponse *PipelineTaskErrResponse
+	if len(orderd) != 0 {
+		lastResponse = orderd[len(orderd)-1]
+	}
+
+	for _, g := range newResponseOrder {
+		if lastResponse == nil {
+			orderd = append(orderd, g)
+			lastResponse = g
+			continue
+		}
+
+		if strings.EqualFold(lastResponse.Msg, g.Msg) {
+			if !g.Ctx.StartTime.IsZero() && g.Ctx.StartTime.Before(lastResponse.Ctx.StartTime) {
+				lastResponse.Ctx.StartTime = g.Ctx.StartTime
+			}
+			if g.Ctx.EndTime.After(lastResponse.Ctx.EndTime) {
+				lastResponse.Ctx.EndTime = g.Ctx.EndTime
+			}
+			lastResponse.Ctx.Count++
+			continue
+		} else {
+			orderd = append(orderd, g)
+			lastResponse = g
+		}
+	}
+	return orderd
+}
+
+func (t *PipelineTaskResult) ConvertErrors() {
+	for _, response := range t.Errors {
+		if !response.Ctx.StartTime.IsZero() {
+			response.Msg = fmt.Sprintf("%s, startTime: %s, endTIme: %s, count: %d",
+				response.Msg, response.Ctx.StartTime.Format("2006-01-02 15:04:05"),
+				response.Ctx.EndTime.Format("2006-01-02 15:04:05"), response.Ctx.Count)
+		}
+	}
 }
 
 func (l *PipelineTaskLoop) Duplicate() *PipelineTaskLoop {

--- a/apistructs/pipeline_task_test.go
+++ b/apistructs/pipeline_task_test.go
@@ -16,9 +16,32 @@ package apistructs
 import (
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPipelineTaskLoop_Duplicate(t *testing.T) {
 	var l *PipelineTaskLoop
 	fmt.Println(l.Duplicate())
+}
+
+func TestPipelineTaskAppendError(t *testing.T) {
+	task := PipelineTaskDTO{}
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "a"})
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "a"})
+	assert.Equal(t, 1, len(task.Result.Errors))
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "b"})
+	assert.Equal(t, 2, len(task.Result.Errors))
+	startA := time.Date(2021, 8, 19, 10, 10, 0, 0, time.Local)
+	endA := time.Date(2021, 8, 19, 10, 30, 0, 0, time.Local)
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "a", Ctx: PipelineTaskErrCtx{StartTime: startA, EndTime: endA}})
+	assert.Equal(t, 3, len(task.Result.Errors))
+	start := time.Date(2021, 8, 19, 10, 9, 0, 0, time.Local)
+	end := time.Date(2021, 8, 19, 10, 29, 0, 0, time.Local)
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "a", Ctx: PipelineTaskErrCtx{StartTime: start, EndTime: end}})
+	assert.Equal(t, uint64(2), task.Result.Errors[2].Ctx.Count)
+	assert.Equal(t, 3, len(task.Result.Errors))
+	assert.Equal(t, start.Unix(), task.Result.Errors[2].Ctx.StartTime.Unix())
+	assert.Equal(t, endA.Unix(), task.Result.Errors[2].Ctx.EndTime.Unix())
 }

--- a/modules/pipeline/pipengine/reconciler/task.go
+++ b/modules/pipeline/pipengine/reconciler/task.go
@@ -22,6 +22,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/rlog"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/taskrun"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/taskrun/taskop"
+	"github.com/erda-project/erda/modules/pipeline/pkg/errorsx"
 	"github.com/erda-project/erda/pkg/loop"
 )
 
@@ -41,10 +42,10 @@ func reconcileTask(tr *taskrun.TaskRun) error {
 	rlog.TDebugf(tr.P.ID, tr.Task.ID, "end do task aop")
 
 	// 系统异常时重试3次
-	const abnormalErrMaxRetryTimes = 3
+	//const abnormalErrMaxRetryTimes = 3
 
 	var platformErrRetryTimes int
-	var sessionNotFoundTimes int
+	//var sessionNotFoundTimes int
 
 	for {
 		// stop reconciler task if pipeline stopping reconcile
@@ -83,24 +84,15 @@ func reconcileTask(tr *taskrun.TaskRun) error {
 			// Do 没有 err 才是正常的，即使失败也是 status=Failed，没有 error
 			abnormalErr := tr.Do(taskOp)
 			if abnormalErr != nil {
-				rlog.TWarnf(tr.P.ID, tr.Task.ID, "failed to handle taskOp: %s, abnormalErr: %v, continue retry", taskOp.Op(), abnormalErr)
-				// if abnormalErr like failed to find Session for client xxx, don`t add platformErrRetryTimes
-				// continue retry until find session
-				if tr.IsSessionNotFound(abnormalErr) {
-					sessionNotFoundTimes++
-					rlog.TWarnf(tr.P.ID, tr.Task.ID, "continue retry task, err: %v, session not found times: %d", abnormalErr, sessionNotFoundTimes)
-					resetTaskForAbnormalRetry(tr, platformErrRetryTimes)
-					continue
+				if errorsx.IsContainUserError(abnormalErr) {
+					rlog.TErrorf(tr.P.ID, tr.Task.ID, "failed to handle taskOp: %s, user abnormalErr: %v, don't need retry", taskOp.Op(), abnormalErr)
+					return abnormalErr
 				}
-				// 小于异常重试次数，继续重试
-				if platformErrRetryTimes < abnormalErrMaxRetryTimes {
-					resetTaskForAbnormalRetry(tr, platformErrRetryTimes)
-					platformErrRetryTimes++
-					continue
-				}
-				// 大于重试次数仍有异常，返回异常
-				rlog.TErrorf(tr.P.ID, tr.Task.ID, "failed to handle taskOp: %s, abnormalErr: %v, reach max retry times, return abnormalErr", taskOp.Op(), abnormalErr)
-				return abnormalErr
+				// don't contain user error mean err is platform error, should retry always
+				rlog.TErrorf(tr.P.ID, tr.Task.ID, "failed to handle taskOp: %s, abnormalErr: %v, continue retry, retry times: %d", taskOp.Op(), abnormalErr, platformErrRetryTimes)
+				resetTaskForAbnormalRetry(tr, platformErrRetryTimes)
+				platformErrRetryTimes++
+				continue
 			}
 			// 没有异常，执行后续逻辑
 		}

--- a/modules/pipeline/pipengine/reconciler/task.go
+++ b/modules/pipeline/pipengine/reconciler/task.go
@@ -135,7 +135,5 @@ func resetTaskForAbnormalRetry(tr *taskrun.TaskRun, abnormalErrRetryTimes int) {
 	rlog.TDebugf(tr.P.ID, tr.Task.ID, "sleep %s before retry abnormal retry", interval.String())
 	time.Sleep(interval)
 
-	// 更新状态
-	tr.Task.Status = apistructs.PipelineStatusAnalyzed
 	tr.Update()
 }

--- a/modules/pipeline/pipengine/reconciler/task_test.go
+++ b/modules/pipeline/pipengine/reconciler/task_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/alecthomas/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/taskrun"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func TestResetTaskForAbnormalRetry(t *testing.T) {
+	tr := &taskrun.TaskRun{
+		P: &spec.Pipeline{},
+		Task: &spec.PipelineTask{
+			Status: apistructs.PipelineStatusAnalyzeFailed,
+		},
+	}
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(tr), "Update",
+		func(tr *taskrun.TaskRun) {
+			return
+		})
+	defer m.Unpatch()
+	tm := monkey.Patch(time.Sleep, func(d time.Duration) {
+		return
+	})
+	defer tm.Unpatch()
+	resetTaskForAbnormalRetry(tr, 1)
+	assert.Equal(t, apistructs.PipelineStatusAnalyzed, tr.Task.Status)
+}

--- a/modules/pipeline/pipengine/reconciler/task_test.go
+++ b/modules/pipeline/pipengine/reconciler/task_test.go
@@ -43,5 +43,5 @@ func TestResetTaskForAbnormalRetry(t *testing.T) {
 	})
 	defer tm.Unpatch()
 	resetTaskForAbnormalRetry(tr, 1)
-	assert.Equal(t, apistructs.PipelineStatusAnalyzed, tr.Task.Status)
+	assert.Equal(t, apistructs.PipelineStatusAnalyzeFailed, tr.Task.Status)
 }

--- a/modules/pipeline/pipengine/reconciler/taskrun/framework.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/framework.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	sessionNotFoundError = "failed to find Session"
+	sessionNotFoundError = "failed to find session"
 )
 
 func (tr *TaskRun) Do(itr TaskOp) error {
@@ -196,5 +196,5 @@ func (tr *TaskRun) LogStep(taskOp Op, step string) {
 }
 
 func (tr *TaskRun) IsSessionNotFound(err error) bool {
-	return strings.Contains(err.Error(), sessionNotFoundError)
+	return strings.Contains(strings.ToLower(err.Error()), sessionNotFoundError)
 }

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -36,6 +36,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/pipengine/pvolumes"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/queue/throttler"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/taskrun"
+	"github.com/erda-project/erda/modules/pipeline/pkg/errorsx"
 	"github.com/erda-project/erda/modules/pipeline/services/apierrors"
 	"github.com/erda-project/erda/modules/pipeline/services/extmarketsvc"
 	"github.com/erda-project/erda/modules/pipeline/spec"
@@ -171,7 +172,7 @@ func (pre *prepare) makeTaskRun() (needRetry bool, err error) {
 		pipelineyml.WithRunParams(p.Snapshot.RunPipelineParams),
 	)
 	if err != nil {
-		return false, apierrors.ErrParsePipelineYml.InternalError(err)
+		return false, errorsx.UserErrorf(err.Error())
 	}
 
 	// 从 extension marketplace 获取 image 和 resource limit
@@ -435,7 +436,7 @@ func (pre *prepare) makeTaskRun() (needRetry bool, err error) {
 		// only k8sjob support create job volume
 		schedExecutor, ok := pre.Executor.(*scheduler.Sched)
 		if !ok {
-			return false, fmt.Errorf("failed to createJobVolume, err: invalid task executor kind")
+			return false, errorsx.UserErrorf("failed to createJobVolume, err: invalid task executor kind")
 		}
 		_, schedPlugin, err := schedExecutor.GetTaskExecutor(task.Type, p.ClusterName, task)
 		if err != nil {

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -75,7 +75,7 @@ func (pre *prepare) WhenDone(data interface{}) error {
 	// no need retry
 	if err != nil {
 		pre.Task.Status = apistructs.PipelineStatusAnalyzeFailed
-		pre.Task.Result.Errors = append(pre.Task.Result.Errors, apistructs.ErrorResponse{Msg: err.Error()})
+		pre.Task.Result.Errors = pre.Task.Result.AppendError(&apistructs.PipelineTaskErrResponse{Msg: err.Error()})
 		return nil
 	}
 
@@ -752,16 +752,14 @@ func condition(task *spec.PipelineTask) bool {
 	if sign.Err != nil {
 		task.Status = apistructs.PipelineStatusFailed
 		if sign.Err != nil {
-			task.Result.Errors = append(task.Result.Errors, apistructs.ErrorResponse{
-				Code: "",
-				Msg:  sign.Err.Error(),
+			task.Result.Errors = task.Result.AppendError(&apistructs.PipelineTaskErrResponse{
+				Msg: sign.Err.Error(),
 			})
 		}
 
 		if sign.Msg != "" {
-			task.Result.Errors = append(task.Result.Errors, apistructs.ErrorResponse{
-				Code: "",
-				Msg:  sign.Msg,
+			task.Result.Errors = task.Result.AppendError(&apistructs.PipelineTaskErrResponse{
+				Msg: sign.Msg,
 			})
 		}
 		return true
@@ -771,16 +769,14 @@ func condition(task *spec.PipelineTask) bool {
 		task.Status = apistructs.PipelineStatusNoNeedBySystem
 		task.Extra.AllowFailure = true
 		if sign.Err != nil {
-			task.Result.Errors = append(task.Result.Errors, apistructs.ErrorResponse{
-				Code: "",
-				Msg:  sign.Err.Error(),
+			task.Result.Errors = task.Result.AppendError(&apistructs.PipelineTaskErrResponse{
+				Msg: sign.Err.Error(),
 			})
 		}
 
 		if sign.Msg != "" {
-			task.Result.Errors = append(task.Result.Errors, apistructs.ErrorResponse{
-				Code: "",
-				Msg:  sign.Msg,
+			task.Result.Errors = task.Result.AppendError(&apistructs.PipelineTaskErrResponse{
+				Msg: sign.Msg,
 			})
 		}
 		return true

--- a/modules/pipeline/pipengine/reconciler/taskrun/update.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/update.go
@@ -68,7 +68,7 @@ func (tr *TaskRun) AppendLastMsg(msg string) error {
 	if err := tr.fetchLatestTask(); err != nil {
 		return err
 	}
-	tr.Task.Result.Errors = append(tr.Task.Result.Errors, apistructs.ErrorResponse{Msg: msg})
+	tr.Task.Result.Errors = tr.Task.Result.AppendError(&apistructs.PipelineTaskErrResponse{Msg: msg})
 	if err := tr.DBClient.UpdatePipelineTaskResult(tr.Task.ID, tr.Task.Result); err != nil {
 		logrus.Errorf("[alert] reconciler: pipelineID: %d, task %q append last message failed, err: %v",
 			tr.P.ID, tr.Task.Name, err)

--- a/modules/pipeline/pkg/errorsx/errors.go
+++ b/modules/pipeline/pkg/errorsx/errors.go
@@ -18,6 +18,10 @@ import (
 	"strings"
 )
 
+const (
+	sessionNotFoundError = "failed to find session"
+)
+
 type errType string
 
 var (
@@ -84,4 +88,16 @@ func IsUserError(err error) bool {
 
 func IsContainUserError(err error) bool {
 	return strings.Contains(err.Error(), fmt.Sprintf("errType: %s", userAbnormalError))
+}
+
+func IsSessionNotFound(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), sessionNotFoundError)
+}
+
+func IsTimeoutError(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "timeout") || strings.Contains(strings.ToLower(err.Error()), "time out")
+}
+
+func IsNetworkError(err error) bool {
+	return IsSessionNotFound(err) || IsTimeoutError(err)
 }

--- a/modules/pipeline/pkg/errorsx/errors.go
+++ b/modules/pipeline/pkg/errorsx/errors.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package errorsx
+
+import (
+	"fmt"
+	"strings"
+)
+
+type errType string
+
+var (
+	platformAbnormalError errType = "platform-error"
+	userAbnormalError     errType = "user-error"
+)
+
+type fundamental struct {
+	msg string
+	errType
+}
+
+func (f *fundamental) Error() string {
+	return fmt.Sprintf("errType: %s, %s", f.errType, f.msg)
+}
+
+func New(message string) error {
+	return &fundamental{
+		msg: message,
+	}
+}
+
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+func PlatformErrorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:     fmt.Sprintf(format, args...),
+		errType: platformAbnormalError,
+	}
+}
+
+func UserErrorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:     fmt.Sprintf(format, args...),
+		errType: userAbnormalError,
+	}
+}
+
+func IsPlatformError(err error) bool {
+	if err == nil {
+		return false
+	}
+	e, ok := err.(*fundamental)
+	if !ok {
+		return false
+	}
+	return e.errType == platformAbnormalError
+}
+
+func IsUserError(err error) bool {
+	if err == nil {
+		return false
+	}
+	e, ok := err.(*fundamental)
+	if !ok {
+		return false
+	}
+	return e.errType == userAbnormalError
+}
+
+func IsContainUserError(err error) bool {
+	return strings.Contains(err.Error(), fmt.Sprintf("errType: %s", userAbnormalError))
+}

--- a/modules/pipeline/pkg/errorsx/errors_test.go
+++ b/modules/pipeline/pkg/errorsx/errors_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package errorsx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPlatformError(t *testing.T) {
+	pErr := PlatformErrorf("failed to do")
+	err := Errorf("failed to do")
+	assert.Equal(t, true, IsPlatformError(pErr))
+	assert.Equal(t, false, IsPlatformError(err))
+}
+
+func TestIsUserError(t *testing.T) {
+	uErr := UserErrorf("failed to do")
+	err := Errorf("failed to do")
+	assert.Equal(t, true, IsUserError(uErr))
+	assert.Equal(t, false, IsUserError(err))
+}
+
+func TestIsContainUserError(t *testing.T) {
+	pErr := PlatformErrorf("failed to do")
+	uErr := UserErrorf("failed to do")
+	assert.Equal(t, false, IsContainUserError(pErr))
+	assert.Equal(t, true, IsContainUserError(uErr))
+}

--- a/modules/pipeline/pkg/errorsx/errors_test.go
+++ b/modules/pipeline/pkg/errorsx/errors_test.go
@@ -16,6 +16,7 @@ package errorsx
 import (
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +39,13 @@ func TestIsContainUserError(t *testing.T) {
 	uErr := UserErrorf("failed to do")
 	assert.Equal(t, false, IsContainUserError(pErr))
 	assert.Equal(t, true, IsContainUserError(uErr))
+}
+
+func TestIsNetworkError(t *testing.T) {
+	sessionErr := errors.New("failed to find Session for client xxx")
+	timeoutErr := errors.New("Get http://xxx.com: net/http TLS handshake timeout")
+	normalErr := errors.New("failed to do")
+	assert.Equal(t, true, IsNetworkError(sessionErr))
+	assert.Equal(t, true, IsNetworkError(timeoutErr))
+	assert.Equal(t, false, IsNetworkError(normalErr))
 }

--- a/modules/pipeline/services/pipelinesvc/callback.go
+++ b/modules/pipeline/services/pipelinesvc/callback.go
@@ -80,8 +80,14 @@ func (s *PipelineSvc) appendPipelineTaskResult(p *spec.Pipeline, task *spec.Pipe
 	}
 	// metadata
 	task.Result.Metadata = append(task.Result.Metadata, cb.Metadata...)
-	// error
-	task.Result.Errors = append(task.Result.Errors, cb.Errors...)
+	// TODO action agent should add err start time and end time
+	taskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
+	for _, e := range cb.Errors {
+		taskErrors = append(taskErrors, &apistructs.PipelineTaskErrResponse{
+			Msg: e.Msg,
+		})
+	}
+	task.Result.Errors = task.Result.AppendError(taskErrors...)
 	// machine stat
 	if cb.MachineStat != nil {
 		task.Result.MachineStat = cb.MachineStat

--- a/modules/pipeline/services/pipelinesvc/callback.go
+++ b/modules/pipeline/services/pipelinesvc/callback.go
@@ -81,13 +81,13 @@ func (s *PipelineSvc) appendPipelineTaskResult(p *spec.Pipeline, task *spec.Pipe
 	// metadata
 	task.Result.Metadata = append(task.Result.Metadata, cb.Metadata...)
 	// TODO action agent should add err start time and end time
-	taskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
+	newTaskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
 	for _, e := range cb.Errors {
-		taskErrors = append(taskErrors, &apistructs.PipelineTaskErrResponse{
+		newTaskErrors = append(newTaskErrors, &apistructs.PipelineTaskErrResponse{
 			Msg: e.Msg,
 		})
 	}
-	task.Result.Errors = task.Result.AppendError(taskErrors...)
+	task.Result.Errors = task.Result.AppendError(newTaskErrors...)
 	// machine stat
 	if cb.MachineStat != nil {
 		task.Result.MachineStat = cb.MachineStat

--- a/modules/pipeline/services/pipelinesvc/callback_test.go
+++ b/modules/pipeline/services/pipelinesvc/callback_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package pipelinesvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func TestAppendPipelineTaskResult(t *testing.T) {
+	cb := apistructs.ActionCallback{
+		Errors: []apistructs.ErrorResponse{
+			apistructs.ErrorResponse{Msg: "a"},
+			apistructs.ErrorResponse{Msg: "b"},
+			apistructs.ErrorResponse{Msg: "a"},
+			apistructs.ErrorResponse{Msg: "a"},
+		},
+	}
+
+	task := &spec.PipelineTask{
+		Result: apistructs.PipelineTaskResult{
+			Errors: []*apistructs.PipelineTaskErrResponse{
+				&apistructs.PipelineTaskErrResponse{Msg: "a"},
+			},
+		},
+	}
+
+	newTaskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
+	for _, e := range cb.Errors {
+		newTaskErrors = append(newTaskErrors, &apistructs.PipelineTaskErrResponse{
+			Msg: e.Msg,
+		})
+	}
+	task.Result.Errors = task.Result.AppendError(newTaskErrors...)
+
+	assert.Equal(t, 3, len(task.Result.Errors))
+}

--- a/modules/pipeline/spec/pipeline_task.go
+++ b/modules/pipeline/spec/pipeline_task.go
@@ -185,6 +185,7 @@ func (pt *PipelineTask) Convert2DTO() *apistructs.PipelineTaskDTO {
 	if pt == nil {
 		return nil
 	}
+	pt.Result.ConvertErrors()
 	task := apistructs.PipelineTaskDTO{
 		ID:         pt.ID,
 		PipelineID: pt.PipelineID,


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
add two error type(platform, user)
retry reconcile task always  if error is platform error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=207028&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer
@sfwn 

