### PR TITLE
use job cluster as cluster name if not empty

### DIFF
--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -51,6 +51,7 @@ const (
 	ISTIO_ALIYUN            ClusterInfoMapKey = "ISTIO_ALIYUN"            // 是否用aliyn asm，true or false
 	ISTIO_INSTALLED         ClusterInfoMapKey = "ISTIO_INSTALLED"         // 是否启用了 istio
 	ISTIO_VERSION           ClusterInfoMapKey = "ISTIO_VERSION"           // istio 的版本
+	JOB_CLUSTER             ClusterInfoMapKey = "JOB_CLUSTER"             // specify the job execute cluster
 )
 
 type ClusterInfoResponse struct {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
use job cluster as cluster name if not empty

#### Which issue(s) this PR fixes:
[source pr](https://github.com/erda-project/erda/pull/3042)

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that cnooc pipeline execute cluster（修复了有些平台希望指定打包集群.）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
