### PR TITLE
Fix/autotest components modify style

### DIFF
--- a/modules/dop/component-protocol/components/test-report/createReportButton/render.go
+++ b/modules/dop/component-protocol/components/test-report/createReportButton/render.go
@@ -83,7 +83,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		return err
 	}
 	ca.Props = map[string]interface{}{
-		"text":    "生成测试报告",
+		"text":    "创建报告",
 		"type":    "primary",
 		"visible": access.Access,
 	}

--- a/modules/dop/component-protocol/scenarios/test-report.yml
+++ b/modules/dop/component-protocol/scenarios/test-report.yml
@@ -5,15 +5,19 @@ hierarchy:
   root: page
   structure:
     page:
-      - head
+      - filter
+      - topHead
       - table
-    head:
-      left: filter
-      right: createReportButton
+    topHead:
+      - createReportButton
 
 components:
   page:
     type: Container
+  topHead:
+    type: Container
+    props:
+      isTopHead: true
   head:
     type: LRContainer
   filter:

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/tabExecuteButton/executeButton.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/tabExecuteButton/executeButton.go
@@ -123,10 +123,9 @@ type Menu struct {
 }
 
 type ClickOperation struct {
-	Key     string      `json:"key"`
-	Confirm string      `json:"confirm"`
-	Reload  bool        `json:"reload"`
-	Meta    interface{} `json:"meta"`
+	Key    string      `json:"key"`
+	Reload bool        `json:"reload"`
+	Meta   interface{} `json:"meta"`
 }
 
 func (ca *ComponentAction) Render(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, gs *apistructs.GlobalStateData) error {
@@ -227,9 +226,8 @@ func (a *ComponentAction) handleDefault() error {
 			Key:  v.Ns,
 			Operations: map[string]interface{}{
 				apistructs.ClickOperation.String(): ClickOperation{
-					Key:     "execute",
-					Confirm: "是否确认执行?",
-					Reload:  true,
+					Key:    "execute",
+					Reload: true,
 					Meta: ClientMetaData{
 						Env:        testClusterName,
 						TestPlanID: a.State.TestPlanID,


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
change test-report component hierarchy
autotest plan cancel add confirm

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=239793&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： autotest components modify style （修复了测试报告创建按钮调整,自动化计划取消加上二次确认）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
