### PR TITLE
service name can only be lowercase

### DIFF
--- a/pkg/parser/diceyml/servicename_visitor.go
+++ b/pkg/parser/diceyml/servicename_visitor.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 )
 
-var serviceNameRegex = regexp.MustCompile("^((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9]))$")
+var serviceNameRegex = regexp.MustCompile("^((([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))$")
 
 // var serviceNameMaxLen = 14 // service name 最长长度
 


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
Service name mandatory lowercase only

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=71555&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDQzNiJdfQ%3D%3D&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)


#### Specified Reviewers:

/assign @Effet 

