### PR TITLE
admin access to the workbench no longer query all organization information

### DIFF
--- a/apistructs/org.go
+++ b/apistructs/org.go
@@ -75,7 +75,11 @@ type OrgSearchRequest struct {
 	PageNo   int `query:"pageNo"`
 	PageSize int `query:"pageSize"`
 
-	OrgID string
+	// The header passed by the org front end is used as the admin account to distinguish the management interface and the user interface
+	// In the case of the user interface, the front end will pass org
+	// The management interface admin needs all org so pass-
+	// The backend determines whether the admin account queries all orgs according to whether org has a value
+	Org string `query:"org"`
 	IdentityInfo
 }
 

--- a/bundle/org.go
+++ b/bundle/org.go
@@ -77,7 +77,7 @@ func (b *Bundle) ListOrgs(req *apistructs.OrgSearchRequest, orgID string) (*apis
 		Header(httputil.UserHeader, req.UserID).
 		Header(httputil.OrgHeader, orgID).
 		Param("q", req.Q).
-		Param("orgId", req.OrgID).
+		Param("org", req.Org).
 		Param("pageNo", strconv.Itoa(req.PageNo)).
 		Param("pageSize", strconv.Itoa(req.PageSize)).
 		Do().

--- a/modules/core-services/endpoints/organization.go
+++ b/modules/core-services/endpoints/organization.go
@@ -592,14 +592,9 @@ func (e *Endpoints) getOrgPermissions(r *http.Request) (bool, []int64, error) {
 	if userID == "" && r.Header.Get(httputil.InternalHeader) != "" {
 		return true, nil, nil
 	}
-
-	orgIDStr := r.URL.Query().Get("orgId")
-	if orgIDStr == "" {
-		orgIDStr = r.Header.Get("Org-ID")
-	}
-
 	// 操作鉴权, 系统管理员可查询企业
-	if e.member.IsAdmin(userID.String()) && orgIDStr == "" { // 系统管理员可查看所有企业列表
+	// Found that org is passed in the request header, even admin does not query all organizations
+	if e.member.IsAdmin(userID.String()) && (r.URL.Query().Get("org") == "" || r.URL.Query().Get("org") == "-") { // 系统管理员可查看所有企业列表
 		return true, nil, nil
 	} else { // 非系统管理员只能查看有权限的企业列表
 		members, err := e.member.ListByScopeTypeAndUser(apistructs.OrgScope, userID.String())

--- a/modules/core-services/endpoints/organization_test.go
+++ b/modules/core-services/endpoints/organization_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/modules/core-services/services/member"
+)
+
+func TestEndpoints_getOrgPermissions(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		want1   []int64
+		wantErr bool
+	}{
+		{
+			name: "",
+			args: args{
+				r: &http.Request{
+					URL: &url.URL{},
+				},
+			},
+			want1:   nil,
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Endpoints{}
+			var me = &member.Member{}
+			patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(me), "IsAdmin", func(mem *member.Member, userID string) bool {
+				return true
+			})
+			defer patch1.Unpatch()
+			e.member = me
+
+			got, got1, err := e.getOrgPermissions(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOrgPermissions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getOrgPermissions() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("getOrgPermissions() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/modules/dop/endpoints/organization.go
+++ b/modules/dop/endpoints/organization.go
@@ -433,6 +433,7 @@ func getOrgListParam(r *http.Request) (*apistructs.OrgSearchRequest, error) {
 		Q:        q,
 		PageNo:   num,
 		PageSize: size,
+		Org:      r.Header.Get("org"),
 		IdentityInfo: apistructs.IdentityInfo{
 			UserID: r.Header.Get(httputil.UserHeader),
 		},

--- a/modules/openapi/component-protocol/scenarios/home-page-sidebar/components/orgSwitch/render.go
+++ b/modules/openapi/component-protocol/scenarios/home-page-sidebar/components/orgSwitch/render.go
@@ -176,13 +176,19 @@ func RenItem(org apistructs.OrgDTO) MenuItem {
 }
 
 func (this *OrgSwitch) RenderList() error {
+	org, err := this.ctxBdl.Bdl.GetDopOrg(this.ctxBdl.Identity.OrgID)
+	if err != nil {
+		return err
+	}
+
 	identity := apistructs.IdentityInfo{UserID: this.ctxBdl.Identity.UserID}
 	req := &apistructs.OrgSearchRequest{
 		IdentityInfo: identity,
 		PageSize:     DefaultPageSize,
-		OrgID:        this.ctxBdl.Identity.OrgID,
+		Org:          org.Name,
 	}
-	pagingOrgDTO, err := this.ctxBdl.Bdl.ListOrgs(req, req.OrgID)
+
+	pagingOrgDTO, err := this.ctxBdl.Bdl.ListOrgs(req, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of this PR

/kind bug


#### What this PR does / why we need it:
When the admin account enters the workbench, all organizations will be queried, and subsequent admin access to these organizations will not pass the verification authority.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=252574&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The admin account no longer queries all organizations       |
| 🇨🇳 中文    |        admin 账号不再查询所有组织      |

