### PR TITLE
fix Redeploy pipelineYmlName

### DIFF
--- a/modules/dop/services/cdp/cdp.go
+++ b/modules/dop/services/cdp/cdp.go
@@ -58,6 +58,11 @@ func (cdp *CDP) CdpNotifyProcess(pipelineEvent *apistructs.PipelineInstanceEvent
 	if err != nil {
 		return err
 	}
+	org, err := cdp.bdl.GetOrg(orgID)
+	if err != nil {
+		logrus.Errorf("failed to get org info err: %s", err)
+		return err
+	}
 	pipelineDetail, err := cdp.bdl.GetPipeline(pipelineData.PipelineID)
 	if err != nil {
 		return err
@@ -171,7 +176,7 @@ func (cdp *CDP) CdpNotifyProcess(pipelineEvent *apistructs.PipelineInstanceEvent
 				"appName":        pipelineDetail.ApplicationName,
 				"projectID":      strconv.FormatUint(pipelineDetail.ProjectID, 10),
 				"projectName":    pipelineDetail.ProjectName,
-				"orgName":        pipelineDetail.OrgName,
+				"orgName":        org.Name,
 				"branch":         pipelineDetail.Branch,
 				"uiPublicURL":    conf.UIPublicURL(),
 			}

--- a/modules/orchestrator/services/runtime/runtime.go
+++ b/modules/orchestrator/services/runtime/runtime.go
@@ -455,7 +455,7 @@ func (r *Runtime) RedeployPipeline(operator user.ID, orgID uint64, runtimeID uin
 			apistructs.LabelAppName:       app.Name,
 			apistructs.LabelProjectName:   app.ProjectName,
 		},
-		PipelineYmlName: fmt.Sprintf("dice-deploy-redeploy-%d", runtime.ID),
+		PipelineYmlName: getRedeployPipelineYmlName(*runtime),
 		ClusterName:     runtime.ClusterName,
 		PipelineSource:  apistructs.PipelineSourceDice,
 		AutoRunAtOnce:   true,
@@ -1908,4 +1908,8 @@ var queryStringDecoder *schema.Decoder
 func init() {
 	queryStringDecoder = schema.NewDecoder()
 	queryStringDecoder.IgnoreUnknownKeys(true)
+}
+
+func getRedeployPipelineYmlName(runtime dbclient.Runtime) string {
+	return fmt.Sprintf("%d/%s/%s/pipeline.yml", runtime.ApplicationID, runtime.Workspace, runtime.Name)
 }

--- a/modules/orchestrator/services/runtime/runtime_test.go
+++ b/modules/orchestrator/services/runtime/runtime_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/orchestrator/dbclient"
 	"github.com/erda-project/erda/pkg/parser/diceyml"
 )
 
@@ -102,4 +103,46 @@ func TestGetRollbackConfig(t *testing.T) {
 	assert.Equal(t, 6, cfg[2]["TEST"])
 	assert.Equal(t, 6, cfg[3]["STAGING"])
 	assert.Equal(t, 8, cfg[3]["PROD"])
+}
+
+func Test_getRedeployPipelineYmlName(t *testing.T) {
+	type args struct {
+		runtime dbclient.Runtime
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases
+		{
+			name: "Filled in the space and scene set",
+			args: args{
+				runtime: dbclient.Runtime{
+					ApplicationID: 1,
+					Workspace:     "PORD",
+					Name:          "master",
+				},
+			},
+			want: "1/PORD/master/pipeline.yml",
+		},
+		{
+			name: "Filled in the space and scene set",
+			args: args{
+				runtime: dbclient.Runtime{
+					ApplicationID: 4,
+					Workspace:     "TEST",
+					Name:          "master",
+				},
+			},
+			want: "4/TEST/master/pipeline.yml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRedeployPipelineYmlName(tt.args.runtime); got != tt.want {
+				t.Errorf("getRedeployPipelineYmlName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
Reason: In this case, the PipelineYmlName of the pipeline running is not bound to the branch
Basic feasible solution: bind the newly created pipeline during redeployment to the default pipeline on the master branch

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
[Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=209949&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDgwNSJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=431&type=BUG)


#### Specified Reviewers:

/assign sfwn

