### PR TITLE
fix: openapi path replace space with _

### DIFF
--- a/modules/core/openapi-ng/routes/openapi-v1/provider.go
+++ b/modules/core/openapi-ng/routes/openapi-v1/provider.go
@@ -71,7 +71,7 @@ func (p *provider) RegisterTo(router transhttp.Router) (err error) {
 
 func replaceOpenapiV1Path(path string) string {
 	path = strings.ReplaceAll(path, "<*>", "**")
-	newPath := strings.NewReplacer("<", "{", ">", "}").Replace(path)
+	newPath := strings.NewReplacer("<", "{", ">", "}", " ", "_").Replace(path)
 	return newPath
 }
 

--- a/modules/core/openapi-ng/routes/openapi-v1/provider_test.go
+++ b/modules/core/openapi-ng/routes/openapi-v1/provider_test.go
@@ -35,6 +35,13 @@ func Test_replaceOpenapiV1Path(t *testing.T) {
 			want: "/api/projects/{projectID}",
 		},
 		{
+			name: "<> path variable with space",
+			args: args{
+				path: "/api/cloud-mysql/<id or name>",
+			},
+			want: "/api/cloud-mysql/{id_or_name}",
+		},
+		{
 			name: "normal",
 			args: args{
 				path: "/api/projects",


### PR DESCRIPTION
#### What type of this PR

/kind bugfix


#### What this PR does / why we need it:

fix openapi proxy path variable name with space, replaced with '_'


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=239128&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyI5MiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)


#### Specified Reviewers:

/assign @johnlanni @recallsong 