### PR TITLE
when "make build-push-all" ,add extension file in image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ build-push-image: prepare
 	./build/scripts/docker_image.sh ${MODULE_PATH} build-push ${EXTENSION_ZIP_ADDRS}
 
 build-push-all:
-	MAKE_BUILD_CMD=build-all ./build/scripts/docker_image.sh / build-push
+	MAKE_BUILD_CMD=build-all ./build/scripts/docker_image.sh / build-push ${EXTENSION_ZIP_ADDRS}
 build-push-base-image:
 	./build/scripts/base_image.sh build-push
 

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR "$GOPATH/src/github.com/erda-project/erda/"
 ARG MODULE_PATH
 ARG EXTENSION_ZIP_ADDRS
 RUN mkdir -p /tmp/dicehub-extension
-RUN if [ ${MODULE_PATH} = dicehub ] ; then ./build/scripts/dicehub/extension-push.sh "${EXTENSION_ZIP_ADDRS}" ; fi
+RUN if [ ${MODULE_PATH} = dicehub ] || [ -z ${MODULE_PATH} ]; then ./build/scripts/dicehub/extension-push.sh "${EXTENSION_ZIP_ADDRS}" ; fi
 
 ARG CONFIG_PATH
 ARG DOCKER_IMAGE


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

when "make build-push-all" ,add extension file in image for init extension data in SQL

I have tested it:
only keep dicehub and dop in /cmd 
make build-push-all EXTENSION_ZIP_ADDRS="https://github.com/erda-project/erda-actions/archive/refs/heads/master.zip"
docker run 
![image](https://user-images.githubusercontent.com/74653472/129835024-e07a2c4a-5a80-4a07-8125-f512a08cc164.png)
extensions dir is right

#### Need cherry-pick to release versions?

/cherry-pick release/1.2
