### PR TITLE
Timed tasks automatically synchronize the extension information of the git address

### DIFF
--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -23,6 +23,8 @@ erda.core.dicehub.release:
   gc_switch: "${RELEASE_GC_SWITCH:true}"
 
 erda.core.dicehub.extension:
+  extension_sources: "${EXTENSION_SOURCES}"
+  extension_sources_cron: "${EXTENSION_SOURCES_CRON:'0 0 21 * * ?'}"
 #  extension_menu: ${EXTENSION_MENU:{"":""}}
 
 mysql:

--- a/modules/dicehub/extension/provider_test.go
+++ b/modules/dicehub/extension/provider_test.go
@@ -55,13 +55,13 @@ func Test_provider(t *testing.T) {
 	_, err = f.Write([]byte(specYml))
 	assert.NoError(t, err)
 
-	fc2 := monkey.PatchInstanceMethod(reflect.TypeOf(p), "RunExtensionsPush", func(_ *extensionService, dir string, extensionVersionMap, extensionTypeMap map[string][]string) (string, string, error) {
+	fc2 := monkey.PatchInstanceMethod(reflect.TypeOf(p), "RunExtensionsPush", func(_ *extensionService, dir string, extensionVersionMap, extensionTypeMap map[string][]string, ok bool) (string, string, error) {
 		if dir != dir1 {
 			return "", "", errors.New("path wrong")
 		}
 		return "", "", nil
 	})
 	defer fc2.Unpatch()
-	err = p.InitExtension(FilePath)
+	err = p.InitExtension(FilePath, false)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
Timed tasks automatically synchronize the extension information of the git address

#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=209340&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=TASK)
