### PR TITLE
get csrf secure from referer firstly; set default http-only to true

### DIFF
--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -43,7 +43,7 @@ type config struct {
 	CookieDomain      string        `file:"cookie_domain" desc:"domain of the CSRF cookie. optional."`
 	CookiePath        string        `file:"cookie_path" default:"/" desc:"path of the CSRF cookie. optional."`
 	CookieMaxAge      time.Duration `file:"cookie_max_age" default:"24h" desc:"max age of the CSRF cookie. optional."`
-	CookieHTTPOnly    bool          `file:"cookie_http_only" desc:"indicates if CSRF cookie is HTTP only. optional."`
+	CookieHTTPOnly    bool          `file:"cookie_http_only" default:"true" desc:"indicates if CSRF cookie is HTTP only. optional."`
 }
 
 type (

--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -259,14 +259,29 @@ func csrfTokenFromQuery(param string) csrfTokenExtractor {
 }
 
 func (p *provider) getScheme(r *http.Request) string {
+	// get from standard header first
+	proto := firstNonEmpty(r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Protocol"))
+	if proto != "" {
+		return proto
+	}
+	// get from referer
 	referer := r.Header.Get("Referer")
-	scheme := "http"
+	scheme := "https"
 	if u, err := url.Parse(referer); err == nil && len(u.Scheme) > 0 {
 		scheme = u.Scheme
 	} else if len(r.URL.Scheme) > 0 {
 		scheme = r.URL.Scheme
 	}
 	return scheme
+}
+
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 func init() {

--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -220,7 +220,7 @@ func (p *provider) setCSRFCookie(rw http.ResponseWriter, r *http.Request, token 
 		cookie.Domain = p.Cfg.CookieDomain
 	}
 	cookie.Expires = time.Now().Add(p.Cfg.CookieMaxAge)
-	cookie.Secure = r.URL.Scheme == "https"
+	cookie.Secure = p.getScheme(r) == "https"
 	cookie.HttpOnly = p.Cfg.CookieHTTPOnly
 	http.SetCookie(rw, cookie)
 	return token
@@ -256,6 +256,17 @@ func csrfTokenFromQuery(param string) csrfTokenExtractor {
 		}
 		return token, nil
 	}
+}
+
+func (p *provider) getScheme(r *http.Request) string {
+	referer := r.Header.Get("Referer")
+	scheme := "http"
+	if u, err := url.Parse(referer); err == nil && len(u.Scheme) > 0 {
+		scheme = u.Scheme
+	} else if len(r.URL.Scheme) > 0 {
+		scheme = r.URL.Scheme
+	}
+	return scheme
 }
 
 func init() {


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

- get csrf secure from referer firstly
- set default http-only to true

before set http-only: 

![before](https://user-images.githubusercontent.com/13919034/131981072-eb452a4a-c39e-4074-9c47-5013821f80e0.png)
after set http-only: 

![after](https://user-images.githubusercontent.com/13919034/131981121-7bd4cb16-e3db-4082-8b89-4b912a255977.png)

