### PR TITLE
check data version when accept from executor done chan

### DIFF
--- a/modules/pipeline/pipengine/reconciler/taskrun/taskrun.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskrun.go
@@ -53,7 +53,7 @@ type TaskRun struct {
 	PExitCh        <-chan struct{}
 	PExitChCancel  context.CancelFunc
 	PExit          bool
-	ExecutorDoneCh chan interface{}
+	ExecutorDoneCh chan spec.ExecutorDoneChanData
 
 	// 轮训状态间隔期间可能任务已经是终态，FakeTimeout = true
 	FakeTimeout bool
@@ -72,7 +72,7 @@ func New(ctx context.Context, task *spec.PipelineTask,
 	extMarketSvc *extmarketsvc.ExtMarketSvc,
 ) *TaskRun {
 	// make executor has buffer, don't block task framework
-	executorCh := make(chan interface{}, 1)
+	executorCh := make(chan spec.ExecutorDoneChanData, 1)
 	return &TaskRun{
 		Ctx:       context.WithValue(ctx, spec.MakeTaskExecutorCtxKey(task), executorCh),
 		Task:      task,

--- a/modules/pipeline/spec/pipeline_task_test.go
+++ b/modules/pipeline/spec/pipeline_task_test.go
@@ -168,3 +168,26 @@ func TestConvertErrors(t *testing.T) {
 	taskDto := task.Convert2DTO()
 	assert.Equal(t, fmt.Sprintf("err\nstartTime: %s\nendTime: %s\ncount: %d", start.Format("2006-01-02 15:04:05"), end.Format("2006-01-02 15:04:05"), 2), taskDto.Result.Errors[0].Msg)
 }
+
+func TestGenerateExecutorVersion(t *testing.T) {
+	normalTask := PipelineTask{ID: 1, Extra: PipelineTaskExtra{}}
+	loopTask := PipelineTask{ID: 1, Extra: PipelineTaskExtra{
+		LoopOptions: &apistructs.PipelineTaskLoopOptions{
+			LoopedTimes: 100,
+		},
+	}}
+	assert.Equal(t, normalTask.GenerateExecutorDoneChanDataVersion(), "executor-done-chan-data-version-1")
+	assert.Equal(t, loopTask.GenerateExecutorDoneChanDataVersion(), "executor-done-chan-data-version-1-loop-100")
+}
+
+func TestCheckExecutorVersion(t *testing.T) {
+	loopTask := PipelineTask{ID: 1, Extra: PipelineTaskExtra{
+		LoopOptions: &apistructs.PipelineTaskLoopOptions{
+			LoopedTimes: 100,
+		},
+	}}
+	actualVersion := "executor-done-chan-data-version-1-loop-100"
+	errVersion := "executor-done-chan-data-version-1-loop-99"
+	assert.Equal(t, loopTask.CheckExecutorDoneChanDataVersion(actualVersion), nil)
+	assert.Equal(t, loopTask.CheckExecutorDoneChanDataVersion(errVersion).Error(), "executor data expected version: executor-done-chan-data-version-1-loop-100, actual version: executor-done-chan-data-version-1-loop-99")
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
check data version when accept from executor done chan

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=264469&issueFilter__urlQuery=eyJzdGF0ZUJlbG9uZ3MiOlsiT1BFTiIsIldPUktJTkciLCJXT05URklYIiwiUkVPUEVOIl0sInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDEyMDUiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjF9&issueViewGroup__urlQuery=eyJ2YWx1ZSI6ImthbmJhbiIsImNoaWxkcmVuVmFsdWUiOnsia2FuYmFuIjoiZGVhZGxpbmUifX0%3D&iterationID=680&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that get outputs error from pre-task （修复了无法从前面loop类型的task获取出参）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that get outputs error from pre-task            |
| 🇨🇳 中文    |  修复了无法从前面loop类型的task获取出参            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
