### PR TITLE
bugfix update pulisher timeout

### DIFF
--- a/modules/dop/services/publisher/publisher.go
+++ b/modules/dop/services/publisher/publisher.go
@@ -162,9 +162,11 @@ func (p *Publisher) Update(updateReq *apistructs.PublisherUpdateRequest) error {
 	}
 
 	// 保证 nexus ${repoFormat}-hosted-repo 存在
-	if err = p.ensureNexusHostedRepo(&publisher); err != nil {
-		return err
-	}
+	go func() {
+		if err = p.ensureNexusHostedRepo(&publisher); err != nil {
+			logrus.Errorf("Update publisher %v ensureNexusHostedRepo error %v", publisher, err)
+		}
+	}()
 
 	return nil
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug

#### What this PR does / why we need it:
Fix the timeout problem of updating publisher information. Connecting to nexus will waste a lot of time when the ensurenexushostedrepo method is called. Change it to asynchronous here

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/bug?id=237928&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Update publisher information timeout fix   |
| 🇨🇳 中文    |      更新发布商信息超时问题修复        |

