### PR TITLE
list agent pod by dice/component=cluster-agent label

### DIFF
--- a/modules/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
@@ -220,7 +220,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 		Type:       "select",
 		Fixed:      true,
 	}
-	for _, option := range []Option{devNs, testNs, productionNs, stagingNs, addonNs, pipelineNs, defaultNs, systemNs, otherNs} {
+	for _, option := range []Option{defaultNs, systemNs, devNs, testNs, productionNs, stagingNs, addonNs, otherNs, pipelineNs} {
 		if option.Children != nil {
 			sort.Slice(option.Children, func(i, j int) bool {
 				return option.Children[i].Label < option.Children[j].Label

--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
@@ -208,7 +208,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 		Type:       "select",
 		Fixed:      true,
 	}
-	for _, option := range []Option{devNs, testNs, productionNs, stagingNs, addonNs, pipelineNs, defaultNs, systemNs, otherNs} {
+	for _, option := range []Option{defaultNs, systemNs, devNs, testNs, productionNs, stagingNs, addonNs, otherNs, pipelineNs} {
 		if option.Children != nil {
 			sort.Slice(option.Children, func(i, j int) bool {
 				return option.Children[i].Label < option.Children[j].Label

--- a/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
@@ -207,7 +207,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 		Type:       "select",
 		Fixed:      true,
 	}
-	for _, option := range []Option{devNs, testNs, productionNs, stagingNs, addonNs, pipelineNs, defaultNs, systemNs, otherNs} {
+	for _, option := range []Option{defaultNs, systemNs, devNs, testNs, productionNs, stagingNs, addonNs, otherNs, pipelineNs} {
 		if option.Children != nil {
 			sort.Slice(option.Children, func(i, j int) bool {
 				return option.Children[i].Label < option.Children[j].Label

--- a/modules/cmp/steve/middleware/shell_handler.go
+++ b/modules/cmp/steve/middleware/shell_handler.go
@@ -100,13 +100,20 @@ func (s *ShellHandler) HandleShell(next http.Handler) http.Handler {
 			LabelSelector: "app=cluster-agent",
 		})
 		if err != nil {
-			logrus.Errorf("failed to list cluster-agent pod in steve handle shell, %v", err)
-			resp.WriteHeader(http.StatusInternalServerError)
-			resp.Write(apistructs.NewSteveError(apistructs.ServerError, "interval server error").JSON())
-			return
+			logrus.Errorf("failed to list cluster-agent pod in steve handle shell by app=cluster-agent label, %v", err)
+			//resp.WriteHeader(http.StatusInternalServerError)
+			//resp.Write(apistructs.NewSteveError(apistructs.ServerError, "interval server error").JSON())
+			//return
 		}
 
-		for _, pod := range pods.Items {
+		diceLabelPods, err := podClient.List(s.ctx, metav1.ListOptions{
+			LabelSelector: "dice/component=cluster-agent",
+		})
+		if err != nil {
+			logrus.Errorf("failed to list cluster-agent pod in steve handle shell by dice/component=cluster-agent label, %v", err)
+		}
+
+		for _, pod := range append(pods.Items, diceLabelPods.Items...) {
 			if !isPodReady(&pod) {
 				continue
 			}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug


#### What this PR does / why we need it:

cluster-agent pod has label dice/component=cluster-agent rather than app=cluster-agent when manual deploy.

#### Specified Reviewers:

/assign @johnlanni 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.3` when this PR is merged.

