### PR TITLE
If it is a MAC system, skip the global configuration internationalizttion information

### DIFF
--- a/pkg/i18n/helper.go
+++ b/pkg/i18n/helper.go
@@ -17,6 +17,7 @@ package i18n
 import (
 	"context"
 	"net/http"
+	"runtime"
 
 	"github.com/erda-project/erda/pkg/goroutine_context"
 )
@@ -41,6 +42,11 @@ func GetLocaleNameByRequest(request *http.Request) string {
 }
 
 func GetGoroutineBindLang() string {
+	// mac system use goroutine_context.GetContext() will panic
+	if runtime.GOOS == "darwin" {
+		return ""
+	}
+
 	globalContext := goroutine_context.GetContext()
 	if globalContext == nil {
 		return ""
@@ -58,6 +64,11 @@ func GetGoroutineBindLang() string {
 }
 
 func SetGoroutineBindLang(localeName string) {
+	// mac system use goroutine_context.GetContext() will panic
+	if runtime.GOOS == "darwin" {
+		return
+	}
+
 	ctx := goroutine_context.GetContext()
 	if ctx == nil {
 		ctx = context.Background()


### PR DESCRIPTION
#### What type of this PR

/kind bugfix


#### What this PR does / why we need it:
The MAC system does not support obtaining the current collaboration process, which will lead to panic


#### Which issue(s) this PR fixes:
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls3NzJdLCJtZW1iZXIiOlsiMTAwMDU2MCJdfQ%3D%3D&id=266876&iterationID=772&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      The i18n global setting header no longer supports the mac system, because the underlying library for getting the coroutine does not support        |
| 🇨🇳 中文    |       i18n 全局设置 header 忽略 Mac 系统，因为底层获取协程的库不支持       |

