### PR TITLE
Mbox deduplicate id column does not exceed the index length limit

### DIFF
--- a/.erda/migrations/cmdb/20211102-mbox-deduplicateid-length.sql
+++ b/.erda/migrations/cmdb/20211102-mbox-deduplicateid-length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `dice_mboxs` MODIFY `deduplicate_id` VARCHAR(191) COMMENT 'deduplicate id';


### PR DESCRIPTION
#### What type of this PR
bugfix


#### What this PR does / why we need it:
Mbox deduplicate id column does not exceed the index length limit

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.4` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
