### PR TITLE
Delete the host described in the namespace of the fdp type of the dice_pipeline_lifecycle_hook_clients table

### DIFF
--- a/.erda/migrations/pipeline/20210826-update-dice-pipeline-lifecycle-hook-clients.sql
+++ b/.erda/migrations/pipeline/20210826-update-dice-pipeline-lifecycle-hook-clients.sql
@@ -1,0 +1,3 @@
+-- because the fdp in erda on erda is no longer the default namespace, but the components are in the same ns
+-- direct update does not determine whether it exists, because pipeline-base.sql is data created with a fixed id
+UPDATE `dice_pipeline_lifecycle_hook_clients` SET host='fdp-master:8080' where id in (1);


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
the fdp in erda on erda is no longer the default namespace, but the components are in the same ns, so remove namespace 
described host

#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://erda.cloud/erda/dop/projects/387/issues/bug?id=217026&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)