### PR TITLE
autotest task table remove page operator

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeTaskTable/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeTaskTable/render.go
@@ -61,11 +61,6 @@ type meta struct {
 	Target RowData `json:"target"`
 }
 
-const (
-	DefaultPageSize = 1000
-	DefaultPageNo   = 1
-)
-
 type Operation struct {
 	Key           string      `json:"key"`
 	Reload        bool        `json:"reload"`
@@ -186,10 +181,6 @@ func (a *ExecuteTaskTable) Render(ctx context.Context, c *cptype.Component, scen
 
 func getOperations(clickableKeys []uint64) map[string]interface{} {
 	return map[string]interface{}{
-		"changePageNo": Operation{
-			Key:    "changePageNo",
-			Reload: true,
-		},
 		"clickRow": Operation{
 			Key:           "clickRow",
 			Reload:        true,
@@ -290,31 +281,14 @@ func getStatus(req apistructs.PipelineStatus) map[string]interface{} {
 func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error {
 	lists := []map[string]interface{}{}
 	clickableKeys := []uint64{}
-	num := (a.State.PageNo - 1) * (a.State.PageSize)
-	ret := a.State.PageSize
 	a.State.Total = 0
 	stepIdx := 1
 	for _, each := range pipeline.PipelineStages {
 
 		a.State.Total += int64(len(each.PipelineTasks))
-		if ret == 0 {
-			continue
-		}
-
-		if int64(len(each.PipelineTasks)) <= num {
-			num -= int64(len(each.PipelineTasks))
-			continue
-		}
 
 		for _, task := range each.PipelineTasks {
-
-			if num > 0 {
-				num--
-				continue
-			}
-
 			var item map[string]interface{}
-
 			// not autotest task
 			// snippet acton remove operation add taskNum
 			if task.Labels == nil || len(task.Labels) == 0 {
@@ -520,19 +494,10 @@ func (a *ExecuteTaskTable) setData(pipeline *apistructs.PipelineDetailDTO) error
 					}
 				}
 			}
-
-			ret--
-			if ret == 0 {
-				break
-			}
 		}
 		stepIdx++
 	}
 
-	if a.State.Total <= (a.State.PageNo-1)*(a.State.PageSize) && a.State.Total > 0 {
-		a.State.PageNo = DefaultPageNo
-		return a.setData(pipeline)
-	}
 	a.Data = make(map[string]interface{})
 	a.Data["list"] = lists
 	a.Operations = getOperations(clickableKeys)
@@ -568,12 +533,15 @@ func (a *ExecuteTaskTable) marshal(c *cptype.Component) error {
 
 func (e *ExecuteTaskTable) handlerListOperation(c *cptype.Component, event cptype.ComponentEvent) error {
 
-	e.State.PageNo = DefaultPageNo
-	e.State.PageSize = DefaultPageSize
-
 	if e.pipelineID == 0 {
 		c.Data = map[string]interface{}{}
 		return nil
+	}
+	if e.State.PageNo == 0 {
+		e.State.PageNo = 1
+	}
+	if e.State.PageSize == 0 {
+		e.State.PageSize = 10
 	}
 	list, err := e.bdl.GetPipeline(e.pipelineID)
 	if err != nil {
@@ -600,6 +568,7 @@ func (e *ExecuteTaskTable) handlerClickRowOperation(c *cptype.Component, event c
 	e.State.Name = res.Meta.Target.Name
 	e.pipelineID = res.Meta.Target.SnippetPipelineID
 	e.State.Unfold = true
+	e.State.PageNo = 1
 	if res.Meta.Target.SnippetPipelineID == 0 {
 		return nil
 	}

--- a/modules/dop/component-protocol/components/issue-gantt/gantt/render.go
+++ b/modules/dop/component-protocol/components/issue-gantt/gantt/render.go
@@ -124,6 +124,9 @@ func (f *ComponentGantt) Render(ctx context.Context, c *cptype.Component, scenar
 			ID:             id,
 			PlanStartedAt:  timeFromMilli(op.Meta.Nodes.Start),
 			PlanFinishedAt: timeFromMilli(op.Meta.Nodes.End),
+			IdentityInfo: apistructs.IdentityInfo{
+				UserID: f.sdk.Identity.UserID,
+			},
 		}); err != nil {
 			return err
 		}

--- a/modules/dop/dao/issue.go
+++ b/modules/dop/dao/issue.go
@@ -956,7 +956,7 @@ func (client *DBClient) FindIssueRoot(req apistructs.IssuePagingRequest) ([]Issu
 	// requirements with children
 	sql = client.Debug().Table("dice_issue_relation b").Joins(joinIssueParent).Joins("LEFT JOIN dice_issues d ON d.id = b.related_issue").
 		Joins("LEFT JOIN dice_issue_state e ON a.state = e.id").Joins("LEFT JOIN dice_issue_state f ON d.state = f.id")
-	sql = sql.Where("a.Type = ?", apistructs.IssueTypeRequirement)
+	sql = sql.Where("a.type = ?", apistructs.IssueTypeRequirement).Where("b.type = ?", apistructs.IssueRelationInclusion)
 	sql = sql.Where("d.deleted = 0").Where("d.project_id = ?", req.ProjectID)
 	sql = applyCondition(sql, req)
 	if len(req.Assignees) > 0 {


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:
Automated testing removes paging events, returns all information, so as to achieve front-end paging


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=263116&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Automated testing removes paging events, returns all information, so as to achieve front-end paging         |
| 🇨🇳 中文    |      自动化测试去除分页事件，返回所有信息，从而实现前端分页        |
