### PR TITLE
fix: cluster init error when use old version

### DIFF
--- a/build/dockerfiles/Dockerfile-cluster-ops
+++ b/build/dockerfiles/Dockerfile-cluster-ops
@@ -33,11 +33,5 @@ COPY --from=build "/tmp/erda/bin/${APP_NAME}" "/app/${APP_NAME}"
 COPY --from=build "/tmp/erda/conf/${CONFIG_PATH}" "/app/conf/${CONFIG_PATH}"
 COPY --from=build "/tmp/erda/pkg/erda-configs" "/app/erda-configs"
 
-# build change at release 1.2
-RUN mkdir -p /app/charts && cd /app/charts \
-    && wget http://terminus-dice.oss.aliyuncs.com/erda-charts/cluster-init/erda-1.1.0.tgz \
-    && wget http://terminus-dice.oss.aliyuncs.com/erda-charts/cluster-init/erda-addons-1.1.0.tgz \
-    && wget http://terminus-dice.oss.aliyuncs.com/erda-charts/cluster-init/erda-base-1.1.0.tgz
-
 CMD ["sh", "-c", "/app/${APP_NAME}"]
 

--- a/pkg/helm/manager.go
+++ b/pkg/helm/manager.go
@@ -142,12 +142,13 @@ func (m *Manager) checkDeployed(chart *ChartSpec) (bool, error) {
 		return false, nil
 	}
 
+	if lr.Chart.Metadata.Version != chart.Version {
+		logrus.Warnf("[%s] installed version %s, spce: %s", chart.ReleaseName, lr.Chart.Metadata.Version, chart.Version)
+	}
+
 	// check status by action type
 	switch chart.Action {
 	case ActionInstall:
-		if lr.Chart.Metadata.Version != chart.Version {
-			return false, fmt.Errorf("[%s] had installed version %s", chart.ReleaseName, lr.Chart.Metadata.Version)
-		}
 		if lr.Info.Status != "deployed" {
 			logrus.Infof("[%s] check status is %s", chart.ChartName, lr.Info.Status)
 			return false, nil
@@ -155,9 +156,6 @@ func (m *Manager) checkDeployed(chart *ChartSpec) (bool, error) {
 		logrus.Infof("[%s] check chart install success", chart.ChartName)
 		return true, nil
 	case ActionUpgrade:
-		if lr.Chart.Metadata.Version != chart.Version {
-			return false, nil
-		}
 		if lr.Info.Status != "deployed" {
 			logrus.Infof("[%s] check status is %s", chart.ChartName, lr.Info.Status)
 			return false, nil


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
fix cluster init error when use old version
e.g. if center cluster version is 1.2, latest erda version is 1.2.1.check installed can't match.
resolve: install doesn't need check install version, through warning instead error.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  cluster init error when use old version            |
| 🇨🇳 中文    |   修复 Erda 版本号导致的集群初始化失败           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
