### PR TITLE
The pipeline link deployed by the deployment center can be viewed in the pipeline

### DIFF
--- a/modules/dop/services/filetree/filetree.go
+++ b/modules/dop/services/filetree/filetree.go
@@ -741,12 +741,21 @@ func (svc *GittarFileTree) GetGittarFileByPipelineId(pipelineId uint64, orgID ui
 	appID := labels[apistructs.LabelAppID]
 	projectID := labels[apistructs.LabelProjectID]
 	branch := labels[apistructs.LabelBranch]
-	names := strings.Split(pipelineDetail.YmlName, branch)
-	ymlName := pipelineDetail.YmlName
-	if len(names) >= 2 {
-		ymlName = names[1]
+
+	var ymlName string
+	// the name starting with dice-deploy-release is the pipeline deployed by the deployment center，
+	// Users do not have an address to see the details of the pipeline, and can only simulate to the pipeline.yml of the corresponding branch first，
+	// todo remove the code when developing other pipeline detail interfaces later
+	if strings.HasPrefix(pipelineDetail.YmlName, "dice-deploy-release") {
+		ymlName = "pipeline.yml"
+	} else {
+		names := strings.Split(pipelineDetail.YmlName, branch)
+		ymlName = pipelineDetail.YmlName
+		if len(names) >= 2 {
+			ymlName = names[1]
+		}
+		ymlName = strings.TrimPrefix(ymlName, "/")
 	}
-	ymlName = strings.TrimPrefix(ymlName, "/")
 
 	inode := fmt.Sprintf("%s/%s/tree/%s/%s", projectID, appID, branch, ymlName)
 	base64Inode := base64.URLEncoding.EncodeToString([]byte(inode))


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
The pipeline link deployed by the deployment center can be viewed in the pipeline

#### Which issue(s) this PR fixes:

erda-issue: [erda-issue](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=222559&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)
