### PR TITLE
restore task uuid after cancel

### DIFF
--- a/apistructs/pipeline_task.go
+++ b/apistructs/pipeline_task.go
@@ -215,7 +215,7 @@ func (t *PipelineTaskResult) AppendError(newResponses ...*PipelineTaskErrRespons
 func (t *PipelineTaskResult) ConvertErrors() {
 	for _, response := range t.Errors {
 		if response.Ctx.Count > 1 {
-			response.Msg = fmt.Sprintf("%s\nstartTime: %s\nendTIme: %s\ncount: %d",
+			response.Msg = fmt.Sprintf("%s\nstartTime: %s\nendTime: %s\ncount: %d",
 				response.Msg, response.Ctx.StartTime.Format("2006-01-02 15:04:05"),
 				response.Ctx.EndTime.Format("2006-01-02 15:04:05"), response.Ctx.Count)
 		}

--- a/apistructs/pipeline_task_test.go
+++ b/apistructs/pipeline_task_test.go
@@ -46,3 +46,16 @@ func TestPipelineTaskAppendError(t *testing.T) {
 	assert.Equal(t, start.Unix(), task.Result.Errors[2].Ctx.StartTime.Unix())
 	assert.Equal(t, endA.Unix(), task.Result.Errors[2].Ctx.EndTime.Unix())
 }
+
+func TestConvertErrors(t *testing.T) {
+	task := PipelineTaskDTO{}
+	start := time.Date(2021, 8, 24, 9, 45, 1, 1, time.Local)
+	end := time.Date(2021, 8, 24, 9, 46, 1, 1, time.Local)
+	task.Result.Errors = task.Result.AppendError(&PipelineTaskErrResponse{Msg: "err", Ctx: PipelineTaskErrCtx{
+		StartTime: start,
+		EndTime:   end,
+		Count:     2,
+	}})
+	task.Result.ConvertErrors()
+	assert.Equal(t, fmt.Sprintf("err\nstartTime: %s\nendTime: %s\ncount: %d", start.Format("2006-01-02 15:04:05"), end.Format("2006-01-02 15:04:05"), 2), task.Result.Errors[0].Msg)
+}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
@@ -225,14 +225,14 @@ func (k *K8sJob) Remove(ctx context.Context, task *spec.PipelineTask) (data inte
 		logrus.Infof("finish to delete job %s", name)
 
 		for index := range job.Volumes {
-			pvcName := fmt.Sprintf("%s-%s-%d", namespace, name, index)
+			pvcName := fmt.Sprintf("%s-%d", name, index)
 			logrus.Infof("start to delete pvc %s", pvcName)
 			err = k.client.ClientSet.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
 			if err != nil {
 				if !k8serrors.IsNotFound(err) {
 					return nil, errors.Wrapf(err, "failed to remove k8s pvc, name: %s", pvcName)
 				}
-				logrus.Warningf("the job %s's pvc %s in namespace %s is not found", job.Name, pvcName, namespace)
+				logrus.Warningf("the job %s's pvc %s in namespace %s is not found", name, pvcName, namespace)
 			}
 			logrus.Infof("finish to delete pvc %s", pvcName)
 		}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
@@ -389,8 +389,12 @@ func (s *Sched) Cancel(ctx context.Context, action *spec.PipelineTask) (data int
 		logrus.Infof("task executor %s execute cancel", taskExecutor.Name())
 		// TODO move all makeJobID to framework
 		// now move makeJobID to framework may change task uuid in database
+		// Restore the task uuid after remove, because gc will make the job id, but cancel don't make the job id
+		oldUUID := action.Extra.UUID
 		action.Extra.UUID = task_uuid.MakeJobID(action)
-		return taskExecutor.Remove(ctx, action)
+		d, err := taskExecutor.Remove(ctx, action)
+		action.Extra.UUID = oldUUID
+		return d, err
 	}
 	var body bytes.Buffer
 	resp, err := httpclient.New().Post(s.addr).

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
@@ -15,6 +15,7 @@
 package scheduler
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -65,7 +66,7 @@ func init() {
 }
 
 func Test_GetTaskExecutor(t *testing.T) {
-	monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "GetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
+	p := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "GetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
 		if len(clusterName) == 0 {
 			return apistructs.ClusterInfo{}, errors.Errorf("clusterName is empty")
 		}
@@ -75,8 +76,9 @@ func Test_GetTaskExecutor(t *testing.T) {
 		}
 		return cluster, nil
 	})
+	defer p.Unpatch()
 
-	monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "Get", func(_ *executor.Manager, name types.Name) (types.TaskExecutor, error) {
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "Get", func(_ *executor.Manager, name types.Name) (types.TaskExecutor, error) {
 		if len(name) == 0 {
 			return nil, errors.Errorf("executor name is empty")
 		}
@@ -86,6 +88,7 @@ func Test_GetTaskExecutor(t *testing.T) {
 		}
 		return e, nil
 	})
+	defer m.Unpatch()
 
 	_, err := s.taskManager.GetCluster("terminus-dev")
 	assert.NoError(t, err)
@@ -159,6 +162,36 @@ func Test_GetTaskExecutor(t *testing.T) {
 	shouldDispatch, _, err = s.GetTaskExecutor(edasTask.Type, edasTask.Extra.ClusterName, edasTask)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, false, shouldDispatch)
+}
+
+func TestCancel(t *testing.T) {
+	s = &Sched{
+		taskManager: taskManager,
+	}
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(s), "GetTaskExecutor", func(_ *Sched, executorType string, clusterName string, task *spec.PipelineTask) (bool, types.TaskExecutor, error) {
+		return false, &k8sjob.K8sJob{}, nil
+	})
+	defer m.Unpatch()
+
+	p := monkey.PatchInstanceMethod(reflect.TypeOf(&k8sjob.K8sJob{}), "Remove", func(_ *k8sjob.K8sJob, ctx context.Context, task *spec.PipelineTask) (data interface{}, err error) {
+		return nil, nil
+	})
+	defer p.Unpatch()
+
+	uuid := "pipeline-123456"
+	ctx := context.Background()
+	task := &spec.PipelineTask{
+		Extra: spec.PipelineTaskExtra{
+			Namespace: "pipeline-1",
+			UUID:      uuid,
+			LoopOptions: &apistructs.PipelineTaskLoopOptions{
+				LoopedTimes: 3,
+			},
+		},
+	}
+	_, err := s.Cancel(ctx, task)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, uuid, task.Extra.UUID)
 }
 
 //import (


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
restore task uuid after remove in cancel func, because gc will make job id but cancel don't make job id

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=209285&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix stop by user task uuid bug            |
| 🇨🇳 中文    |   修复stopbyuser时将taskuuid修改的问题           |

