### PR TITLE
openapi-ng fix router for openapi-v1 match-any

### DIFF
--- a/modules/core/openapi-ng/routes/openapi-v1/provider.go
+++ b/modules/core/openapi-ng/routes/openapi-v1/provider.go
@@ -70,6 +70,7 @@ func (p *provider) RegisterTo(router transhttp.Router) (err error) {
 }
 
 func replaceOpenapiV1Path(path string) string {
+	path = strings.ReplaceAll(path, "<*>", "**")
 	newPath := strings.NewReplacer("<", "{", ">", "}").Replace(path)
 	return newPath
 }

--- a/modules/core/openapi-ng/routes/openapi-v1/provider_test.go
+++ b/modules/core/openapi-ng/routes/openapi-v1/provider_test.go
@@ -41,6 +41,13 @@ func Test_replaceOpenapiV1Path(t *testing.T) {
 			},
 			want: "/api/projects",
 		},
+		{
+			name: "*",
+			args: args{
+				path: "/api/repo/<*>",
+			},
+			want: "/api/repo/**",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

openapi-ng fix router for openapi-v1 match-any

for examples:
- gittar `/api/repo/*`
- fdp `/api/fdp/*`

#### Specified Reviewers:

/assign @recallsong 

#### Need cherry-pick to release versions?

need /cherry-pick release/1.3