### PR TITLE
fix: openapi cp proxy resolve embed unmarshal to show logic error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/mock v1.5.0
-	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0
 	github.com/googlecloudplatform/flink-operator v0.0.0-00010101000000-000000000000
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
#### What type of this PR

/kind bugfix

#### What this PR does / why we need it:

openapi cp proxy show logic error correctly.
Json Unmarshal will use embed pb struct's custom unmarshal method before this change, so `code` and `err` will be ignored.

Before:
![image](https://user-images.githubusercontent.com/13919034/131468075-76285779-4535-43ae-b74e-145394ce52f4.png)

After: 
![image](https://user-images.githubusercontent.com/13919034/131467963-875bc6ba-299b-45c4-84ce-d5c39bca9f71.png)


#### Specified Reviewers:

/assign @Effet 