### PR TITLE
request and response information are also returned when the automated test fails to execute

### DIFF
--- a/pkg/apitestsv2/apitest.go
+++ b/pkg/apitestsv2/apitest.go
@@ -218,19 +218,18 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 	httpResp, err := req.Params(apiReq.Params).
 		RawBody(bytes.NewBufferString(apiReq.Body.Content.(string))).
 		Do().Body(&buffer)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	// resp
 	apiResp := apistructs.APIResp{
-		Status:  httpResp.StatusCode(),
-		Headers: httpResp.Headers(),
 		Body:    buffer.Bytes(),
 		BodyStr: buffer.String(),
 	}
+	if httpResp != nil {
+		apiResp.Status = httpResp.StatusCode()
+		apiResp.Headers = httpResp.Headers()
+	}
 
-	return &apiReq, &apiResp, nil
+	return &apiReq, &apiResp, err
 }
 
 func (at *APITest) renderAtOnce(apiReq *apistructs.APIInfo, caseParams map[string]*apistructs.CaseParams) error {

--- a/pkg/apitestsv2/apitest_test.go
+++ b/pkg/apitestsv2/apitest_test.go
@@ -16,11 +16,13 @@ package apitestsv2
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/encoding/jsonpath"
 )
 
@@ -30,4 +32,69 @@ func TestJsonPath(t *testing.T) {
 	data, err := jsonpath.Get(a, "success")
 	assert.NoError(t, err)
 	spew.Dump(data)
+}
+
+func TestAPITest_Invoke(t *testing.T) {
+	type fields struct {
+		API       *apistructs.APIInfo
+		APIResult *apistructs.ApiTestInfo
+		opt       option
+	}
+	type args struct {
+		testEnv    *apistructs.APITestEnvData
+		caseParams map[string]*apistructs.CaseParams
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *apistructs.APIRequestInfo
+		want1   *apistructs.APIResp
+		wantErr bool
+	}{
+		{
+			name: "test_normal",
+			fields: fields{
+				API: &apistructs.APIInfo{
+					URL:    "www.erda.cloud",
+					Name:   "TEST",
+					Method: "GET",
+				},
+				APIResult: &apistructs.ApiTestInfo{},
+				opt:       option{},
+			},
+			args: args{
+				testEnv:    &apistructs.APITestEnvData{},
+				caseParams: nil,
+			},
+			want: &apistructs.APIRequestInfo{
+				URL:     "http://www.erda.cloud",
+				Method:  "GET",
+				Headers: map[string][]string{"Accept-Encoding": {"identity"}},
+				Params:  map[string][]string{},
+				Body: apistructs.APIBody{
+					Content: "",
+				},
+			},
+			want1:   &apistructs.APIResp{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &APITest{
+				API:       tt.fields.API,
+				APIResult: tt.fields.APIResult,
+				opt:       tt.fields.opt,
+			}
+			got, _, err := at.Invoke(nil, tt.args.testEnv, tt.args.caseParams)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Invoke() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Invoke() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of this PR

/kind bugfix


#### What this PR does / why we need it:
request and response information are also returned when the automated test fails to execute

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=252901&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Request and response information are also returned when the automated test fails to execute        |
| 🇨🇳 中文    |       自动化测试执行失败的时候也返回 request 和 response 信息        |
