### PR TITLE
Modify the type of the executed_time of the autotest-testplan,and fix the bug of taskHistoryTable will panic

### DIFF
--- a/modules/dop/dao/testplan_v2.go
+++ b/modules/dop/dao/testplan_v2.go
@@ -36,7 +36,7 @@ type TestPlanV2 struct {
 	SpaceID     uint64
 	IsArchived  bool
 	PassRate    float64
-	ExecuteTime time.Time
+	ExecuteTime *time.Time
 }
 
 // TableName table name
@@ -58,7 +58,7 @@ func (tp *TestPlanV2) Convert2DTO() apistructs.TestPlanV2 {
 		CreateAt:    &tp.CreatedAt,
 		UpdateAt:    &tp.UpdatedAt,
 		PassRate:    tp.PassRate,
-		ExecuteTime: &tp.ExecuteTime,
+		ExecuteTime: tp.ExecuteTime,
 	}
 }
 
@@ -82,7 +82,7 @@ func (tp TestPlanV2Join) Convert2DTO() *apistructs.TestPlanV2 {
 		Steps:       []*apistructs.TestPlanV2Step{},
 		IsArchived:  tp.IsArchived,
 		PassRate:    tp.PassRate,
-		ExecuteTime: &tp.ExecuteTime,
+		ExecuteTime: tp.ExecuteTime,
 	}
 }
 

--- a/modules/dop/services/autotest_v2/testplan_v2.go
+++ b/modules/dop/services/autotest_v2/testplan_v2.go
@@ -37,12 +37,14 @@ func (svc *Service) CreateTestPlanV2(req apistructs.TestPlanV2CreateRequest) (ui
 
 	// create test plan
 	testPlanV2 := &dao.TestPlanV2{
-		Name:      req.Name,
-		Desc:      req.Desc,
-		CreatorID: req.UserID,
-		UpdaterID: req.UserID,
-		SpaceID:   req.SpaceID,
-		ProjectID: req.ProjectID,
+		Name:        req.Name,
+		Desc:        req.Desc,
+		CreatorID:   req.UserID,
+		UpdaterID:   req.UserID,
+		SpaceID:     req.SpaceID,
+		ProjectID:   req.ProjectID,
+		ExecuteTime: nil,
+		PassRate:    float64(0),
 	}
 
 	if err := svc.db.CreateTestPlanV2(testPlanV2); err != nil {

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
@@ -521,6 +521,11 @@ func (e *ExecuteTaskTable) handlerListOperation(bdl protocol.ContextBundle, c *a
 		e.State.PageNo = DefaultPageNo
 		e.State.PageSize = DefaultPageSize
 	}
+
+	if e.State.PipelineDetail == nil {
+		c.Data = map[string]interface{}{}
+		return nil
+	}
 	if e.State.PipelineDetail.ID == 0 {
 		c.Data = map[string]interface{}{}
 		return nil

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executeTaskTable
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+)
+
+func Test_handlerListOperation(t *testing.T) {
+	ctx := protocol.ContextBundle{
+		InParams: map[string]interface{}{},
+	}
+	ctx1 := context.WithValue(context.Background(), protocol.GlobalInnerKeyCtxBundle.String(), ctx)
+	a := &ExecuteTaskTable{}
+	a.State.PipelineDetail = nil
+	err := a.Render(ctx1, &apistructs.Component{}, apistructs.ComponentProtocolScenario{},
+		apistructs.ComponentEvent{
+			Operation:     apistructs.ExecuteChangePageNoOperationKey,
+			OperationData: nil,
+		}, nil)
+	assert.NoError(t, err)
+	a.State.PipelineDetail = &apistructs.PipelineDetailDTO{
+		PipelineDTO: apistructs.PipelineDTO{
+			ID: 0,
+		},
+	}
+	assert.NoError(t, err)
+}

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -264,12 +264,12 @@ func convertSortData(req *apistructs.TestPlanV2PagingRequest, c *apistructs.Comp
 }
 
 func convertExecuteTime(data *apistructs.TestPlanV2) string {
-	executeTime := ""
+	if data.ExecuteTime == nil {
+		return ""
+	}
+	var executeTime string
 	if data.ExecuteTime != nil {
 		executeTime = data.ExecuteTime.Format("2006-01-02 15:04:05")
-	}
-	if executeTime == "0001-01-01 00:00:00" {
-		executeTime = ""
 	}
 	return executeTime
 }

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -268,9 +268,7 @@ func convertExecuteTime(data *apistructs.TestPlanV2) string {
 		return ""
 	}
 	var executeTime string
-	if data.ExecuteTime != nil {
-		executeTime = data.ExecuteTime.Format("2006-01-02 15:04:05")
-	}
+	executeTime = data.ExecuteTime.Format("2006-01-02 15:04:05")
 	return executeTime
 }
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
@@ -59,18 +59,21 @@ func Test_ConvertSortData(t *testing.T) {
 }
 
 func Test_executeTime(t *testing.T) {
-	time := time.Now()
-	data := &apistructs.TestPlanV2{
-		ExecuteTime: nil,
+	nowTime := time.Now()
+	var data = []*apistructs.TestPlanV2{
+		{
+			ExecuteTime: nil,
+		},
+		{
+			ExecuteTime: &nowTime,
+		},
 	}
-	executeTime := convertExecuteTime(data)
-	want := ""
-	assert.Equal(t, want, executeTime)
-
-	data = &apistructs.TestPlanV2{
-		ExecuteTime: &time,
+	want := []string{
+		"",
+		nowTime.Format("2006-01-02 15:04:05"),
 	}
-	executeTime = convertExecuteTime(data)
-	want = time.Format("2006-01-02 15:04:05")
-	assert.Equal(t, want, executeTime)
+	for i := range data {
+		executeTime := convertExecuteTime(data[i])
+		assert.Equal(t, executeTime, want[i])
+	}
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind feature

#### What this PR does / why we need it:

Modify the type of the executed_time of the autotest-testplan,
if type is time.time{}. when data in SQL is NULL, after time.format(), will be 0001-01-01  
so modify it to *time.time

and fix the bug of taskHistoryTable will panic

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       modity the type of executed_time, fix  taskHistoryTable panic     |
| 🇨🇳 中文    |   修改执行时间的类型，修复执行历史记录列表可能panic的问题          |
