### PR TITLE
add terminus_define_tag lable for spark job

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/util.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/util.go
@@ -72,7 +72,7 @@ func addMainApplicationFile(conf *apistructs.BigdataConf) (string, error) {
 	return "", errors.Errorf("invalid job spec, resource %s", appResource)
 }
 
-func addLabels() map[string]string {
+func addLabels(conf *apistructs.BigdataConf) map[string]string {
 	labels := make(map[string]string)
 
 	// "dice/job": ""

--- a/modules/pipeline/pkg/containers/task_container.go
+++ b/modules/pipeline/pkg/containers/task_container.go
@@ -31,9 +31,9 @@ func GenContainers(task *spec.PipelineTask) ([]apistructs.TaskContainer, error) 
 		if spec.FlinkConf != nil {
 			return GenFlinkContainers(task), nil
 		}
-		//if spec.SparkConf != nil {
-		//	executorName = "k8sspark"
-		//}
+		if spec.SparkConf != nil {
+			return GenSparkContainers(task), nil
+		}
 	}
 	return GenTaskContainer(task), nil
 }
@@ -82,6 +82,35 @@ func GenFlinkContainers(task *spec.PipelineTask) []apistructs.TaskContainer {
 	containers = append(containers, apistructs.TaskContainer{
 		TaskName:    MakeFlinkTaskManagerName(task.Name),
 		ContainerID: MakeFLinkTaskManagerID(task.Extra.UUID),
+	})
+	return containers
+}
+
+func MakeSparkTaskDriverName(name string) string {
+	return fmt.Sprintf("%s-task-driver", name)
+}
+
+func MakeSparkTaskDriverID(uuid string) string {
+	return fmt.Sprintf("%s-task-driver", uuid)
+}
+
+func MakeSparkTaskExecutorName(name string) string {
+	return fmt.Sprintf("%s-task-executor", name)
+}
+
+func MakeSparkTaskExecutorID(uuid string) string {
+	return fmt.Sprintf("%s-task-executor", uuid)
+}
+
+func GenSparkContainers(task *spec.PipelineTask) []apistructs.TaskContainer {
+	containers := make([]apistructs.TaskContainer, 0)
+	containers = append(containers, apistructs.TaskContainer{
+		TaskName:    MakeSparkTaskDriverName(task.Name),
+		ContainerID: MakeSparkTaskDriverID(task.Extra.UUID),
+	})
+	containers = append(containers, apistructs.TaskContainer{
+		TaskName:    MakeSparkTaskExecutorName(task.Name),
+		ContainerID: MakeSparkTaskExecutorID(task.Extra.UUID),
 	})
 	return containers
 }

--- a/modules/pipeline/pkg/containers/task_container_test.go
+++ b/modules/pipeline/pkg/containers/task_container_test.go
@@ -49,4 +49,19 @@ func TestGenContainers(t *testing.T) {
 	k8sflinkContainers, err := GenContainers(k8sflinkTask)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 3, len(k8sflinkContainers))
+
+	k8sSparkTask := &spec.PipelineTask{
+		Name: "k8sjob",
+		Extra: spec.PipelineTaskExtra{
+			UUID: "pipeline-123456",
+			Action: pipelineyml.Action{
+				Params: map[string]interface{}{
+					"bigDataConf": "{\n      \"class\": \"io.terminus.erda.fdp.SparkSqlMain\",\n      \"image\": \"docker.io/terminus/spark-py:ai_v1.0\",\n      \"resource\": \"local:///opt/spark/py_action/jobs.py\",\n      \"sparkConf\": {\n        \"deps\": {\n          \"pyFiles\": [\n            \"local:///opt/spark/py_action/predict.zip\"\n          ]\n        },\n        \"driverResource\": {\n          \"cpu\": \"1\",\n          \"memory\": \"1024m\",\n          \"replica\": 1\n        },\n        \"executorResource\": {\n          \"cpu\": \"1\",\n          \"memory\": \"1024m\",\n          \"replica\": 1\n        },\n        \"kind\": \"cluster\",\n        \"type\": \"Java\"\n      }\n    }",
+				},
+			},
+		},
+	}
+	k8sSparkContainers, err := GenContainers(k8sSparkTask)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 2, len(k8sSparkContainers))
 }


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind feature

#### What this PR does / why we need it:
support spark job logs

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=240364&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=772&type=REQUIREMENT)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support spark job logs （实现spark 任务日志查看）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Support spark job logs             |
| 🇨🇳 中文    |   实现spark 任务日志查看           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
