### PR TITLE
csrf-interceptor set-cookie if token is invalid

### DIFF
--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -156,9 +156,11 @@ func (p *provider) Interceptor(h http.HandlerFunc) http.HandlerFunc {
 				}
 			}
 		}
+		needSetCookie := false
 		if len(token) <= 0 {
 			// Generate token
 			token = p.generator.gen(r)
+			needSetCookie = true
 		}
 
 		// Store token in the context
@@ -168,7 +170,9 @@ func (p *provider) Interceptor(h http.HandlerFunc) http.HandlerFunc {
 		rw.Header().Add(echo.HeaderVary, echo.HeaderCookie)
 
 		// Set CSRF cookie
-		p.setCSRFCookie(rw, r, token)
+		if needSetCookie {
+			p.setCSRFCookie(rw, r, token)
+		}
 
 		h(rw, r)
 	}

--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -151,6 +151,9 @@ func (p *provider) Interceptor(h http.HandlerFunc) http.HandlerFunc {
 				}
 				if !p.generator.valid(token, clientToken, r) {
 					p.Log.Warnf("invalid csrf token: %s", token)
+					rw.WriteHeader(http.StatusForbidden)
+					// compatible, client should recognize response's Set-Cookie header and correct cookie name
+					common.WriteError(errors.New("invalid csrf token"), rw)
 					p.setCSRFCookie(rw, r, "")
 					return
 				}


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

Not return set-cookie if token is valid.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/bug?id=219588&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJSRU9QRU4iXSwibGFiZWxJRHMiOlsxNDUzXX0%3D&issueGantt__urlQuery=eyJ0b3RhbCI6NjQsInBhZ2VObyI6MSwicGFnZVNpemUiOjIwMCwiaXNzdWVWaWV3R3JvdXBWYWx1ZSI6ImdhbnR0IiwiSXNzdWVUeXBlIjoiQlVHIn0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTAwfQ%3D%3D&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)

#### Specified Reviewers:

/assign @recallsong 
