### PR TITLE
check permission add project and app name

### DIFF
--- a/apistructs/permission.go
+++ b/apistructs/permission.go
@@ -172,7 +172,13 @@ type PermissionList struct {
 	Exist bool `json:"exist"`
 
 	// 无权限（access=false）时，该字段返回联系人 ID 列表，例如无应用权限时，返回应用管理员列表
-	ContactsWhenNoPermission []string `json:"contactsWhenNoPermission,omitempty"`
+	ContactsWhenNoPermission []string   `json:"contactsWhenNoPermission,omitempty"`
+	ScopeInfo                *ScopeInfo `json:"scopeInfo"`
+}
+
+type ScopeInfo struct {
+	ProjectName string `json:"projectName"`
+	AppName     string `json:"appName"`
 }
 
 // PermissionListResponse 权限列表响应信息

--- a/modules/core-services/endpoints/permission_test.go
+++ b/modules/core-services/endpoints/permission_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/core-services/model"
+	"github.com/erda-project/erda/modules/core-services/services/application"
+	"github.com/erda-project/erda/modules/core-services/services/project"
+)
+
+func TestEndpoints_buildScopeInfo(t *testing.T) {
+	type args struct {
+		accessReq  apistructs.ScopeRoleAccessRequest
+		permission apistructs.PermissionList
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    apistructs.PermissionList
+		wantErr bool
+	}{
+		{
+			name: "test_app_name",
+			args: args{
+				accessReq: apistructs.ScopeRoleAccessRequest{
+					Scope: apistructs.Scope{
+						Type: "app",
+						ID:   "1",
+					},
+				},
+				permission: apistructs.PermissionList{},
+			},
+			want: apistructs.PermissionList{
+				ScopeInfo: &apistructs.ScopeInfo{
+					ProjectName: "test",
+					AppName:     "test",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Endpoints{}
+
+			var app = &application.Application{}
+
+			patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(app), "Get", func(app *application.Application, applicationID int64) (*model.Application, error) {
+				return &model.Application{
+					Name:      "test",
+					ProjectID: 1,
+				}, nil
+			})
+			defer patch1.Unpatch()
+
+			var pj = &project.Project{}
+			patch2 := monkey.PatchInstanceMethod(reflect.TypeOf(pj), "GetModelProject", func(project *project.Project, projectID int64) (*model.Project, error) {
+				return &model.Project{
+					DisplayName: "test",
+				}, nil
+			})
+			defer patch2.Unpatch()
+
+			e.app = app
+			e.project = pj
+
+			got, err := e.buildScopeInfo(tt.args.accessReq, tt.args.permission)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildScopeInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildScopeInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:
Added permission verification to return project name and application name

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=248325&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTYsNDQwOF0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=-1&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Added permission verification to return project name and application name        |
| 🇨🇳 中文    |        权限校验增加返回项目名称和应用名称      |


#### Need cherry-pick to release versions?

/cherry-pick release/1.4
