### PR TITLE
audit: cleanup interval days configurable from env, default is 180d

### DIFF
--- a/modules/core-services/conf/conf.go
+++ b/modules/core-services/conf/conf.go
@@ -50,9 +50,6 @@ type Conf struct {
 	OpenAPIDomain         string `env:"OPENAPI_PUBLIC_ADDR"` // Deprecated: after cli refactored
 	AvatarStorageURL      string `env:"AVATAR_STORAGE_URL"`  // file:///avatars or oss://appkey:appsecret@endpoint/bucket
 	LicenseKey            string `env:"LICENSE_KEY"`
-	AuditCleanCron        string `env:"AUDIT_CLEAN_CRON" default:"0 0 3 * * ?"`   // 审计软删除任务执行周期
-	AuditArchiveCron      string `env:"AUDIT_ARCHIVE_CRON" default:"0 0 4 * * ?"` // 审计归档任务执行周期
-	SysAuditCleanIterval  int    `env:"SYS_AUDIT_CLEAN_ITERVAL" default:"-7"`     // 系统审计清除周期
 	RedisMasterName       string `default:"my-master" env:"REDIS_MASTER_NAME"`
 	RedisSentinelAddrs    string `default:"" env:"REDIS_SENTINELS_ADDR"`
 	RedisAddr             string `default:"127.0.0.1:6379" env:"REDIS_ADDR"`
@@ -94,6 +91,12 @@ type Conf struct {
 	// File types can carry active content, separated by comma, can add more types like jsp
 	FileTypesCanCarryActiveContent string `env:"FILETYPES_CAN_CARRY_ACTIVE_CONTENT" default:"html,js,xml,htm"`
 	// --- 文件管理 end ---
+
+	// audit
+	AuditCleanCron           string `env:"AUDIT_CLEAN_CRON" default:"0 0 3 * * ?"`     // audit soft delete cron
+	AuditArchiveCron         string `env:"AUDIT_ARCHIVE_CRON" default:"0 0 4 * * ?"`   // audit archive cron
+	SysAuditCleanInterval    int    `env:"SYS_AUDIT_CLEAN_INTERVAL" default:"-7"`      // sys audit clean interval
+	OrgAuditMaxRetentionDays uint64 `env:"ORG_AUDIT_MAX_RETENTION_DAYS" default:"180"` // org level audit max retention days
 }
 
 var (
@@ -348,9 +351,9 @@ func AuditArchiveCron() string {
 	return cfg.AuditArchiveCron
 }
 
-// SysAuditCleanIterval 返回 sys scope 审计事件软删除周期
-func SysAuditCleanIterval() int {
-	return cfg.SysAuditCleanIterval
+// SysAuditCleanInterval 返回 sys scope 审计事件软删除周期
+func SysAuditCleanInterval() int {
+	return cfg.SysAuditCleanInterval
 }
 
 // RedisMasterName 返回redis master name
@@ -454,4 +457,8 @@ func FileTypeCarryActiveContentAllowed() bool {
 
 func FileTypesCanCarryActiveContent() []string {
 	return strutil.Split(cfg.FileTypesCanCarryActiveContent, ",")
+}
+
+func OrgAuditMaxRetentionDays() uint64 {
+	return cfg.OrgAuditMaxRetentionDays
 }

--- a/modules/core-services/endpoints/audit.go
+++ b/modules/core-services/endpoints/audit.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/core-services/conf"
 	"github.com/erda-project/erda/modules/core-services/services/apierrors"
 	"github.com/erda-project/erda/modules/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
@@ -350,8 +351,8 @@ func checkAuditCreateRequest(req *apistructs.Audit) error {
 
 func checkSetAuditParam(auditSetReq apistructs.AuditSetCleanCronRequest) (int64, int64, error) {
 	var orgID, interval int64
-	if auditSetReq.Interval < 1 || auditSetReq.Interval > 30 {
-		return orgID, interval, errors.Errorf("invalid request, interval should be between 1 and 30")
+	if auditSetReq.Interval < 1 || auditSetReq.Interval > conf.OrgAuditMaxRetentionDays() {
+		return orgID, interval, errors.Errorf("invalid request, max retention days should be between 1 and %d", conf.OrgAuditMaxRetentionDays())
 	}
 
 	interval, orgID = int64(-auditSetReq.Interval), int64(auditSetReq.OrgID)

--- a/modules/core-services/services/audit/audit.go
+++ b/modules/core-services/services/audit/audit.go
@@ -253,7 +253,7 @@ func (a *Audit) cronCleanAudit() {
 		}
 	}
 	// 软删除系统审计事件
-	startAt := time.Now().AddDate(0, 0, conf.SysAuditCleanIterval())
+	startAt := time.Now().AddDate(0, 0, conf.SysAuditCleanInterval())
 	if err := a.db.DeleteAuditsByTimeAndSys(startAt); err != nil {
 		logrus.Errorf(err.Error())
 	}


### PR DESCRIPTION
#### What type of this PR

/kind feature


#### What this PR does / why we need it:

- Audit cleanup interval days configurable from env
- default is 180d


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=66752&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIiwiUkVTT0xWRUQiXSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=506&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Audit log max retention days adjust to 180 days         |
| 🇨🇳 中文    |    审计日志最大保留天数默认调整为 180 天          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.3` when this PR is merged.
