### PR TITLE
fix BUG: duplicate data in the test plan list and the env of plan is not refreshed

### DIFF
--- a/modules/dop/dao/testplan_v2.go
+++ b/modules/dop/dao/testplan_v2.go
@@ -69,7 +69,7 @@ type TestPlanV2Join struct {
 }
 
 // Convert2DTO convert DAO to DTO
-func (tp *TestPlanV2Join) Convert2DTO() *apistructs.TestPlanV2 {
+func (tp TestPlanV2Join) Convert2DTO() *apistructs.TestPlanV2 {
 	return &apistructs.TestPlanV2{
 		ID:          tp.ID,
 		Name:        tp.Name,

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/protocol.yml
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/protocol.yml
@@ -320,6 +320,38 @@ rendering:
       state:
         - name: "pipelineId"
           value: "{{ executeHistoryTable.pipelineId }}"
+    - name: envDrawer
+    - name: envBaseInfoTitle
+    - name: envBaseInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTitle
+    - name: envGlobalInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderTitle
+    - name: envHeaderTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
   executeTaskTable:
     - name: executeInfo
       state:
@@ -397,6 +429,38 @@ rendering:
       state:
         - name: "pipelineId"
           value: "{{ executeHistoryTable.pipelineId }}"
+    - name: envDrawer
+    - name: envBaseInfoTitle
+    - name: envBaseInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTitle
+    - name: envGlobalInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderTitle
+    - name: envHeaderTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
   refreshButton:
     - name: executeHistoryTable
     - name: executeInfo
@@ -497,6 +561,38 @@ rendering:
       state:
         - name: "visible"
           value: "{{ executeTaskBreadcrumb.visible }}"
+    - name: envDrawer
+    - name: envBaseInfoTitle
+    - name: envBaseInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTitle
+    - name: envGlobalInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envGlobalText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderTitle
+    - name: envHeaderTable
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderInfo
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
+    - name: envHeaderText
+      state:
+        - name: "envData"
+          value: "{{ executeInfo.envData }}"
   __DefaultRendering__:
     - name: fileDetail
     - name: fileConfig

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/protocol.yml
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/protocol.yml
@@ -623,3 +623,4 @@ rendering:
       state:
         - name: "testPlanId"
           value: "{{ fileDetail.testPlanId }}"
+# TODO: move executeInfo.envData to global state

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -192,7 +192,7 @@ func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Compo
 				RenderType: "progress",
 				Value:      data.PassRate,
 			},
-			ExecuteTime: data.ExecuteTime.Format("2006-01-02 15:04:05"),
+			ExecuteTime: convertExecuteTime(data),
 		}
 		if data.IsArchived == true {
 			item.Operate.Operations["archive"] = map[string]interface{}{
@@ -261,6 +261,17 @@ func convertSortData(req *apistructs.TestPlanV2PagingRequest, c *apistructs.Comp
 	}
 
 	return nil
+}
+
+func convertExecuteTime(data *apistructs.TestPlanV2) string {
+	executeTime := ""
+	if data.ExecuteTime != nil {
+		executeTime = data.ExecuteTime.Format("2006-01-02 15:04:05")
+	}
+	if executeTime == "0001-01-01 00:00:00" {
+		executeTime = ""
+	}
+	return executeTime
 }
 
 // TODO:

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
@@ -16,6 +16,7 @@ package table
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert"
 
@@ -55,4 +56,21 @@ func Test_ConvertSortData(t *testing.T) {
 		Asc:     false,
 	}
 	assert.Equal(t, want, req)
+}
+
+func Test_executeTime(t *testing.T) {
+	time := time.Now()
+	data := &apistructs.TestPlanV2{
+		ExecuteTime: nil,
+	}
+	executeTime := convertExecuteTime(data)
+	want := ""
+	assert.Equal(t, want, executeTime)
+
+	data = &apistructs.TestPlanV2{
+		ExecuteTime: &time,
+	}
+	executeTime = convertExecuteTime(data)
+	want = time.Format("2006-01-02 15:04:05")
+	assert.Equal(t, want, executeTime)
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

func (tp *TestPlanV2Join) Convert2DTO() will cause duplicate executeTime
change  *TestPlanV2Join to TestPlanV2Join

plan env should refresh when click ExecuteHistoryTable
