### PR TITLE
add erda-cli view cmd 

### DIFF
--- a/tools/cli/cmd/build.go
+++ b/tools/cli/cmd/build.go
@@ -139,7 +139,7 @@ func RunBuild(ctx *command.Context, repo, branch, filename, alias string) (err e
 	if !pipelineResp.Success {
 		return errors.Errorf("build fail: %+v", pipelineResp.Error)
 	}
-	ctx.Succ("building for branch: %s, pipelineID: %d, you can view building status via \nerda-cli pipe -i %d -b %s -r %s --host %s",
+	ctx.Succ("building for branch: %s, pipelineID: %d, you can view building status via \nerda-cli view -i %d -b %s -r %s --host %s",
 		branch, pipelineResp.Data.ID, pipelineResp.Data.ID, branch, repo, ctx.CurrentOpenApiHost)
 
 	return nil

--- a/tools/cli/cmd/build.go
+++ b/tools/cli/cmd/build.go
@@ -139,7 +139,7 @@ func RunBuild(ctx *command.Context, repo, branch, filename, alias string) (err e
 	if !pipelineResp.Success {
 		return errors.Errorf("build fail: %+v", pipelineResp.Error)
 	}
-	ctx.Succ("building for branch: %s, pipelineID: %d, you can view building status via \nerda-cli view -i %d -b %s -r %s --host %s",
+	ctx.Succ("building for branch: %s, pipelineID: %d, you can view building status via \nerda-cli view -w -i %d -b %s -r %s --host %s",
 		branch, pipelineResp.Data.ID, pipelineResp.Data.ID, branch, repo, ctx.CurrentOpenApiHost)
 
 	return nil
@@ -225,11 +225,13 @@ func BuildCheckLoop(ctx *command.Context, buildID string) error {
 			pipelineInfo.Status == apistructs.PipelineStatusTimeout {
 			fmt.Print(color_str.Green(fmt.Sprintf("build faild, status: %s, time elapsed: %s\n",
 				pipelineInfo.Status, format.ToTimeSpanString(int(pipelineInfo.CostTimeSec)))))
-			fmt.Println(pipelineInfo.Extra.ShowMessage.Stacks)
-
+			var msg = "nil"
+			if showMessage := pipelineInfo.Extra.ShowMessage; showMessage != nil {
+				fmt.Println(showMessage.Stacks)
+				msg = showMessage.Msg
+			}
 			return fmt.Errorf(format.FormatErrMsg("pipeline info",
-				"build error: "+pipelineInfo.Extra.ShowMessage.Msg, false))
-
+				"build error: "+msg, false))
 		}
 
 		if pipelineInfo.Status == apistructs.PipelineStatusSuccess {

--- a/tools/cli/cmd/fetch_pipe.go
+++ b/tools/cli/cmd/fetch_pipe.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/pkg/terminal/table"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var FETCH_PIPE = command.Command{
+	Name:      "pipe",
+	ShortHelp: "Show build status",
+	Example: `
+  $ erda-cli pipe -b develop -i <pipelineID> -h https://openapi.erda.cloud
+`,
+	Flags: []command.Flag{
+		command.StringFlag{
+			Short:        "r",
+			Name:         "repo",
+			Doc:          "the repo on Erda DOP",
+			DefaultValue: os.Getenv("ERDA_REPO"),
+		},
+		command.StringFlag{Short: "b", Name: "branch", Doc: "specify branch to show pipeline status, default is current branch", DefaultValue: ""},
+		command.IntFlag{Short: "i", Name: "pipelineID", Doc: "specify pipeline id to show pipeline status", DefaultValue: 0},
+	},
+	Run: RunFetchPipe,
+}
+
+// RunBuildsInspect displays detailed information on the build record
+func RunFetchPipe(ctx *command.Context, repo, branch string, pipelineID int) (err error) {
+	if _, err := os.Stat(".git"); err != nil {
+		return err
+	}
+
+	if branch == "" {
+		b, err := common.GetWorkspaceBranch()
+		if err != nil {
+			return err
+		}
+		branch = b
+	}
+
+	// TODO gittar-adaptor 提供 API 根据 branch & git remote url 查询 pipelineID
+	// fetch appID
+	var orgName, projectName, appName string
+	if repo != "" {
+		orgName, projectName, appName, err = common.GetWorkspaceInfoFromErdaRepo(repo)
+	} else {
+		orgName, projectName, appName, err = common.GetWorkspaceInfo()
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to GetWorksapceInfo, repo: %s", repo)
+	}
+
+	org, err := common.GetOrgDetail(ctx, orgName)
+	if err != nil {
+		return err
+	}
+
+	orgID := strconv.FormatUint(org.Data.ID, 10)
+	repoStats, err := common.GetRepoStats(ctx, orgID, projectName, appName)
+	if err != nil {
+		return errors.Wrapf(err, "orgID: %v, projectName: %s, appName: %s", orgID, projectName, appName)
+	}
+	// fetch ymlName path
+	var pipelineCombResp apistructs.PipelineInvokedComboResponse
+	response, err := ctx.Get().Path("/api/cicds/actions/app-invoked-combos").
+		Param("appID", strconv.FormatInt(repoStats.Data.ApplicationID, 10)).
+		Do().JSON(&pipelineCombResp)
+	if err != nil {
+		return err
+	}
+	if !response.IsOK() {
+		return errors.Errorf("status fail, status code: %d, err: %+v", response.StatusCode(), pipelineCombResp.Error)
+	}
+	if !pipelineCombResp.Success {
+		return errors.Errorf("status fail: %+v", pipelineCombResp.Error)
+	}
+	var ymlName string
+	for _, v := range pipelineCombResp.Data {
+		if v.Branch == branch {
+			for _, item := range v.PagingYmlNames {
+				if item != apistructs.DefaultPipelineYmlName {
+					ymlName = item
+				}
+			}
+		}
+	}
+
+	// fetch pipeline info
+	var pipelineInfoResp apistructs.PipelineDetailResponse
+	response, err = ctx.Get().Path(fmt.Sprintf("/api/pipelines/%d", pipelineID)).
+		Do().JSON(&pipelineInfoResp)
+	if err != nil {
+		return err
+	}
+	if !response.IsOK() {
+		return errors.Errorf("status fail, status code: %d, err: %+v", response.StatusCode(), pipelineInfoResp.Error)
+	}
+	if !pipelineInfoResp.Success {
+		return errors.Errorf("status fail: %+v", pipelineInfoResp.Error)
+	}
+
+	data := [][]string{}
+	var currentStageIndex int
+	for i, stage := range pipelineInfoResp.Data.PipelineStages {
+		success := true
+		for _, task := range stage.PipelineTasks {
+			success = success && task.Status.IsSuccessStatus()
+			data = append(data, []string{
+				strconv.Itoa(pipelineID),
+				strconv.FormatUint(task.ID, 10),
+				task.Name,
+				task.Status.String(),
+				task.TimeBegin.Format("2006-01-02 15:04:05"),
+			})
+		}
+		if success {
+			currentStageIndex = i
+		}
+	}
+
+	fmt.Printf("Pipeline progress (success/total): %d/%d\n\n",
+		currentStageIndex+1, len(pipelineInfoResp.Data.PipelineStages))
+
+	defer seeMore(ctx, orgName, int(repoStats.Data.ProjectID), int(repoStats.Data.ApplicationID), branch, pipelineID, ymlName)
+	defer printMetadata(pipelineInfoResp.Data.PipelineStages)
+
+	return table.NewTable().Header([]string{
+		"pipelineID", "taskID", "taskName", "taskStatus", "startedAt",
+	}).Data(data).Flush()
+}
+
+func seeMore(ctx *command.Context, orgName string, projectID, appID int, branch string, pipelineID int, pipelineName string) {
+	frontUrl := ctx.Get().Path(fmt.Sprintf("/%s/dop/projects/%v/apps/%v/pipeline",
+		orgName, projectID, appID)).
+		Param("pipelineID", strconv.Itoa(pipelineID)).
+		Param("nodeId", base64.StdEncoding.EncodeToString([]byte(strings.Join([]string{
+			strconv.FormatInt(int64(projectID), 10),
+			strconv.FormatInt(int64(appID), 10),
+			"tree",
+			branch,
+			pipelineName,
+		}, "/")))).GetUrl()
+	frontUrl = strings.TrimPrefix(frontUrl, "https://")
+	frontUrl = strings.TrimPrefix(frontUrl, "http://")
+	if u, err := url.Parse(frontUrl); err == nil {
+		u.Host = strings.ReplaceAll(u.Host, "openapi.", "")
+		fmt.Printf("see more at %s\n", u.String())
+	} else {
+		fmt.Printf("failed to parse %s", frontUrl)
+	}
+}
+
+func printMetadata(pipelineStages []apistructs.PipelineStageDetailDTO) {
+	var meta []map[string]map[string]string
+	for _, pipelineStage := range pipelineStages {
+		s := make(map[string]map[string]string)
+		for _, pipelineTask := range pipelineStage.PipelineTasks {
+			t := make(map[string]string)
+			for _, metadata := range pipelineTask.Result.Metadata {
+				t[metadata.Name] = metadata.Value
+			}
+			s[pipelineTask.Name] = t
+		}
+		meta = append(meta, s)
+	}
+	fmt.Println("\nPipeline Metadata")
+	_ = yaml.NewEncoder(os.Stdout).Encode(meta)
+}

--- a/tools/cli/cmd/view.go
+++ b/tools/cli/cmd/view.go
@@ -59,7 +59,9 @@ var VIEW = command.Command{
 // RunViewPipe displays detailed information on the build record
 func RunViewPipe(ctx *command.Context, repo, branch string, pipelineID int, watch bool) (err error) {
 	if watch {
-		_ = BuildCheckLoop(ctx, strconv.FormatInt(int64(pipelineID), 10))
+		if err = BuildCheckLoop(ctx, strconv.FormatInt(int64(pipelineID), 10)); err != nil {
+			fmt.Println("[Warn]", err)
+		}
 	}
 
 	if _, err := os.Stat(".git"); err != nil {

--- a/tools/cli/common/workspace.go
+++ b/tools/cli/common/workspace.go
@@ -35,6 +35,15 @@ func GetWorkspaceBranch() (string, error) {
 	return branch, nil
 }
 
+func GetOriginRepo() string {
+	return GetRepo("origin")
+}
+
+func GetRepo(remote string) string {
+	out, _ := exec.Command("git", "config", "--get", "remote."+remote+".url").CombinedOutput()
+	return string(out)
+}
+
 func GetWorkspaceInfo() (org string, project string, app string, err error) {
 	remoteCmd := exec.Command("git", "remote", "get-url", "origin")
 	out, err := remoteCmd.CombinedOutput()
@@ -44,7 +53,11 @@ func GetWorkspaceInfo() (org string, project string, app string, err error) {
 
 	re := regexp.MustCompile(`\r?\n`)
 	newStr := re.ReplaceAllString(string(out), "")
-	u, err := url.Parse(newStr)
+	return GetWorkspaceInfoFromErdaRepo(newStr)
+}
+
+func GetWorkspaceInfoFromErdaRepo(erdaRepo string) (org, project, app string, err error) {
+	u, err := url.Parse(erdaRepo)
 	if err != nil {
 		return "", "", "", err
 	}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:
Without changing the original command line function, modify the `erda-cli build` command and add the `erda-cli view` command to create a pipeline and build applications without leaving the IDE or command line. Very useful for M1 users.

![image](https://user-images.githubusercontent.com/25881576/144010995-eb8431e6-0b77-4b04-b6e9-d8b84cc5382a.png)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
