### PR TITLE
move dingtalk struct from aliyun_sms.go to dingtalk_work_notice.go

### DIFF
--- a/modules/core-services/services/notify/channel/kind/dingtalk_work_notice.go
+++ b/modules/core-services/services/notify/channel/kind/dingtalk_work_notice.go
@@ -16,25 +16,21 @@ package kind
 
 import "github.com/erda-project/erda/pkg/common/errors"
 
-type AliyunSMS struct {
-	AccessKeyId     string
-	AccessKeySecret string
-	SignName        string
-	TemplateCode    string
+type DingDingWorkNotice struct {
+	AgentId   int64
+	AppKey    string
+	AppSecret string
 }
 
-func (asm *AliyunSMS) Validate() error {
-	if asm.SignName == "" {
-		return errors.NewMissingParameterError("signName")
+func (ding *DingDingWorkNotice) Validate() error {
+	if ding.AgentId == 0 {
+		return errors.NewMissingParameterError("agentId")
 	}
-	if asm.TemplateCode == "" {
-		return errors.NewMissingParameterError("templateCode")
+	if ding.AppSecret == "" {
+		return errors.NewMissingParameterError("appSecret")
 	}
-	if asm.AccessKeyId == "" {
-		return errors.NewMissingParameterError("accessKeyId")
-	}
-	if asm.AccessKeySecret == "" {
-		return errors.NewMissingParameterError("accessKeySecret")
+	if ding.AppKey == "" {
+		return errors.NewMissingParameterError("appKey")
 	}
 	return nil
 }

--- a/modules/core-services/services/notify/channel/kind/dingtalk_work_notice_test.go
+++ b/modules/core-services/services/notify/channel/kind/dingtalk_work_notice_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kind
+
+import "testing"
+
+func TestDingDingWorkNotice_Validate(t *testing.T) {
+	type fields struct {
+		AgentId   int64
+		AppKey    string
+		AppSecret string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "case1",
+			fields: fields{
+				AgentId:   0,
+				AppKey:    "ss",
+				AppSecret: "ss",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case2",
+			fields: fields{
+				AgentId:   2,
+				AppKey:    "",
+				AppSecret: "ss",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case3",
+			fields: fields{
+				AgentId:   3,
+				AppKey:    "",
+				AppSecret: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case4",
+			fields: fields{
+				AgentId:   0,
+				AppKey:    "",
+				AppSecret: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "2",
+			fields: fields{
+				AgentId:   3,
+				AppKey:    "ss",
+				AppSecret: "ss",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ding := &DingDingWorkNotice{
+				AgentId:   tt.fields.AgentId,
+				AppKey:    tt.fields.AppKey,
+				AppSecret: tt.fields.AppSecret,
+			}
+			if err := ding.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind refactor

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       move dingtalk struct from aliyun_sms.go to dingtalk_work_notice.go       |
| 🇨🇳 中文    |     移动钉钉工作通知中的结构体和方法         |
