### PR TITLE
autotest step concurrency interface display

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-detail/components/executeTaskTable/render.go
@@ -213,6 +213,12 @@ func getProps() map[string]interface{} {
 				Ellipsis:  true,
 			},
 			{
+				Title:     "步骤",
+				DataIndex: "step",
+				Width:     85,
+				Ellipsis:  true,
+			},
+			{
 				Title:     "子任务数",
 				DataIndex: "tasksNum",
 				Width:     85,
@@ -291,6 +297,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 	num := (a.State.PageNo - 1) * (a.State.PageSize)
 	ret := a.State.PageSize
 	a.State.Total = 0
+	stepIdx := 1
 	for _, each := range pipeline.PipelineStages {
 		a.State.Total += int64(len(each.PipelineTasks))
 		if ret == 0 {
@@ -425,6 +432,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"type":     transformStepType(res.Type),
 					"path":     path,
 					"time":     a.getCostTime(task),
+					"step":     stepIdx,
 				}
 
 				if task.SnippetPipelineID != nil && (res.Type == apistructs.StepTypeScene ||
@@ -460,6 +468,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"type":     transformStepType(apistructs.AutotestSceneSet),
 					"path":     "",
 					"time":     a.getCostTime(task),
+					"step":     stepIdx,
 				}
 				if task.SnippetPipelineDetail != nil {
 					list["tasksNum"] = task.SnippetPipelineDetail.DirectSnippetTasksNum
@@ -493,6 +502,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"type":     transformStepType(apistructs.AutotestScene),
 					"path":     "",
 					"time":     a.getCostTime(task),
+					"step":     stepIdx,
 				}
 				if task.SnippetPipelineDetail != nil {
 					list["tasksNum"] = task.SnippetPipelineDetail.DirectSnippetTasksNum
@@ -507,6 +517,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 				break
 			}
 		}
+		stepIdx++
 	}
 	if a.State.Total <= (a.State.PageNo-1)*(a.State.PageSize) && a.State.Total > 0 {
 		a.State.PageNo = DefaultPageNo

--- a/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/executeTaskTable/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-scenes/components/executeTaskTable/render.go
@@ -217,6 +217,12 @@ func getProps() map[string]interface{} {
 				Ellipsis:  true,
 			},
 			{
+				Title:     "步骤",
+				DataIndex: "step",
+				Width:     85,
+				Ellipsis:  true,
+			},
+			{
 				Title:     "子任务数",
 				DataIndex: "tasksNum",
 				Width:     85,
@@ -282,7 +288,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 	num := (a.State.PageNo - 1) * (a.State.PageSize)
 	ret := a.State.PageSize
 	a.State.Total = 0
-
+	stepIdx := 1
 	for _, each := range pipeline.PipelineStages {
 
 		a.State.Total += int64(len(each.PipelineTasks))
@@ -352,6 +358,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"status":   getStatus(task.Status),
 					"type":     transformStepType(apistructs.StepAPIType(task.Type)),
 					"path":     "",
+					"step":     stepIdx,
 				}
 			} else {
 				// autotest task
@@ -429,6 +436,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"status":   getStatus(task.Status),
 					"type":     transformStepType(res.Type),
 					"path":     path,
+					"step":     stepIdx,
 				}
 
 				// scene or configSheet add other info
@@ -448,6 +456,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 				break
 			}
 		}
+		stepIdx++
 	}
 
 	if a.State.Total <= (a.State.PageNo-1)*(a.State.PageSize) && a.State.Total > 0 {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
autotest openapi component step concurrency interface display

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=237839&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that autotest step concurrency interface display （修复了并行编排的接口或场景集在执行明细中无法看出编排关系）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->



#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
