### PR TITLE
feat(addon): set addon_id/redis label for the addon to split pod to different nodes

### DIFF
--- a/modules/scheduler/executor/plugins/edas/edas.go
+++ b/modules/scheduler/executor/plugins/edas/edas.go
@@ -2216,7 +2216,7 @@ func (e *EDAS) Scale(ctx context.Context, specObj interface{}) (interface{}, err
 		err   error
 	)
 	if appID, err = e.getAppID(appName); err != nil {
-		errMsg := fmt.Sprintf("get appID errL: %v", err)
+		errMsg := fmt.Sprintf("get appID err in scale: %v", err)
 		logrus.Errorf(errMsg)
 		return nil, fmt.Errorf(errMsg)
 	}

--- a/modules/scheduler/executor/plugins/k8s/statefulset_test.go
+++ b/modules/scheduler/executor/plugins/k8s/statefulset_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/erda-project/erda/modules/scheduler/executor/plugins/k8s/persistentvolumeclaim"
 	"github.com/erda-project/erda/modules/scheduler/executor/plugins/k8s/statefulset"
 	"github.com/erda-project/erda/pkg/http/httpclient"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
@@ -285,4 +286,68 @@ func TestParseJobSpecTemplate(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, clusterInfo["MOUNTPOINT_PATH"], newPath)
+}
+
+func TestCreateStatefulSet(t *testing.T) {
+	kubernetes := &Kubernetes{}
+
+	info := StatefulsetInfo{
+		sg: &apistructs.ServiceGroup{
+			Dice: apistructs.Dice{
+				ID:     "fake-test-dice",
+				Type:   "addon",
+				Labels: nil,
+				Services: []apistructs.Service{
+					apistructs.Service{
+						Name:          "fake-test-service",
+						Namespace:     "fake-test",
+						Image:         "",
+						ImageUsername: "",
+						ImagePassword: "",
+						Cmd:           "",
+						Ports:         nil,
+						ProxyPorts:    nil,
+						Vip:           "",
+						ShortVIP:      "",
+						ProxyIp:       "",
+						PublicIp:      "",
+						Scale:         0,
+						Resources: apistructs.Resources{
+							Cpu:  100,
+							Mem:  200,
+							Disk: 0,
+						},
+						Depends:            nil,
+						Env:                nil,
+						Labels:             map[string]string{"ADDON_GROUP_ID": "11111111"},
+						DeploymentLabels:   nil,
+						Selectors:          nil,
+						Binds:              nil,
+						Volumes:            nil,
+						Hosts:              nil,
+						HealthCheck:        nil,
+						NewHealthCheck:     nil,
+						SideCars:           nil,
+						InitContainer:      nil,
+						InstanceInfos:      nil,
+						MeshEnable:         nil,
+						TrafficSecurity:    diceyml.TrafficSecurity{},
+						WorkLoad:           "",
+						ProjectServiceName: "",
+						K8SSnippet:         nil,
+						StatusDesc:         apistructs.StatusDesc{},
+					},
+				},
+				ServiceDiscoveryKind: "",
+				ServiceDiscoveryMode: "",
+				ProjectNamespace:     "",
+			},
+		},
+		namespace:   "fake-test",
+		envs:        map[string]string{},
+		annotations: map[string]string{},
+	}
+
+	err := kubernetes.createStatefulSet(info)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature


#### What this PR does / why we need it:
- feat(addon): set addon_id/Redis label for the addon to split pod to different nodes

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  feat(addon): support set addon_id/Redis label for the addon to split pod to different nodes  |
| 🇨🇳 中文    |   支持给 addon 设置 addon_id 或 redis 标签，以便将 pod 打散到不通的节点上           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
