### PR TITLE
streaming log consumer default to earliest

### DIFF
--- a/conf/monitor/streaming/streaming.yaml
+++ b/conf/monitor/streaming/streaming.yaml
@@ -129,7 +129,7 @@ log-persist-v1:
     group: "${LOG_GROUP_ID:spot-monitor-log-dev}"
     parallelism: ${LOG_CONSUMERS:3}
     options:
-      auto.offset.reset: "${KAFKA_AUTO_OFFSET_RESET:latest}"
+      auto.offset.reset: "${KAFKA_AUTO_OFFSET_RESET:earliest}"
       auto.commit.interval.ms: "${KAFKA_AUTO_COMMIT_INTERVAL_MS:1000}"
       queued.max.messages.kbytes: ${LOGS_STORE_INPUT_CONSUMER_QUEUE_SIZE_KB:102400} # 300MB = 100MB * parallelism
   output:

--- a/conf/monitor/streaming/streaming.yaml
+++ b/conf/monitor/streaming/streaming.yaml
@@ -106,6 +106,8 @@ log-persist:
   input:
     topics: "${LOG_TOPICS:spot-container-log,spot-job-log}"
     group: "${LOG_GROUP_ID:erda-logs-dev}"
+    options:
+      auto.offset.reset: "${LOG_PERSIST_INPUT_KAFKA_AUTO_OFFSET_RESET:earliest}"
   id_keys: "${LOG_ID_KEYS:TERMINUS_DEFINE_TAG,terminus_define_tag,MESOS_TASK_ID,mesos_task_id}"
   read_timeout: "5s"
   buffer_size: ${LOG_BATCH_SIZE:200}

--- a/conf/monitor/streaming/streaming.yaml
+++ b/conf/monitor/streaming/streaming.yaml
@@ -108,6 +108,7 @@ log-persist:
     group: "${LOG_GROUP_ID:erda-logs-dev}"
     options:
       auto.offset.reset: "${LOG_PERSIST_INPUT_KAFKA_AUTO_OFFSET_RESET:earliest}"
+      queued.max.messages.kbytes: ${LOG_PERSIST_INPUT_KAFKA_QUEUE_SIZE_KB:102400}
   id_keys: "${LOG_ID_KEYS:TERMINUS_DEFINE_TAG,terminus_define_tag,MESOS_TASK_ID,mesos_task_id}"
   read_timeout: "5s"
   buffer_size: ${LOG_BATCH_SIZE:200}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix


#### What this PR does / why we need it:
- fix log missing when new erda deployed 
[(SO)](https://stackoverflow.com/questions/32390265/what-determines-kafka-consumer-offset)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODEsNjgwLDc3Ml0sIm1lbWJlciI6WyIxMDAwMzAxIl0sImxhYmVsIjpbMTQ1NV19&id=210672&iterationID=881&pId=0&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
