### PR TITLE
edit autotest plan reload table but not reset pageNum

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
@@ -72,6 +72,7 @@ func (tpm *TestPlanManageFormModal) Render(ctx context.Context, c *apistructs.Co
 			}
 			c.State["visible"] = false
 			c.State["formData"] = nil
+			c.State["reloadTablePageNo"] = false
 		} else if _, ok := c.State["isCreate"]; ok && c.State["isCreate"].(bool) {
 			defer delete(c.State, "isCreate")
 			// 创建完需要把这个数据置为false
@@ -89,6 +90,7 @@ func (tpm *TestPlanManageFormModal) Render(ctx context.Context, c *apistructs.Co
 			}
 			c.State["visible"] = false
 			c.State["formData"] = nil
+			c.State["reloadTablePageNo"] = true
 		}
 	}
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -90,7 +90,14 @@ func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Compo
 
 	switch event.Operation.String() {
 	case apistructs.InitializeOperation.String(), apistructs.RenderingOperation.String():
-		cond.PageNo = 1
+		// the table needs to be refreshed when other components are rendered, but the paging still needs to be maintained
+		reloadTablePageNo, ok := c.State["reloadTablePageNo"].(bool)
+		if !ok {
+			reloadTablePageNo = true
+		}
+		if reloadTablePageNo {
+			cond.PageNo = 1
+		}
 	case "edit":
 		var operationData OperationData
 		odBytes, err := json.Marshal(event.OperationData)

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+)
+
+func TestTestPlanManageTable_Render(t *testing.T) {
+	type args struct {
+		ctx      context.Context
+		c        *apistructs.Component
+		scenario apistructs.ComponentProtocolScenario
+		event    apistructs.ComponentEvent
+		gs       *apistructs.GlobalStateData
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test_default_render",
+			args: args{
+				ctx:      context.Background(),
+				c:        &apistructs.Component{},
+				scenario: apistructs.ComponentProtocolScenario{},
+				event: apistructs.ComponentEvent{
+					Operation: apistructs.InitializeOperation,
+				},
+				gs: &apistructs.GlobalStateData{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bdl = protocol.ContextBundle{}
+			var dl = bundle.Bundle{}
+			monkey.PatchInstanceMethod(reflect.TypeOf(&dl), "PagingTestPlansV2", func(b *bundle.Bundle, req apistructs.TestPlanV2PagingRequest) (*apistructs.TestPlanV2PagingResponseData, error) {
+				return &apistructs.TestPlanV2PagingResponseData{}, nil
+			})
+			bdl.Bdl = &dl
+			bdl.InParams = map[string]interface{}{"projectId": 1}
+			tt.args.ctx = context.WithValue(tt.args.ctx, protocol.GlobalInnerKeyCtxBundle.String(), bdl)
+
+			tpmt := &TestPlanManageTable{}
+			if err := tpmt.Render(tt.args.ctx, tt.args.c, tt.args.scenario, tt.args.event, tt.args.gs); (err != nil) != tt.wantErr {
+				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/protocol.yml
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/protocol.yml
@@ -11,7 +11,9 @@ hierarchy:
 rendering:
   formModal:
     - name: table
-
+      state:
+        - name: "reloadTablePageNo"
+          value: "{{ formModal.reloadTablePageNo }}"
   table:
     - name: formModal
       state:


### PR DESCRIPTION
#### What type of this PR
/kind bugfix
 
#### What this PR does / why we need it:
When the user edits the name of the plan, the paging data of the table will be reloaded. This behavior does not conform to the user's operating habits

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=223455&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      After the automated test pagination is edited, the pagination will no longer change        |
| 🇨🇳 中文    |       自动化测试分页编辑后，分页不再变化       |
