### PR TITLE
pipeline remove default cron compensator

### DIFF
--- a/pkg/parser/pipelineyml/graph_pipelineyml.go
+++ b/pkg/parser/pipelineyml/graph_pipelineyml.go
@@ -230,7 +230,20 @@ func ConvertToGraphPipelineYml(data []byte) (*apistructs.PipelineYml, error) {
 		}
 		result.Stages = append(result.Stages, stageActions)
 	}
+
+	result.CronCompensator = cronCompensatorReset(result.CronCompensator)
 	return result, nil
+}
+
+func cronCompensatorReset(cronCompensator *apistructs.CronCompensator) *apistructs.CronCompensator {
+	if cronCompensator != nil {
+		if cronCompensator.Enable == DefaultCronCompensator.Enable &&
+			cronCompensator.LatestFirst == DefaultCronCompensator.LatestFirst &&
+			cronCompensator.StopIfLatterExecuted == DefaultCronCompensator.StopIfLatterExecuted {
+			return nil
+		}
+	}
+	return cronCompensator
 }
 
 func toApiParam(pipelineInput *PipelineParam) (params *apistructs.PipelineParam) {

--- a/pkg/parser/pipelineyml/graph_pipelineyml_test.go
+++ b/pkg/parser/pipelineyml/graph_pipelineyml_test.go
@@ -18,9 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
 )
 
 func TestConvertGraphPipelineYml(t *testing.T) {
@@ -39,4 +42,56 @@ func TestConvertToGraphPipelineYml(t *testing.T) {
 	b, err := json.MarshalIndent(graph, "", "  ")
 	assert.NoError(t, err)
 	fmt.Println(string(b))
+}
+
+func Test_cronCompensatorReset(t *testing.T) {
+	type args struct {
+		cronCompensator *apistructs.CronCompensator
+	}
+	tests := []struct {
+		name string
+		args args
+		want *apistructs.CronCompensator
+	}{
+		{
+			name: "test_nil",
+			args: args{
+				cronCompensator: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "test_default",
+			args: args{
+				cronCompensator: &apistructs.CronCompensator{
+					Enable:               DefaultCronCompensator.Enable,
+					LatestFirst:          DefaultCronCompensator.LatestFirst,
+					StopIfLatterExecuted: DefaultCronCompensator.StopIfLatterExecuted,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "test_other",
+			args: args{
+				cronCompensator: &apistructs.CronCompensator{
+					Enable:               true,
+					LatestFirst:          false,
+					StopIfLatterExecuted: true,
+				},
+			},
+			want: &apistructs.CronCompensator{
+				Enable:               true,
+				LatestFirst:          false,
+				StopIfLatterExecuted: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cronCompensatorReset(tt.args.cronCompensator); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("cronCompensatorReset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/parser/pipelineyml/visitor_cron.go
+++ b/pkg/parser/pipelineyml/visitor_cron.go
@@ -120,11 +120,6 @@ func (v *CronVisitor) Visit(s *Spec) {
 		v.nextTimes = append(v.nextTimes, nextTime)
 		scheduleFrom = nextTime
 	}
-
-	// compensator
-	if s.CronCompensator == nil {
-		s.CronCompensator = &DefaultCronCompensator
-	}
 }
 
 func ListNextCronTime(cronExpr string, ops ...CronVisitorOption) ([]time.Time, error) {


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
The default timing compensation will make users think that this is a timing task switch, so the default timing compensation configuration is removed


#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=210303&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=TASK)
