### PR TITLE
mysql-cli action render

### DIFF
--- a/bundle/addon.go
+++ b/bundle/addon.go
@@ -149,6 +149,32 @@ func (b *Bundle) ListAddonByProjectID(projectID, orgID int64) (*apistructs.Addon
 	return &data, nil
 }
 
+// listConfigSheetAddon query the data source of the configuration sheet
+func (b *Bundle) ListConfigSheetAddon(params url.Values, orgID string, userID string) (*apistructs.AddonListResponse, error) {
+	host, err := b.urls.Orchestrator()
+	if err != nil {
+		return nil, err
+	}
+	hc := b.hc
+
+	var data apistructs.AddonListResponse
+	r, err := hc.Get(host).
+		Path(fmt.Sprintf("/api/addons")).
+		Header(httputil.InternalHeader, "bundle").
+		Header(httputil.UserHeader, userID).
+		Header(httputil.OrgHeader, orgID).
+		Params(params).
+		Do().
+		JSON(&data)
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !r.IsOK() {
+		return nil, toAPIError(r.StatusCode(), data.Error)
+	}
+	return &data, nil
+}
+
 func (b *Bundle) AddonConfigCallback(addonID string, req apistructs.AddonConfigCallBackResponse) (*apistructs.PostAddonConfigCallBackResponse, error) {
 	host, err := b.urls.Orchestrator()
 	if err != nil {
@@ -218,7 +244,7 @@ func (b *Bundle) FindClusterResource(clusterName, orgID string) (*apistructs.Res
 	return &(resp.Data), nil
 }
 
-func (b *Bundle) GetAddon(addonid string) (*apistructs.AddonFetchResponseData, error) {
+func (b *Bundle) GetAddon(addonid string, orgID string, userID string) (*apistructs.AddonFetchResponseData, error) {
 	host, err := b.urls.Orchestrator()
 	if err != nil {
 		return nil, err
@@ -226,7 +252,10 @@ func (b *Bundle) GetAddon(addonid string) (*apistructs.AddonFetchResponseData, e
 	hc := b.hc
 	var resp apistructs.AddonFetchResponse
 	r, err := hc.Get(host).
-		Path(fmt.Sprintf("/api/addon/%s", addonid)).
+		Path(fmt.Sprintf("/api/addons/%s", addonid)).
+		Header(httputil.InternalHeader, "bundle").
+		Header(httputil.UserHeader, userID).
+		Header(httputil.OrgHeader, orgID).
 		Do().
 		JSON(&resp)
 	if err != nil {

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/mysql-cli.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/mysql-cli.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/erda-project/erda/apistructs"
+
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+)
+
+func mysqlCliRender(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, globalStateData *apistructs.GlobalStateData) (err error) {
+	bdl := ctx.Value(protocol.GlobalInnerKeyCtxBundle.String()).(protocol.ContextBundle)
+
+	var formData map[string]interface{}
+	switch string(event.Operation) {
+	case "changeDateSource":
+		stateMap, ok := c.State["formData"].(map[string]interface{})
+		if !ok {
+			goto RESULT
+		}
+
+		params, ok := stateMap["params"].(map[string]interface{})
+		if !ok {
+			goto RESULT
+		}
+
+		datasource, ok := params["datasource"].(string)
+		if !ok {
+			goto RESULT
+		}
+
+		addon, err := bdl.Bdl.GetAddon(datasource, bdl.Identity.OrgID, bdl.Identity.UserID)
+		if err != nil {
+			return err
+		}
+
+		if addon.Config["MYSQL_DATABASE"] != nil {
+			params["database"] = addon.Config["MYSQL_DATABASE"]
+		}
+		stateMap["params"] = params
+		formData = stateMap
+	default:
+		var param = map[string]interface{}{}
+		if actionData, ok := bdl.InParams["actionData"].(map[string]interface{}); ok {
+			if params, ok := actionData["params"]; ok {
+				param = params.(map[string]interface{})
+			}
+		}
+
+		formData = map[string]interface{}{
+			"params": param,
+		}
+	}
+
+RESULT:
+
+	c.Operations = map[string]interface{}{
+		"change": map[string]changeStruct{
+			"params.datasource": {
+				Key:    "changeDateSource",
+				Reload: true,
+			},
+		},
+	}
+
+	var field []apistructs.FormPropItem
+	props, ok := c.Props.(map[string]interface{})
+	if !ok {
+		return err
+	}
+	for key, val := range props {
+		if key == "fields" {
+			field = val.([]apistructs.FormPropItem)
+			break
+		}
+	}
+
+	query := make(map[string][]string)
+	query["displayName"] = []string{"MySQL", "Custom", "AliCloud-Rds"}
+	query["workspace"] = []string{"TEST"}
+	query["type"] = []string{"database_addon"}
+	query["value"] = []string{bdl.InParams["projectId"].(string)}
+	query["projectId"] = []string{bdl.InParams["projectId"].(string)}
+	addons, err := bdl.Bdl.ListConfigSheetAddon(query, bdl.Identity.OrgID, bdl.Identity.UserID)
+	if err != nil {
+		return err
+	}
+
+	var dataSourceList []map[string]interface{}
+	for _, addon := range addons.Data {
+
+		var name = addon.Name
+		if addon.Tag != "" {
+			name += fmt.Sprintf("(%s)", addon.Tag)
+		}
+
+		dataSourceList = append(dataSourceList, map[string]interface{}{
+			"value": addon.ID,
+			"name":  name,
+		})
+	}
+
+	newField := fillMysqlCliFields(field, dataSourceList)
+	newProps := map[string]interface{}{
+		"fields": newField,
+	}
+	c.Props = newProps
+	c.State["formData"] = formData
+	return nil
+}
+
+func fillMysqlCliFields(field []apistructs.FormPropItem, dataSourceList []map[string]interface{}) []apistructs.FormPropItem {
+	taskParams := apistructs.FormPropItem{
+		Component: "formGroup",
+		ComponentProps: map[string]interface{}{
+			"title": "任务参数",
+		},
+		Group: "params",
+		Key:   "params",
+	}
+
+	dataSourceSelect := apistructs.FormPropItem{
+		Label:     "datasource",
+		Component: "select",
+		Required:  true,
+		ComponentProps: map[string]interface{}{
+			"options": dataSourceList,
+		},
+		Group:    "params",
+		Key:      "params.datasource",
+		LabelTip: "数据源",
+	}
+
+	databaseField := apistructs.FormPropItem{
+		Label:     "database",
+		Component: "input",
+		Required:  true,
+		Key:       "params.database",
+		ComponentProps: map[string]interface{}{
+			"placeholder": "请输入数据",
+		},
+		Group:    "params",
+		LabelTip: "数据库名称",
+	}
+
+	sqlField := apistructs.FormPropItem{
+		Label:     "sql",
+		Component: "textarea",
+		Required:  true,
+		Key:       "params.sql",
+		ComponentProps: map[string]interface{}{
+			"autoSize": map[string]interface{}{
+				"minRows": 2,
+				"maxRows": 12,
+			},
+			"placeholder": "请输入数据",
+		},
+		Group:    "params",
+		LabelTip: "sql语句",
+	}
+
+	var newField []apistructs.FormPropItem
+	for _, val := range field {
+		newField = append(newField, val)
+		if strings.EqualFold(val.Key, "if") {
+			newField = append(newField, taskParams)
+			newField = append(newField, dataSourceSelect)
+			newField = append(newField, databaseField)
+			newField = append(newField, sqlField)
+		}
+	}
+	return newField
+}

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/mysql-cli_test.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/mysql-cli_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func Test_fillMysqlCliFields(t *testing.T) {
+	type args struct {
+		field          []apistructs.FormPropItem
+		dataSourceList []map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want []apistructs.FormPropItem
+	}{
+		{
+			name: "test_execution_conditions",
+			args: args{
+				field: []apistructs.FormPropItem{
+					{
+						Key: "if",
+					},
+				},
+				dataSourceList: nil,
+			},
+			want: []apistructs.FormPropItem{
+				{
+					Key: "if",
+				},
+				{
+					Component: "formGroup",
+					ComponentProps: map[string]interface{}{
+						"title": "任务参数",
+					},
+					Group: "params",
+					Key:   "params",
+				},
+				{
+					Label:     "datasource",
+					Component: "select",
+					Required:  true,
+					ComponentProps: map[string]interface{}{
+						"options": nil,
+					},
+					Group:    "params",
+					Key:      "params.datasource",
+					LabelTip: "数据源",
+				},
+				{
+					Label:     "database",
+					Component: "input",
+					Required:  true,
+					Key:       "params.database",
+					ComponentProps: map[string]interface{}{
+						"placeholder": "请输入数据",
+					},
+					Group:    "params",
+					LabelTip: "数据库名称",
+				},
+				{
+					Label:     "sql",
+					Component: "textarea",
+					Required:  true,
+					Key:       "params.sql",
+					ComponentProps: map[string]interface{}{
+						"autoSize": map[string]interface{}{
+							"minRows": 2,
+							"maxRows": 12,
+						},
+						"placeholder": "请输入数据",
+					},
+					Group:    "params",
+					LabelTip: "sql语句",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fillMysqlCliFields(tt.args.field, tt.args.dataSourceList)
+			assert.Equal(t, len(got), len(tt.want))
+			for index, v := range got {
+				assert.Equal(t, v.Key, tt.want[index].Key)
+				assert.Equal(t, v.Label, tt.want[index].Label)
+				assert.Equal(t, v.Group, tt.want[index].Group)
+				assert.Equal(t, v.Component, tt.want[index].Component)
+			}
+		})
+	}
+}

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
@@ -305,6 +305,8 @@ func registerActionTypeRender() {
 		actionTypeRender["testplan-run"] = testPlanRun
 
 		actionTypeRender["testscene-run"] = testSceneRun
+
+		actionTypeRender["mysql-cli"] = mysqlCliRender
 	})
 }
 


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
mysql-cli action add componentized rendering, In this way, the user can automatically fill in the database after selecting the data source

#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=57004&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)

Associated pr: https://github.com/erda-project/erda-actions/pull/177#issue-724284291