### PR TITLE
fix: edas list recent change order info error

### DIFF
--- a/modules/scheduler/executor/plugins/edas/edas.go
+++ b/modules/scheduler/executor/plugins/edas/edas.go
@@ -1043,7 +1043,11 @@ func (e *EDAS) deleteAppByName(appName string) error {
 		return err
 	}
 
-	orderList, _ := e.listRecentChangeOrderInfo(appID)
+	orderList, err := e.listRecentChangeOrderInfo(appID)
+	if err != nil {
+		logrus.Errorf("failed to list recent change order info, app id: %s, err: %v", appID, err)
+		return err
+	}
 
 	if len(orderList.ChangeOrder) > 0 && orderList.ChangeOrder[0].Status == 1 {
 		e.abortChangeOrder(orderList.ChangeOrder[0].ChangeOrderId)


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
edas list recent change order info error

will cause scheduler panic

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix edas list recent change order info error             |
| 🇨🇳 中文    |    修复 edas 接口错误          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
