### PR TITLE
when testplan executed, send messgae with orgID and projectID

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/tabExecuteButton/executeButton.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/tabExecuteButton/executeButton.go
@@ -106,6 +106,8 @@ type ClientMetaData struct {
 	Env        string `json:"env"`
 	TestPlanID uint64 `json:"testPlanID"`
 	ConfigEnv  string `json:"ConfigEnv"`
+	OrgID      uint64 `json:"orgID"`
+	ProjectID  uint64 `json:"projectID"`
 }
 
 type Props struct {
@@ -210,6 +212,8 @@ func (a *ComponentAction) handleDefault() error {
 						Env:        testClusterName,
 						TestPlanID: a.State.TestPlanID,
 						ConfigEnv:  "",
+						OrgID:      project.OrgID,
+						ProjectID:  project.ID,
 					},
 				},
 			},
@@ -228,6 +232,8 @@ func (a *ComponentAction) handleDefault() error {
 						Env:        testClusterName,
 						TestPlanID: a.State.TestPlanID,
 						ConfigEnv:  v.Ns,
+						OrgID:      project.OrgID,
+						ProjectID:  project.ID,
 					},
 				},
 			},
@@ -251,6 +257,10 @@ func (a *ComponentAction) handleClick(event apistructs.ComponentEvent, gs *apist
 	req.ClusterName = metaData.Env
 	req.ConfigManageNamespaces = metaData.ConfigEnv
 	req.UserID = a.CtxBdl.Identity.UserID
+	req.Labels = map[string]string{
+		apistructs.LabelProjectID: strconv.FormatUint(metaData.ProjectID, 10),
+		apistructs.LabelOrgID:     strconv.FormatUint(metaData.OrgID, 10),
+	}
 	a.State.ActiveKey = "Execute"
 	pipeline, err := a.CtxBdl.Bdl.ExecuteDiceAutotestTestPlan(req)
 	if err != nil {

--- a/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
@@ -17,7 +17,6 @@ package testplan_after
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/erda-project/erda/modules/dop/services/autotest"
 	"strconv"
 	"strings"
 	"time"
@@ -28,6 +27,7 @@ import (
 	testplanpb "github.com/erda-project/erda-proto-go/core/dop/autotest/testplan/pb"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/dop/services/autotest"
 	"github.com/erda-project/erda/modules/pipeline/aop"
 	"github.com/erda-project/erda/modules/pipeline/aop/aoptypes"
 	"github.com/erda-project/erda/modules/pipeline/spec"

--- a/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
@@ -16,6 +16,8 @@ package testplan_after
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/erda-project/erda/modules/dop/services/autotest"
 	"strconv"
 	"strings"
 	"time"
@@ -119,25 +121,7 @@ func (p *provider) Handle(ctx *aoptypes.TuneContext) error {
 		req.PassRate = float64(apiSuccessNum) / float64(apiTotalNum) * 100
 	}
 
-	ev2 := &apistructs.EventCreateRequest{
-		EventHeader: apistructs.EventHeader{
-			Event:         bundle.AutoTestPlanExecuteEvent,
-			Action:        bundle.UpdateAction,
-			OrgID:         "-1",
-			ProjectID:     "-1",
-			ApplicationID: "-1",
-			TimeStamp:     time.Now().Format("2006-01-02 15:04:05"),
-		},
-		Sender:  bundle.SenderDOP,
-		Content: req,
-	}
-
-	// create event
-	if err := p.Bundle.CreateEvent(ev2); err != nil {
-		logrus.Warnf("failed to send autoTestPlan update event, (%v)", err)
-		return err
-	}
-	return nil
+	return p.sendMessage(req, ctx.SDK.Pipeline.Snapshot.Secrets[autotest.CmsCfgKeyAPIGlobalConfig])
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
@@ -187,4 +171,39 @@ func convertReport(pipelineID uint64, report spec.PipelineReport) (ApiReportMeta
 		return ApiReportMeta{}, err
 	}
 	return meta, nil
+}
+
+func (p *provider) sendMessage(req testplanpb.Content, configString string) error {
+	// get projectID from GlobalConfig
+	config := apistructs.AutoTestAPIConfig{}
+	err := json.Unmarshal([]byte(configString), &config)
+	if err != nil {
+		return err
+	}
+
+	projectID, err := strconv.ParseUint(config.Header["project-id"], 10, 64)
+	project, err := p.Bundle.GetProject(projectID)
+	if err != nil {
+		return err
+	}
+
+	ev2 := &apistructs.EventCreateRequest{
+		EventHeader: apistructs.EventHeader{
+			Event:         bundle.AutoTestPlanExecuteEvent,
+			Action:        bundle.UpdateAction,
+			OrgID:         fmt.Sprintf("%d", project.OrgID),
+			ProjectID:     fmt.Sprintf("%d", project.ID),
+			ApplicationID: "-1",
+			TimeStamp:     time.Now().Format("2006-01-02 15:04:05"),
+		},
+		Sender:  bundle.SenderDOP,
+		Content: req,
+	}
+
+	// create event
+	if err := p.Bundle.CreateEvent(ev2); err != nil {
+		logrus.Warnf("failed to send autoTestPlan update event, (%v)", err)
+		return err
+	}
+	return nil
 }

--- a/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
@@ -176,8 +176,8 @@ func (p *provider) sendMessage(req testplanpb.Content, ctx *aoptypes.TuneContext
 		EventHeader: apistructs.EventHeader{
 			Event:         bundle.AutoTestPlanExecuteEvent,
 			Action:        bundle.UpdateAction,
-			OrgID:         ctx.SDK.Pipeline.Labels[apistructs.LabelProjectID],
-			ProjectID:     ctx.SDK.Pipeline.Labels[apistructs.LabelOrgID],
+			OrgID:         ctx.SDK.Pipeline.Labels[apistructs.LabelOrgID],
+			ProjectID:     ctx.SDK.Pipeline.Labels[apistructs.LabelProjectID],
 			ApplicationID: "-1",
 			TimeStamp:     time.Now().Format("2006-01-02 15:04:05"),
 		},

--- a/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin_test.go
+++ b/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin_test.go
@@ -15,15 +15,15 @@
 package testplan_after
 
 import (
-	"bou.ke/monkey"
-	testplanpb "github.com/erda-project/erda-proto-go/core/dop/autotest/testplan/pb"
-	"github.com/erda-project/erda/bundle"
 	"reflect"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/alecthomas/assert"
 
+	testplanpb "github.com/erda-project/erda-proto-go/core/dop/autotest/testplan/pb"
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/modules/pipeline/spec"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml"
 )


### PR DESCRIPTION
#### What type of this PR

/kind bugfix

#### What this PR does / why we need it:

send messgae with orgID and projectID
eventBox get http path form webHook, if orgID and projectID are -1 ,will insert two httpPath

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/bug?id=222230&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDgzMiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=429&type=BUG)

#### Specified Reviewers:

/assign @your-reviewer

#### Need cherry-pick to release versions?

/cherry-pick release/1.3
