### PR TITLE
Solve the failure of querying node details without passing version

### DIFF
--- a/modules/pipeline/services/pipelinesvc/snippet_test.go
+++ b/modules/pipeline/services/pipelinesvc/snippet_test.go
@@ -195,11 +195,14 @@ func Test_getActionDetail(t *testing.T) {
 
 		bdl := &bundle.Bundle{}
 		s.bdl = bdl
-
-		monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetExtensionVersion", func(b *bundle.Bundle, req apistructs.ExtensionVersionGetRequest) (*apistructs.ExtensionVersion, error) {
-			return &apistructs.ExtensionVersion{
-				Spec: data.spec,
-			}, nil
+		monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "SearchExtensions", func(b *bundle.Bundle, req apistructs.ExtensionSearchRequest) (map[string]apistructs.ExtensionVersion, error) {
+			var extensionVersion = map[string]apistructs.ExtensionVersion{}
+			for _, v := range req.Extensions {
+				extensionVersion[v] = apistructs.ExtensionVersion{
+					Spec: data.spec,
+				}
+			}
+			return extensionVersion, nil
 		})
 
 		monkey.Patch(handlerActionOutputsWithJq, func(action *apistructs.PipelineYmlAction, jq string) ([]string, error) {


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
The version field is not passed when querying the action details on the front end, and the query interface will return a 404 error

