### PR TITLE
fix the i18n in apim chart

### DIFF
--- a/modules/hepa/provider.go
+++ b/modules/hepa/provider.go
@@ -56,7 +56,11 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		path := strings.Replace(req.URL.Path, "/api/gateway/openapi/metrics/charts", "/api/metrics", 1)
 		path += "?" + req.URL.RawQuery
 		logrus.Infof("monitor proxy url:%s", path)
-		code, body, err := util.CommonRequest("GET", discover.Monitor()+path, nil)
+		headers := make(map[string]string)
+		for key, values := range req.Header {
+			headers[key] = values[0]
+		}
+		code, body, err := util.CommonRequest("GET", discover.Monitor()+path, nil, headers)
 		if err != nil {
 			logrus.Error(err)
 			code = http.StatusInternalServerError


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix


#### What this PR does / why we need it:
when hepa proxy the metric request to monitor, missing the Lang header will lead to i18n not work.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
