### PR TITLE
Cherry pick of #1524: bugfix:fix msp project overview

### DIFF
--- a/modules/msp/tenant/db/dbmock.go
+++ b/modules/msp/tenant/db/dbmock.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	MYSQL = "mysql"
+)
+
+func MockInit(dialect string) (*gorm.DB, sqlmock.Sqlmock, error) {
+	db, mock, err := sqlmock.New()
+	if nil != err {
+		return nil, nil, nil
+	}
+	mysqldb, err := gorm.Open(dialect, db)
+	return mysqldb, mock, err
+}

--- a/modules/msp/tenant/db/dbmock.go
+++ b/modules/msp/tenant/db/dbmock.go
@@ -1,16 +1,15 @@
 // Copyright (c) 2021 Terminus, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package db
 

--- a/modules/msp/tenant/db/project_test.go
+++ b/modules/msp/tenant/db/project_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+)
+
+func TestMSPProjectDB_Query(t *testing.T) {
+	mysqldb, _, _ := MockInit(MYSQL)
+	type fields struct {
+		DB *gorm.DB
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *MSPProject
+		wantErr bool
+	}{
+		{name: "case1", fields: fields{DB: mysqldb}, args: args{id: "1"}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &MSPProjectDB{
+				DB: tt.fields.DB,
+			}
+			got, err := db.Query(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Query() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSPProjectDB_Delete(t *testing.T) {
+	mysqldb, _, _ := MockInit(MYSQL)
+	type fields struct {
+		DB *gorm.DB
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *MSPProject
+		wantErr bool
+	}{
+		{name: "case1", fields: fields{DB: mysqldb}, args: args{id: "1"}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &MSPProjectDB{
+				DB: tt.fields.DB,
+			}
+			got, err := db.Delete(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Delete() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSPProjectDB_Update(t *testing.T) {
+	mysqldb, _, _ := MockInit(MYSQL)
+	type fields struct {
+		DB *gorm.DB
+	}
+	type args struct {
+		project *MSPProject
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *MSPProject
+		wantErr bool
+	}{
+		{name: "case1", fields: fields{DB: mysqldb}, args: args{project: nil}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &MSPProjectDB{
+				DB: tt.fields.DB,
+			}
+			got, err := db.Update(tt.args.project)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Update() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMSPProjectDB_Create(t *testing.T) {
+	mysqldb, _, _ := MockInit(MYSQL)
+	type fields struct {
+		DB *gorm.DB
+	}
+	type args struct {
+		project *MSPProject
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *MSPProject
+		wantErr bool
+	}{
+		{name: "case1", fields: fields{DB: mysqldb}, args: args{project: nil}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &MSPProjectDB{
+				DB: tt.fields.DB,
+			}
+			got, err := db.Create(tt.args.project)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Create() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/msp/tenant/db/project_test.go
+++ b/modules/msp/tenant/db/project_test.go
@@ -1,16 +1,15 @@
 // Copyright (c) 2021 Terminus, Inc.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 package db
 

--- a/modules/msp/tenant/project/project.service.go
+++ b/modules/msp/tenant/project/project.service.go
@@ -294,7 +294,16 @@ func (s *projectService) GetProject(ctx context.Context, req *pb.GetProjectReque
 }
 
 func (s *projectService) DeleteProject(ctx context.Context, req *pb.DeleteProjectRequest) (*pb.DeleteProjectResponse, error) {
-	_, err := s.MSPProjectDB.Delete(req.ProjectId)
+
+	proj, err := s.MSPProjectDB.Query(req.ProjectId)
+	if err != nil {
+		return nil, err
+	}
+	if proj == nil {
+		return &pb.DeleteProjectResponse{Data: nil}, nil
+	}
+
+	_, err = s.MSPProjectDB.Delete(req.ProjectId)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/msp/tenant/project/project.service_test.go
+++ b/modules/msp/tenant/project/project.service_test.go
@@ -20,6 +20,8 @@ import (
 
 	servicehub "github.com/erda-project/erda-infra/base/servicehub"
 	pb "github.com/erda-project/erda-proto-go/msp/tenant/project/pb"
+	"github.com/erda-project/erda/modules/msp/instance/db/monitor"
+	"github.com/erda-project/erda/modules/msp/tenant/db"
 )
 
 func Test_projectService_GetProjects(t *testing.T) {
@@ -79,6 +81,63 @@ func Test_projectService_GetProjects(t *testing.T) {
 	}
 }
 
+func Test_projectService_GetProjectsTenantsIDs(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req *pb.GetProjectsTenantsIDsRequest
+	}
+	tests := []struct {
+		name     string
+		service  string
+		config   string
+		args     args
+		wantResp *pb.GetProjectsTenantsIDsResponse
+		wantErr  bool
+	}{
+		// TODO: Add test cases.
+		//		{
+		//			"case 1",
+		//			"erda.msp.tenant.project.ProjectService",
+		//			`
+		//erda.msp.tenant.project:
+		//`,
+		//			args{
+		//				context.TODO(),
+		//				&pb.GetProjectsTenantsIDsRequest{
+		//					// TODO: setup fields
+		//				},
+		//			},
+		//			&pb.GetProjectsTenantsIDsResponse{
+		//				// TODO: setup fields.
+		//			},
+		//			false,
+		//		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := servicehub.New()
+			events := hub.Events()
+			go func() {
+				hub.RunWithOptions(&servicehub.RunOptions{Content: tt.config})
+			}()
+			err := <-events.Started()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			srv := hub.Service(tt.service).(pb.ProjectServiceServer)
+			got, err := srv.GetProjectsTenantsIDs(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("projectService.GetProjectsTenantsIDs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantResp) {
+				t.Errorf("projectService.GetProjectsTenantsIDs() = %v, want %v", got, tt.wantResp)
+			}
+		})
+	}
+}
+
 func Test_projectService_CreateProject(t *testing.T) {
 	type args struct {
 		ctx context.Context
@@ -131,6 +190,228 @@ func Test_projectService_CreateProject(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.wantResp) {
 				t.Errorf("projectService.CreateProject() = %v, want %v", got, tt.wantResp)
+			}
+		})
+	}
+}
+
+func Test_projectService_UpdateProject(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req *pb.UpdateProjectRequest
+	}
+	tests := []struct {
+		name     string
+		service  string
+		config   string
+		args     args
+		wantResp *pb.UpdateProjectResponse
+		wantErr  bool
+	}{
+		// TODO: Add test cases.
+		//		{
+		//			"case 1",
+		//			"erda.msp.tenant.project.ProjectService",
+		//			`
+		//erda.msp.tenant.project:
+		//`,
+		//			args{
+		//				context.TODO(),
+		//				&pb.UpdateProjectRequest{
+		//					// TODO: setup fields
+		//				},
+		//			},
+		//			&pb.UpdateProjectResponse{
+		//				// TODO: setup fields.
+		//			},
+		//			false,
+		//		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := servicehub.New()
+			events := hub.Events()
+			go func() {
+				hub.RunWithOptions(&servicehub.RunOptions{Content: tt.config})
+			}()
+			err := <-events.Started()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			srv := hub.Service(tt.service).(pb.ProjectServiceServer)
+			got, err := srv.UpdateProject(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("projectService.UpdateProject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantResp) {
+				t.Errorf("projectService.UpdateProject() = %v, want %v", got, tt.wantResp)
+			}
+		})
+	}
+}
+
+func Test_projectService_GetProject(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req *pb.GetProjectRequest
+	}
+	tests := []struct {
+		name     string
+		service  string
+		config   string
+		args     args
+		wantResp *pb.GetProjectResponse
+		wantErr  bool
+	}{
+		// TODO: Add test cases.
+		//		{
+		//			"case 1",
+		//			"erda.msp.tenant.project.ProjectService",
+		//			`
+		//erda.msp.tenant.project:
+		//`,
+		//			args{
+		//				context.TODO(),
+		//				&pb.GetProjectRequest{
+		//					// TODO: setup fields
+		//				},
+		//			},
+		//			&pb.GetProjectResponse{
+		//				// TODO: setup fields.
+		//			},
+		//			false,
+		//		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := servicehub.New()
+			events := hub.Events()
+			go func() {
+				hub.RunWithOptions(&servicehub.RunOptions{Content: tt.config})
+			}()
+			err := <-events.Started()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			srv := hub.Service(tt.service).(pb.ProjectServiceServer)
+			got, err := srv.GetProject(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("projectService.GetProject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantResp) {
+				t.Errorf("projectService.GetProject() = %v, want %v", got, tt.wantResp)
+			}
+		})
+	}
+}
+
+func Test_projectService_GetProjectOverview(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		req *pb.GetProjectOverviewRequest
+	}
+	tests := []struct {
+		name     string
+		service  string
+		config   string
+		args     args
+		wantResp *pb.GetProjectOverviewResponse
+		wantErr  bool
+	}{
+		// TODO: Add test cases.
+		//		{
+		//			"case 1",
+		//			"erda.msp.tenant.project.ProjectService",
+		//			`
+		//erda.msp.tenant.project:
+		//`,
+		//			args{
+		//				context.TODO(),
+		//				&pb.GetProjectOverviewRequest{
+		//					// TODO: setup fields
+		//				},
+		//			},
+		//			&pb.GetProjectOverviewResponse{
+		//				// TODO: setup fields.
+		//			},
+		//			false,
+		//		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := servicehub.New()
+			events := hub.Events()
+			go func() {
+				hub.RunWithOptions(&servicehub.RunOptions{Content: tt.config})
+			}()
+			err := <-events.Started()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			srv := hub.Service(tt.service).(pb.ProjectServiceServer)
+			got, err := srv.GetProjectOverview(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("projectService.GetProjectOverview() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantResp) {
+				t.Errorf("projectService.GetProjectOverview() = %v, want %v", got, tt.wantResp)
+			}
+		})
+	}
+}
+
+func Test_projectService_DeleteProject(t *testing.T) {
+	init, _, _ := db.MockInit(db.MYSQL)
+	projectDB := db.MSPProjectDB{DB: init}
+	tenantDB := db.MSPTenantDB{DB: init}
+	monitorDB := monitor.MonitorDB{DB: init}
+
+	type fields struct {
+		p            *provider
+		MSPProjectDB *db.MSPProjectDB
+		MSPTenantDB  *db.MSPTenantDB
+		MonitorDB    *monitor.MonitorDB
+	}
+	type args struct {
+		ctx context.Context
+		req *pb.DeleteProjectRequest
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *pb.DeleteProjectResponse
+		wantErr bool
+	}{
+		{
+			name:    "case1",
+			fields:  fields{p: nil, MSPProjectDB: &projectDB, MSPTenantDB: &tenantDB, MonitorDB: &monitorDB},
+			args:    args{ctx: nil, req: &pb.DeleteProjectRequest{ProjectId: "1"}},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &projectService{
+				p:            tt.fields.p,
+				MSPProjectDB: tt.fields.MSPProjectDB,
+				MSPTenantDB:  tt.fields.MSPTenantDB,
+				MonitorDB:    tt.fields.MonitorDB,
+			}
+			got, err := s.DeleteProject(tt.args.ctx, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteProject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteProject() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #1524 on release/1.2.

Squashed commit message:

```
commit c9061f040f539f4a74c05a5d56098e322baa82da
Author: innerpeacez <innerpeace.zhai@gmail.com>
Date:   Wed Aug 25 16:54:53 2021 +0800

    bugfix:fix msp project overview (#1524)
    
    * fix msp project overview
    
    * add test ut
    
    * add ut TestMSPProjectDB_Query()
    
    * import format
    
    * add license and add uts
    
    * add ut Test_projectService_DeleteProject()
```

What type of this PR
Add one of the following kinds:
/kind bug

Which issue(s) this PR fixes:
project overview data error.
delete old project fail.
Specified Reviewers:
/assign @liuhaoyang @recallsong