### PR TITLE
automated test query plan list error strconv.ParseUint: parsing "1.000022e+06": invalid syntax problem solved

### DIFF
--- a/modules/openapi/component-protocol/pkg/type_conversion/parse.go
+++ b/modules/openapi/component-protocol/pkg/type_conversion/parse.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package type_conversion
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func InterfaceToUint64(value interface{}) (uint64, error) {
+	if value == nil {
+		return 0, fmt.Errorf("can not parse value")
+	}
+
+	switch value.(type) {
+	case int:
+		return uint64(value.(int)), nil
+	case float64:
+		return uint64(value.(float64)), nil
+	case string:
+		intValue, err := strconv.ParseInt(value.(string), 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(intValue), nil
+	}
+	return 0, fmt.Errorf("can not parse value")
+}

--- a/modules/openapi/component-protocol/pkg/type_conversion/parse_test.go
+++ b/modules/openapi/component-protocol/pkg/type_conversion/parse_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package type_conversion
+
+import "testing"
+
+func TestInterfaceToUint64(t *testing.T) {
+	type args struct {
+		value interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name: "test_int",
+			args: args{
+				value: 1,
+			},
+			want:    uint64(1),
+			wantErr: false,
+		},
+		{
+			name: "test_string",
+			args: args{
+				value: "1",
+			},
+			want:    uint64(1),
+			wantErr: false,
+		},
+		{
+			name: "test_float64",
+			args: args{
+				value: float64(1),
+			},
+			want:    uint64(1),
+			wantErr: false,
+		},
+		{
+			name: "test_empty",
+			args: args{
+				value: nil,
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "test_other",
+			args: args{
+				value: int32(1),
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InterfaceToUint64(tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InterfaceToUint64() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("InterfaceToUint64() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
@@ -17,13 +17,12 @@ package formModal
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strconv"
 
 	"github.com/pkg/errors"
 
 	"github.com/erda-project/erda/apistructs"
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/type_conversion"
 	auto_test_plan_list "github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list"
 )
 
@@ -41,8 +40,7 @@ type FormModalData struct {
 
 func (tpm *TestPlanManageFormModal) Render(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, gs *apistructs.GlobalStateData) error {
 	bdl := ctx.Value(protocol.GlobalInnerKeyCtxBundle.String()).(protocol.ContextBundle)
-	projectIDStr := fmt.Sprintf("%v", bdl.InParams["projectId"])
-	projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
+	projectID, err := type_conversion.InterfaceToUint64(bdl.InParams["projectId"])
 	if err != nil {
 		return err
 	}

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/type_conversion"
 	auto_test_plan_list "github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list"
 )
 
@@ -74,11 +75,12 @@ const (
 
 func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, gs *apistructs.GlobalStateData) error {
 	bdl := ctx.Value(protocol.GlobalInnerKeyCtxBundle.String()).(protocol.ContextBundle)
-	projectIDStr := fmt.Sprintf("%v", bdl.InParams["projectId"])
-	projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
+
+	projectID, err := type_conversion.InterfaceToUint64(bdl.InParams["projectId"])
 	if err != nil {
 		return err
 	}
+
 	cond := apistructs.TestPlanV2PagingRequest{ProjectID: projectID, PageNo: 1, PageSize: auto_test_plan_list.DefaultTablePageSize}
 	cond.UserID = bdl.Identity.UserID
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/apiEditor/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/apiEditor/render.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/type_conversion"
 	"github.com/erda-project/erda/pkg/expression"
 )
 
@@ -108,7 +109,11 @@ func (ae *ApiEditor) Render(ctx context.Context, c *apistructs.Component, scenar
 	}
 	ae.State.SceneId = sceneID
 
-	projecrIDStr := fmt.Sprintf("%v", bdl.InParams["projectId"])
+	projectID, err := type_conversion.InterfaceToUint64(bdl.InParams["projectId"])
+	if err != nil {
+		return err
+	}
+	projecrIDStr := strconv.FormatUint(projectID, 10)
 
 	// 获取小试一把信息
 	if _, ok := c.State["isFirstIn"]; ok {


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
this problem will block users from accessing the schedule list, resulting in unavailability of the function

#### Which issue(s) this PR fixes:
erda-issue: [erda-issue](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=221807&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiMTAwMDU2MCJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=467&type=BUG)