### PR TITLE
auto sync extension by source

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -5,11 +5,9 @@ FROM ${BASE_DOCKER_IMAGE} as build
 RUN mkdir -p "$GOPATH/src/github.com/erda-project/erda/"
 COPY . "$GOPATH/src/github.com/erda-project/erda/"
 WORKDIR "$GOPATH/src/github.com/erda-project/erda/"
+RUN mv extensions /tmp/dicehub-extension
 
 ARG MODULE_PATH
-ARG EXTENSION_ZIP_ADDRS
-RUN mkdir -p /tmp/dicehub-extension
-RUN if [ ${MODULE_PATH} = dicehub ] || [ -z ${MODULE_PATH} ]; then ./build/scripts/dicehub/extension-push.sh "${EXTENSION_ZIP_ADDRS}" ; fi
 
 ARG CONFIG_PATH
 ARG DOCKER_IMAGE

--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -24,7 +24,7 @@ erda.core.dicehub.release:
 
 erda.core.dicehub.extension:
   extension_sources: "${EXTENSION_SOURCES}"
-  extension_sources_cron: "${EXTENSION_SOURCES_CRON:0 0 21 * * ?}"
+  extension_sources_cron: "${EXTENSION_SOURCES_CRON:0 */5 * * * ?}"
 #  extension_menu: ${EXTENSION_MENU:{"":""}}
 
 mysql:

--- a/modules/dicehub/extension/action.go
+++ b/modules/dicehub/extension/action.go
@@ -17,7 +17,6 @@ package extension
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -48,43 +47,6 @@ type Version struct {
 	ReadmeContent []byte           // content of readme.md
 
 	SwaggerContent []byte // content of swagger.yml
-}
-
-func (s *extensionService) pushGitExtensions(gitAddr string) error {
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(dir)
-
-	// git init
-	// todo only first time clone, other times git pull
-	command := exec.Command("sh", "-c", "git clone "+gitAddr)
-	command.Dir = dir
-	output, err := command.CombinedOutput()
-	if err != nil {
-		logrus.Errorf("git clone extensions address stderr %v", string(output))
-		return err
-	}
-
-	return s.InitExtension(dir, true)
-}
-
-func (s *extensionService) TimedTaskSynchronizationExtensions() {
-	logrus.Infof("start to TimeTaskSynchronizationExtensions")
-
-	if s.p.Cfg.ExtensionSources == "" {
-		return
-	}
-
-	for _, gitAddr := range strings.Split(s.p.Cfg.ExtensionSources, ",") {
-		err := s.pushGitExtensions(gitAddr)
-		if err != nil {
-			logrus.Errorf("error to sync git address %s extension", gitAddr)
-		}
-	}
-
-	logrus.Infof("end to TimeTaskSynchronizationExtensions")
 }
 
 func (s *extensionService) InitExtension(addr string, forceUpdate bool) error {

--- a/modules/dicehub/extension/source.go
+++ b/modules/dicehub/extension/source.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ExtensionSource interface {
+	match(addr string) bool
+	add(addr string) error
+	remove(addr string) error
+	start() error
+}
+
+type GitExtensionSource struct {
+	GitCloneAddr map[string]string
+}
+
+func (g GitExtensionSource) match(addr string) bool {
+	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") || strings.HasPrefix(addr, "git@") {
+		return true
+	}
+	return false
+}
+
+func (g GitExtensionSource) add(addr string) error {
+
+	if g.GitCloneAddr[addr] == "" {
+		dir, err := ioutil.TempDir(os.TempDir(), "*")
+		if err != nil {
+			logrus.Error("gitExtensionSource tempDir error %v", err)
+			return err
+		}
+
+		command := exec.Command("sh", "-c", "git clone "+addr)
+		command.Dir = dir
+		output, err := command.CombinedOutput()
+		if err != nil {
+			logrus.Errorf("git clone extensions address stderr %v", string(output))
+			return err
+		}
+		g.GitCloneAddr[addr] = dir
+	}
+
+	return AddSyncExtension(g.GitCloneAddr[addr])
+}
+
+func (g GitExtensionSource) remove(addr string) error {
+	err := RemoveSyncExtension(addr)
+	if err != nil {
+		return err
+	}
+
+
+}
+
+type FileExtensionSource struct {
+	watcher *fsnotify.Watcher
+	watchAddrList map[string]string
+}
+
+func (f FileExtensionSource) match(addr string) bool {
+	s, err := os.Stat(addr)
+	if err != nil {
+		return false
+	}
+	return s.IsDir()
+}
+
+func (f FileExtensionSource) add(addr string) error {
+	if f.watchAddrList[addr] == "" {
+		f.watchAddrList[addr] = addr
+	}
+
+	err := f.watcher.Add(addr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f FileExtensionSource) remove(addr string) error {
+	return f.watcher.Remove(addr)
+}
+
+
+
+var extensionSources []ExtensionSource
+
+func RegisterExtensionSource(source ExtensionSource)  {
+	extensionSources = append(extensionSources, source)
+}
+
+func AddSyncExtension(addr string) error {
+	for _, source := range extensionSources {
+		if source.match(addr) {
+			err := source.add(addr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func RemoveSyncExtension(addr string) error {
+	for _, source := range extensionSources {
+		if source.match(addr) {
+			err := source.remove(addr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+
+

--- a/modules/dicehub/extension/source.go
+++ b/modules/dicehub/extension/source.go
@@ -12,41 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package source
+package extension
 
 import (
-	"github.com/fsnotify/fsnotify"
-	"github.com/sirupsen/logrus"
+	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda-proto-go/core/dicehub/extension/pb"
+	"github.com/erda-project/erda/pkg/cron"
+	"github.com/erda-project/erda/pkg/limit_sync_group"
 )
 
-type ExtensionSource interface {
+type Source interface {
 	match(addr string) bool
 	add(addr string) error
 	remove(addr string) error
-	start() error
+	start()
 }
 
+// git source
+// Pull the code when adding, and then use FileExtensionSource to monitor the file, and wait for the regular pull to update the file
+// remove remove file monitoring and associated information
+// start continues to pull and update local files according to the association relationship
 type GitExtensionSource struct {
-	GitCloneAddr map[string]string
+	Cfg              *config
+	GitCloneAddr     sync.Map
+	GitCloneRepoName sync.Map
+	f                *FileExtensionSource
 }
 
-func (g GitExtensionSource) match(addr string) bool {
+// Match the address starting with http:// | https:// | git@
+func (g *GitExtensionSource) match(addr string) bool {
 	if strings.HasPrefix(addr, "http://") || strings.HasPrefix(addr, "https://") || strings.HasPrefix(addr, "git@") {
 		return true
 	}
 	return false
 }
 
-func (g GitExtensionSource) add(addr string) error {
-
-	if g.GitCloneAddr[addr] == "" {
+// Download the addr address, and then generate the association relationship between the git address and the local address
+// Then add the local file to the local file monitoring
+func (g *GitExtensionSource) add(addr string) error {
+	_, ok := g.GitCloneAddr.Load(addr)
+	if !ok {
 		dir, err := ioutil.TempDir(os.TempDir(), "*")
 		if err != nil {
-			logrus.Error("gitExtensionSource tempDir error %v", err)
+			logrus.Errorf("gitExtensionSource tempDir error %v", err)
 			return err
 		}
 
@@ -57,27 +76,119 @@ func (g GitExtensionSource) add(addr string) error {
 			logrus.Errorf("git clone extensions address stderr %v", string(output))
 			return err
 		}
-		g.GitCloneAddr[addr] = dir
-	}
 
-	return AddSyncExtension(g.GitCloneAddr[addr])
+		fileInfoList, err := ioutil.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		if len(fileInfoList) == 0 {
+			return fmt.Errorf("repo not have file")
+		}
+		g.GitCloneRepoName.Store(addr, fileInfoList[0].Name())
+		g.GitCloneAddr.Store(addr, dir)
+
+		return g.f.add(dir)
+	}
+	return nil
 }
 
-func (g GitExtensionSource) remove(addr string) error {
-	err := RemoveSyncExtension(addr)
-	if err != nil {
-		return err
+// Take out the local address corresponding to git addr and remove the file monitoring of the local address
+func (g *GitExtensionSource) remove(addr string) error {
+	value, ok := g.GitCloneAddr.Load(addr)
+	if ok {
+		err := g.f.remove(value.(string))
+		if err != nil {
+			return err
+		}
+		g.GitCloneAddr.Delete(addr)
+		g.GitCloneRepoName.Delete(addr)
 	}
-
-
+	return nil
 }
 
+// Timed task pulls and updates all git addresses
+func (g *GitExtensionSource) start() {
+	go func() {
+		c := cron.New()
+		err := c.AddFunc(g.Cfg.ExtensionSourcesCron, func() {
+			var gitCloneRepoNameMap = map[string]string{}
+			g.GitCloneRepoName.Range(func(key, value interface{}) bool {
+				gitCloneRepoNameMap[key.(string)] = value.(string)
+				return true
+			})
+
+			wait := limit_sync_group.NewSemaphore(10)
+			g.GitCloneAddr.Range(func(gitAddr, localAddr interface{}) bool {
+				wait.Add(1)
+				go func(gitAddr, localAddr interface{}) {
+					defer wait.Done()
+
+					// Open the write lock, only after all the files are written, the local file monitoring can start execution
+					lock := g.f.getAddrRLock(localAddr.(string))
+					if lock != nil {
+						lock.Lock()
+						defer lock.Unlock()
+					}
+
+					command := exec.Command("sh", "-c", "git pull")
+					command.Dir = filepath.Join(localAddr.(string), gitCloneRepoNameMap[gitAddr.(string)])
+					output, err := command.CombinedOutput()
+					if err != nil {
+						logrus.Errorf("git clone extensions address stderr %v", string(output))
+					}
+				}(gitAddr, localAddr)
+				return true
+			})
+			wait.Wait()
+
+		})
+		if err != nil {
+			panic(fmt.Errorf("error to add cron task %v", err))
+		} else {
+			c.Start()
+		}
+	}()
+}
+
+// local file source
+// match matches the local folder
+// add Add a folder address to the file change monitoring
+// remove removes a folder from file change monitoring
+// start Open file monitoring, continuously monitor file changes, and update extension
 type FileExtensionSource struct {
-	watcher *fsnotify.Watcher
-	watchAddrList map[string]string
+	watcher    *fsnotify.Watcher
+	s          *extensionService
+	lock       sync.Mutex
+	AddrRWLock map[string]*sync.RWMutex
 }
 
-func (f FileExtensionSource) match(addr string) bool {
+// Obtain the read-write lock of the local file
+func (f *FileExtensionSource) getAddrRLock(addr string) *sync.RWMutex {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	rwLock, ok := f.AddrRWLock[addr]
+	if ok {
+		return rwLock
+	}
+	return nil
+}
+
+// Create a read-write lock for the local address
+func (f *FileExtensionSource) setAddrRLock(addr string) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	_, ok := f.AddrRWLock[addr]
+	if !ok {
+		f.AddrRWLock[addr] = &sync.RWMutex{}
+	}
+}
+
+// match directory
+func (f *FileExtensionSource) match(addr string) bool {
+	return isDir(addr)
+}
+
+func isDir(addr string) bool {
 	s, err := os.Stat(addr)
 	if err != nil {
 		return false
@@ -85,28 +196,218 @@ func (f FileExtensionSource) match(addr string) bool {
 	return s.IsDir()
 }
 
-func (f FileExtensionSource) add(addr string) error {
-	if f.watchAddrList[addr] == "" {
-		f.watchAddrList[addr] = addr
+// Mandatory overwrite extension
+// Add the local address to the monitoring list
+func (f *FileExtensionSource) add(addr string) error {
+	f.lock.Lock()
+	err := f.s.InitExtension(addr, true)
+	if err != nil {
+		return err
 	}
+	f.lock.Unlock()
 
-	err := f.watcher.Add(addr)
+	f.setAddrRLock(addr)
+	f.addDirWatch(addr)
+	return nil
+}
+
+// Get all the folders of the file address and add them to the monitoring list
+func (f *FileExtensionSource) addDirWatch(addr string) {
+	if err := filepath.Walk(addr, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+
+			if strings.Contains(path, "/.git") {
+				return nil
+			}
+
+			fmt.Println("addDirWatch dir", path)
+			err := f.watcher.Add(path)
+
+			if err != nil {
+				logrus.Errorf("addDirWatch add watch %v error %v", path, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		logrus.Errorf("addDirWatch error %v", err)
+	}
+}
+
+// Get all the folders of the file address and move them out to the monitoring list
+func (f *FileExtensionSource) remoteDirWatch(addr string) {
+	if err := filepath.Walk(addr, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+
+			if strings.Contains(path, "/.git") {
+				return nil
+			}
+			fmt.Println("remoteDirWatch dir", path)
+
+			err := f.watcher.Remove(path)
+
+			if err != nil {
+				logrus.Errorf("remoteDirWatch add watch %v error %v", path, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		logrus.Errorf("remoteDirWatch error %v", err)
+	}
+}
+
+// Remove the monitoring list
+func (f *FileExtensionSource) remove(addr string) error {
+	f.remoteDirWatch(addr)
+	return nil
+}
+
+// Turn on local file monitoring
+func (f *FileExtensionSource) start() {
+	go func() {
+		for {
+			select {
+			case event, ok := <-f.watcher.Events:
+				if !ok {
+					continue
+				}
+
+				fmt.Println("event name: ", event.Name)
+				fmt.Println("event op: ", event.Op.String())
+
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					if !isWatchFile(event.Name) {
+						continue
+					}
+					err := f.updateOrCreateExtension(event.Name)
+					if err != nil {
+						logrus.Errorf("file write watch: failed to update or create action event %v error %v", event.Name, err)
+					}
+				}
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
+					if isDir(event.Name) {
+						f.remoteDirWatch(event.Name)
+					}
+				}
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					go func(event fsnotify.Event) {
+
+						var matchAddr string
+						for addr := range f.AddrRWLock {
+							if strings.HasPrefix(event.Name, addr) {
+								matchAddr = addr
+							}
+						}
+
+						// Use read locks to prevent conflicts with write locks
+						// Because pull may not completely update the file, it may cause problems with recursive scanning of files and adding them to monitoring
+						lock := f.getAddrRLock(matchAddr)
+						if lock != nil {
+							lock.RLock()
+							defer lock.RUnlock()
+						}
+
+						if isDir(event.Name) {
+							// Add all new files to monitoring
+							f.addDirWatch(event.Name)
+							// Scan all files, whether there is an extension that needs to be updated
+							if err := filepath.Walk(event.Name, func(path string, info fs.FileInfo, err error) error {
+								if !info.IsDir() && isWatchFile(path) {
+									err := f.updateOrCreateExtension(path)
+									if err != nil {
+										logrus.Errorf("file create watch: failed to update or create action event %v error %v", path, err)
+									}
+								}
+								return nil
+							}); err != nil {
+								logrus.Errorf("watch create error %v:", err)
+							}
+						}
+
+						// If it is created for update operation
+						if !isWatchFile(event.Name) {
+							return
+						}
+						err := f.updateOrCreateExtension(event.Name)
+						if err != nil {
+							logrus.Errorf("file create watch: failed to update or create action event %v error %v", event.Name, err)
+						}
+					}(event)
+				}
+			case err, ok := <-f.watcher.Errors:
+				if !ok {
+					continue
+				}
+				logrus.Println("file error watch:", err)
+			}
+		}
+	}()
+}
+
+func (f *FileExtensionSource) updateOrCreateExtension(fileAddr string) error {
+	version, err := NewVersion(filepath.Dir(fileAddr))
+	if err != nil {
+		return err
+	}
+	specData := version.Spec
+
+	var request = &pb.ExtensionVersionCreateRequest{
+		Name:        specData.Name,
+		Version:     specData.Version,
+		SpecYml:     string(version.SpecContent),
+		DiceYml:     string(version.DiceContent),
+		SwaggerYml:  string(version.SwaggerContent),
+		Readme:      string(version.ReadmeContent),
+		Public:      specData.Public,
+		ForceUpdate: true,
+		All:         false,
+		IsDefault:   specData.IsDefault,
+	}
+	_, err = f.s.CreateExtensionVersionByRequest(request)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (f FileExtensionSource) remove(addr string) error {
-	return f.watcher.Remove(addr)
+func isWatchFile(name string) bool {
+	if strings.HasSuffix(name, "dice.yml") || strings.HasSuffix(name, "spec.yml") || strings.HasSuffix(name, "README.md") {
+		return true
+	}
+	return false
 }
 
+func NewFileExtensionSource(s *extensionService) *FileExtensionSource {
+	var fileExtensionSource FileExtensionSource
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		panic(err)
+	}
+	fileExtensionSource.watcher = watcher
+	fileExtensionSource.s = s
+	fileExtensionSource.AddrRWLock = map[string]*sync.RWMutex{}
+	return &fileExtensionSource
+}
 
+func NewGitExtensionSource(cfg *config, f *FileExtensionSource) *GitExtensionSource {
+	var gitExtensionSource GitExtensionSource
+	gitExtensionSource.Cfg = cfg
+	gitExtensionSource.f = f
+	return &gitExtensionSource
+}
 
-var extensionSources []ExtensionSource
+var extensionSources []Source
+var once sync.Once
 
-func RegisterExtensionSource(source ExtensionSource)  {
+func RegisterExtensionSource(source Source) {
 	extensionSources = append(extensionSources, source)
+}
+
+func StartSyncExtensionSource() {
+	once.Do(func() {
+		for _, source := range extensionSources {
+			source.start()
+		}
+	})
 }
 
 func AddSyncExtension(addr string) error {
@@ -132,6 +433,3 @@ func RemoveSyncExtension(addr string) error {
 	}
 	return nil
 }
-
-
-

--- a/modules/dicehub/extension/source_test.go
+++ b/modules/dicehub/extension/source_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extension
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/alecthomas/assert"
+)
+
+func TestAddSyncExtension(t *testing.T) {
+	var s = &extensionService{}
+	file := NewFileExtensionSource(s)
+	RegisterExtensionSource(file)
+
+	patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(s), "InitExtension", func(s *extensionService, addr string, forceUpdate bool) error {
+		return fmt.Errorf("test")
+	})
+	defer patch1.Unpatch()
+
+	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	assert.NoError(t, err)
+
+	err = AddSyncExtension(dir)
+	assert.Error(t, err)
+}
+
+func TestFileExtensionSource_add(t *testing.T) {
+
+	var s = &extensionService{}
+	file := NewFileExtensionSource(s)
+
+	patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(s), "InitExtension", func(s *extensionService, addr string, forceUpdate bool) error {
+		return nil
+	})
+	defer patch1.Unpatch()
+
+	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	assert.NoError(t, err)
+
+	err = file.add(dir)
+	assert.NoError(t, err)
+}
+
+func Test_isDir(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	assert.NoError(t, err)
+	got := isDir(dir)
+	assert.True(t, got)
+
+	file, err := ioutil.TempFile(os.TempDir(), "*")
+	assert.NoError(t, err)
+	got = isDir(file.Name())
+	assert.True(t, !got)
+}
+
+func TestGitExtensionSource_match(t *testing.T) {
+	type args struct {
+		addr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "test_http",
+			args: args{
+				addr: "http://test.git",
+			},
+			want: true,
+		},
+		{
+			name: "test_https",
+			args: args{
+				addr: "http://test.git",
+			},
+			want: true,
+		},
+		{
+			name: "test_git",
+			args: args{
+				addr: "git@github.com:erda-project/erda.git",
+			},
+			want: true,
+		},
+		{
+			name: "test_file",
+			args: args{
+				addr: "/test/aaa",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitExtensionSource{}
+			if got := g.match(tt.args.addr); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of this PR

/kind feature


#### What this PR does / why we need it:
The update architecture of the extension source is upgraded, and the local source and github source are automatically updated without manual operation, and directly monitor file changes


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/all?id=264393&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdLCJhc3NpZ25lZUlEcyI6WyIxMDAwNTYwIl19&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Automatic update of dicehub extension source monitoring file changes       |
| 🇨🇳 中文    |        dicehub extension 源监听文件变更自动更新      |

