### PR TITLE
disable mysql basic ha

### DIFF
--- a/modules/orchestrator/services/addon/addon_deploy_test.go
+++ b/modules/orchestrator/services/addon/addon_deploy_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestMysqlPreProcess(t *testing.T) {
+	params := &apistructs.AddonHandlerCreateItem{Plan: apistructs.AddonBasic}
+	addonSpec := &apistructs.AddonExtension{Plan: map[string]apistructs.AddonPlanItem{
+		apistructs.AddonBasic: {
+			Nodes: 2,
+		},
+	}}
+	addonDeployGroup := &apistructs.ServiceGroupCreateV2Request{
+		GroupLabels: map[string]string{
+			"ADDON_GROUPS": "2",
+		},
+	}
+	mysqlPreProcess(params, addonSpec, addonDeployGroup)
+	assert.Equal(t, "1", addonDeployGroup.GroupLabels["ADDON_GROUPS"])
+	assert.Equal(t, 1, addonSpec.Plan[apistructs.AddonBasic].Nodes)
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature
basic mysql: disable master-slave mode, use standalone mode


#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | basic mysql: disable master-slave mode, use standalone mode |
| 🇨🇳 中文    | 基础版本的mysql，去除 slave，只发布 standalone master |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
