### PR TITLE
fix the problem of panic when clicking the execution details when there is no execution data

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/cancelExecuteButton/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/cancelExecuteButton/render.go
@@ -68,13 +68,17 @@ func (ca *ComponentAction) Render(ctx context.Context, c *apistructs.Component, 
 		if _, ok := c.State["visible"]; ok {
 			visible = c.State["visible"].(bool)
 		}
-		pipelineId := ca.State.PipelineDetail.ID
-		if pipelineId > 0 {
-			if !ca.State.PipelineDetail.Status.IsReconcilerRunningStatus() {
+		if ca.State.PipelineDetail == nil {
+			visible = false
+		} else {
+			pipelineId := ca.State.PipelineDetail.ID
+			if pipelineId > 0 {
+				if !ca.State.PipelineDetail.Status.IsReconcilerRunningStatus() {
+					visible = false
+				}
+			} else {
 				visible = false
 			}
-		} else {
-			visible = false
 		}
 		c.Props = map[string]interface{}{
 			"text":    "取消执行",

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/cancelExecuteButton/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/cancelExecuteButton/render_test.go
@@ -15,9 +15,13 @@
 package cancelExecuteButton
 
 import (
+	"context"
 	"testing"
 
+	"github.com/alecthomas/assert"
+
 	"github.com/erda-project/erda/apistructs"
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
 )
 
 func TestComponentAction_marshal(t *testing.T) {
@@ -100,4 +104,25 @@ func TestComponentAction_Import(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestComponentAction_Render(t *testing.T) {
+	ctx := protocol.ContextBundle{
+		InParams: map[string]interface{}{},
+	}
+	ctx1 := context.WithValue(context.Background(), protocol.GlobalInnerKeyCtxBundle.String(), ctx)
+	a := &ComponentAction{}
+	a.State.PipelineDetail = nil
+	err := a.Render(ctx1, &apistructs.Component{}, apistructs.ComponentProtocolScenario{},
+		apistructs.ComponentEvent{
+			Operation:     apistructs.RenderingOperation,
+			OperationData: nil,
+		}, nil)
+	assert.NoError(t, err)
+	a.State.PipelineDetail = &apistructs.PipelineDetailDTO{
+		PipelineDTO: apistructs.PipelineDTO{
+			ID: 0,
+		},
+	}
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug


#### What this PR does / why we need it:

 the problem of panic when clicking the execution details when there is no execution data

<img width="1179" alt="xxx" src="https://user-images.githubusercontent.com/32703277/132479652-10525daa-585c-4c12-be70-10f906764d73.png">
to
<img width="1182" alt="zzzz" src="https://user-images.githubusercontent.com/32703277/132479658-871c9212-9fe0-4f73-8592-59fb062e9f3d.png">

#### Specified Reviewers:

/assign @sfwn


