### PR TITLE
add smtp info api

### DIFF
--- a/modules/eventbox/subscriber/email/email.go
+++ b/modules/eventbox/subscriber/email/email.go
@@ -45,6 +45,16 @@ type MailSubscriber struct {
 	bundle             *bundle.Bundle
 }
 
+type MailSubscriberInfo struct {
+	Host               string
+	Port               string
+	User               string
+	Password           string
+	DisplayUser        string
+	IsSSL              bool
+	InsecureSkipVerify bool
+}
+
 type MailData struct {
 	Template    string            `json:"template"`
 	Params      map[string]string `json:"params"`
@@ -54,6 +64,21 @@ type MailData struct {
 }
 
 type Option func(*MailSubscriber)
+
+func NewMailSubscriberInfo(host, port, user, password, displayUser, isSSLStr, insecureSkipVerify string) *MailSubscriberInfo {
+	subscriber := &MailSubscriberInfo{
+		Host:        host,
+		Port:        port,
+		User:        user,
+		Password:    password,
+		DisplayUser: displayUser,
+	}
+	isSSL, _ := strconv.ParseBool(isSSLStr)
+	subscriber.IsSSL = isSSL
+	isInsecureSkipVerify, _ := strconv.ParseBool(insecureSkipVerify)
+	subscriber.InsecureSkipVerify = isInsecureSkipVerify
+	return subscriber
+}
 
 func New(host, port, user, password, displayUser, isSSLStr, insecureSkipVerify string, bundle *bundle.Bundle) subscriber.Subscriber {
 	subscriber := &MailSubscriber{

--- a/modules/openapi/api/apis/eventbox/eventbox_smtp_info.go
+++ b/modules/openapi/api/apis/eventbox/eventbox_smtp_info.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventbox
+
+import "github.com/erda-project/erda/modules/openapi/api/apis"
+
+var EVENTBOX_WEBSOCKET = apis.ApiSpec{
+	Path:        "/api/websocket/<a>/<b>/websocket",
+	BackendPath: "/api/dice/eventbox/ws/<a>/<b>/websocket",
+	Host:        "eventbox.marathon.l4lb.thisdcos.directory:9528",
+	Scheme:      "ws",
+	Method:      "GET",
+	CheckLogin:  true,
+	Doc: `
+summary: dice's websocket proxy
+`,
+}

--- a/modules/openapi/api/apis/eventbox/eventbox_smtp_info.go
+++ b/modules/openapi/api/apis/eventbox/eventbox_smtp_info.go
@@ -14,16 +14,16 @@
 
 package eventbox
 
-import "github.com/erda-project/erda/modules/openapi/api/apis"
+import (
+	"github.com/erda-project/erda/modules/openapi/api/apis"
+)
 
-var EVENTBOX_WEBSOCKET = apis.ApiSpec{
-	Path:        "/api/websocket/<a>/<b>/websocket",
-	BackendPath: "/api/dice/eventbox/ws/<a>/<b>/websocket",
+var EVENTBOX_SMTP_INFO = apis.ApiSpec{
+	Path:        "/api/dice/eventbox/actions/get-smtp-info",
+	BackendPath: "/api/dice/eventbox/actions/get-smtp-info",
 	Host:        "eventbox.marathon.l4lb.thisdcos.directory:9528",
-	Scheme:      "ws",
+	Scheme:      "http",
 	Method:      "GET",
-	CheckLogin:  true,
-	Doc: `
-summary: dice's websocket proxy
-`,
+	IsOpenAPI:   true,
+	CheckToken:  true,
 }


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:
Increase the query interface of smtp information and provide it for remote query of email action

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Increase the query interface of smtp information      |
| 🇨🇳 中文    |       增加 smtp 的信息的查询接口       |


#### Need cherry-pick to release versions?

/cherry-pick release/1.5
/cherry-pick release/1.4
/cherry-pick release/1.3
