### PR TITLE
fix imported autotest config sheet display outputs error

### DIFF
--- a/modules/openapi/component-protocol/pkg/autotest/step/output.go
+++ b/modules/openapi/component-protocol/pkg/autotest/step/output.go
@@ -16,10 +16,12 @@ package step
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
 	"github.com/erda-project/erda/pkg/expression"
 )
 
@@ -29,14 +31,14 @@ type APISpec struct {
 	Loop    *apistructs.PipelineTaskLoop `json:"loop"`
 }
 
-func GetStepAllOutput(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle) (map[string]map[string]string, error) {
+func GetStepAllOutput(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle, gs *apistructs.GlobalStateData) (map[string]map[string]string, error) {
 	var outputs = map[string]map[string]string{}
 	apiOutput, err := buildStepOutPut(steps)
 	if err != nil {
 		return nil, err
 	}
 
-	configSheetOutput, err := buildConfigSheetStepOutPut(steps, bdl)
+	configSheetOutput, err := buildConfigSheetStepOutPut(steps, bdl, gs)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,7 @@ func MakeStepOutputSelectKey(stepID string, stepName string, key string) string 
 	return "#" + stepID + "-" + stepName + ":" + key
 }
 
-func buildConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle) (map[string]map[string]string, error) {
+func buildConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle, gs *apistructs.GlobalStateData) (map[string]map[string]string, error) {
 
 	outputs := make(map[string]map[string]string, 0)
 
@@ -177,7 +179,7 @@ func buildConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundl
 	req.SnippetConfigs = snippetConfigs
 	detail, err := bdl.GetPipelineActionParamsAndOutputs(req)
 	if err != nil {
-		return nil, err
+		(*gs)[protocol.GlobalInnerKeyError.String()] = fmt.Sprintf("failed to query step outputs, please check config sheets")
 	}
 
 	for alias, detail := range detail {
@@ -198,7 +200,7 @@ func buildConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundl
 	return outputs, nil
 }
 
-func GetConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle) (map[string]map[string]string, error) {
+func GetConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundle.Bundle, gs *apistructs.GlobalStateData) (map[string]map[string]string, error) {
 
 	outputs := make(map[string]map[string]string, 0)
 
@@ -247,7 +249,7 @@ func GetConfigSheetStepOutPut(steps []apistructs.AutoTestSceneStep, bdl *bundle.
 	req.SnippetConfigs = snippetConfigs
 	detail, err := bdl.GetPipelineActionParamsAndOutputs(req)
 	if err != nil {
-		return nil, err
+		(*gs)[protocol.GlobalInnerKeyError.String()] = fmt.Sprintf("failed to query step outputs, err: %v", err)
 	}
 
 	for alias, detail := range detail {

--- a/modules/openapi/component-protocol/pkg/autotest/step/output_test.go
+++ b/modules/openapi/component-protocol/pkg/autotest/step/output_test.go
@@ -187,13 +187,14 @@ func TestGetStepAllOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var bdl = &bundle.Bundle{}
 			var patch *monkey.PatchGuard
+			var gs = &apistructs.GlobalStateData{}
 			if tt.args.ConfigOutput != nil {
 				patch = monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetPipelineActionParamsAndOutputs", func(b *bundle.Bundle, req apistructs.SnippetQueryDetailsRequest) (map[string]apistructs.SnippetQueryDetail, error) {
 					return tt.args.ConfigOutput, nil
 				})
 			}
 
-			got, err := GetStepAllOutput(tt.args.steps, bdl)
+			got, err := GetStepAllOutput(tt.args.steps, bdl, gs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetStepAllOutput() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -288,13 +289,14 @@ func TestGetConfigSheetStepOutPut(t *testing.T) {
 
 			var bdl = &bundle.Bundle{}
 			var patch *monkey.PatchGuard
+			var gs = &apistructs.GlobalStateData{}
 			if tt.args.ConfigOutput != nil {
 				patch = monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetPipelineActionParamsAndOutputs", func(b *bundle.Bundle, req apistructs.SnippetQueryDetailsRequest) (map[string]apistructs.SnippetQueryDetail, error) {
 					return tt.args.ConfigOutput, nil
 				})
 			}
 
-			got, err := GetConfigSheetStepOutPut(tt.args.steps, bdl)
+			got, err := GetConfigSheetStepOutPut(tt.args.steps, bdl, gs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetConfigSheetStepOutPut() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/apiEditor/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/apiEditor/render.go
@@ -185,7 +185,7 @@ LABEL:
 	}
 	inputs = append(inputs, Input{Label: "前置接口出参", Value: "前置接口出参", IsLeaf: false, Children: stepChildren1})
 
-	maps, err = step.GetConfigSheetStepOutPut(steps, bdl.Bdl)
+	maps, err = step.GetConfigSheetStepOutPut(steps, bdl.Bdl, gs)
 	if err != nil {
 		return err
 	}

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/configSheetInParams/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/configSheetInParams/render.go
@@ -175,7 +175,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *apistructs.Component,
 			return err
 		}
 	case apistructs.InitializeOperation, apistructs.RenderingOperation:
-		err := ca.handleDefault()
+		err := ca.handleDefault(gs)
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *apistructs.Component,
 	return nil
 }
 
-func (i *ComponentAction) handleDefault() error {
+func (i *ComponentAction) handleDefault(gs *apistructs.GlobalStateData) error {
 	// 选中的 step
 	var configSheetID string
 	var autotestGetSceneStepReq apistructs.AutotestGetSceneStepReq
@@ -233,7 +233,8 @@ func (i *ComponentAction) handleDefault() error {
 	}
 	result, err := i.CtxBdl.Bdl.GetFileTreeNode(req, uint64(orgID))
 	if err != nil {
-		return err
+		(*gs)[protocol.GlobalInnerKeyError.String()] = fmt.Sprintf("failed to query file tree nodes, please check config sheets")
+		result = &apistructs.UnifiedFileTreeNode{Meta: map[string]interface{}{}}
 	}
 	_, ok := result.Meta[apistructs.AutoTestFileTreeNodeMetaKeyPipelineYml]
 	if ok {

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/outPutForm/outPutForm.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/outPutForm/outPutForm.go
@@ -21,7 +21,7 @@ import (
 	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/autotest/step"
 )
 
-func (i *ComponentOutPutForm) SetProps() error {
+func (i *ComponentOutPutForm) SetProps(gs *apistructs.GlobalStateData) error {
 	paramsNameProp := PropColumn{
 		Title: "参数名",
 		Key:   PropsKeyParamsName,
@@ -58,7 +58,7 @@ func (i *ComponentOutPutForm) SetProps() error {
 			Props:    PropRenderProp{},
 		},
 	}
-	lt, err := i.RenderOnChange()
+	lt, err := i.RenderOnChange(gs)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (i *ComponentOutPutForm) SetProps() error {
 	return nil
 }
 
-func (i *ComponentOutPutForm) RenderListOutPutForm() error {
+func (i *ComponentOutPutForm) RenderListOutPutForm(gs *apistructs.GlobalStateData) error {
 	rsp, err := i.ctxBdl.Bdl.ListAutoTestSceneOutput(i.State.AutotestSceneRequest)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func (i *ComponentOutPutForm) RenderListOutPutForm() error {
 		list = append(list, pd)
 	}
 	i.Data.List = list
-	if err = i.SetProps(); err != nil {
+	if err = i.SetProps(gs); err != nil {
 		return err
 	}
 	return nil
@@ -104,7 +104,7 @@ func (i *ComponentOutPutForm) RenderUpdateOutPutForm() error {
 }
 
 // 可编辑器的初始值
-func (i *ComponentOutPutForm) RenderOnChange() ([]PropChangeOption, error) {
+func (i *ComponentOutPutForm) RenderOnChange(gs *apistructs.GlobalStateData) ([]PropChangeOption, error) {
 	list, err := i.ctxBdl.Bdl.ListAutoTestSceneStep(i.State.AutotestSceneRequest)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (i *ComponentOutPutForm) RenderOnChange() ([]PropChangeOption, error) {
 		stepNameMap[strconv.FormatUint(s.ID, 10)] = s.Name
 	}
 
-	outputs, err := step.GetStepAllOutput(steps, i.ctxBdl.Bdl)
+	outputs, err := step.GetStepAllOutput(steps, i.ctxBdl.Bdl, gs)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/outPutForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/outPutForm/render.go
@@ -143,7 +143,7 @@ func (i *ComponentOutPutForm) Render(ctx context.Context, c *apistructs.Componen
 
 	switch event.Operation {
 	case apistructs.InitializeOperation, apistructs.RenderingOperation:
-		err = i.RenderListOutPutForm()
+		err = i.RenderListOutPutForm(gs)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func (i *ComponentOutPutForm) Render(ctx context.Context, c *apistructs.Componen
 		if err != nil {
 			return err
 		}
-		err = i.RenderListOutPutForm()
+		err = i.RenderListOutPutForm(gs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
fix config sheet that created by imported excel display error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=239888&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix：fix config sheet that created by imported excel display error （修复了导入的场景集配置单参数不存在,导致render整个报错.）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
