### PR TITLE
Fix home page content table group for users without any projects

### DIFF
--- a/modules/dop/services/workbench/workbench.go
+++ b/modules/dop/services/workbench/workbench.go
@@ -159,6 +159,9 @@ func (w *Workbench) SetDiffFinishedIssueNum(req apistructs.IssuePagingRequest, i
 }
 
 func (w *Workbench) GetUndoneProjectItems(req apistructs.WorkbenchRequest, userID string) (*apistructs.WorkbenchResponse, error) {
+	if len(req.ProjectIDs) == 0 {
+		return &apistructs.WorkbenchResponse{}, nil
+	}
 	req.IssuePagingRequest = apistructs.IssuePagingRequest{
 		OrgID:    int64(req.OrgID),
 		PageNo:   1,

--- a/modules/dop/services/workbench/workbench_test.go
+++ b/modules/dop/services/workbench/workbench_test.go
@@ -94,7 +94,9 @@ func TestWorkbench_GetUndoneProjectItems(t *testing.T) {
 		{
 			name: "test",
 			args: args{
-				req: apistructs.WorkbenchRequest{},
+				req: apistructs.WorkbenchRequest{
+					ProjectIDs: []uint64{1},
+				},
 			},
 			want: &apistructs.WorkbenchResponse{
 				Data: apistructs.WorkbenchResponseData{
@@ -104,6 +106,14 @@ func TestWorkbench_GetUndoneProjectItems(t *testing.T) {
 					},
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name: "empty",
+			args: args{
+				req: apistructs.WorkbenchRequest{},
+			},
+			want:    &apistructs.WorkbenchResponse{},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
#### What type of this PR
bugfix


#### What this PR does / why we need it:
Fix home page content table group for users without any projects

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=248918&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMDczIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
