### PR TITLE
set enableWorkspace default true for bigdata job schedule

### DIFF
--- a/apistructs/cluster.go
+++ b/apistructs/cluster.go
@@ -138,14 +138,16 @@ type ClusterListResponse struct {
 
 // ClusterSchedConfig 调度器初始化配置
 type ClusterSchedConfig struct {
-	MasterURL                string `json:"dcosURL"`
-	AuthType                 string `json:"authType"` // basic, token
-	AuthUsername             string `json:"authUsername"`
-	AuthPassword             string `json:"authPassword"`
-	CACrt                    string `json:"caCrt"`
-	ClientCrt                string `json:"clientCrt"`
-	ClientKey                string `json:"clientKey"`
-	EnableTag                bool   `json:"enableTag"`
+	MasterURL    string `json:"dcosURL"`
+	AuthType     string `json:"authType"` // basic, token
+	AuthUsername string `json:"authUsername"`
+	AuthPassword string `json:"authPassword"`
+	CACrt        string `json:"caCrt"`
+	ClientCrt    string `json:"clientCrt"`
+	ClientKey    string `json:"clientKey"`
+	EnableTag    bool   `json:"enableTag"`
+	// TODO enableWorkspace should be refactor, now pipeline will set default true
+	EnableWorkspace          *bool  `json:"enableWorkspace,omitempty"`
 	EdasConsoleAddr          string `json:"edasConsoleAddr"`
 	AccessKey                string `json:"accessKey"`
 	AccessSecret             string `json:"accessSecret"`

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/logic/shceduleinfo.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/logic/shceduleinfo.go
@@ -33,9 +33,15 @@ func GetScheduleInfo(cluster apistructs.ClusterInfo, executorName, executorKind 
 	if cluster.SchedConfig != nil {
 		enableTag = cluster.SchedConfig.EnableTag
 	}
+	// TODO migrate enableWorkspace, cluster-manager should control this param
+	enableWorkspace := true
+	if cluster.SchedConfig != nil && cluster.SchedConfig.EnableWorkspace != nil {
+		enableWorkspace = *cluster.SchedConfig.EnableWorkspace
+	}
 	configs := executorconfig.ExecutorWholeConfigs{
 		BasicConfig: map[string]string{
-			"ENABLETAG": strconv.FormatBool(enableTag),
+			"ENABLETAG":        strconv.FormatBool(enableTag),
+			"ENABLE_WORKSPACE": strconv.FormatBool(enableWorkspace),
 		},
 	}
 	scheduleInfo2, scheduleInfo, _, err := schedulepolicy.LabelFilterChain(&configs, executorName, strutil.ToUpper(executorKind), job)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
set enableWorkspace default true for bigdata job schedule
TODO: cluster-manager should control enableWorkspace, enableTag and so on

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/bug?id=202730&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1MDZdLCJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=506&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | set enableWorkspace default true for bigdata job schedule             |
| 🇨🇳 中文    |  修复1.1迁移之后enable_workspace默认都是false的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
