### PR TITLE
keep iterations order after set issue summaries

### DIFF
--- a/modules/dop/endpoints/iteration.go
+++ b/modules/dop/endpoints/iteration.go
@@ -307,8 +307,10 @@ func (e *Endpoints) PagingIterations(ctx context.Context, r *http.Request, vars 
 		}
 	}
 	iterations := make([]apistructs.Iteration, 0, len(iterationModels))
-	for _, itr := range iterationMap {
-		iterations = append(iterations, *itr)
+	for _, itrModel := range iterationModels {
+		if itr, existed := iterationMap[int64(itrModel.ID)]; existed {
+			iterations = append(iterations, *itr)
+		}
 	}
 	// userIDs
 	var userIDs []string


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
keep iterations order after set issue summaries

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=261505&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that keep iterations order after set issue summaries （修复了迭代排序的问题）
`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | keep iterations order after set issue summaries              |
| 🇨🇳 中文    |    修复了迭代排序的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
