### PR TITLE
bugfix: add missing log fields settings

### DIFF
--- a/conf/monitor/monitor/logs/default_field_settings.yml
+++ b/conf/monitor/monitor/logs/default_field_settings.yml
@@ -14,6 +14,16 @@ fields:
     display: false
     group: 0
     allow_edit: false
+  - field_name: offset
+    support_aggregation: false
+    display: false
+    group: 0
+    allow_edit: false
+  - field_name: timestampNanos
+    support_aggregation: false
+    display: false
+    group: 0
+    allow_edit: false
   - field_name: stream
     support_aggregation: false
     display: false


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix


#### What this PR does / why we need it:
log-analysis, offset and timestampNanos fields should not display by default.


#### Specified Reviewers:

/assign @liuhaoyang 