### PR TITLE
bugfix: autotest set-cookie do not overwrite all existed cookie

### DIFF
--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -222,7 +222,6 @@ func (p *provider) setCSRFCookie(rw http.ResponseWriter, r *http.Request, token 
 	cookie.Expires = time.Now().Add(p.Cfg.CookieMaxAge)
 	cookie.Secure = p.getScheme(r) == "https"
 	cookie.HttpOnly = p.Cfg.CookieHTTPOnly
-	fmt.Println("===---", cookie.Secure, p.getScheme(r), p.getScheme(r) == "https")
 	http.SetCookie(rw, cookie)
 	return token
 }

--- a/modules/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
+++ b/modules/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotest_cookie_keep_before
+
+import (
+	"fmt"
+	"strings"
+)
+
+// appendOrReplaceSetCookiesToCookie
+// - append cookie item if cookie name not exist
+// - replace cookie item if cookie already exist
+//
+// @setCookies: [{COOKIE1=def; Path=/; Domain=xxx; Expires=Fri, 03 Sep 2021 15:12:15 GMT},{...}]
+// @originCookie: COOKIE2=abc; COOKIE2=abc
+func appendOrReplaceSetCookiesToCookie(setCookies []string, originCookie string) string {
+	// transfer originCookie to map
+	cookieItems := strings.Split(originCookie, ";")
+	cookieKvMap := map[string]string{}
+	orderedCookieKeys := make([]string, 0, len(cookieItems)+len(setCookies))
+	for _, item := range cookieItems {
+		item = strings.TrimSpace(item)
+		kv := strings.SplitN(item, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		cookieKvMap[k] = v
+		orderedCookieKeys = append(orderedCookieKeys, k)
+	}
+
+	// handle each set-cookie
+	for _, setCookie := range setCookies {
+		if len(setCookie) == 0 {
+			continue
+		}
+
+		// cookieKV: COOKIE1=def
+		cookieKV := strings.SplitN(setCookie, ";", 2)[0]
+		kv := strings.SplitN(cookieKV, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+
+		// set order: add new cookie key at the end
+		if _, ok := cookieKvMap[k]; !ok {
+			orderedCookieKeys = append(orderedCookieKeys, k)
+		}
+
+		// put value from set-cookie into cookie map
+		cookieKvMap[k] = v
+	}
+
+	// construct kv to cookie
+	newCookieItems := make([]string, 0, len(cookieKvMap))
+	for _, key := range orderedCookieKeys {
+		item := fmt.Sprintf("%s=%s", key, cookieKvMap[key])
+		newCookieItems = append(newCookieItems, item)
+	}
+	newCookieStr := strings.Join(newCookieItems, "; ")
+
+	return newCookieStr
+}

--- a/modules/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
+++ b/modules/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotest_cookie_keep_before
+
+import (
+	"testing"
+)
+
+func Test_appendOrReplaceSetCookiesToCookie(t *testing.T) {
+	type args struct {
+		setCookies   []string
+		originCookie string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "all empty",
+			args: args{
+				setCookies:   nil,
+				originCookie: "",
+			},
+			want: "",
+		},
+		{
+			name: "set-cookie of one existed cookie",
+			args: args{
+				setCookies:   []string{`cookie_a=aa; Path=/; Domain=xxx; Expires=Fri, 03 Sep 2021 15:12:15 GMT`},
+				originCookie: "cookie_a=a; cookie_b=b",
+			},
+			want: "cookie_a=aa; cookie_b=b",
+		},
+		{
+			name: "set-cookie of tow existed cookie(a,c) and append one(d), and originCookie is splitted by `;`, not `; `",
+			args: args{
+				setCookies:   []string{`cookie_a=aa; Path=/; Domain=xxx; Expires=Fri, 03 Sep 2021 15:12:15 GMT`, `cookie_c=C`, `cookie_d=dd`},
+				originCookie: "cookie_a=a;cookie_b=b;cookie_c=c",
+			},
+			want: "cookie_a=aa; cookie_b=b; cookie_c=C; cookie_d=dd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendOrReplaceSetCookiesToCookie(tt.args.setCookies, tt.args.originCookie); got != tt.want {
+				t.Errorf("appendOrReplaceSetCookiesToCookie() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

/kind bugfix

#### What this PR does / why we need it:

After this pr, autotest's set-cookie will not overwrite all existed cookie. 

Otherwise, a single set-cookie will cause other cookie lost and 401 indeed.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=219588&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)
screenshot see erda issue

#### Specified Reviewers:

/assign @Effet @kakj-go 