### PR TITLE
automated test plan pass rate display retains 2 decimal places

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -198,7 +198,7 @@ func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Compo
 			ExecuteApiNum: strconv.FormatInt(data.ExecuteApiNum, 10),
 			PassRate: PassRate{
 				RenderType: "progress",
-				Value:      fmt.Sprintf("%.f", data.PassRate),
+				Value:      fmt.Sprintf("%.2f", data.PassRate),
 			},
 			ExecuteTime: convertExecuteTime(data),
 		}

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/table_test.go
@@ -133,7 +133,7 @@ func Test_Render(t *testing.T) {
 		}, gs)
 	assert.NoError(t, err)
 	list := c.Data["list"].([]TableItem)
-	want := []string{"10", "0"}
+	want := []string{"10.00", "0.00"}
 	wantExecuteApiNum := []string{"1", "2"}
 	for i := range list {
 		assert.Equal(t, list[i].PassRate.Value, want[i])


### PR DESCRIPTION
#### What type of this PR
/kind bugfix

#### What this PR does / why we need it:
The execution rate of the automated test plan does not retain 2 decimal places but uses %.f for the value, which will cause 99.89 to become 100, which leads to inconsistencies.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=249480&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       automated test plan execution pass rate retains 2 decimal places       |
| 🇨🇳 中文    |        自动化测试计划执行通过率保留2位小数      |


#### Need cherry-pick to release versions?

/cherry-pick release/1.4