### PR TITLE
update pod status color; display N/A when pod metrics less than 1e-4

### DIFF
--- a/modules/cmp/component-protocol/components/cmp-dashboard-podDetail/podStatus/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-podDetail/podStatus/render.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable"
 	"github.com/erda-project/erda/modules/cmp/component-protocol/types"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/components/base"
 )
@@ -66,26 +67,9 @@ func (podStatus *PodStatus) Render(ctx context.Context, c *cptype.Component, s c
 		return fmt.Errorf("pod %s/%s has invalid fields length", namespace, name)
 	}
 	status := fields[2]
-	color := ""
-	switch status {
-	case "Completed":
-		color = "steelBlue"
-	case "ContainerCreating":
-		color = "orange"
-	case "CrashLoopBackOff":
-		color = "red"
-	case "Error":
-		color = "maroon"
-	case "Evicted":
-		color = "darkgoldenrod"
-	case "ImagePullBackOff":
-		color = "darksalmon"
-	case "Pending":
-		color = "teal"
-	case "Running":
-		color = "lightgreen"
-	case "Terminating":
-		color = "brown"
+	color := podsTable.PodStatusToColor[status]
+	if color == "" {
+		color = "darkslategray"
 	}
 
 	podStatus.Data.Labels.Color = color

--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable/render.go
@@ -426,7 +426,13 @@ func parseResPercent(usedPercent float64, totQty *resource.Quantity, kind string
 	} else {
 		status = "error"
 	}
-	return status, fmt.Sprintf("%.2f", usedPercent), fmt.Sprintf("%s/%s", usedQtyString, totQty.String())
+	tip := fmt.Sprintf("%s/%s", usedQtyString, totQty.String())
+	value := fmt.Sprintf("%.2f", usedPercent)
+	if usedRes < 1e-4 {
+		tip = "N/A"
+		value = "N/A"
+	}
+	return status, value, tip
 }
 
 func convertUnit(bytes float64) string {

--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable/render.go
@@ -556,7 +556,7 @@ var PodStatusToColor = map[string]string{
 	"Evicted":           "darkgoldenrod",
 	"ImagePullBackOff":  "darksalmon",
 	"Pending":           "teal",
-	"Running":           "lightgreen",
+	"Running":           "green",
 	"Terminating":       "brown",
 }
 

--- a/modules/cmp/component-protocol/components/cmp-dashboard-workload-detail/podsTable/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-workload-detail/podsTable/render.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsTable"
 	"github.com/erda-project/erda/modules/cmp/component-protocol/types"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/components/base"
 )
@@ -564,26 +565,9 @@ func matchSelector(selector, labels map[string]interface{}) bool {
 }
 
 func (p *ComponentPodsTable) parsePodStatus(state string) Status {
-	color := ""
-	switch state {
-	case "Completed":
-		color = "steelBlue"
-	case "ContainerCreating":
-		color = "orange"
-	case "CrashLoopBackOff":
-		color = "red"
-	case "Error":
-		color = "maroon"
-	case "Evicted":
-		color = "darkgoldenrod"
-	case "ImagePullBackOff":
-		color = "darksalmon"
-	case "Pending":
-		color = "teal"
-	case "Running":
-		color = "lightgreen"
-	case "Terminating":
-		color = "brown"
+	color := podsTable.PodStatusToColor[state]
+	if color == "" {
+		color = "darkslategray"
 	}
 	return Status{
 		RenderType: "tagsRow",

--- a/modules/cmp/component-protocol/components/cmp-dashboard-workload-detail/podsTable/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-workload-detail/podsTable/render.go
@@ -430,7 +430,13 @@ func parseResPercent(usedPercent float64, totQty *resource.Quantity, kind string
 	} else {
 		status = "error"
 	}
-	return status, fmt.Sprintf("%.2f", usedPercent), fmt.Sprintf("%s/%s", usedQtyString, totQty.String())
+	tip := fmt.Sprintf("%s/%s", usedQtyString, totQty.String())
+	value := fmt.Sprintf("%.2f", usedPercent)
+	if usedRes < 1e-4 {
+		tip = "N/A"
+		value = "N/A"
+	}
+	return status, value, tip
 }
 
 func convertUnit(bytes float64) string {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug

#### What this PR does / why we need it:

1. Change pod color from lightgreen to green for Running status
2. Change pod metrics to "N/A" if result less than 1e-4

#### Specified Reviewers:

/assign @johnlanni 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


