### PR TITLE
jump over empty addon

### DIFF
--- a/modules/orchestrator/services/deployment/deployment_context.go
+++ b/modules/orchestrator/services/deployment/deployment_context.go
@@ -712,6 +712,10 @@ func (fsm *DeployFSMContext) requestAddons() error {
 
 	var baseAddons []apistructs.AddonCreateItem
 	for name, a := range fsm.Spec.AddOns {
+		if a == nil {
+			fsm.d.Log(fmt.Sprintf("addon information is empty, jump over, addon name: %s", name))
+			continue
+		}
 		plan := strings.SplitN(a.Plan, ":", 2)
 		if len(plan) != 2 {
 			return errors.Errorf("addon plan information is not compliant")


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
jump over nil addon field

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=263634&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that jump over empty addon （修复了orchestrator遇到空的addon配置panic的问题）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that jump over empty addon            |
| 🇨🇳 中文    |   修复了orchestrator遇到空的addon配置panic的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
