### PR TITLE
fix: actionagent close filewatcher when action done

### DIFF
--- a/build/dockerfiles/Dockerfile-action-agent
+++ b/build/dockerfiles/Dockerfile-action-agent
@@ -10,7 +10,7 @@ COPY . /go/src/github.com/erda-project/erda/
 WORKDIR /go/src/github.com/erda-project/erda/
 
 RUN set -x \
-	&& eval "GOOS=linux GOARCH=amd64 go build -mod=vendor $BUILD_FLAGS -o /opt/action/agent ./cmd/actionagent"
+	&& eval "GOOS=linux GOARCH=amd64 go build -mod=readonly $BUILD_FLAGS -o /opt/action/agent ./cmd/actionagent"
 
 RUN md5sum /opt/action/agent | cut -d ' ' -f1 > /opt/action/action-agent-md5 && cat /opt/action/action-agent-md5
 

--- a/modules/actionagent/file_watch.go
+++ b/modules/actionagent/file_watch.go
@@ -32,8 +32,12 @@ import (
 )
 
 func (agent *Agent) watchFiles() {
+	if agent.Ctx == nil || agent.Cancel == nil {
+		agent.AppendError(fmt.Errorf("init watchFiles need a cancelable context"))
+		return
+	}
 
-	watcher, err := filewatch.New()
+	watcher, err := filewatch.New(agent.Ctx)
 	if err != nil {
 		agent.AppendError(err)
 		return

--- a/modules/actionagent/file_watch_collector.go
+++ b/modules/actionagent/file_watch_collector.go
@@ -104,6 +104,7 @@ func (agent *Agent) asyncPushCollectorLog() {
 		receivedNum++
 		if receivedNum == 2 {
 			agent.FileWatcher.GracefulDoneC <- struct{}{}
+			break
 		}
 	}
 }

--- a/modules/actionagent/file_watch_test.go
+++ b/modules/actionagent/file_watch_test.go
@@ -15,44 +15,13 @@
 package actionagent
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
-	"github.com/alecthomas/assert"
+	"github.com/stretchr/testify/assert"
 )
-
-//func TestWatchFiles(t *testing.T) {
-//	logrus.SetLevel(logrus.DebugLevel)
-//	logrus.Debug("begin watch files")
-//
-//	fw, err := filewatch.New()
-//	assert.NoError(t, err)
-//	ctx, cancel := context.WithCancel(context.Background())
-//	agent := Agent{
-//		EasyUse: EasyUse{
-//			EnablePushLog2Collector: true,
-//			CollectorAddr:           "collector.default.svc.cluster.local:7076",
-//			TaskLogID:               "agent-push-1",
-//
-//			RunMultiStdoutFilePath: "/tmp/stdout",
-//			RunMultiStderrFilePath: "/tmp/stderr",
-//		},
-//		Ctx:         ctx,
-//		Cancel:      cancel,
-//		FileWatcher: fw,
-//	}
-//
-//	go agent.watchFiles()
-//
-//	// mock logic done
-//	time.Sleep(time.Millisecond * 10) // very fast action done
-//
-//	// teardown
-//	agent.PreStop()
-//
-//	time.Sleep(time.Second * 1)
-//}
 
 func TestSlice(t *testing.T) {
 	f := func(flogs *[]string, line string) {
@@ -92,4 +61,20 @@ func TestDesensitizeLine(t *testing.T) {
 		assert.Equal(t, v.want, v.line)
 	}
 
+}
+
+func TestAgent_BadWatchFiles(t *testing.T) {
+	badAgent := Agent{}
+	badAgent.watchFiles()
+	assert.True(t, len(badAgent.Errs) > 0)
+}
+
+func TestAgent_watchFiles(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	agent := Agent{
+		Ctx:    ctx,
+		Cancel: cancel,
+	}
+	agent.watchFiles()
+	t.Logf("no error here")
 }

--- a/modules/actionagent/prestop_test.go
+++ b/modules/actionagent/prestop_test.go
@@ -14,14 +14,16 @@
 
 package actionagent
 
-func (agent *Agent) PreStop() {
-	// TODO invoke /opt/action/pre-stop
+import (
+	"context"
+	"testing"
+)
 
-	go agent.stopWatchFiles()
-
-	// 打包目录并上传
-	agent.uploadDir()
-
-	// agent cancel context to stop other running things
-	agent.Cancel()
+func TestAgent_PreStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	agent := Agent{
+		Ctx:    ctx,
+		Cancel: cancel,
+	}
+	agent.PreStop()
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

Agent close filewatcher when action done.

Otherwise, filewatcher will wait 10s to force close it.

Tested on hkci.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=222900&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)

#### Specified Reviewers:

/assign @kakj-go @Effet 

#### Need cherry-pick to release versions?

1.3 & 1.2