### PR TITLE
autotest not set bootstrap token

### DIFF
--- a/modules/pipeline/pipengine/reconciler/reconcile.go
+++ b/modules/pipeline/pipengine/reconciler/reconcile.go
@@ -85,6 +85,9 @@ func (r *Reconciler) reconcile(ctx context.Context, pipelineID uint64) error {
 				}
 				r.processingTasks.Delete(buildTaskDagName(p.ID, schedulableTasks[i].Name))
 				err = r.reconcile(ctx, pipelineID)
+				if err != nil {
+					logrus.Errorf("defer reconcile error %v", err)
+				}
 				wg.Done()
 			}()
 

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -649,6 +649,11 @@ func contextVolumes(context spec.PipelineTaskContext) []apistructs.MetadataField
 }
 
 func (pre *prepare) generateOpenapiTokenForPullBootstrapInfo(task *spec.PipelineTask) error {
+
+	if task.Type == apistructs.ActionTypeWait || task.Type == apistructs.ActionTypeAPITest || task.Type == apistructs.ActionTypeSnippet {
+		return nil
+	}
+
 	// 申请到的 token 只能请求 get-bootstrap-info api，并且保证 pipelineID 和 taskID 必须匹配
 	tokenInfo, err := pre.Bdl.GetOpenapiOAuth2Token(apistructs.OpenapiOAuth2TokenGetRequest{
 		ClientID:     "pipeline",

--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare_test.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskop
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_prepare_generateOpenapiTokenForPullBootstrapInfo(t *testing.T) {
+	type args struct {
+		task *spec.PipelineTask
+	}
+	tests := []struct {
+		name    string
+		pre     prepare
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test_api-test",
+			pre:  prepare{},
+			args: args{
+				task: &spec.PipelineTask{
+					Type: apistructs.ActionTypeAPITest,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_wait",
+			pre:  prepare{},
+			args: args{
+				task: &spec.PipelineTask{
+					Type: apistructs.ActionTypeWait,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_snippet",
+			pre:  prepare{},
+			args: args{
+				task: &spec.PipelineTask{
+					Type: apistructs.ActionTypeSnippet,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.pre.generateOpenapiTokenForPullBootstrapInfo(tt.args.task); (err != nil) != tt.wantErr {
+				t.Errorf("generateOpenapiTokenForPullBootstrapInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR
/kind feature

#### What this PR does / why we need it:
Bootstrap token is no longer set for automated testing. In automated testing, a large number of interfaces to apply for tokens cause excessive pressure on the openapi interface, and the applied tokens are useless


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=247030&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTYsNDQwOF0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXSwiZmluaXNoZWRBdFN0YXJ0RW5kIjpbMTYzNjEyODAwMDAwMCxudWxsXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=467&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Pipeline special judgment api-test, wait and snippet type actions no longer apply for bootstrap token        |
| 🇨🇳 中文    |       pipeline 特殊判断api-test,wait和snippet类型的action不再申请 bootstrap token       |


#### Need cherry-pick to release versions?
/cherry-pick release/1.4
