### PR TITLE
fix: update the container env when scale the service group

### DIFF
--- a/modules/scheduler/executor/plugins/k8s/deployment.go
+++ b/modules/scheduler/executor/plugins/k8s/deployment.go
@@ -899,6 +899,8 @@ func (k *Kubernetes) scaleDeployment(ctx context.Context, sg *apistructs.Service
 		return setContainerErr
 	}
 
+	k.UpdateContainerResourceEnv(scalingService.Resources, &container)
+
 	deploy.Spec.Template.Spec.Containers[0] = container
 
 	_, projectID, workspace, runtimeID := extractContainerEnvs(deploy.Spec.Template.Spec.Containers)
@@ -971,4 +973,33 @@ func (k *Kubernetes) setContainerResources(service apistructs.Service, container
 	}
 
 	return nil
+}
+func (k *Kubernetes) UpdateContainerResourceEnv(originResource apistructs.Resources, container *apiv1.Container) {
+	for index, env := range container.Env {
+		var needToUpdate = false
+		switch env.Name {
+		case "DICE_CPU_ORIGIN":
+			needToUpdate = true
+			env.Value = fmt.Sprintf("%f", originResource.Cpu)
+		case "DICE_CPU_REQUEST":
+			needToUpdate = true
+			env.Value = container.Resources.Requests.Cpu().AsDec().String()
+		case "DICE_CPU_LIMIT":
+			needToUpdate = true
+			env.Value = container.Resources.Limits.Cpu().AsDec().String()
+		case "DICE_MEM_ORIGIN":
+			needToUpdate = true
+			env.Value = fmt.Sprintf("%f", originResource.Mem)
+		case "DICE_MEM_REQUEST":
+			needToUpdate = true
+			env.Value = fmt.Sprintf("%d", container.Resources.Requests.Memory().Value()/1024/1024)
+		case "DICE_MEM_LIMIT":
+			needToUpdate = true
+			env.Value = fmt.Sprintf("%d", container.Resources.Limits.Memory().Value()/1024/1024)
+		}
+		if needToUpdate {
+			container.Env[index] = env
+		}
+	}
+	return
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:
- fix: update the container env when scale the service group

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Bugfix: Fix the bug that will not update the resource environment variables of the container when scaling the service group |
| 🇨🇳 中文    | 修复扩展 Service Group 时不会更新容器资源环境变量的bug |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
