### PR TITLE
bugfix pipeline repeated execution

### DIFF
--- a/modules/pipeline/pipengine/reconciler/define.go
+++ b/modules/pipeline/pipengine/reconciler/define.go
@@ -59,6 +59,8 @@ type Reconciler struct {
 	processingTasks sync.Map
 	// teardownPipelines store pipeline id which is in the process of tear down
 	teardownPipelines sync.Map
+	// processPipelines store reconciler pipeline id
+	processingPipelines sync.Map
 
 	// svc
 	actionAgentSvc  *actionagentsvc.ActionAgentSvc
@@ -88,8 +90,9 @@ func New(js jsonstore.JsonStore, etcd *etcd.Store, bdl *bundle.Bundle, dbClient 
 		bdl:      bdl,
 		dbClient: dbClient,
 
-		processingTasks:   sync.Map{},
-		teardownPipelines: sync.Map{},
+		processingTasks:     sync.Map{},
+		teardownPipelines:   sync.Map{},
+		processingPipelines: sync.Map{},
 
 		actionAgentSvc:  actionAgentSvc,
 		extMarketSvc:    extMarketSvc,

--- a/modules/pipeline/pipengine/reconciler/listen.go
+++ b/modules/pipeline/pipengine/reconciler/listen.go
@@ -46,93 +46,95 @@ func (r *Reconciler) Listen(ctx context.Context) {
 				func(key string, _ interface{}, t storetypes.ChangeType) (_ error) {
 
 					// async reconcile, non-blocking, so we can watch subsequent incoming pipelines
-					go func() {
-						rlog.Infof("watched a key change, key: %s, changeType: %s", key, t.String())
-
-						// parse pipelineID
-						pipelineID, err := parsePipelineIDFromWatchedKey(key)
-						if err != nil {
-							rlog.Errorf("failed to parse pipelineID from watched key, key: %s, err: %v", key, err)
-							return
-						}
-
-						// add into queue
-						popCh, needRetryIfErr, err := r.QueueManager.PutPipelineIntoQueue(pipelineID)
-						if err != nil {
-							rlog.PErrorf(pipelineID, "failed to put pipeline into queue")
-							if needRetryIfErr {
-								r.reconcileAgain(pipelineID)
-								return
-							}
-							// no need retry, treat as failed
-							_ = r.updatePipelineStatus(&spec.Pipeline{
-								PipelineBase: spec.PipelineBase{
-									ID:     pipelineID,
-									Status: apistructs.PipelineStatusFailed,
-								}})
-							return
-						}
-						rlog.PInfof(pipelineID, "added into queue, waiting to pop from the queue")
-						<-popCh
-						rlog.PInfof(pipelineID, "pop from the queue, begin reconcile")
-						var p spec.Pipeline
-						_ = loop.New(loop.WithDeclineRatio(2), loop.WithDeclineLimit(time.Second*10)).Do(func() (abort bool, err error) {
-							p, err = r.dbClient.GetPipeline(pipelineID)
-							if err != nil {
-								rlog.PWarnf(pipelineID, "failed to get pipeline, err: %v, will continue until get pipeline", err)
-								return false, err
-							}
-							return true, nil
-						})
-						if p.Status.IsEndStatus() {
-							rlog.PErrorf(pipelineID, "unable to reconcile end status pipeline")
-							return
-						}
-
-						if err := r.updateStatusBeforeReconcile(p); err != nil {
-							rlog.PErrorf(p.ID, "Failed to update pipeline status before reconcile, err: %v", err)
-							return
-						}
-
-						// construct context for pipeline reconciler
-						pCtx := makeContextForPipelineReconcile(pipelineID)
-						go func() {
-							for {
-								select {
-								case <-ctx.Done():
-									pCancel, ok := pCtx.Value(ctxKeyPipelineExitChCancelFunc).(context.CancelFunc)
-									if ok {
-										pCancel()
-									}
-									return
-								case <-pCtx.Done():
-									return
-								}
-							}
-						}()
-
-						// reconciler
-						reconcileErr := r.reconcile(pCtx, pipelineID)
-
-						defer func() {
-							r.teardownCurrentReconcile(pCtx, pipelineID)
-							if err := r.updateStatusAfterReconcile(pCtx, pipelineID); err != nil {
-								rlog.PErrorf(pipelineID, "failed to update status after reconcile, err: %v", err)
-							}
-
-							// if reconcile failed, put and wait next reconcile
-							if reconcileErr != nil {
-								rlog.PErrorf(pipelineID, "failed to reconcile pipeline, err: %v", err)
-								r.reconcileAgain(pipelineID)
-							}
-						}()
-					}()
+					go r.doWatch(ctx, key, t)
 
 					return nil
 				},
 			)
 		}
 	}
+}
+
+func (r *Reconciler) doWatch(ctx context.Context, key string, t storetypes.ChangeType) {
+	rlog.Infof("watched a key change, key: %s, changeType: %s", key, t.String())
+
+	// parse pipelineID
+	pipelineID, err := parsePipelineIDFromWatchedKey(key)
+	if err != nil {
+		rlog.Errorf("failed to parse pipelineID from watched key, key: %s, err: %v", key, err)
+		return
+	}
+
+	// add into queue
+	popCh, needRetryIfErr, err := r.QueueManager.PutPipelineIntoQueue(pipelineID)
+	if err != nil {
+		rlog.PErrorf(pipelineID, "failed to put pipeline into queue")
+		if needRetryIfErr {
+			r.reconcileAgain(pipelineID)
+			return
+		}
+		// no need retry, treat as failed
+		_ = r.updatePipelineStatus(&spec.Pipeline{
+			PipelineBase: spec.PipelineBase{
+				ID:     pipelineID,
+				Status: apistructs.PipelineStatusFailed,
+			}})
+		return
+	}
+	rlog.PInfof(pipelineID, "added into queue, waiting to pop from the queue")
+	<-popCh
+	rlog.PInfof(pipelineID, "pop from the queue, begin reconcile")
+	var p spec.Pipeline
+	_ = loop.New(loop.WithDeclineRatio(2), loop.WithDeclineLimit(time.Second*10)).Do(func() (abort bool, err error) {
+		p, err = r.dbClient.GetPipeline(pipelineID)
+		if err != nil {
+			rlog.PWarnf(pipelineID, "failed to get pipeline, err: %v, will continue until get pipeline", err)
+			return false, err
+		}
+		return true, nil
+	})
+	if p.Status.IsEndStatus() {
+		rlog.PErrorf(pipelineID, "unable to reconcile end status pipeline")
+		return
+	}
+
+	if err := r.updateStatusBeforeReconcile(p); err != nil {
+		rlog.PErrorf(p.ID, "Failed to update pipeline status before reconcile, err: %v", err)
+		return
+	}
+
+	// construct context for pipeline reconciler
+	pCtx := makeContextForPipelineReconcile(pipelineID)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				pCancel, ok := pCtx.Value(ctxKeyPipelineExitChCancelFunc).(context.CancelFunc)
+				if ok {
+					pCancel()
+				}
+				return
+			case <-pCtx.Done():
+				return
+			}
+		}
+	}()
+
+	// reconciler
+	reconcileErr := r.reconcile(pCtx, pipelineID)
+
+	defer func() {
+		r.teardownCurrentReconcile(pCtx, pipelineID)
+		if err := r.updateStatusAfterReconcile(pCtx, pipelineID); err != nil {
+			rlog.PErrorf(pipelineID, "failed to update status after reconcile, err: %v", err)
+		}
+
+		// if reconcile failed, put and wait next reconcile
+		if reconcileErr != nil {
+			rlog.PErrorf(pipelineID, "failed to reconcile pipeline, err: %v", err)
+			r.reconcileAgain(pipelineID)
+		}
+	}()
 }
 
 // reconcileAgain add to reconciler again, wait next reconcile


### PR DESCRIPTION
#### What type of this PR
/kind bugfix


#### What this PR does / why we need it:
After the timing task is turned on and the compensation is not executed, the pipeline is repeatedly executed, which will cause the pipeline to directly change to the successful state, and the task state in the pipeline is noNeedBySystem


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=245842&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=467&type=TASK)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The pipeline adds a map to verify whether the pipeline is running       |
| 🇨🇳 中文    |      流水线增加 map 校验 pipeline 是否正在跑        |


#### Need cherry-pick to release versions?
