### PR TITLE
bugfix: set log-service replicas default to 0

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -707,7 +707,7 @@ services:
       network:
         mode: "container"
     deployments:
-      replicas: ${replicas:0}
+      replicas: 0
       labels:
         GROUP: "spot-v2"
     health_check:


### PR DESCRIPTION
#### What type of this PR
/kind feature


#### What this PR does / why we need it:
log-service should not use the ${replicas} variable.


#### Specified Reviewers:

/assign @liuhaoyang 