### PR TITLE
Fix bug: DOP pod failed to start

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -60,6 +60,7 @@ services:
       replicas: 1
     envs:
       DEBUG: "true"
+      GOLANG_PROTOBUF_REGISTRATION_CONFLICT: "ignore"
     health_check:
       exec: { }
       http:


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

add GOLANG_PROTOBUF_REGISTRATION_CONFLICT  env.
it will cause DOP pod start failed

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        fix bug: DOP pod failed to start  |
| 🇨🇳 中文    |      修复DOP容器无法启动的bug        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
