### PR TITLE
autotest plan action show search input, and set pageSize

### DIFF
--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/testplan-run.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/testplan-run.go
@@ -47,6 +47,8 @@ func testPlanRun(ctx context.Context, c *apistructs.Component, scenario apistruc
 	// get testplan
 	testPlanRequest := apistructs.TestPlanV2PagingRequest{
 		ProjectID: uint64(projectId),
+		PageNo:    1,
+		PageSize:  999,
 	}
 	testPlanRequest.UserID = bdl.Identity.UserID
 	plans, err := bdl.Bdl.PagingTestPlansV2(testPlanRequest)
@@ -99,7 +101,9 @@ func fillTestPlanFields(field []apistructs.FormPropItem, testPlans []map[string]
 		Required:  true,
 		Key:       "params.test_plan",
 		ComponentProps: map[string]interface{}{
-			"options": testPlans,
+			"options":          testPlans,
+			"showSearch":       true,
+			"optionFilterProp": "children",
 		},
 		Group: "params",
 	}
@@ -109,7 +113,9 @@ func fillTestPlanFields(field []apistructs.FormPropItem, testPlans []map[string]
 		Required:  true,
 		Key:       "params.cms",
 		ComponentProps: map[string]interface{}{
-			"options": cms,
+			"options":          cms,
+			"showSearch":       true,
+			"optionFilterProp": "children",
 		},
 		Group: "params",
 	}

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/testscene_run.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/testscene_run.go
@@ -235,7 +235,9 @@ func fillFields(field []apistructs.FormPropItem, testSpaces []map[string]interfa
 		Required:  true,
 		Key:       "params.test_space",
 		ComponentProps: map[string]interface{}{
-			"options": testSpaces,
+			"options":          testSpaces,
+			"showSearch":       true,
+			"optionFilterProp": "children",
 		},
 		Group: "params",
 	}
@@ -245,7 +247,9 @@ func fillFields(field []apistructs.FormPropItem, testSpaces []map[string]interfa
 		Required:  true,
 		Key:       "params.test_scene_set",
 		ComponentProps: map[string]interface{}{
-			"options": testSceneSets,
+			"options":          testSceneSets,
+			"showSearch":       true,
+			"optionFilterProp": "children",
 		},
 		Group: "params",
 	}
@@ -259,7 +263,9 @@ func fillFields(field []apistructs.FormPropItem, testSpaces []map[string]interfa
 		Required:  true,
 		Key:       "params.test_scene",
 		ComponentProps: map[string]interface{}{
-			"options": testScenes,
+			"options":          testScenes,
+			"showSearch":       true,
+			"optionFilterProp": "children",
 		},
 		Group: "params",
 	}


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
The data queried in the action drop-down box executed by the automated test plan is missing. All data should be queried, and then the search box should be searched.


#### test image
![image](https://user-images.githubusercontent.com/28723047/133225729-193be314-e93a-4ea4-ab4c-d360a6ac750c.png)

![image](https://user-images.githubusercontent.com/28723047/133225780-3608bcb8-6340-4d7e-9dd0-28f71b873c68.png)
