### PR TITLE
release/1.2 Support pushing extensions according to the git directory of repo/addons

### DIFF
--- a/modules/dicehub/service/extension/action.go
+++ b/modules/dicehub/service/extension/action.go
@@ -118,7 +118,7 @@ func (s *Extension) RunExtensionsPush(dir string, extensionVersionMap, extension
 		}
 	}
 	if !needCreate {
-		return "", "", errors.New("extension is existed")
+		return specData.Name, specData.Version, errors.New("extension is existed")
 	}
 
 	var request = &apistructs.ExtensionVersionCreateRequest{
@@ -136,7 +136,7 @@ func (s *Extension) RunExtensionsPush(dir string, extensionVersionMap, extension
 
 	_, err = s.CreateExtensionVersion(request)
 	if err != nil {
-		return "", "", err
+		return request.Name, request.Version, err
 	}
 
 	return request.Name, request.Version, err
@@ -209,7 +209,7 @@ func (repo *Repo) locate(dirname string, deep int) {
 
 	for _, cur := range infos {
 		// only find path /repoName/actions/actionsName
-		if deep == 1 && (cur.Name() != "actions" || !cur.IsDir()) {
+		if deep == 1 && cur.Name() != "actions" && cur.Name() != "addons" {
 			continue
 		}
 		repo.locate(filepath.Join(dirname, cur.Name()), deep+1)


### PR DESCRIPTION
What type of this PR
/kind feature

What this PR does / why we need it:
in infos, cur.Isdir() must be true . No need to judge

add /addons in init extension path

if push failed, return name and version