### PR TITLE
restore task uuid after cancel

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
@@ -226,14 +226,14 @@ func (k *K8sJob) Remove(ctx context.Context, task *spec.PipelineTask) (data inte
 		logrus.Infof("finish to delete job %s", name)
 
 		for index := range job.Volumes {
-			pvcName := fmt.Sprintf("%s-%s-%d", namespace, name, index)
+			pvcName := fmt.Sprintf("%s-%d", name, index)
 			logrus.Infof("start to delete pvc %s", pvcName)
 			err = k.client.ClientSet.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
 			if err != nil {
 				if !k8serrors.IsNotFound(err) {
 					return nil, errors.Wrapf(err, "failed to remove k8s pvc, name: %s", pvcName)
 				}
-				logrus.Warningf("the job %s's pvc %s in namespace %s is not found", job.Name, pvcName, namespace)
+				logrus.Warningf("the job %s's pvc %s in namespace %s is not found", name, pvcName, namespace)
 			}
 			logrus.Infof("finish to delete pvc %s", pvcName)
 		}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
@@ -375,8 +375,12 @@ func (s *Sched) Cancel(ctx context.Context, action *spec.PipelineTask) (data int
 		logrus.Infof("task executor %s execute cancel", taskExecutor.Name())
 		// TODO move all makeJobID to framework
 		// now move makeJobID to framework may change task uuid in database
+		// Restore the task uuid after remove, because gc will make the job id, but cancel don't make the job id
+		oldUUID := action.Extra.UUID
 		action.Extra.UUID = task_uuid.MakeJobID(action)
-		return taskExecutor.Remove(ctx, action)
+		d, err := taskExecutor.Remove(ctx, action)
+		action.Extra.UUID = oldUUID
+		return d, err
 	}
 	var body bytes.Buffer
 	resp, err := httpclient.New().Post(s.addr).

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
@@ -14,6 +14,7 @@
 package scheduler
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -64,7 +65,7 @@ func init() {
 }
 
 func Test_GetTaskExecutor(t *testing.T) {
-	monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "GetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
+	p := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "GetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
 		if len(clusterName) == 0 {
 			return apistructs.ClusterInfo{}, errors.Errorf("clusterName is empty")
 		}
@@ -74,8 +75,9 @@ func Test_GetTaskExecutor(t *testing.T) {
 		}
 		return cluster, nil
 	})
+	defer p.Unpatch()
 
-	monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "Get", func(_ *executor.Manager, name types.Name) (types.TaskExecutor, error) {
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "Get", func(_ *executor.Manager, name types.Name) (types.TaskExecutor, error) {
 		if len(name) == 0 {
 			return nil, errors.Errorf("executor name is empty")
 		}
@@ -85,6 +87,7 @@ func Test_GetTaskExecutor(t *testing.T) {
 		}
 		return e, nil
 	})
+	defer m.Unpatch()
 
 	_, err := s.taskManager.GetCluster("terminus-dev")
 	assert.NoError(t, err)
@@ -158,6 +161,36 @@ func Test_GetTaskExecutor(t *testing.T) {
 	shouldDispatch, _, err = s.GetTaskExecutor(edasTask.Type, edasTask.Extra.ClusterName, edasTask)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, false, shouldDispatch)
+}
+
+func TestCancel(t *testing.T) {
+	s = &Sched{
+		taskManager: taskManager,
+	}
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(s), "GetTaskExecutor", func(_ *Sched, executorType string, clusterName string, task *spec.PipelineTask) (bool, types.TaskExecutor, error) {
+		return false, &k8sjob.K8sJob{}, nil
+	})
+	defer m.Unpatch()
+
+	p := monkey.PatchInstanceMethod(reflect.TypeOf(&k8sjob.K8sJob{}), "Remove", func(_ *k8sjob.K8sJob, ctx context.Context, task *spec.PipelineTask) (data interface{}, err error) {
+		return nil, nil
+	})
+	defer p.Unpatch()
+
+	uuid := "pipeline-123456"
+	ctx := context.Background()
+	task := &spec.PipelineTask{
+		Extra: spec.PipelineTaskExtra{
+			Namespace: "pipeline-1",
+			UUID:      uuid,
+			LoopOptions: &apistructs.PipelineTaskLoopOptions{
+				LoopedTimes: 3,
+			},
+		},
+	}
+	_, err := s.Cancel(ctx, task)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, uuid, task.Extra.UUID)
 }
 
 //import (


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
hotfix stop by user task uuid bug

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=209285&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   hotfix stop by user task uuid bug           |
| 🇨🇳 中文    |    hotfix stopByUser类型的task uuid变更的bug          |
