### PR TITLE
magic temp hack: dop inject DOP_ADDR to localhost:9527 to fix internal invoke timeout issue in cp

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -58,7 +58,7 @@ services:
       replicas: 1
     envs:
       DEBUG: "true"
-      MONITOR_ADDR: monitor:7096
+      DOP_ADDR: localhost:9527 # TODO remove it after internal bundle invoke inside cp issue-manage adjusted
     health_check:
       exec: { }
       http:


### PR DESCRIPTION
#### What type of this PR

/kind bugfix

#### What this PR does / why we need it:

magic temp hack: dop inject DOP_ADDR to localhost:9527 to fix internal invoke timeout issue in cp.

TODO change to internal method invoke in component-protocol and remove this hack.

#### Specified Reviewers:

/assign @Effet 