### PR TITLE
fix: openapi csrf token set default to false

### DIFF
--- a/modules/core/openapi-ng/interceptors/csrf/csrf.go
+++ b/modules/core/openapi-ng/interceptors/csrf/csrf.go
@@ -43,7 +43,7 @@ type config struct {
 	CookieDomain      string        `file:"cookie_domain" desc:"domain of the CSRF cookie. optional."`
 	CookiePath        string        `file:"cookie_path" default:"/" desc:"path of the CSRF cookie. optional."`
 	CookieMaxAge      time.Duration `file:"cookie_max_age" default:"24h" desc:"max age of the CSRF cookie. optional."`
-	CookieHTTPOnly    bool          `file:"cookie_http_only" default:"true" desc:"indicates if CSRF cookie is HTTP only. optional."`
+	CookieHTTPOnly    bool          `file:"cookie_http_only" default:"false" desc:"indicates if CSRF cookie is HTTP only. optional."`
 }
 
 type (


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

Frontend JS cannot set OPENAPI-CSRF-TOKEN header from cookie if http-only is true .

#### Specified Reviewers:

/assign @Effet @recallsong 

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.3` when this PR is merged.