### PR TITLE
autotest plan action filter archived

### DIFF
--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/testplan-run.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/testplan-run.go
@@ -46,9 +46,10 @@ func testPlanRun(ctx context.Context, c *apistructs.Component, scenario apistruc
 
 	// get testplan
 	testPlanRequest := apistructs.TestPlanV2PagingRequest{
-		ProjectID: uint64(projectId),
-		PageNo:    1,
-		PageSize:  999,
+		ProjectID:  uint64(projectId),
+		PageNo:     1,
+		PageSize:   999,
+		IsArchived: &[]bool{false}[0],
 	}
 	testPlanRequest.UserID = bdl.Identity.UserID
 	plans, err := bdl.Bdl.PagingTestPlansV2(testPlanRequest)


### PR DESCRIPTION
#### What type of this PR
/kind bug


#### What this PR does / why we need it:
Optimize user experience, automated test plan execution can now select archived plans


#### Which issue(s) this PR fixes:
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/bug?id=238292&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Automated test plan execution action to filter out archived plans         |
| 🇨🇳 中文    |         自动化测试计划执行 action 过滤掉已归档的计划     |

#### Need cherry-pick to release versions?

/cherry-pick release/1.4

