### PR TITLE
multi-instance dicehub synchronizes local extension

### DIFF
--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -36,3 +36,7 @@ mysql:
 
 metricq-client:
   endpoint: "http://${MONITOR_ADDR:monitor.default.svc.cluster.local:7096}"
+
+
+etcd-election@initExtension:
+  root_path: erda/component-leader/dicehub/init_extension


### PR DESCRIPTION

#### What type of this PR
/kind bug

#### What this PR does / why we need it:
When multi instance dicehub synchronizes the extension, it is set that only a single instance can be synchronized

#### Which issue(s) this PR fixes:

erda-issue: [erda-issue](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=210670&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)

test image:
![image](https://user-images.githubusercontent.com/28723047/133185232-b2f23ed0-fc17-45f9-a2d4-17116408309d.png)

![image](https://user-images.githubusercontent.com/28723047/133185461-1b316ea5-5899-425b-bc62-744c4461f946.png)
