### PR TITLE
init toolTip,value,path if report is nil

### DIFF
--- a/modules/dop/component-protocol/components/code-coverage/treeMapChart/render.go
+++ b/modules/dop/component-protocol/components/code-coverage/treeMapChart/render.go
@@ -70,8 +70,13 @@ func (i *ComponentAction) GenComponentState(c *cptype.Component) error {
 }
 
 func (c *ComponentAction) setProps(ctx context.Context, recordID uint64) error {
-	var data []*apistructs.CodeCoverageNode
-	var root *apistructs.CodeCoverageNode
+	var (
+		data      []*apistructs.CodeCoverageNode
+		root      *apistructs.CodeCoverageNode
+		path      string
+		rootValue []float64
+		toolTip   apistructs.ToolTip
+	)
 	title := cputil.I18n(ctx, "report-details")
 	var maxDepth int
 	projectName := ""
@@ -85,6 +90,9 @@ func (c *ComponentAction) setProps(ctx context.Context, recordID uint64) error {
 			maxDepth = reportContent[0].MaxDepth()
 			data = reportContent[0].Nodes
 			root = reportContent[0]
+			path = root.Path
+			rootValue = root.Value
+			toolTip = root.ToolTip
 		}
 		// mysql default time 1000-01-01
 		if record.ReportTime.Year() != 1000 {
@@ -141,9 +149,9 @@ func (c *ComponentAction) setProps(ctx context.Context, recordID uint64) error {
 					"type":            "treemap",
 					"roam":            false,
 					"leafDepth":       maxDepth,
-					"tooltip":         root.ToolTip,
-					"value":           root.Value,
-					"path":            root.Path,
+					"tooltip":         toolTip,
+					"value":           rootValue,
+					"path":            path,
 					"bottom":          30,
 					"width":           "100%",
 					"height":          "90%",


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
init toolTip,value,path if report is nil

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/bug?id=245903&issueFilter__urlQuery=eyJpdGVyYXRpb25JRHMiOls1NDFdLCJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6InRhYmxlIiwiY2hpbGRyZW5WYWx1ZSI6eyJrYW5iYW4iOiJkZWFkbGluZSJ9fQ%3D%3D&iterationID=541&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that init toolTip,value,path if report is nil （修复了测试覆盖率没有报告的时候panic的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->



#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
