### PR TITLE
fix: solve the problem of getting nil context in the goroutine caused by the context being recycled

### DIFF
--- a/modules/gittar/helper/git_hooks.go
+++ b/modules/gittar/helper/git_hooks.go
@@ -116,8 +116,8 @@ func preReceiveHook(pushEvents []*models.PayloadPushEvent, c *webcontext.Context
 
 // trigger event
 func PostReceiveHook(pushEvents []*models.PayloadPushEvent, c *webcontext.Context) {
-	pusher := c.MustGet("user").(*models.User)
-	repository := c.MustGet("repository").(*gitmodule.Repository)
+	pusher := c.User
+	repository := c.Repository
 
 	size, err := repository.CalcRepoSize()
 	if err == nil {


### PR DESCRIPTION
… by the context being recycled

#### What type of this PR
/kind bug


#### What this PR does / why we need it:
When use context of echo in the goroutine, if another request coming when the goroutine is not finish, the context will be recycled, so the context is nil.
![image](https://user-images.githubusercontent.com/23724009/136955858-2c08f95f-3784-4463-bf45-64cc96beee29.png)




#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
