### PR TITLE
task policy

### DIFF
--- a/apistructs/pipeline_yml.go
+++ b/apistructs/pipeline_yml.go
@@ -106,6 +106,28 @@ type PipelineYmlAction struct {
 	Disable       bool                   `json:"disable,omitempty"`                                        // task is disable or enable
 	Loop          *PipelineTaskLoop      `json:"loop,omitempty"`                                           // 循环执行
 	SnippetStages *SnippetStages         `json:"snippetStages,omitempty"`                                  // snippetStages snippet 展开
+	Policy        *Policy                `json:"policy,omitempty"`                                         // action execution strategy
+}
+
+type PolicyType string
+
+// todo add other types of implementation
+// try-latest-result (if not exist -> new-run)
+// force-latest-result (throw error or wait?)
+//
+// try-latest-success-result
+// force-latest-success-result
+//
+// new-run (default, can omit)
+//
+// run-once-from-root-pipeline
+const (
+	NewRunPolicyType                 PolicyType = "new-run"
+	TryLatestSuccessResultPolicyType PolicyType = "try-latest-success-result"
+)
+
+type Policy struct {
+	Type PolicyType `json:"type,omitempty"`
 }
 
 type SnippetStages struct {

--- a/modules/pipeline/pipengine/reconciler/policy.go
+++ b/modules/pipeline/pipengine/reconciler/policy.go
@@ -1,0 +1,1 @@
+package reconciler

--- a/modules/pipeline/pipengine/reconciler/policy.go
+++ b/modules/pipeline/pipengine/reconciler/policy.go
@@ -1,1 +1,123 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reconciler
+
+import (
+	"fmt"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/dbclient"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+	"github.com/erda-project/erda/pkg/parser/pipelineyml"
+)
+
+type PolicyHandlerOptions struct {
+	dbClient *dbclient.Client
+}
+
+type PolicyType interface {
+	ResetTask(*spec.PipelineTask, PolicyHandlerOptions) (*spec.PipelineTask, error)
+}
+
+var policyTypeAdaptor = map[apistructs.PolicyType]PolicyType{
+	apistructs.TryLatestSuccessResultPolicyType: TryLastSuccessResult{},
+	apistructs.NewRunPolicyType:                 NewRun{},
+}
+
+type NewRun struct{}
+
+func (run NewRun) ResetTask(task *spec.PipelineTask, options PolicyHandlerOptions) (*spec.PipelineTask, error) {
+	return task, nil
+}
+
+type TryLastSuccessResult struct{}
+
+func (t TryLastSuccessResult) ResetTask(task *spec.PipelineTask, opt PolicyHandlerOptions) (*spec.PipelineTask, error) {
+	if !task.IsSnippet {
+		return task, nil
+	}
+
+	if task.Extra.Action.SnippetConfig == nil {
+		return task, nil
+	}
+
+	ymlName, source := getPipelineSourceAndNameBySnippetConfig(task.Extra.Action.SnippetConfig)
+
+	runSuccessPipeline, _, _, _, err := opt.dbClient.PageListPipelines(apistructs.PipelinePageListRequest{
+		Sources:        []apistructs.PipelineSource{source},
+		YmlNames:       []string{ymlName},
+		Statuses:       []string{apistructs.PipelineStatusSuccess.String()},
+		PageNum:        1,
+		PageSize:       1,
+		IncludeSnippet: true,
+		DescCols:       []string{apistructs.PipelinePageListRequestIdColumn},
+	})
+	if err != nil {
+		return task, err
+	}
+	if len(runSuccessPipeline) <= 0 {
+		return task, nil
+	}
+	pipeline := runSuccessPipeline[0]
+
+	beforeSuccessTask, err := opt.dbClient.GetPipelineTask(pipeline.ParentTaskID)
+	if err != nil {
+		return task, err
+	}
+
+	if beforeSuccessTask.ID <= 0 {
+		return task, nil
+	}
+
+	task.Status = beforeSuccessTask.Status
+	task.Result = beforeSuccessTask.Result
+	task.IsSnippet = beforeSuccessTask.IsSnippet
+	task.SnippetPipelineDetail = beforeSuccessTask.SnippetPipelineDetail
+	task.TimeBegin = beforeSuccessTask.TimeBegin
+	task.TimeEnd = beforeSuccessTask.TimeEnd
+	task.CostTimeSec = beforeSuccessTask.CostTimeSec
+	task.QueueTimeSec = beforeSuccessTask.QueueTimeSec
+	task.SnippetPipelineID = beforeSuccessTask.SnippetPipelineID
+	if task.Extra.Action.Policy != nil {
+		task.Extra.CurrentPolicy = apistructs.Policy{
+			Type: task.Extra.Action.Policy.Type,
+		}
+	}
+	return task, nil
+}
+
+func getPipelineSourceAndNameBySnippetConfig(snippetConfig *pipelineyml.SnippetConfig) (ymlName string, sources apistructs.PipelineSource) {
+	return snippetConfig.Name, apistructs.PipelineSource(snippetConfig.Source)
+}
+
+func (r *Reconciler) adaptPolicy(task *spec.PipelineTask) (result *spec.PipelineTask, err error) {
+	if task == nil {
+		return task, fmt.Errorf("task was empty")
+	}
+	if task.Extra.Action.Policy == nil {
+		return task, nil
+	}
+
+	handler := policyTypeAdaptor[task.Extra.Action.Policy.Type]
+	if handler == nil {
+		return task, nil
+	}
+
+	opt := PolicyHandlerOptions{
+		dbClient: r.dbClient,
+	}
+
+	return handler.ResetTask(task, opt)
+}

--- a/modules/pipeline/pipengine/reconciler/policy_test.go
+++ b/modules/pipeline/pipengine/reconciler/policy_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/bmizerany/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/dbclient"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+	"github.com/erda-project/erda/pkg/parser/pipelineyml"
+)
+
+func Test_handlerFactoryNewPolicyType(t *testing.T) {
+	type args struct {
+		task *spec.PipelineTask
+		opt  PolicyHandlerOptions
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult *spec.PipelineTask
+		wantErr    bool
+	}{
+		{
+			name: "test",
+			args: args{
+				task: &spec.PipelineTask{
+					ID: 1,
+				},
+			},
+			wantErr: false,
+			wantResult: &spec.PipelineTask{
+				ID: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, err := NewRun{}.ResetTask(tt.args.task, tt.args.opt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handlerFactoryNewPolicyType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("handlerFactoryNewPolicyType() gotResult = %v, want %v", gotResult, tt.wantResult)
+			}
+		})
+	}
+}
+
+func Test_handlerLastSuccessResultPolicyType(t *testing.T) {
+	type args struct {
+		task *spec.PipelineTask
+
+		mockSuccessPipelines []spec.Pipeline
+		mockTasks            spec.PipelineTask
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult *spec.PipelineTask
+		wantErr    bool
+	}{
+		{
+			name: "test_not_snippet",
+			args: args{
+				task: &spec.PipelineTask{
+					IsSnippet: false,
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				IsSnippet: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_empty_snippetConfig",
+			args: args{
+				task: &spec.PipelineTask{
+					IsSnippet: true,
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				IsSnippet: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_not_find_success_pipeline",
+			args: args{
+				task: &spec.PipelineTask{
+					IsSnippet: true,
+					Extra: spec.PipelineTaskExtra{
+						Action: pipelineyml.Action{
+							SnippetConfig: &pipelineyml.SnippetConfig{
+								Name:   "name",
+								Source: "source",
+							},
+						},
+					},
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				IsSnippet: true,
+				Extra: spec.PipelineTaskExtra{
+					Action: pipelineyml.Action{
+						SnippetConfig: &pipelineyml.SnippetConfig{
+							Name:   "name",
+							Source: "source",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_not_find_task",
+			args: args{
+				task: &spec.PipelineTask{
+					Name:      "name",
+					Type:      "type",
+					IsSnippet: true,
+					Extra: spec.PipelineTaskExtra{
+						Action: pipelineyml.Action{
+							SnippetConfig: &pipelineyml.SnippetConfig{
+								Name:   "name",
+								Source: "source",
+							},
+						},
+					},
+				},
+				mockSuccessPipelines: []spec.Pipeline{
+					{
+						PipelineBase: spec.PipelineBase{
+							ID: 1,
+						},
+					},
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				Name:      "name",
+				Type:      "type",
+				IsSnippet: true,
+				Extra: spec.PipelineTaskExtra{
+					Action: pipelineyml.Action{
+						SnippetConfig: &pipelineyml.SnippetConfig{
+							Name:   "name",
+							Source: "source",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_success",
+			args: args{
+				task: &spec.PipelineTask{
+					Name:      "name",
+					Type:      "type",
+					IsSnippet: true,
+					Extra: spec.PipelineTaskExtra{
+						Action: pipelineyml.Action{
+							SnippetConfig: &pipelineyml.SnippetConfig{
+								Name:   "name",
+								Source: "source",
+							},
+						},
+					},
+				},
+				mockSuccessPipelines: []spec.Pipeline{
+					{
+						PipelineBase: spec.PipelineBase{
+							ID: 1,
+						},
+					},
+				},
+				mockTasks: spec.PipelineTask{
+					ID:        1,
+					Name:      "name",
+					Type:      "type",
+					Status:    apistructs.PipelineStatusSuccess,
+					IsSnippet: true,
+					Extra: spec.PipelineTaskExtra{
+						Action: pipelineyml.Action{
+							SnippetConfig: &pipelineyml.SnippetConfig{
+								Name:   "name",
+								Source: "source",
+							},
+						},
+					},
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				Name:      "name",
+				Type:      "type",
+				IsSnippet: true,
+				Status:    apistructs.PipelineStatusSuccess,
+				Extra: spec.PipelineTaskExtra{
+					Action: pipelineyml.Action{
+						SnippetConfig: &pipelineyml.SnippetConfig{
+							Name:   "name",
+							Source: "source",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := PolicyHandlerOptions{}
+			dbClient := &dbclient.Client{}
+			patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "PageListPipelines", func(client *dbclient.Client, req apistructs.PipelinePageListRequest, ops ...dbclient.SessionOption) ([]spec.Pipeline, []uint64, int64, int64, error) {
+				return tt.args.mockSuccessPipelines, nil, 0, 0, nil
+			})
+
+			patch2 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "GetPipelineTask", func(client *dbclient.Client, id interface{}) (spec.PipelineTask, error) {
+				return tt.args.mockTasks, nil
+			})
+
+			opt.dbClient = dbClient
+			defer patch1.Unpatch()
+			defer patch2.Unpatch()
+
+			gotResult, err := TryLastSuccessResult{}.ResetTask(tt.args.task, opt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handlerLastSuccessResultPolicyType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, gotResult.Type, tt.wantResult.Type)
+			assert.Equal(t, gotResult.Name, tt.wantResult.Name)
+			assert.Equal(t, gotResult.Status, tt.wantResult.Status)
+			assert.Equal(t, gotResult.Extra, tt.wantResult.Extra)
+		})
+	}
+}
+
+func TestReconciler_adaptorPolicy(t *testing.T) {
+	type args struct {
+		task *spec.PipelineTask
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult *spec.PipelineTask
+		wantErr    bool
+	}{
+		{
+			name: "test",
+			args: args{
+				task: &spec.PipelineTask{
+					Name:      "name",
+					Type:      "type",
+					IsSnippet: true,
+					Extra: spec.PipelineTaskExtra{
+						Action: pipelineyml.Action{
+							SnippetConfig: &pipelineyml.SnippetConfig{
+								Name:   "name",
+								Source: "source",
+							},
+						},
+					},
+				},
+			},
+			wantResult: &spec.PipelineTask{
+				Name:      "name",
+				Type:      "type",
+				IsSnippet: true,
+				Extra: spec.PipelineTaskExtra{
+					Action: pipelineyml.Action{
+						SnippetConfig: &pipelineyml.SnippetConfig{
+							Name:   "name",
+							Source: "source",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+			gotResult, err := r.adaptPolicy(tt.args.task)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("adaptorPolicy() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotResult, tt.wantResult) {
+				t.Errorf("adaptorPolicy() gotResult = %v, want %v", gotResult, tt.wantResult)
+			}
+		})
+	}
+}

--- a/modules/pipeline/pipengine/reconciler/reconcile.go
+++ b/modules/pipeline/pipengine/reconciler/reconcile.go
@@ -95,6 +95,10 @@ func (r *Reconciler) reconcile(ctx context.Context, pipelineID uint64) error {
 				return
 			}
 
+			if task.Status.IsEndStatus() {
+				return
+			}
+
 			if task.IsSnippet {
 				task, err = r.reconcileSnippetTask(task, &p)
 				return

--- a/modules/pipeline/pipengine/reconciler/reconcile_data_process.go
+++ b/modules/pipeline/pipengine/reconciler/reconcile_data_process.go
@@ -95,6 +95,10 @@ func (r *Reconciler) saveTask(task *spec.PipelineTask, pipeline *spec.Pipeline) 
 		pt = task
 	}
 
+	pt, err = r.adaptPolicy(pt)
+	if err != nil {
+		return nil, err
+	}
 	// save action
 	if err := r.dbClient.CreatePipelineTask(pt); err != nil {
 		logrus.Errorf("[alert] failed to create pipeline task when create pipeline graph: %v", err)

--- a/modules/pipeline/spec/pipeline_task.go
+++ b/modules/pipeline/spec/pipeline_task.go
@@ -105,6 +105,8 @@ type PipelineTaskExtra struct {
 	AppliedResources apistructs.PipelineAppliedResources `json:"appliedResources,omitempty"`
 
 	EncryptSecretKeys []string `json:"encryptSecretKeys"` // the encrypt envs' key list
+
+	CurrentPolicy apistructs.Policy `json:"currentPolicy"` // task execution strategy
 }
 
 type FlinkSparkConf struct {

--- a/pkg/parser/pipelineyml/define.go
+++ b/pkg/parser/pipelineyml/define.go
@@ -134,6 +134,8 @@ type Action struct {
 
 	Caches []ActionCache `yaml:"caches,omitempty"` // action 构建缓存
 
+	Policy *Policy `yaml:"policy,omitempty"` // action execution strategy
+
 	SnippetConfig *SnippetConfig `yaml:"snippet_config,omitempty"` // snippet 类型的 action 的配置
 
 	If string `yaml:"if,omitempty"` // 条件执行
@@ -161,6 +163,10 @@ type Action struct {
 	// 隐式命名空间为一个 alias，对应流水线上下文目录下的一个目录。
 	// Namespaces 即使声明，同时会注入默认值 alias，也就是说每个 action 至少会有一个 namespace。
 	Namespaces []string `yaml:"namespaces,omitempty"`
+}
+
+type Policy struct {
+	Type apistructs.PolicyType `yaml:"type,omitempty"`
 }
 
 type SnippetConfig struct {

--- a/pkg/parser/pipelineyml/graph_pipelineyml.go
+++ b/pkg/parser/pipelineyml/graph_pipelineyml.go
@@ -77,6 +77,12 @@ func ConvertGraphPipelineYmlContent(data []byte) ([]byte, error) {
 				})
 			}
 
+			if frontendAction.Policy != nil {
+				maps[ActionType(frontendAction.Type)].Policy = &Policy{
+					Type: frontendAction.Policy.Type,
+				}
+			}
+
 			actions = append(actions, maps)
 		}
 		s.Stages = append(s.Stages, &Stage{Actions: actions})
@@ -238,6 +244,12 @@ func ConvertToGraphPipelineYml(data []byte) (*apistructs.PipelineYml, error) {
 
 				if action.SnippetConfig != nil {
 					resultAction.SnippetConfig = action.SnippetConfig.toApiSnippetConfig()
+				}
+
+				if action.Policy != nil {
+					resultAction.Policy = &apistructs.Policy{
+						Type: action.Policy.Type,
+					}
 				}
 
 				stageActions = append(stageActions, resultAction)


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:
The pipeline task execution strategy is added. The new strategy can make the task no longer execute but directly fetch the latest successful result. This function can be used in automated testing, and users can save time to execute the same set of scenarios


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=228823&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTYsNDQwOF0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXSwiZmluaXNoZWRBdFN0YXJ0RW5kIjpbMTYzNjEyODAwMDAwMCxudWxsXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      The task of the pipeline increases the configuration of the execution strategy        |
| 🇨🇳 中文    |       流水线的任务增加执行策略的配置       |

#### Need cherry-pick to release versions?

