### PR TITLE
fix: stop queueManager&throttler when pipeline lost leader

### DIFF
--- a/modules/pipeline/pipengine/engine.go
+++ b/modules/pipeline/pipengine/engine.go
@@ -75,7 +75,6 @@ func (engine *Engine) OnceDo(
 
 func (engine *Engine) StartReconciler(ctx context.Context) {
 	go engine.reconciler.Listen(ctx)
-	go engine.reconciler.ContinueBackupThrottler(ctx)
 
 	// 开始 Listen 后再开始加载已经在处理中的流水线，否则组件还未准备好，包括 eventManger(阻塞)
 	go func() {

--- a/modules/pipeline/pipengine/reconciler/define.go
+++ b/modules/pipeline/pipengine/reconciler/define.go
@@ -95,12 +95,6 @@ func New(js jsonstore.JsonStore, etcd *etcd.Store, bdl *bundle.Bundle, dbClient 
 		extMarketSvc:    extMarketSvc,
 		pipelineSvcFunc: pipelineSvcFunc,
 	}
-	if err := r.loadThrottler(); err != nil {
-		return nil, err
-	}
-	if err := r.loadQueueManger(); err != nil {
-		return nil, err
-	}
 	return &r, nil
 }
 

--- a/modules/pipeline/pipengine/reconciler/listen.go
+++ b/modules/pipeline/pipengine/reconciler/listen.go
@@ -31,6 +31,11 @@ import (
 
 // Listen watch incoming pipelines which need to be scheduled from etcd.
 func (r *Reconciler) Listen(ctx context.Context) {
+
+	if err := r.beforeListen(ctx); err != nil {
+		panic(fmt.Errorf("failed to start listen, failed to do beforeListen, err: %v", err))
+	}
+
 	rlog.Infof("start listen")
 	for {
 		select {

--- a/modules/pipeline/pipengine/reconciler/queuemanage/manager/stop.go
+++ b/modules/pipeline/pipengine/reconciler/queuemanage/manager/stop.go
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconciler
+package manager
 
-import (
-	"context"
-
-	"github.com/erda-project/erda/modules/pipeline/pipengine/reconciler/queuemanage/manager"
-)
-
-// loadQueueManger
-func (r *Reconciler) loadQueueManger(ctx context.Context) error {
-	// init queue manager
-	r.QueueManager = manager.New(ctx, manager.WithDBClient(r.dbClient))
-
-	return nil
+func (mgr *defaultManager) Stop() {
+	if mgr == nil {
+		return
+	}
+	for _, stopCh := range mgr.queueStopChanByID {
+		go func(ch chan struct{}) {
+			defer func() { recover() }()
+			ch <- struct{}{}
+		}(stopCh)
+	}
+	return
 }

--- a/modules/pipeline/pipengine/reconciler/queuemanage/types/manager.go
+++ b/modules/pipeline/pipengine/reconciler/queuemanage/types/manager.go
@@ -26,4 +26,5 @@ type QueueManager interface {
 	PutPipelineIntoQueue(pipelineID uint64) (popCh <-chan struct{}, needRetryIfErr bool, err error)
 	PopOutPipelineFromQueue(pipelineID uint64)
 	BatchUpdatePipelinePriorityInQueue(pq *apistructs.PipelineQueue, pipelineIDs []uint64) error
+	Stop()
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:

Stop queueManager&throttler when pipeline lost leader. Otherwise, multi pipeline queueManager instances will check & push pipeline in the meanwhile and cause error.

Tested in hkci.
![image](https://user-images.githubusercontent.com/13919034/134503592-60cadf62-1835-4468-a4e5-e99e342f70b0.png)


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=228022&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)


#### Specified Reviewers:

/assign @chengjoey @Effet 