### PR TITLE
Feat(scheduler): compose deploy& sts nodeantiaffinity with workspace

### DIFF
--- a/modules/scheduler/executor/plugins/k8s/daemonset.go
+++ b/modules/scheduler/executor/plugins/k8s/daemonset.go
@@ -113,8 +113,8 @@ func (k *Kubernetes) newDaemonSet(service *apistructs.Service, sg *apistructs.Se
 	}
 
 	if v := k.options["FORCE_BLUE_GREEN_DEPLOY"]; v != "true" &&
-		(strutil.ToUpper(service.Env["DICE_WORKSPACE"]) == apistructs.DevWorkspace.String() ||
-			strutil.ToUpper(service.Env["DICE_WORKSPACE"]) == apistructs.TestWorkspace.String()) {
+		(strutil.ToUpper(service.Env[DiceWorkSpace]) == apistructs.DevWorkspace.String() ||
+			strutil.ToUpper(service.Env[DiceWorkSpace]) == apistructs.TestWorkspace.String()) {
 		daemonset.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
 	}
 
@@ -140,7 +140,7 @@ func (k *Kubernetes) newDaemonSet(service *apistructs.Service, sg *apistructs.Se
 	//Set the over-score ratio according to the environment
 	cpuSubscribeRatio := k.cpuSubscribeRatio
 	memSubscribeRatio := k.memSubscribeRatio
-	switch strutil.ToUpper(service.Env["DICE_WORKSPACE"]) {
+	switch strutil.ToUpper(service.Env[DiceWorkSpace]) {
 	case "DEV":
 		cpuSubscribeRatio = k.devCpuSubscribeRatio
 		memSubscribeRatio = k.devMemSubscribeRatio

--- a/modules/scheduler/executor/plugins/k8s/k8s_test.go
+++ b/modules/scheduler/executor/plugins/k8s/k8s_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func TestComposeDeploymentNodeAffinityPreferredWithServiceWorkspace(t *testing.T) {
+	k := Kubernetes{}
+	workspace := "DEV"
+
+	deploymentPreferred := []apiv1.PreferredSchedulingTerm{
+		{
+			Weight: 60,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-test",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 80,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-staging",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 100,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-prod",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 100,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/stateful-service",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+	}
+
+	resPreferred := k.composeDeploymentNodeAntiAffinityPreferred(workspace)
+	assert.DeepEqual(t, deploymentPreferred, resPreferred)
+}
+
+func TestComposeStatefulSetNodeAffinityPreferredWithServiceWorkspace(t *testing.T) {
+	k := Kubernetes{}
+	workspace := "PROD"
+
+	statefulSetPreferred := []apiv1.PreferredSchedulingTerm{
+		{
+			Weight: 60,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-dev",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 60,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-test",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 80,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/workspace-staging",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+		{
+			Weight: 100,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{
+						Key:      "dice/stateless-service",
+						Operator: apiv1.NodeSelectorOpDoesNotExist,
+					},
+				},
+			},
+		},
+	}
+	resPreferred := k.composeStatefulSetNodeAntiAffinityPreferred(workspace)
+	assert.DeepEqual(t, statefulSetPreferred, resPreferred)
+}

--- a/modules/scheduler/executor/plugins/k8s/statefulset.go
+++ b/modules/scheduler/executor/plugins/k8s/statefulset.go
@@ -81,6 +81,12 @@ func (k *Kubernetes) createStatefulSet(info StatefulsetInfo) error {
 			PodLabels: map[string]string{"addon_id": info.sg.Dice.ID},
 		}}, k).Affinity
 
+	if v, ok := service.Env[DiceWorkSpace]; ok {
+		affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			k.composeStatefulSetNodeAntiAffinityPreferred(v)...)
+	}
+
 	set.Spec.Template = apiv1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: info.namespace,
@@ -125,7 +131,7 @@ func (k *Kubernetes) createStatefulSet(info StatefulsetInfo) error {
 	// Set the over-score ratio according to the environment
 	cpuSubscribeRatio := k.cpuSubscribeRatio
 	memSubscribeRatio := k.memSubscribeRatio
-	switch strutil.ToUpper(service.Env["DICE_WORKSPACE"]) {
+	switch strutil.ToUpper(service.Env[DiceWorkSpace]) {
 	case "DEV":
 		cpuSubscribeRatio = k.devCpuSubscribeRatio
 		memSubscribeRatio = k.devMemSubscribeRatio

--- a/modules/scheduler/executor/plugins/k8s/type.go
+++ b/modules/scheduler/executor/plugins/k8s/type.go
@@ -40,6 +40,7 @@ const (
 
 	// default sa
 	defaultServiceAccountName = "default"
+	DiceWorkSpace             = "DICE_WORKSPACE"
 )
 
 var envReg = regexp.MustCompile(`\$\{([^}]+?)\}`)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature


#### What this PR does / why we need it:
- update(scheduler): compose deploy& sts nodeantiaffinity with workspace

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  feat(scheduler): compose deploy& sts nodeantiaffinity with workspace            |
| 🇨🇳 中文    |    在 scheduler 中根据 workspace 为 deploy 和 sts 资源生成 node anti affinity           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
