### PR TITLE
feature: issue-kanban order by updatedAt desc

### DIFF
--- a/modules/dop/component-protocol/components/issue-manage/issueKanban/issue_kanban.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueKanban/issue_kanban.go
@@ -94,7 +94,7 @@ func (cl *CartList) Delete(issueID int64) {
 }
 
 func (cl *CartList) Add(c IssueCart) {
-	cl.List = append([]IssueCart{c}, cl.List...)
+	cl.List = append(cl.List, c)
 }
 
 const (

--- a/modules/dop/component-protocol/components/issue-manage/issueKanban/render.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueKanban/render.go
@@ -101,6 +101,8 @@ func (i ComponentIssueBoard) GetFilterReq() (*IssueFilterRequest, error) {
 	}
 	req.PageSize = defaultPageSize
 	req.PageNo = 1
+	req.OrderBy = "updated_at"
+	req.Asc = false
 	return &req, nil
 }
 

--- a/modules/dop/dao/issue.go
+++ b/modules/dop/dao/issue.go
@@ -278,7 +278,7 @@ func (client *DBClient) PagingIssues(req apistructs.IssuePagingRequest, queryIDs
 		sql = sql.Where("stage IN (?)", req.TaskType)
 	}
 	if len(req.ExceptIDs) > 0 {
-		sql = sql.Not("dice_issues.id", req.ExceptIDs)
+		sql = sql.Where("dice_issues.id NOT IN (?)", req.ExceptIDs)
 	}
 	if req.StartCreatedAt > 0 {
 		startCreatedAt := time.Unix(req.StartCreatedAt/1000, 0)

--- a/modules/dop/endpoints/issue.go
+++ b/modules/dop/endpoints/issue.go
@@ -145,6 +145,8 @@ func (e *Endpoints) PagingIssues(ctx context.Context, r *http.Request, vars map[
 		pageReq.OrderBy = "plan_finished_at"
 	case "assignee":
 		pageReq.OrderBy = "assignee"
+	case "updatedAt", "updated_at":
+		pageReq.OrderBy = "updated_at"
 	default:
 		return apierrors.ErrPagingIssues.InvalidParameter("orderBy").ToResp(), nil
 	}


### PR DESCRIPTION
#### What type of this PR

/kind feature


#### What this PR does / why we need it:

- feature: issue-kanban order by updatedAt desc
- fix: issue paging expectIDs use `WHERE NOT IN` clause
- feature: issue-kanban custom panel update issue's updatedAt


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=263111&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyI5MiJdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=TASK)


#### Specified Reviewers:

/assign @Effet 

