### PR TITLE
project dashboard add internationalization

### DIFF
--- a/conf/monitor/monitor/chartview/report/bug.json
+++ b/conf/monitor/monitor/chartview/report/bug.json
@@ -13,6 +13,12 @@
       "i": "view-f6623ce7",
       "view": {
         "title": "缺陷按状态分布",
+        "i18n": {
+          "title": {
+            "en": "bug are distributed by state",
+            "zh": "缺陷按状态分布"
+          }
+        },
         "description": "",
         "chartType": "chart:pie",
         "dataSourceType": "api",
@@ -74,6 +80,12 @@
       "i": "view-fd2ecfbe",
       "view": {
         "title": "缺陷新增 / 关闭趋势",
+        "i18n": {
+          "title": {
+            "en": "bug add/close trend",
+            "zh": "缺陷新增 / 关闭趋势"
+          }
+        },
         "description": "",
         "chartType": "chart:line",
         "dataSourceType": "api",
@@ -138,6 +150,12 @@
       "i": "view-1e86c4a6",
       "view": {
         "title": "缺陷按严重等级分布",
+        "i18n": {
+          "title": {
+            "en": "bug distribution by severity level",
+            "zh": "缺陷按严重等级分布"
+          }
+        },
         "description": "",
         "chartType": "chart:pie",
         "dataSourceType": "api",
@@ -199,6 +217,12 @@
       "i": "view-91fd7d1f",
       "view": {
         "title": "缺陷平均响应时间 (天)",
+        "i18n": {
+          "title": {
+            "en": "bug defect response time (MD)",
+            "zh": "缺陷平均响应时间 (天)"
+          }
+        },
         "description": "",
         "chartType": "card",
         "dataSourceType": "api",
@@ -262,6 +286,12 @@
       "i": "view-d8d99372",
       "view": {
         "title": "缺陷平均修复工作量（人天)",
+        "i18n": {
+          "title": {
+            "en": "bug average repair workload（MD)",
+            "zh": "缺陷平均修复工作量（人天)"
+          }
+        },
         "description": "",
         "chartType": "card",
         "dataSourceType": "api",
@@ -325,6 +355,12 @@
       "i": "view-8b1ee412",
       "view": {
         "title": "缺陷按优先级分布",
+        "i18n": {
+          "title": {
+            "en": "bug distribution by priority",
+            "zh": "缺陷按优先级分布"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",
@@ -423,6 +459,12 @@
       "i": "view-a844c5b7",
       "view": {
         "title": "缺陷按重新打开分布",
+        "i18n": {
+          "title": {
+            "en": "bug press to reopen the distribution",
+            "zh": "缺陷按重新打开分布"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",
@@ -519,6 +561,12 @@
       "i": "view-7fb8a372",
       "view": {
         "title": "缺陷按人员分布",
+        "i18n": {
+          "title": {
+            "en": "bug distribution by personnel",
+            "zh": "缺陷按人员分布"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",

--- a/conf/monitor/monitor/chartview/report/working.json
+++ b/conf/monitor/monitor/chartview/report/working.json
@@ -13,6 +13,12 @@
       "i": "view-98ae03fd",
       "view": {
         "title": "实际工作量 (人天)",
+        "i18n": {
+          "title": {
+            "en": "actual workload (MD)",
+            "zh": "实际工作量 (人天)"
+          }
+        },
         "description": "",
         "chartType": "card",
         "dataSourceType": "api",
@@ -60,6 +66,12 @@
       "i": "view-73d60bcb",
       "view": {
         "title": "预计工作量 (人天)",
+        "i18n": {
+          "title": {
+            "en": "estimated workload (MD)",
+            "zh": "预计工作量 (人天)"
+          }
+        },
         "description": "",
         "chartType": "card",
         "dataSourceType": "api",
@@ -107,6 +119,12 @@
       "i": "view-cdb72329",
       "view": {
         "title": "成员工作量分布 (人天)",
+        "i18n": {
+          "title": {
+            "en": "member workload distribution (MD)",
+            "zh": "成员工作量分布 (人天)"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",
@@ -173,6 +191,12 @@
       "i": "view-2161e559",
       "view": {
         "title": "缺陷 耗时TOP10 (人天)",
+        "i18n": {
+          "title": {
+            "en": "BUG time consuming TOP10 (MD)",
+            "zh": "缺陷 耗时TOP10 (人天)"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",
@@ -242,6 +266,12 @@
       "i": "view-1e55a4eb",
       "view": {
         "title": "任务 耗时TOP10 (人天)",
+        "i18n": {
+          "title": {
+            "en": "task time consuming TOP10 (MD)",
+            "zh": "任务 耗时TOP10 (人天)"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",
@@ -311,6 +341,12 @@
       "i": "view-970a9935",
       "view": {
         "title": "人员事件分布 (个)",
+        "i18n": {
+          "title": {
+            "en": "personnel incident distribution (num)",
+            "zh": "人员事件分布 (个)"
+          }
+        },
         "description": "",
         "chartType": "chart:bar",
         "dataSourceType": "api",


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
In the case of the project market in English, the title of each statistical chart is still in Chinese, and two English market configurations are added, so that the English environment can query the English market configuration


#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=206478&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)