### PR TITLE
fix: deal with the case that costTimeSec is negative

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
@@ -505,6 +505,9 @@ func (a *ExecuteTaskTable) getCostTime(task apistructs.PipelineTaskDTO) string {
 	if !task.Status.IsEndStatus() {
 		return "-"
 	}
+	if task.CostTimeSec < 0 {
+		return "-"
+	}
 	return time.Unix(task.CostTimeSec, 0).In(time.UTC).Format("15:04:05")
 }
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render_test.go
@@ -81,6 +81,14 @@ func TestGetCostTime(t *testing.T) {
 			},
 			"00:59:59",
 		},
+		{
+			apistructs.PipelineTaskDTO{
+				Status:      apistructs.PipelineStatusSuccess,
+				IsSnippet:   true,
+				CostTimeSec: -1,
+			},
+			"-",
+		},
 	}
 	r := ExecuteTaskTable{
 		CtxBdl: protocol.ContextBundle{


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
fix: deal with the case that costTimeSec is negative
if costTimeSec is -1, the time format is "23:59:59"


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?
/cherry-pick release/1.3

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
