### PR TITLE
Fix the error when the user did not fill in the .yml when creating the pipeline

### DIFF
--- a/modules/openapi/component-protocol/scenarios/app-pipeline-tree/components/nodeFormModal/render.go
+++ b/modules/openapi/component-protocol/scenarios/app-pipeline-tree/components/nodeFormModal/render.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/erda-project/erda/apistructs"
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
@@ -109,7 +110,7 @@ func (a *ComponentNodeFormModal) handlerSubmitOperation(ctxBdl protocol.ContextB
 	if formData.Branch == "" || formData.Name == "" {
 		return fmt.Errorf("name %s or branch %s error: value is empty", formData.Name, formData.Branch)
 	}
-	if formData.Name == "pipeline.yml" {
+	if formData.Name == "pipeline.yml" || formData.Name == "pipeline" || formData.Name == "pipeline.yaml" {
 		return fmt.Errorf("can not add pipeline.yml yml already exists")
 	} else {
 		pinode := fmt.Sprintf("%s/%s/tree/%s/.dice/pipelines", inParams.ProjectId, inParams.AppId, formData.Branch)
@@ -117,6 +118,12 @@ func (a *ComponentNodeFormModal) handlerSubmitOperation(ctxBdl protocol.ContextB
 		req.Scope = apistructs.FileTreeScopeProjectApp
 		req.ScopeID = inParams.ProjectId
 		req.Name = formData.Name
+
+		// assuming that the user did not fill in the .yml suffix, it will be filled in automatically when creating
+		req.Name = strings.TrimSuffix(req.Name, ".yaml")
+		if !strings.HasSuffix(req.Name, ".yml") {
+			req.Name += ".yml"
+		}
 		req.UserID = ctxBdl.Identity.UserID
 		req.Type = apistructs.UnifiedFileTreeNodeTypeFile
 		req.Pinode = base64.StdEncoding.EncodeToString([]byte(pinode))


### PR DESCRIPTION
#### What type of this PR
/kind bug

#### What this PR does / why we need it:
An error is reported when the user does not fill in the .yml when creating the pipeline, which is a bad experience for the user

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/bug?id=236595&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       When the user creates the pipeline, it is automatically spliced ​​when there is no .yml suffix       |
| 🇨🇳 中文    |       用户创建流水线的时候没有.yml后缀时自动拼接上       |


#### Need cherry-pick to release versions?

/cherry-pick release/1.4