### PR TITLE
support patch container snippet through erda.yml

### DIFF
--- a/apistructs/service.go
+++ b/apistructs/service.go
@@ -292,7 +292,7 @@ type Service struct {
 	// ProjectServiceName means use service name with servicegroup id when create k8s service
 	ProjectServiceName string `json:"projectServiceName,omitempty"`
 	// K8s Container Snippet
-	K8SSnippet *diceyml.ContainerSnippet `json:"k8sSnippet,omitempty"`
+	K8SSnippet *diceyml.K8SSnippet `json:"k8sSnippet,omitempty"`
 
 	StatusDesc
 }

--- a/apistructs/service.go
+++ b/apistructs/service.go
@@ -291,6 +291,8 @@ type Service struct {
 
 	// ProjectServiceName means use service name with servicegroup id when create k8s service
 	ProjectServiceName string `json:"projectServiceName,omitempty"`
+	// K8s Container Snippet
+	K8SSnippet *diceyml.ContainerSnippet `json:"k8sSnippet,omitempty"`
 
 	StatusDesc
 }

--- a/modules/scheduler/executor/plugins/k8s/addon/interface.go
+++ b/modules/scheduler/executor/plugins/k8s/addon/interface.go
@@ -16,6 +16,7 @@ package addon
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/erda-project/erda/apistructs"
 )
@@ -42,6 +43,7 @@ type K8SUtil interface {
 }
 
 type DeploymentUtil interface {
+	Patch(namespace, deployName, containerName string, snippet v1.Container) error
 	Create(*appsv1.Deployment) error
 	Get(namespace, name string) (*appsv1.Deployment, error)
 	List(namespace string, labelSelector map[string]string) (appsv1.DeploymentList, error)

--- a/modules/scheduler/executor/plugins/k8s/deployment.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment.go
@@ -52,12 +52,12 @@ func (k *Kubernetes) createDeployment(service *apistructs.Service, sg *apistruct
 	if err != nil {
 		return errors.Errorf("failed to create deployment, name: %s, (%v)", service.Name, err)
 	}
-	if service.K8SSnippet == nil {
+	if service.K8SSnippet == nil || service.K8SSnippet.Container == nil {
 		return nil
 	}
-	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet))
+	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
 	if err != nil {
-		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet, err)
+		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet.Container, err)
 	}
 	return nil
 }
@@ -120,12 +120,12 @@ func (k *Kubernetes) putDeployment(deployment *appsv1.Deployment, service *apist
 	if err != nil {
 		return errors.Errorf("failed to update deployment, name: %s, (%v)", service.Name, err)
 	}
-	if service.K8SSnippet == nil {
+	if service.K8SSnippet == nil || service.K8SSnippet.Container == nil {
 		return nil
 	}
-	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet))
+	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
 	if err != nil {
-		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet, err)
+		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet.Container, err)
 	}
 	return nil
 }

--- a/modules/scheduler/executor/plugins/k8s/deployment.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment.go
@@ -55,7 +55,7 @@ func (k *Kubernetes) createDeployment(service *apistructs.Service, sg *apistruct
 	if service.K8SSnippet == nil || service.K8SSnippet.Container == nil {
 		return nil
 	}
-	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
+	err = k.deploy.Patch(deployment.Namespace, deployment.Name, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
 	if err != nil {
 		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet.Container, err)
 	}
@@ -123,7 +123,7 @@ func (k *Kubernetes) putDeployment(deployment *appsv1.Deployment, service *apist
 	if service.K8SSnippet == nil || service.K8SSnippet.Container == nil {
 		return nil
 	}
-	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
+	err = k.deploy.Patch(deployment.Namespace, deployment.Name, service.Name, (apiv1.Container)(*service.K8SSnippet.Container))
 	if err != nil {
 		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet.Container, err)
 	}

--- a/modules/scheduler/executor/plugins/k8s/deployment.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment.go
@@ -48,7 +48,18 @@ func (k *Kubernetes) createDeployment(service *apistructs.Service, sg *apistruct
 		return errors.Errorf("failed to generate deployment struct, name: %s, (%v)", service.Name, err)
 	}
 
-	return k.deploy.Create(deployment)
+	err = k.deploy.Create(deployment)
+	if err != nil {
+		return errors.Errorf("failed to create deployment, name: %s, (%v)", service.Name, err)
+	}
+	if service.K8SSnippet == nil {
+		return nil
+	}
+	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet))
+	if err != nil {
+		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet, err)
+	}
+	return nil
 }
 
 func (k *Kubernetes) getDeploymentStatusFromMap(service *apistructs.Service, deployments map[string]appsv1.Deployment) (apistructs.StatusDesc, error) {
@@ -104,8 +115,19 @@ func (k *Kubernetes) getDeployment(namespace, name string) (*appsv1.Deployment, 
 	return k.deploy.Get(namespace, name)
 }
 
-func (k *Kubernetes) putDeployment(deployment *appsv1.Deployment) error {
-	return k.deploy.Put(deployment)
+func (k *Kubernetes) putDeployment(deployment *appsv1.Deployment, service *apistructs.Service) error {
+	err := k.deploy.Put(deployment)
+	if err != nil {
+		return errors.Errorf("failed to update deployment, name: %s, (%v)", service.Name, err)
+	}
+	if service.K8SSnippet == nil {
+		return nil
+	}
+	err = k.deploy.Patch(deployment.Name, deployment.Namespace, service.Name, (apiv1.Container)(*service.K8SSnippet))
+	if err != nil {
+		return errors.Errorf("failed to patch deployment, name: %s, snippet: %+v, (%v)", service.Name, *service.K8SSnippet, err)
+	}
+	return nil
 }
 
 func (k *Kubernetes) deleteDeployment(namespace, name string) error {

--- a/modules/scheduler/executor/plugins/k8s/deployment/deployment.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment/deployment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/erda-project/erda/modules/scheduler/executor/plugins/k8s/k8sapi"
 	"github.com/erda-project/erda/modules/scheduler/executor/plugins/k8s/k8serror"
@@ -58,6 +59,37 @@ func WithCompleteParams(addr string, client *httpclient.HTTPClient) Option {
 		d.addr = addr
 		d.client = client
 	}
+}
+
+// Patch patchs the k8s deployment object
+func (d *Deployment) Patch(namespace, deploymentName, containerName string, snippet v1.Container) error {
+	snippet.Name = containerName
+	spec := appsv1.DeploymentSpec{
+		Template: v1.PodTemplateSpec{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					snippet,
+				},
+			},
+		},
+	}
+	var b bytes.Buffer
+	resp, err := d.client.Patch(d.addr).
+		Path("/apis/apps/v1/namespaces/"+namespace+"/deployments/"+deploymentName).
+		JSONBody(spec).
+		Header("Content-Type", "application/strategic-merge-patch+json").
+		Do().
+		Body(&b)
+
+	if err != nil {
+		return errors.Errorf("failed to patch deployment, name: %s, (%v)", deploymentName, err)
+	}
+
+	if !resp.IsOK() {
+		return errors.Errorf("failed to patch deployment, name: %s, statuscode: %v, body: %v",
+			deploymentName, resp.StatusCode(), b.String())
+	}
+	return nil
 }
 
 // Create creates a k8s deployment object

--- a/modules/scheduler/executor/plugins/k8s/k8s.go
+++ b/modules/scheduler/executor/plugins/k8s/k8s.go
@@ -797,7 +797,7 @@ func (k *Kubernetes) updateOneByOne(sg *apistructs.ServiceGroup) error {
 				if err != nil {
 					return err
 				}
-				if err = k.putDeployment(desiredDeployment); err != nil {
+				if err = k.putDeployment(desiredDeployment, &svc); err != nil {
 					logrus.Debugf("failed to update deployment in update interface, name: %s, (%v)", svc.Name, err)
 					return err
 				}

--- a/modules/scheduler/impl/servicegroup/servicegroup.go
+++ b/modules/scheduler/impl/servicegroup/servicegroup.go
@@ -285,6 +285,7 @@ func convertServiceGroup(req apistructs.ServiceGroupCreateV2Request, clusterinfo
 			InitContainer:    service.Init,
 			MeshEnable:       service.MeshEnable,
 			TrafficSecurity:  service.TrafficSecurity,
+			K8SSnippet:       service.K8SSnippet,
 		}
 		sgServices = append(sgServices, sgService)
 	}

--- a/pkg/parser/diceyml/define.go
+++ b/pkg/parser/diceyml/define.go
@@ -136,10 +136,14 @@ type Service struct {
 	MeshEnable      *bool                    `yaml:"mesh_enable,omitempty" json:"mesh_enable,omitempty"`
 	TrafficSecurity TrafficSecurity          `yaml:"traffic_security,omitempty" json:"traffic_security,omitempty"`
 	Endpoints       []Endpoint               `yaml:"endpoints,omitempty" json:"endpoints,omitempty"`
-	K8SSnippet      *ContainerSnippet        `yaml:"k8s_snippet,omitempty" json:"k8s_snippet,omitempty"`
+	K8SSnippet      *K8SSnippet              `yaml:"k8s_snippet,omitempty" json:"k8s_snippet,omitempty"`
 }
 
 type ContainerSnippet v1.Container
+
+type K8SSnippet struct {
+	Container *ContainerSnippet `yaml:"container,omitempty" json:"container,omitempty"`
+}
 
 type ServicePort struct {
 	Port       int            `yaml:"port" json:"port"`
@@ -523,7 +527,8 @@ type DiceYmlVisitor interface {
 	VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)
 	VisitDeployments(v DiceYmlVisitor, obj *Deployments)
 	VisitBinds(v DiceYmlVisitor, obj *Binds)
-	VisitK8SSnippet(v DiceYmlVisitor, obj *ContainerSnippet)
+	VisitK8SSnippet(v DiceYmlVisitor, obj *K8SSnippet)
+	VisitContainerSnippet(v DiceYmlVisitor, obj *ContainerSnippet)
 }
 
 func (obj *Object) Accept(v DiceYmlVisitor) {
@@ -563,6 +568,9 @@ func (obj *Service) Accept(v DiceYmlVisitor) {
 	obj.Deployments.Accept(v)
 	obj.HealthCheck.Accept(v)
 	obj.Binds.Accept(v)
+	if obj.K8SSnippet == nil {
+		obj.K8SSnippet = new(K8SSnippet)
+	}
 	obj.K8SSnippet.Accept(v)
 }
 func (obj *Services) Accept(v DiceYmlVisitor) {
@@ -613,8 +621,16 @@ func (obj *Binds) Accept(v DiceYmlVisitor) {
 	v.VisitBinds(v, obj)
 }
 
-func (obj *ContainerSnippet) Accept(v DiceYmlVisitor) {
+func (obj *K8SSnippet) Accept(v DiceYmlVisitor) {
 	v.VisitK8SSnippet(v, obj)
+	if obj.Container == nil {
+		obj.Container = new(ContainerSnippet)
+	}
+	obj.Container.Accept(v)
+}
+
+func (obj *ContainerSnippet) Accept(v DiceYmlVisitor) {
+	v.VisitContainerSnippet(v, obj)
 }
 
 type DefaultVisitor struct {
@@ -641,13 +657,14 @@ func (o *DefaultVisitor) VisitJobs(v DiceYmlVisitor, obj *Jobs) {
 	}
 	o.currentJob = ""
 }
-func (o *DefaultVisitor) VisitJob(v DiceYmlVisitor, obj *Job)                   {}
-func (*DefaultVisitor) VisitAddOn(v DiceYmlVisitor, obj *AddOn)                 {}
-func (*DefaultVisitor) VisitAddOns(v DiceYmlVisitor, obj *AddOns)               {}
-func (*DefaultVisitor) VisitResources(v DiceYmlVisitor, obj *Resources)         {}
-func (*DefaultVisitor) VisitHealthCheck(v DiceYmlVisitor, obj *HealthCheck)     {}
-func (*DefaultVisitor) VisitHTTPCheck(v DiceYmlVisitor, obj *HTTPCheck)         {}
-func (*DefaultVisitor) VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)         {}
-func (*DefaultVisitor) VisitDeployments(v DiceYmlVisitor, obj *Deployments)     {}
-func (*DefaultVisitor) VisitBinds(v DiceYmlVisitor, obj *Binds)                 {}
-func (*DefaultVisitor) VisitK8SSnippet(v DiceYmlVisitor, obj *ContainerSnippet) {}
+func (o *DefaultVisitor) VisitJob(v DiceYmlVisitor, obj *Job)                         {}
+func (*DefaultVisitor) VisitAddOn(v DiceYmlVisitor, obj *AddOn)                       {}
+func (*DefaultVisitor) VisitAddOns(v DiceYmlVisitor, obj *AddOns)                     {}
+func (*DefaultVisitor) VisitResources(v DiceYmlVisitor, obj *Resources)               {}
+func (*DefaultVisitor) VisitHealthCheck(v DiceYmlVisitor, obj *HealthCheck)           {}
+func (*DefaultVisitor) VisitHTTPCheck(v DiceYmlVisitor, obj *HTTPCheck)               {}
+func (*DefaultVisitor) VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)               {}
+func (*DefaultVisitor) VisitDeployments(v DiceYmlVisitor, obj *Deployments)           {}
+func (*DefaultVisitor) VisitBinds(v DiceYmlVisitor, obj *Binds)                       {}
+func (*DefaultVisitor) VisitK8SSnippet(v DiceYmlVisitor, obj *K8SSnippet)             {}
+func (*DefaultVisitor) VisitContainerSnippet(v DiceYmlVisitor, obj *ContainerSnippet) {}

--- a/pkg/parser/diceyml/define.go
+++ b/pkg/parser/diceyml/define.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/erda-project/erda/pkg/strutil"
 )
@@ -46,7 +47,7 @@ type Object struct {
 	Services     Services          `yaml:"services" json:"services,omitempty"`
 	Jobs         Jobs              `yaml:"jobs,omitempty" json:"jobs,omitempty"`
 	AddOns       AddOns            `yaml:"addons" json:"addons,omitempty"`
-	Environments EnvObjects        `yaml:"environments,omitempty" json:"-"`
+	Environments EnvObjects        `yaml:"environments,omitempty" json:"environments,omitempty"`
 	Values       ValueObjects      `yaml:"values" json:"values,omitempty"`
 }
 type EnvMap map[string]string
@@ -135,7 +136,10 @@ type Service struct {
 	MeshEnable      *bool                    `yaml:"mesh_enable,omitempty" json:"mesh_enable,omitempty"`
 	TrafficSecurity TrafficSecurity          `yaml:"traffic_security,omitempty" json:"traffic_security,omitempty"`
 	Endpoints       []Endpoint               `yaml:"endpoints,omitempty" json:"endpoints,omitempty"`
+	K8SSnippet      *ContainerSnippet        `yaml:"k8s_snippet,omitempty" json:"k8s_snippet,omitempty"`
 }
+
+type ContainerSnippet v1.Container
 
 type ServicePort struct {
 	Port       int            `yaml:"port" json:"port"`
@@ -519,6 +523,7 @@ type DiceYmlVisitor interface {
 	VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)
 	VisitDeployments(v DiceYmlVisitor, obj *Deployments)
 	VisitBinds(v DiceYmlVisitor, obj *Binds)
+	VisitK8SSnippet(v DiceYmlVisitor, obj *ContainerSnippet)
 }
 
 func (obj *Object) Accept(v DiceYmlVisitor) {
@@ -558,6 +563,7 @@ func (obj *Service) Accept(v DiceYmlVisitor) {
 	obj.Deployments.Accept(v)
 	obj.HealthCheck.Accept(v)
 	obj.Binds.Accept(v)
+	obj.K8SSnippet.Accept(v)
 }
 func (obj *Services) Accept(v DiceYmlVisitor) {
 	v.VisitServices(v, obj)
@@ -607,6 +613,10 @@ func (obj *Binds) Accept(v DiceYmlVisitor) {
 	v.VisitBinds(v, obj)
 }
 
+func (obj *ContainerSnippet) Accept(v DiceYmlVisitor) {
+	v.VisitK8SSnippet(v, obj)
+}
+
 type DefaultVisitor struct {
 	// used when iter on Object.Services
 	currentService string
@@ -631,12 +641,13 @@ func (o *DefaultVisitor) VisitJobs(v DiceYmlVisitor, obj *Jobs) {
 	}
 	o.currentJob = ""
 }
-func (o *DefaultVisitor) VisitJob(v DiceYmlVisitor, obj *Job)               {}
-func (*DefaultVisitor) VisitAddOn(v DiceYmlVisitor, obj *AddOn)             {}
-func (*DefaultVisitor) VisitAddOns(v DiceYmlVisitor, obj *AddOns)           {}
-func (*DefaultVisitor) VisitResources(v DiceYmlVisitor, obj *Resources)     {}
-func (*DefaultVisitor) VisitHealthCheck(v DiceYmlVisitor, obj *HealthCheck) {}
-func (*DefaultVisitor) VisitHTTPCheck(v DiceYmlVisitor, obj *HTTPCheck)     {}
-func (*DefaultVisitor) VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)     {}
-func (*DefaultVisitor) VisitDeployments(v DiceYmlVisitor, obj *Deployments) {}
-func (*DefaultVisitor) VisitBinds(v DiceYmlVisitor, obj *Binds)             {}
+func (o *DefaultVisitor) VisitJob(v DiceYmlVisitor, obj *Job)                   {}
+func (*DefaultVisitor) VisitAddOn(v DiceYmlVisitor, obj *AddOn)                 {}
+func (*DefaultVisitor) VisitAddOns(v DiceYmlVisitor, obj *AddOns)               {}
+func (*DefaultVisitor) VisitResources(v DiceYmlVisitor, obj *Resources)         {}
+func (*DefaultVisitor) VisitHealthCheck(v DiceYmlVisitor, obj *HealthCheck)     {}
+func (*DefaultVisitor) VisitHTTPCheck(v DiceYmlVisitor, obj *HTTPCheck)         {}
+func (*DefaultVisitor) VisitExecCheck(v DiceYmlVisitor, obj *ExecCheck)         {}
+func (*DefaultVisitor) VisitDeployments(v DiceYmlVisitor, obj *Deployments)     {}
+func (*DefaultVisitor) VisitBinds(v DiceYmlVisitor, obj *Binds)                 {}
+func (*DefaultVisitor) VisitK8SSnippet(v DiceYmlVisitor, obj *ContainerSnippet) {}

--- a/pkg/parser/diceyml/diceyml.go
+++ b/pkg/parser/diceyml/diceyml.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/pkg/strutil"
 )

--- a/pkg/parser/diceyml/diceyml_test.go
+++ b/pkg/parser/diceyml/diceyml_test.go
@@ -52,11 +52,12 @@ services:
         l4_protocol: "UDP"
         default: true
     k8s_snippet:
-      stdin: true
-      workingDir: aaa
-      imagePullPolicy: Always
-      securityContext:
-        privileged: true
+      container:
+        stdin: true
+        workingDir: aaa
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
     health_check:
       exec:
         cmd: "echo 1"
@@ -115,12 +116,13 @@ services:
       cpu: 0.1
       mem: 512
     k8s_snippet:
-      name: abc
-      stdin: true
-      workingDir: aaa
-      imagePullPolicy: Always
-      securityContext:
-        privileged: true
+      container:
+        name: abc
+        stdin: true
+        workingDir: aaa
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
 `
 
 func TestDiceYmlObj(t *testing.T) {
@@ -144,9 +146,9 @@ func TestDicalYmlK8SSnippet(t *testing.T) {
 	d, err := New([]byte(yml), true)
 	assert.Nil(t, err)
 	assert.NotNil(t, d.obj.Services["web"].K8SSnippet)
-	assert.NotNil(t, d.obj.Services["web"].K8SSnippet.SecurityContext)
-	assert.Equal(t, true, *d.obj.Services["web"].K8SSnippet.SecurityContext.Privileged)
-	assert.EqualValues(t, "Always", d.obj.Services["web"].K8SSnippet.ImagePullPolicy)
+	assert.NotNil(t, d.obj.Services["web"].K8SSnippet.Container.SecurityContext)
+	assert.Equal(t, true, *d.obj.Services["web"].K8SSnippet.Container.SecurityContext.Privileged)
+	assert.EqualValues(t, "Always", d.obj.Services["web"].K8SSnippet.Container.ImagePullPolicy)
 	_, err = New([]byte(wrongSnippetYml), true)
 	assert.NotNil(t, err)
 }

--- a/pkg/parser/diceyml/diceyml_test.go
+++ b/pkg/parser/diceyml/diceyml_test.go
@@ -51,6 +51,12 @@ services:
         protocol: "DNS"
         l4_protocol: "UDP"
         default: true
+    k8s_snippet:
+      stdin: true
+      workingDir: aaa
+      imagePullPolicy: Always
+      securityContext:
+        privileged: true
     health_check:
       exec:
         cmd: "echo 1"
@@ -89,6 +95,34 @@ values:
   
 `
 
+var wrongSnippetYml = `version: 2.0
+services:
+  web:
+    ports:
+      - 8080
+      - port: 20880
+      - port: 1234
+        protocol: "UDP"
+      - port: 4321
+        protocol: "HTTP"
+      - port: 53
+        protocol: "DNS"
+        l4_protocol: "UDP"
+        default: true
+    deployments:
+      replicas: 1
+    resources:
+      cpu: 0.1
+      mem: 512
+    k8s_snippet:
+      name: abc
+      stdin: true
+      workingDir: aaa
+      imagePullPolicy: Always
+      securityContext:
+        privileged: true
+`
+
 func TestDiceYmlObj(t *testing.T) {
 	d, err := New([]byte(yml), true)
 	assert.Nil(t, err)
@@ -104,6 +138,17 @@ func TestDiceYmlObj(t *testing.T) {
 	assert.Equal(t, "DNS", string(obj.Services["web"].Ports[4].Protocol))
 	assert.Equal(t, "UDP", string(obj.Services["web"].Ports[4].L4Protocol))
 	assert.Equal(t, true, obj.Services["web"].Ports[4].Default)
+}
+
+func TestDicalYmlK8SSnippet(t *testing.T) {
+	d, err := New([]byte(yml), true)
+	assert.Nil(t, err)
+	assert.NotNil(t, d.obj.Services["web"].K8SSnippet)
+	assert.NotNil(t, d.obj.Services["web"].K8SSnippet.SecurityContext)
+	assert.Equal(t, true, *d.obj.Services["web"].K8SSnippet.SecurityContext.Privileged)
+	assert.EqualValues(t, "Always", d.obj.Services["web"].K8SSnippet.ImagePullPolicy)
+	_, err = New([]byte(wrongSnippetYml), true)
+	assert.NotNil(t, err)
 }
 
 func TestDiceYmlFieldnameValidate(t *testing.T) {

--- a/pkg/parser/diceyml/fieldname_validate_visitor.go
+++ b/pkg/parser/diceyml/fieldname_validate_visitor.go
@@ -80,8 +80,8 @@ func (o *FieldnameValidateVisitor) VisitService(v DiceYmlVisitor, obj *Service) 
 	for k := range o.currentService {
 		switch i := k.(type) {
 		case string:
-			if !contain(i, []string{"image", "cmd", "labels", "ports", "envs", "hosts", "resources", "volumes", "deployments", "depends_on", "expose", "health_check", "binds", "sidecars", "init", "traffic_security", "endpoints", "mesh_enable"}) {
-				o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{o.currentServiceName}, i)] = fmt.Errorf("[%s] field '%s' not one of [image, cmd, ports, envs, hosts, labels, resources, volumes, deployments, depends_on, expose, health_check, binds, sidecars，init, traffic_security, endpoints, mesh_enable]", o.currentServiceName, i)
+			if !contain(i, []string{"image", "cmd", "labels", "ports", "envs", "hosts", "resources", "volumes", "deployments", "depends_on", "expose", "health_check", "binds", "sidecars", "init", "traffic_security", "endpoints", "mesh_enable", "k8s_snippet"}) {
+				o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{o.currentServiceName}, i)] = fmt.Errorf("[%s] field '%s' not one of [image, cmd, ports, envs, hosts, labels, resources, volumes, deployments, depends_on, expose, health_check, binds, sidecars，init, traffic_security, endpoints, mesh_enable, k8s_snippet]", o.currentServiceName, i)
 			}
 		default:
 			o.collectErrors[yamlHeaderRegex("_"+strconv.Itoa(len(o.collectErrors)))] = fmt.Errorf("[%s] %v not string type", o.currentServiceName, k)
@@ -210,6 +210,23 @@ func (o *FieldnameValidateVisitor) VisitExecCheck(v DiceYmlVisitor, obj *ExecChe
 			}
 		default:
 			o.collectErrors[yamlHeaderRegex("_"+strconv.Itoa(len(o.collectErrors)))] = fmt.Errorf("[%s]/[health_check]/[exec] %v not string type", o.currentServiceName, k)
+		}
+	}
+}
+
+func (o *FieldnameValidateVisitor) VisitK8SSnippet(v DiceYmlVisitor, obj *ContainerSnippet) {
+	res, ok := o.currentService["k8s_snippet"].(map[interface{}]interface{})
+	if !ok {
+		return
+	}
+	for k := range res {
+		switch i := k.(type) {
+		case string:
+			if !contain(i, []string{"workingDir", "envFrom", "env", "livenessProbe", "readinessProbe", "startupProbe", "lifeCycle", "terminationMessagePath", "terminationMessagePolicy", "imagePullPolicy", "securityContext", "stdin", "stdinOnce", "tty"}) {
+				o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{o.currentServiceName, "k8s_snippet"}, i)] = fmt.Errorf(`[%s]/[k8s_snippet] field '%s' is not supported, only support this container fields ["workingDir", "envFrom", "env", "livenessProbe", "readinessProbe", "startupProbe", "lifeCycle", "terminationMessagePath", "terminationMessagePolicy", "imagePullPolicy", "securityContext", "stdin", "stdinOnce", "tty"]`, o.currentServiceName, i)
+			}
+		default:
+			o.collectErrors[yamlHeaderRegex("_"+strconv.Itoa(len(o.collectErrors)))] = fmt.Errorf("[%s]/[k8s_snippet] %v not string type", o.currentServiceName, k)
 		}
 	}
 }

--- a/pkg/parser/diceyml/utils.go
+++ b/pkg/parser/diceyml/utils.go
@@ -17,7 +17,7 @@ import (
 	"reflect"
 	"regexp"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func assignWithoutEmpty(p interface{}, src interface{}) {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature


#### What this PR does / why we need it:
we can use k8s_snippet in the erda.yml like this:

```yaml
version: 2.0
services:
  web:
    ports:
     - port: 8080
    deployments:
      replicas: 1
    resources:
      cpu: 1
      mem: 512
    k8s_snippet:
      container:
        readinessProbe:
          failureThreshold: 20
          periodSeconds: 15
          successThreshold: 1
          tcpSocket:
            port: 8080
          timeoutSeconds: 10
```


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   erda.yml now support the `k8s_snippet` field which will patch to the container definition of the k8s deployment resource.   |
| 🇨🇳 中文    |   erda.yml 支持了一个新字段 `k8s_snippet`，可以调整对应的 k8s deployment 中关于 container 的配置定义  |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
