### PR TITLE
fix: manual-test case paging `LIKE` clause use correct testSet directory

### DIFF
--- a/modules/dop/dao/testcase.go
+++ b/modules/dop/dao/testcase.go
@@ -244,7 +244,7 @@ func (client *DBClient) PagingTestCases(req apistructs.TestCasePagingRequest) ([
 	baseSQL = baseSQL.Where("`tc`.`project_id` = ?", req.ProjectID)
 	// test set id
 	if req.TestSetID > 0 {
-		baseSQL = baseSQL.Where("`ts`.`directory` LIKE '" + baseTestSet.Directory + "%'")
+		baseSQL = baseSQL.Where("`ts`.`directory` LIKE ? OR `ts`.`directory` = ?", baseTestSet.Directory+"/%", baseTestSet.Directory)
 	}
 	// recycled
 	baseSQL = baseSQL.Where("`tc`.`recycled` = ?", req.Recycled)

--- a/modules/dop/dao/testplan_testcase_relation.go
+++ b/modules/dop/dao/testplan_testcase_relation.go
@@ -311,7 +311,7 @@ func (client *DBClient) PagingTestPlanCaseRelations(req apistructs.TestPlanCaseR
 	baseSQL = baseSQL.Where("`rel`.`test_plan_id` = ?", req.TestPlanID)
 	// testset
 	if req.TestSetID > 0 {
-		baseSQL = baseSQL.Where("`ts`.`directory` LIKE '" + baseTestSet.Directory + "%'")
+		baseSQL = baseSQL.Where("`ts`.`directory` LIKE ? OR `ts`.`directory` = ?", baseTestSet.Directory+"/%", baseTestSet.Directory)
 	}
 	// name
 	if req.Query != "" {


### PR DESCRIPTION
#### What type of this PR

/kind bugfix

#### What this PR does / why we need it:

fix: manual-test case paging `LIKE` clause use correct testSet directory

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=248026&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyI5MiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### Need cherry-pick to release versions?

/cherry-pick release/1.5-alpha1 release/1.4
