### PR TITLE
autotest table remove page show

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
@@ -58,7 +58,7 @@ type meta struct {
 }
 
 const (
-	DefaultPageSize = 15
+	DefaultPageSize = 1000
 	DefaultPageNo   = 1
 )
 
@@ -558,10 +558,8 @@ func (a *ExecuteTaskTable) marshal(c *apistructs.Component) error {
 
 func (e *ExecuteTaskTable) handlerListOperation(bdl protocol.ContextBundle, c *apistructs.Component, inParams inParams, event apistructs.ComponentEvent) error {
 
-	if e.State.PageNo == 0 {
-		e.State.PageNo = DefaultPageNo
-		e.State.PageSize = DefaultPageSize
-	}
+	e.State.PageNo = DefaultPageNo
+	e.State.PageSize = DefaultPageSize
 
 	if e.State.PipelineDetail == nil {
 		c.Data = map[string]interface{}{}

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/executeTaskTable/render.go
@@ -56,7 +56,7 @@ type meta struct {
 }
 
 const (
-	DefaultPageSize = 15
+	DefaultPageSize = 1000
 	DefaultPageNo   = 1
 )
 
@@ -488,10 +488,8 @@ func (a *ExecuteTaskTable) marshal(c *apistructs.Component) error {
 
 func (e *ExecuteTaskTable) handlerListOperation(bdl protocol.ContextBundle, c *apistructs.Component, inParams inParams, event apistructs.ComponentEvent) error {
 
-	if e.State.PageNo == 0 {
-		e.State.PageNo = DefaultPageNo
-		e.State.PageSize = DefaultPageSize
-	}
+	e.State.PageNo = DefaultPageNo
+	e.State.PageSize = DefaultPageSize
 
 	if e.State.PipelineID == 0 {
 		c.Data = map[string]interface{}{}


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
Repair the automatic test paging display, click to jump from the scene on the second page to the scene set, and then click the data on the second page of the scene set will lead to jump to the scene,  Fix using non paging to fix


#### Which issue(s) this PR fixes:
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=236472&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1NDFdLCJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTYsNDQwNV0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Fix the problem of performing detailed paging jump     |
| 🇨🇳 中文    |      修复执行明细分页跳转的问题        |


#### Need cherry-pick to release versions?
/cherry-pick release/1.3