### PR TITLE
loop task not reset begintime

### DIFF
--- a/modules/pipeline/pipengine/reconciler/taskrun/task_loop.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/task_loop.go
@@ -120,7 +120,6 @@ func (tr *TaskRun) resetTaskForLoop() {
 	tr.Task.QueueTimeSec = -1
 	tr.Task.Extra.TimeBeginQueue = time.Time{}
 	tr.Task.Extra.TimeEndQueue = time.Time{}
-	tr.Task.TimeBegin = time.Time{}
 	tr.Task.TimeEnd = time.Time{}
 	// reset task result
 	tr.Task.Result = apistructs.PipelineTaskResult{}

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/queue.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/queue.go
@@ -116,7 +116,12 @@ func (q *queue) WhenDone(data interface{}) error {
 	q.Task.Status = apistructs.PipelineStatusRunning
 	q.Task.Extra.TimeEndQueue = time.Now()
 	q.Task.QueueTimeSec = costtimeutil.CalculateTaskQueueTimeSec(q.Task)
+	beforeTimeBegin := q.Task.TimeBegin
 	q.Task.TimeBegin = time.Now()
+	// loop task timeBegin not reset
+	if q.Task.Extra.LoopOptions != nil && !beforeTimeBegin.IsZero() {
+		q.Task.TimeBegin = beforeTimeBegin
+	}
 	logrus.Infof("reconciler: pipelineID: %d, task %q end queue (%s -> %s, queue: %ds)",
 		q.P.ID, q.Task.Name, apistructs.PipelineStatusQueue, apistructs.PipelineStatusRunning, q.Task.QueueTimeSec)
 	return nil

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/queue_test.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/queue_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskop
+
+import (
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/bmizerany/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/commonutil/costtimeutil"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_queue_WhenDone(t *testing.T) {
+	tests := []struct {
+		name    string
+		q       queue
+		wantErr bool
+	}{
+		{
+			name: "test_reset_time_begin",
+			q: queue{
+				P: &spec.Pipeline{
+					PipelineBase: spec.PipelineBase{
+						ID: 1,
+					},
+				},
+				Task: &spec.PipelineTask{
+					Extra: spec.PipelineTaskExtra{
+						LoopOptions: &apistructs.PipelineTaskLoopOptions{},
+					},
+					TimeBegin: time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch := monkey.Patch(costtimeutil.CalculateTaskQueueTimeSec, func(task *spec.PipelineTask) (cost int64) {
+				return 0
+			})
+			defer patch.Unpatch()
+			if err := tt.q.WhenDone(nil); (err != nil) != tt.wantErr {
+				t.Errorf("WhenDone() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.q.Task.TimeBegin.Unix(), time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC).Unix())
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR
/kind bugfix

#### What this PR does / why we need it:
The start execution time is not reset when the pipeline cyclic task is executed. The result of the reset is that the user cannot know the execution time of the cyclic task


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=242852&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=541&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The pipeline does not reset the start execution time of the cyclic task       |
| 🇨🇳 中文    |      pipeline 不重置循环任务的开始执行时间        |

#### Need cherry-pick to release versions?

/cherry-pick release/1.4
