### PR TITLE
fix(scheduler): compose deployment with imagepullsecrets

### DIFF
--- a/modules/scheduler/executor/plugins/k8s/deployment_test.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/scheduler/executor/plugins/k8s/secret"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
+)
+
+func TestNewDeployment(t *testing.T) {
+	service := &apistructs.Service{
+		Name:          "test-service",
+		Namespace:     "test",
+		Image:         "test",
+		ImageUsername: "",
+		ImagePassword: "",
+		Cmd:           "",
+		Ports:         nil,
+		ProxyPorts:    nil,
+		Vip:           "",
+		ShortVIP:      "",
+		ProxyIp:       "",
+		PublicIp:      "",
+		Scale:         0,
+		Resources: apistructs.Resources{
+			Cpu: 0.1,
+			Mem: 512,
+		},
+		Depends:            nil,
+		Env:                nil,
+		Labels:             nil,
+		DeploymentLabels:   nil,
+		Selectors:          nil,
+		Binds:              nil,
+		Volumes:            nil,
+		Hosts:              nil,
+		HealthCheck:        nil,
+		NewHealthCheck:     nil,
+		SideCars:           nil,
+		InitContainer:      nil,
+		InstanceInfos:      nil,
+		MeshEnable:         nil,
+		TrafficSecurity:    diceyml.TrafficSecurity{},
+		WorkLoad:           "",
+		ProjectServiceName: "",
+		K8SSnippet:         nil,
+		StatusDesc:         apistructs.StatusDesc{},
+	}
+
+	servicegroup := &apistructs.ServiceGroup{
+		Dice: apistructs.Dice{
+			ID:                   "test",
+			Type:                 "service",
+			Labels:               map[string]string{},
+			Services:             []apistructs.Service{*service},
+			ServiceDiscoveryKind: "",
+			ServiceDiscoveryMode: "",
+			ProjectNamespace:     "",
+		},
+	}
+
+	k := &Kubernetes{
+		secret: &secret.Secret{},
+	}
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(k.secret), "Get", func(sec *secret.Secret, namespace, name string) (*apiv1.Secret, error) {
+		return &apiv1.Secret{}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(k), "CopyErdaSecrets", func(kube *Kubernetes, originns, dstns string) ([]apiv1.Secret, error) {
+		return []apiv1.Secret{}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(k), "AddPodMountVolume", func(kube *Kubernetes, service *apistructs.Service, podSpec *apiv1.PodSpec,
+		secretvolmounts []apiv1.VolumeMount, secretvolumes []apiv1.Volume) error {
+		return nil
+	})
+	_, err := k.newDeployment(service, servicegroup)
+	assert.Equal(t, err, nil)
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
- fix(scheduler): compose deployment with image pull secrets

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Bugfix： Fix the bug that returns an error when the namespace hasn't aliyun secret in scheduler  |
| 🇨🇳 中文    | 修复了 scheduler 在 namespace 中没有 aliyun secret 报错的问题 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
