### PR TITLE
scene set execution configuration sheet detailed display

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeTaskTable/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeTaskTable/render.go
@@ -365,6 +365,7 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					"path":     "",
 					"step":     stepIdx,
 				}
+				lists = append(lists, item)
 			} else {
 				switch task.Labels[apistructs.AutotestType] {
 				case apistructs.AutotestSceneStep:


### PR DESCRIPTION
#### What type of this PR

/kind bugfix


#### What this PR does / why we need it:
The details of the execution configuration sheet of the scene set cannot be displayed, resulting in the user not being able to see the log


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=262679&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Scene set detailed configuration sheet display       |
| 🇨🇳 中文    |        场景集明细配置单展示      |

