### PR TITLE
pipeline legacy and infra http server use the same route and port

### DIFF
--- a/conf/pipeline/pipeline.yaml
+++ b/conf/pipeline/pipeline.yaml
@@ -3,7 +3,7 @@ pipeline:
 service-register:
 
 http-server:
-  addr: ":3082"
+  addr: ":3081"
 grpc-server:
   addr: ":30810"
 

--- a/modules/pipeline/initialize.go
+++ b/modules/pipeline/initialize.go
@@ -190,9 +190,10 @@ func (p *provider) do() error {
 		endpoints.WithReconciler(r),
 	)
 
-	server := httpserver.New(conf.ListenAddr())
 	//server.Router().Path("/metrics").Methods(http.MethodGet).Handler(promxp.Handler("pipeline"))
+	server := httpserver.New(conf.ListenAddr())
 	server.RegisterEndpoint(ep.Routes())
+	p.Router.Any("/**", server.Router())
 
 	// 加载 event manager
 	events.Initialize(bdl, publisher, dbClient)
@@ -217,8 +218,6 @@ func (p *provider) do() error {
 		return err
 	}
 
-	//return server, nil
-	p.server = server
 	return nil
 }
 

--- a/modules/pipeline/provider.go
+++ b/modules/pipeline/provider.go
@@ -22,33 +22,25 @@ import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 	_ "github.com/erda-project/erda-infra/providers/etcd"
 	election "github.com/erda-project/erda-infra/providers/etcd-election"
+	"github.com/erda-project/erda-infra/providers/httpserver"
 	"github.com/erda-project/erda-proto-go/core/pipeline/cms/pb"
 	_ "github.com/erda-project/erda/modules/pipeline/aop/plugins"
-	"github.com/erda-project/erda/pkg/http/httpserver"
 )
 
 type provider struct {
 	CmsService         pb.CmsServiceServer `autowired:"erda.core.pipeline.cms.CmsService"`
 	ReconcilerElection election.Interface  `autowired:"etcd-election@reconciler"`
 	GcElection         election.Interface  `autowired:"etcd-election@gc"`
-	server             *httpserver.Server
+	Router             httpserver.Router   `autowired:"http-router"`
 }
 
 func (p *provider) Run(ctx context.Context) error {
 	logrus.Infof("[alert] starting pipeline instance")
 	var err error
-	done := make(chan struct{}, 1)
-
-	go func() {
-		err = p.server.ListenAndServe()
-		done <- struct{}{}
-	}()
 
 	select {
 	case <-ctx.Done():
-	case <-done:
 	}
-
 	return err
 }
 


### PR DESCRIPTION
#### What type of this PR
/kind feature


#### What this PR does / why we need it:
When protobuf adds an open interface, the address port of the route will be old, and it is impossible to specify a route to any port, which causes the open interface declared by protobuf to be unable to be routed, so the pipeline components need to be changed to use the same routing port

