### PR TITLE
feature: optimize scheduler startup time

### DIFF
--- a/modules/scheduler/conf/conf.go
+++ b/modules/scheduler/conf/conf.go
@@ -15,6 +15,8 @@
 package conf
 
 import (
+	"time"
+
 	"github.com/erda-project/erda/pkg/envconf"
 )
 
@@ -39,6 +41,8 @@ type Conf struct {
 	TerminalSecurity bool `env:"TERMINAL_SECURITY" default:"false"`
 
 	WsDiceRootDomain string `env:"WS_DICE_ROOT_DOMAIN" default:"app.terminus.io,erda.cloud"`
+
+	ExecutorClientTimeout int `env:"EXECUTOR_CLIENT_TIMEOUT" default:"10"`
 }
 
 var cfg Conf
@@ -95,4 +99,8 @@ func TerminalSecurity() bool {
 
 func WsDiceRootDomain() string {
 	return cfg.WsDiceRootDomain
+}
+
+func ExecutorClientTimeout() time.Duration {
+	return time.Duration(cfg.ExecutorClientTimeout) * time.Second
 }

--- a/modules/scheduler/executor/util/util.go
+++ b/modules/scheduler/executor/util/util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/scheduler/conf"
 	"github.com/erda-project/erda/pkg/http/httpclient"
 )
 
@@ -256,6 +257,7 @@ func GetClient(clusterName string, manageConfig *apistructs.ManageConfig) (strin
 
 	hcOptions := []httpclient.OpOption{
 		httpclient.WithHTTPS(),
+		httpclient.WithTimeout(conf.ExecutorClientTimeout(), conf.ExecutorClientTimeout()),
 	}
 
 	// check mange config type


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature
/kind bugfix

#### What this PR does / why we need it:
1.  optimize timeout，default 10s.
2. optimize start order with client-go and http-client.
3. change the executor startup mode to asynchronous.

Testing result:
clusters: 5 error cluster and 2 normal cluster.
timeout: 5s

before: 6min18s
```shell
time="2021-12-02 14:58:48.076" level=info msg="provider scheduler is initializing"
......
time="2021-12-02 15:05:06.905958304" level=info msg="added endpoint: GET /api/capacity"
```

after:
- service start：0.26s
- executor create complete：5s

```shell
time="2021-12-03 14:13:14.418" level=info msg="provider scheduler is initializing"
time="2021-12-03 14:13:14.597375116" level=info msg="created executor: EDASFORSHELECTRICTEST"
...
time="2021-12-03 14:13:14.679703234" level=info msg="added endpoint: GET /api/capacity"
...
time="2021-12-03 14:13:15.737746077" level=info msg="created executor: MARATHONFORERDAHONGKONG"
....
time="2021-12-03 14:13:16.149189864" level=info msg="created executor: K8SFORSHELECTRICTEST"
....
time="2021-12-03 14:13:19.538159338" level=error msg="failed to create executor(name: MARATHONFORFAKECLUSTER5, key: /dice/scheduler/configs/cluster/fake-cluster-5-service-k8s) error: failed to get k8s client for cluster fake-cluster-5, Get \"https://172.16.0.5:6443/api?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
time="2021-12-03 14:13:19.584628436" level=error msg="failed to create executor(name: MARATHONFORFAKECLUSTER4, key: /dice/scheduler/configs/cluster/fake-cluster-4-service-k8s) error: failed to get k8s client for cluster fake-cluster-4, Get \"https://172.16.0.4:6443/api?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
time="2021-12-03 14:13:19.587779935" level=error msg="failed to create executor(name: MARATHONFORFAKECLUSTER3, key: /dice/scheduler/configs/cluster/fake-cluster-3-service-k8s) error: failed to get k8s client for cluster fake-cluster-3, Get \"https://172.16.0.3:6443/api?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
time="2021-12-03 14:13:19.603450016" level=error msg="failed to create executor(name: MARATHONFORFAKECLUSTER2, key: /dice/scheduler/configs/cluster/fake-cluster-2-service-k8s) error: failed to get k8s client for cluster fake-cluster-2, Get \"https://172.16.0.2:6443/api?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
time="2021-12-03 14:13:19.603530409" level=error msg="failed to create executor(name: MARATHONFORFAKECLUSTER1, key: /dice/scheduler/configs/cluster/fake-cluster-1-service-k8s) error: failed to get k8s client for cluster fake-cluster-1, Get \"https://172.16.0.1:6443/api?timeout=5s\": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"
```


#### Specified Reviewers:

/assign @luobily @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  optimize scheduler startup time  |
| 🇨🇳 中文    |  优化调度器启动时间   |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
