### PR TITLE
fix: test-dashboard polish each score before calc total score

### DIFF
--- a/modules/dop/component-protocol/components/test-dashboard/overview_group/quality_chart/render.go
+++ b/modules/dop/component-protocol/components/test-dashboard/overview_group/quality_chart/render.go
@@ -254,13 +254,8 @@ func (q *Q) calcBugReopenRate(ctx context.Context, h *gshelper.GSHelper) decimal
 
 // polishToFloat64Score set precision to 2, range from 0-100
 func polishToFloat64Score(scoreDecimal decimal.Decimal) float64 {
+	scoreDecimal = polishScore(scoreDecimal)
 	score, _ := scoreDecimal.Float64()
-	if score < 0 {
-		score = 0
-	}
-	if score > 100 {
-		score = 100
-	}
 	return numeral.Round(score, 2)
 }
 
@@ -271,9 +266,20 @@ func (q *Q) calcGlobalQualityScore(ctx context.Context, scores ...decimal.Decima
 	}
 	total := decimal.NewFromInt(0)
 	for _, score := range scores {
-		total = total.Add(score)
+		total = total.Add(polishScore(score))
 	}
 	var avg decimal.Decimal
 	avg = total.Div(decimal.NewFromInt(int64(len(scores))))
 	return avg
+}
+
+// polishScore range from 0-100
+func polishScore(scoreDecimal decimal.Decimal) decimal.Decimal {
+	if scoreDecimal.LessThan(decimal.NewFromInt(0)) {
+		scoreDecimal = decimal.NewFromInt(0)
+	}
+	if scoreDecimal.GreaterThan(decimal.NewFromInt(100)) {
+		scoreDecimal = decimal.NewFromInt(100)
+	}
+	return scoreDecimal
 }


### PR DESCRIPTION
#### What type of this PR

/kind bug


#### What this PR does / why we need it:

test-dashboard polish each score before calc total score


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=240804&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyI5MiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.4` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
