### PR TITLE
bugfix: add terminusKey for LogAnalyze menu item

### DIFF
--- a/modules/msp/menu/menu.service.go
+++ b/modules/msp/menu/menu.service.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ahmetb/go-linq/v3"
+
 	"github.com/erda-project/erda-proto-go/msp/menu/pb"
 	tenantpb "github.com/erda-project/erda-proto-go/msp/tenant/pb"
 	"github.com/erda-project/erda/bundle"
@@ -345,7 +347,8 @@ func (s *menuService) adjustMenuParams(items []*pb.MenuItem) []*pb.MenuItem {
 		case "MonitorCenter":
 			monitor = item
 		case "DiagnoseAnalyzer":
-			loghub = item
+			loghub, _ = linq.From(item.Children).
+				FirstWith(func(i interface{}) bool { return i.(*pb.MenuItem).Key == "LogAnalyze" }).(*pb.MenuItem)
 		}
 	}
 	if monitor != nil {


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix


#### What this PR does / why we need it:
bugfix: add terminusKey for LogAnalyze menu item, to fix the bug that create log-analysis-rule with wrong scopeId


#### Specified Reviewers:

/assign @liuhaoyang 


#### Need cherry-pick to release versions?

/cherry-pick release/1.5-alpha.4
