### PR TITLE
remove mobile init key

### DIFF
--- a/modules/openapi/component-protocol/scenarios/app-pipeline-tree/components/fileTree/render.go
+++ b/modules/openapi/component-protocol/scenarios/app-pipeline-tree/components/fileTree/render.go
@@ -31,8 +31,8 @@ import (
 const (
 	OperationKeyClickBranchExpandChildren = "branchExpandChildren"
 
-	mobileInitBranchKey = "mobile_init_branch_key"
-	mobileInitKey       = "mobile_init_key"
+	mobileInitBranchKey = "mobile_init_branch"
+	mobileInitKey       = "mobile_init"
 
 	I18nLocalePrefixKey                = "wb.content.pipeline.file.tree."
 	defaultPipelineI18nKey             = "defaultPipeline"


### PR DESCRIPTION
#### What type of this PR
/kind bugfix

#### What this PR does / why we need it:
The key agreed upon with the front end accidentally added the key suffix

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Remove the suffix key of mobile_init_key        |
| 🇨🇳 中文    |        去除 mobile_init_key 的后缀 key      |


#### Need cherry-pick to release versions?
/cherry-pick release/1.4
