### PR TITLE
when creating a pipeline to cache action information, add a lock to read the map

### DIFF
--- a/modules/pipeline/services/pipelinesvc/passedDataWhenCreate.go
+++ b/modules/pipeline/services/pipelinesvc/passedDataWhenCreate.go
@@ -27,9 +27,8 @@ import (
 // passedDataWhenCreate stores data passed recursively when create graph.
 type passedDataWhenCreate struct {
 	extMarketSvc     *extmarketsvc.ExtMarketSvc
-	actionJobDefines map[string]*diceyml.Job
-	actionJobSpecs   map[string]*apistructs.ActionSpec
-	lock             sync.Mutex
+	actionJobDefines *sync.Map
+	actionJobSpecs   *sync.Map
 }
 
 func (that *passedDataWhenCreate) getActionJobDefine(actionTypeVersion string) *diceyml.Job {
@@ -39,17 +38,30 @@ func (that *passedDataWhenCreate) getActionJobDefine(actionTypeVersion string) *
 	if that.actionJobDefines == nil {
 		return nil
 	}
-	return that.actionJobDefines[actionTypeVersion]
+
+	if value, ok := that.actionJobDefines.Load(actionTypeVersion); ok {
+		if job, ok := value.(*diceyml.Job); ok {
+			return job
+		}
+	}
+	return nil
 }
 
 func (that *passedDataWhenCreate) getActionJobSpecs(actionTypeVersion string) *apistructs.ActionSpec {
+
 	if that == nil {
 		return nil
 	}
 	if that.actionJobDefines == nil {
 		return nil
 	}
-	return that.actionJobSpecs[actionTypeVersion]
+
+	if value, ok := that.actionJobSpecs.Load(actionTypeVersion); ok {
+		if spec, ok := value.(*apistructs.ActionSpec); ok {
+			return spec
+		}
+	}
+	return nil
 }
 
 func (that *passedDataWhenCreate) initData(extMarketSvc *extmarketsvc.ExtMarketSvc) {
@@ -58,13 +70,12 @@ func (that *passedDataWhenCreate) initData(extMarketSvc *extmarketsvc.ExtMarketS
 	}
 
 	if that.actionJobDefines == nil {
-		that.actionJobDefines = make(map[string]*diceyml.Job)
+		that.actionJobDefines = &sync.Map{}
 	}
 	if that.actionJobSpecs == nil {
-		that.actionJobSpecs = make(map[string]*apistructs.ActionSpec)
+		that.actionJobSpecs = &sync.Map{}
 	}
 	that.extMarketSvc = extMarketSvc
-	that.lock = sync.Mutex{}
 }
 
 func (that *passedDataWhenCreate) putPassedDataByPipelineYml(pipelineYml *pipelineyml.PipelineYml) error {
@@ -81,7 +92,7 @@ func (that *passedDataWhenCreate) putPassedDataByPipelineYml(pipelineYml *pipeli
 				}
 				extItem := extmarketsvc.MakeActionTypeVersion(action)
 				// extension already searched, skip
-				if _, ok := that.actionJobDefines[extItem]; ok {
+				if _, ok := that.actionJobDefines.Load(extItem); ok {
 					continue
 				}
 				extItems = append(extItems, extmarketsvc.MakeActionTypeVersion(action))
@@ -95,14 +106,11 @@ func (that *passedDataWhenCreate) putPassedDataByPipelineYml(pipelineYml *pipeli
 		return apierrors.ErrCreatePipelineGraph.InternalError(err)
 	}
 
-	that.lock.Lock()
-	defer that.lock.Unlock()
-
 	for extItem, actionJobDefine := range actionJobDefines {
-		that.actionJobDefines[extItem] = actionJobDefine
+		that.actionJobDefines.Store(extItem, actionJobDefine)
 	}
 	for extItem, actionJobSpec := range actionJobSpecs {
-		that.actionJobSpecs[extItem] = actionJobSpec
+		that.actionJobSpecs.Store(extItem, actionJobSpec)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:
The passedDataWhenCreate method will read the map concurrently, which will cause the pipeline to restart


#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=206764&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=431&type=BUG)
