### PR TITLE
Syntax ${{ outputs.xxx.xxx.wrap_double_quotes }}, add double quotes to the replaced value of the outputs placeholder

### DIFF
--- a/pkg/parser/pipelineyml/visitor_ref_op.go
+++ b/pkg/parser/pipelineyml/visitor_ref_op.go
@@ -29,7 +29,9 @@ import (
 const (
 	RefOpOutput = "OUTPUT"
 
-	RefOpExEscape = "escape"
+	RefOpExEscape           = "escape"
+	RefOpExWrapDoubleQuotes = "wrap_single_quotes"
+	RefOpExWrapSingleQuotes = "wrap_double_quotes"
 )
 
 // RefOp split from ${alias:OPERATION:key}
@@ -392,6 +394,10 @@ func (v *RefOpVisitor) handleRefEx(output string, refOp RefOp) string {
 	switch refOp.Ex {
 	case RefOpExEscape:
 		return expression.Quote(output)
+	case RefOpExWrapDoubleQuotes:
+		return fmt.Sprintf(`"%v"`, output)
+	case RefOpExWrapSingleQuotes:
+		return fmt.Sprintf(`'%v'`, output)
 	default:
 		// do nothing
 		return output


### PR DESCRIPTION
#### What type of this PR

/kind feature

#### What this PR does / why we need it:

```yaml
# before yaml
name: ${{ outputs.xxx.name }}
# ${{ outputs.xxx.name }} = #1
```

```yaml
# replace after
name:  #1
# error  yaml
```

```yaml
# before yaml
name: ${{ outputs.xxx.name.wrap_double_quotes }}
# ${{ outputs.xxx.name }} = #1
```

```yaml
# replace after
name:  "#1"
# good  yaml
```


Because yml file performs template replacement, some replacement strings have # prefix, which will cause problems in the entire yml file

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODEsNzcyXSwibWVtYmVyIjpbIjEwMDA1NjAiXX0%3D&id=265771&iterationID=772&pId=0&type=BUG)



#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Syntax ${{ outputs.xxx.xxx.wrap_double_quotes }}, add double quotes to the replaced value of the outputs placeholder     |
| 🇨🇳 中文    |      语法 ${{ outputs.xxx.xxx.wrap_double_quotes }}，给 outputs 占位符替换后的值增加双引号        |


