### PR TITLE
fix: get k8sNamespace rather than namespace in s-pod-info

### DIFF
--- a/modules/cmp/component-protocol/components/cmp-dashboard-events-list/eventTable/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-events-list/eventTable/render.go
@@ -115,11 +115,11 @@ func (t *ComponentEventTable) GenComponentState(component *cptype.Component) err
 }
 
 func (t *ComponentEventTable) DecodeURLQuery() error {
-	query, ok := t.sdk.InParams["eventTable__urlQuery"].(string)
+	urlQuery, ok := t.sdk.InParams["eventTable__urlQuery"].(string)
 	if !ok {
 		return nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(query)
+	decoded, err := base64.StdEncoding.DecodeString(urlQuery)
 	if err != nil {
 		return err
 	}

--- a/modules/core-services/endpoints/namespace.go
+++ b/modules/core-services/endpoints/namespace.go
@@ -34,7 +34,7 @@ func (e *Endpoints) GetAllNamespaces(ctx context.Context, r *http.Request, vars 
 
 	var namespaces []string
 	for _, pod := range podsInfo {
-		namespaces = append(namespaces, pod.Namespace)
+		namespaces = append(namespaces, pod.K8sNamespace)
 	}
 	return httpserver.OkResp(namespaces)
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:

/kind bug

#### What this PR does / why we need it:

get k8sNamespace rather than namespace in s-pod-info

#### Specified Reviewers:

/assign @johnlanni 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | get k8sNamespace rather than namespace in s-pod-info |
| 🇨🇳 中文    | 从s-pod-info中获取命名空间时取k8s_namespace字段而不是取namespace字段 |


#### Need cherry-pick to release versions?

Need cherry-pick to release/1.3
