### PR TITLE
Fix page size reset to default when filter conditions change

### DIFF
--- a/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
@@ -318,6 +318,12 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 			return err
 		}
 		cond.PageSize = 10
+		if _, ok := c.State["pageNo"]; ok {
+			cond.PageNo = uint64(c.State["pageNo"].(float64))
+		}
+		if _, ok := c.State["pageSize"]; ok {
+			cond.PageSize = uint64(c.State["pageSize"].(float64))
+		}
 	} else {
 		issuetype := sdk.InParams["fixedIssueType"].(string)
 		switch issuetype {

--- a/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
@@ -317,13 +317,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		if err := json.Unmarshal(filterCondS, &cond); err != nil {
 			return err
 		}
-		cond.PageSize = 10
-		if _, ok := c.State["pageNo"]; ok {
-			cond.PageNo = uint64(c.State["pageNo"].(float64))
-		}
-		if _, ok := c.State["pageSize"]; ok {
-			cond.PageSize = uint64(c.State["pageSize"].(float64))
-		}
+		resetPageInfo(&cond, c.State)
 	} else {
 		issuetype := sdk.InParams["fixedIssueType"].(string)
 		switch issuetype {
@@ -789,4 +783,14 @@ func init() {
 	base.InitProviderWithCreator("issue-manage", "issueTable", func() servicehub.Provider {
 		return &ComponentAction{}
 	})
+}
+
+func resetPageInfo(req *apistructs.IssuePagingRequest, state map[string]interface{}) {
+	req.PageSize = 10
+	if _, ok := state["pageNo"]; ok {
+		req.PageNo = uint64(state["pageNo"].(float64))
+	}
+	if _, ok := state["pageSize"]; ok {
+		req.PageSize = uint64(state["pageSize"].(float64))
+	}
 }

--- a/modules/dop/component-protocol/components/issue-manage/issueTable/render_test.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueTable/render_test.go
@@ -17,6 +17,7 @@ package issueTable
 import (
 	"testing"
 
+	"github.com/erda-project/erda/apistructs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,5 +34,40 @@ func TestGetTotalPage(t *testing.T) {
 	}
 	for _, v := range data {
 		assert.Equal(t, getTotalPage(v.total, v.pageSize), v.page)
+	}
+}
+
+func Test_resetPageInfo(t *testing.T) {
+	type args struct {
+		req   *apistructs.IssuePagingRequest
+		state map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "reset",
+			args: args{
+				req: &apistructs.IssuePagingRequest{},
+				state: map[string]interface{}{
+					"pageNo":   float64(1),
+					"pageSize": float64(2),
+				},
+			},
+		},
+	}
+
+	expected := []*apistructs.IssuePagingRequest{
+		{
+			PageNo:   1,
+			PageSize: 2,
+		},
+	}
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetPageInfo(tt.args.req, tt.args.state)
+			assert.Equal(t, expected[i], tt.args.req)
+		})
 	}
 }

--- a/modules/dop/component-protocol/components/issue-manage/issueTable/render_test.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueTable/render_test.go
@@ -17,8 +17,9 @@ package issueTable
 import (
 	"testing"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
 )
 
 func TestGetTotalPage(t *testing.T) {


### PR DESCRIPTION
#### What type of this PR
bug

#### What this PR does / why we need it:
Fix page size reset to default when filter conditions change

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=208473&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMTA3MyJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


