### PR TITLE
revert proto refactor temporary to fix delete runtime bug

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -21,7 +21,7 @@ import (
 	// providers and modules
 	_ "github.com/erda-project/erda-infra/providers"
 	_ "github.com/erda-project/erda/modules/orchestrator"
-	_ "github.com/erda-project/erda/modules/orchestrator/components"
+	//_ "github.com/erda-project/erda/modules/orchestrator/components"
 )
 
 func main() {

--- a/conf/orchestrator/orchestrator.yaml
+++ b/conf/orchestrator/orchestrator.yaml
@@ -14,7 +14,7 @@ grpc-server:
   addr: ":7080"
 service-register:
 
-erda.orchestrator.runtime:
+# erda.orchestrator.runtime:
 mysql:
   host: "${MYSQL_HOST:localhost}"
   port: ${MYSQL_PORT:3306}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug

###

Only GET /api/runtimes/{:idOrName} was refactored, however Delete /api/runtimes/{:idOrName} was also handled by new http server unexpectedly. Revert the change to fix the runtimes can't delete.

