### PR TITLE
fix: label node when import cluster which erda inner

### DIFF
--- a/modules/cmp/impl/clusters/import_cluster.go
+++ b/modules/cmp/impl/clusters/import_cluster.go
@@ -33,6 +33,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	decoder "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -53,6 +55,7 @@ const (
 	ClusterAgentSA   = "cluster-agent"
 	ClusterAgentCR   = "cluster-agent-cr"
 	ClusterAgentCRB  = "cluster-agent-crb"
+	ErdaOrgLabel     = "dice/org-%s"
 )
 
 var (
@@ -95,6 +98,45 @@ func (c *Clusters) importCluster(userID string, req *apistructs.ImportCluster) e
 		return nil
 	}
 
+	if req.ClusterName == conf.ErdaClusterName() {
+		ic, err := rest.InClusterConfig()
+		if err != nil {
+			// Erda doesn't at kubernetes cluster
+			if err == rest.ErrNotInCluster {
+				return nil
+			}
+			logrus.Errorf("get incluster rest config error: %v", err)
+			return err
+		}
+
+		inClusterCs, err := kubernetes.NewForConfig(ic)
+		if err != nil {
+			logrus.Errorf("new incluster clientSet error: %v", err)
+			return err
+		}
+
+		nodes, err := inClusterCs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			logrus.Errorf("get kubernetes nodes error: %v", err)
+			return err
+		}
+
+		orgDTO, err := c.bdl.GetOrg(req.OrgID)
+		if err != nil {
+			logrus.Errorf("get org info error: %v", err)
+			return err
+		}
+
+		for _, node := range nodes.Items {
+			node.Labels[fmt.Sprintf(ErdaOrgLabel, orgDTO.Name)] = "true"
+			if _, err = inClusterCs.CoreV1().Nodes().Update(context.Background(), &node, metav1.UpdateOptions{}); err != nil {
+				logrus.Errorf("label node: %s, error: %v", node.Name, err)
+				return err
+			}
+		}
+		return nil
+	}
+
 	ci, err := c.bdl.GetCluster(req.ClusterName)
 	if err != nil {
 		return err
@@ -112,7 +154,7 @@ func (c *Clusters) importCluster(userID string, req *apistructs.ImportCluster) e
 		return err
 	}
 
-	if req.ClusterName == conf.ErdaClusterName() || !(status == statusOffline || status == statusUnknown) {
+	if !(status == statusOffline || status == statusUnknown) {
 		return nil
 	}
 
@@ -582,7 +624,7 @@ func (c *Clusters) renderCommonDeployConfig(orgName, clusterName string) (*Rende
 			{Name: "DEBUG", Value: "true"},
 			{Name: "ERDA_CHART_VERSION", Value: conf.ErdaVersion()},
 			{Name: "HELM_NAMESPACE", Value: getWorkerNamespace()},
-			{Name: "NODE_LABELS", Value: fmt.Sprintf("dice/org-%s=true", orgName)},
+			{Name: "NODE_LABELS", Value: fmt.Sprintf(ErdaOrgLabel+"=true", orgName)},
 			{Name: "ERDA_CHART_VALUES", Value: generateSetValues(ci)},
 			{Name: "HELM_REPO_URL", Value: conf.HelmRepoURL()},
 			{Name: "HELM_REPO_USERNAME", Value: conf.HelmRepoUsername()},


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
label node when import cluster（erda inner cluster）

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  label node when import cluster（erda inner cluster）            |
| 🇨🇳 中文    |    修复导入 Erda 所在 Kubernetes 集群时未打企业标的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
