### PR TITLE
fix: change the error prompt from Chinese to English for addon delete

### DIFF
--- a/modules/orchestrator/services/addon/addon.go
+++ b/modules/orchestrator/services/addon/addon.go
@@ -1365,7 +1365,7 @@ func (a *Addon) DeleteTenant(userID, addonTenantID string) error {
 			return err
 		}
 		if !permissionResult.Access {
-			return errors.New("权限不足")
+			return errors.New("access denied")
 		}
 	}
 
@@ -1401,7 +1401,7 @@ func (a *Addon) Delete(userID, routingInstanceID string) error {
 			return err
 		}
 		if !permissionResult.Access {
-			return errors.New("权限不足")
+			return errors.New("access denied")
 		}
 	}
 	// 若引用关系存在，不能删除
@@ -1411,7 +1411,7 @@ func (a *Addon) Delete(userID, routingInstanceID string) error {
 		return err
 	}
 	if count > 0 {
-		return errors.New("addon正在被引用，无法删除")
+		return errors.New("addon is being referenced,can't delete")
 	}
 
 	routingInstance, err := a.db.GetInstanceRouting(routingInstanceID)

--- a/modules/orchestrator/services/addon/addon.go
+++ b/modules/orchestrator/services/addon/addon.go
@@ -1411,7 +1411,7 @@ func (a *Addon) Delete(userID, routingInstanceID string) error {
 		return err
 	}
 	if count > 0 {
-		return errors.New("addon is being referenced,can't delete")
+		return errors.New("addon is being referenced, can't delete")
 	}
 
 	routingInstance, err := a.db.GetInstanceRouting(routingInstanceID)

--- a/modules/orchestrator/services/addon/addon_test.go
+++ b/modules/orchestrator/services/addon/addon_test.go
@@ -82,3 +82,31 @@ func TestConcurrentReadWriteAppInfos(t *testing.T) {
 		assert.Equal(t, true, ok)
 	}
 }
+
+func TestDeleteAddonUsed(t *testing.T) {
+	var db *dbclient.DBClient
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "GetInstanceRouting",
+		func(*dbclient.DBClient, string) (*dbclient.AddonInstanceRouting, error) {
+			return &dbclient.AddonInstanceRouting{}, nil
+		},
+	)
+
+	addon := Addon{}
+	monkey.PatchInstanceMethod(reflect.TypeOf(&addon), "DeleteTenant",
+		func(*Addon, string, string) error {
+			return nil
+		},
+	)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "GetAttachmentCountByRoutingInstanceID",
+		func(*dbclient.DBClient, string) (int64, error) {
+			return 1, nil
+		},
+	)
+	defer monkey.UnpatchAll()
+
+	err := addon.Delete("", "")
+	if err.Error() != "addon is being referenced, can't delete" {
+		t.Fatal("the err is not equal with expected")
+	}
+}


### PR DESCRIPTION
#### What type of this PR

/kind feature



#### What this PR does / why we need it:
feature: change the error prompt from Chinese to English for addon delete


#### Which issue(s) this PR fixes:
https://erda.cloud/erda/dop/projects/387/issues/all?id=206519&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyNjEiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
