### PR TITLE
Auto test space archive status color by status

### DIFF
--- a/apistructs/autotest_space.go
+++ b/apistructs/autotest_space.go
@@ -58,6 +58,19 @@ func (s AutoTestSpaceArchiveStatus) GetZhName() string {
 	}
 }
 
+func (s AutoTestSpaceArchiveStatus) GetFrontEndStatus() string {
+	switch s {
+	case TestSpaceInit:
+		return "default"
+	case TestSpaceInProgress:
+		return "processing"
+	case TestSpaceCompleted:
+		return "success"
+	default:
+		return ""
+	}
+}
+
 func (s AutoTestSpaceArchiveStatus) Valid() bool {
 	switch s {
 	case TestSpaceInit, TestSpaceInProgress, TestSpaceCompleted:

--- a/modules/openapi/component-protocol/scenarios/auto-test-space-list/components/spaceList/operation.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-space-list/components/spaceList/operation.go
@@ -77,7 +77,7 @@ type operationData struct {
 	Meta meta `json:"meta"`
 }
 
-func setCommand(space spaceItem) map[string]interface{} {
+func setCommand(space spaceItem, status apistructs.AutoTestSpaceArchiveStatus) map[string]interface{} {
 	return map[string]interface{}{
 		"key": "set",
 		"state": spaceFormModal.State{
@@ -87,7 +87,7 @@ func setCommand(space spaceItem) map[string]interface{} {
 				"id":            space.ID,
 				"name":          space.Title,
 				"desc":          space.Description,
-				"archiveStatus": space.ArchiveStatus.Status,
+				"archiveStatus": status,
 			},
 		},
 		"target": "spaceFormModal",

--- a/modules/openapi/component-protocol/scenarios/auto-test-space-list/components/spaceList/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-space-list/components/spaceList/render.go
@@ -65,9 +65,8 @@ type spaceItem struct {
 }
 
 type ArchiveStatus struct {
-	Color  string                                `json:"color"`
-	Status apistructs.AutoTestSpaceArchiveStatus `json:"status"`
-	Text   string                                `json:"text"`
+	Status string `json:"status"`
+	Text   string `json:"text"`
 }
 
 type ExtraInfos struct {
@@ -249,8 +248,7 @@ func (a *ComponentSpaceList) setData(projectID int64, spaces apistructs.AutoTest
 			Description: each.Description,
 			PrefixImg:   "default_test_case",
 			ArchiveStatus: ArchiveStatus{
-				Color:  "red",
-				Status: each.ArchiveStatus,
+				Status: each.ArchiveStatus.GetFrontEndStatus(),
 				Text:   i18nLocale.Get(fmt.Sprintf("autoTestSpace%s", each.ArchiveStatus)),
 			},
 			Operations: map[string]interface{}{},
@@ -271,7 +269,7 @@ func (a *ComponentSpaceList) setData(projectID int64, spaces apistructs.AutoTest
 			},
 		}
 		if each.Status == apistructs.TestSpaceFailed {
-			edit.Command = setCommand(item)
+			edit.Command = setCommand(item, each.ArchiveStatus)
 			edit.Disabled = true
 			item.Operations["a-edit"] = edit
 			deleteOp.Meta = setMeta(item)
@@ -283,7 +281,7 @@ func (a *ComponentSpaceList) setData(projectID int64, spaces apistructs.AutoTest
 			item.Operations["export"] = export
 			item.Operations["retry"] = retry
 		} else {
-			edit.Command = setCommand(item)
+			edit.Command = setCommand(item, each.ArchiveStatus)
 			copyOp.Meta = setMeta(item)
 			deleteOp.Meta = setMeta(item)
 			deleteOp.Disabled = true


### PR DESCRIPTION
#### What type of this PR
bugfix


#### What this PR does / why we need it:
Auto test space archive status color by status

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=250883&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAxMDczIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
