### PR TITLE
cron compensate generate new map when create pipeline

### DIFF
--- a/modules/pipeline/spec/pipeline_cron.go
+++ b/modules/pipeline/spec/pipeline_cron.go
@@ -148,3 +148,28 @@ func (pc *PipelineCron) GetOrgID() uint64 {
 	orgID, _ := strconv.ParseUint(orgIDStr, 10, 64)
 	return orgID
 }
+
+func (pc *PipelineCron) GenCompensateCreatePipelineReqNormalLabels(triggerTime time.Time) map[string]string {
+	normalLabels := make(map[string]string)
+	for k, v := range pc.Extra.NormalLabels {
+		normalLabels[k] = v
+	}
+	normalLabels[apistructs.LabelPipelineTriggerMode] = apistructs.PipelineTriggerModeCron.String()
+	normalLabels[apistructs.LabelPipelineType] = apistructs.PipelineTypeNormal.String()
+	normalLabels[apistructs.LabelPipelineYmlSource] = apistructs.PipelineYmlSourceContent.String()
+	normalLabels[apistructs.LabelPipelineCronTriggerTime] = strconv.FormatInt(triggerTime.UnixNano(), 10)
+	normalLabels[apistructs.LabelPipelineCronID] = strconv.FormatUint(pc.ID, 10)
+	return normalLabels
+}
+
+func (pc *PipelineCron) GenCompensateCreatePipelineReqFilterLabels() map[string]string {
+	filterLabels := make(map[string]string)
+	for k, v := range pc.Extra.FilterLabels {
+		filterLabels[k] = v
+	}
+	if _, ok := filterLabels[apistructs.LabelPipelineTriggerMode]; ok {
+		filterLabels[apistructs.LabelPipelineTriggerMode] = apistructs.PipelineTriggerModeCron.String()
+	}
+	filterLabels[apistructs.LabelPipelineCronCompensated] = "true"
+	return filterLabels
+}

--- a/modules/pipeline/spec/pipeline_cron_test.go
+++ b/modules/pipeline/spec/pipeline_cron_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestGenCompensateCreatePipelineReqNormalLabels(t *testing.T) {
+	pc := PipelineCron{ID: 1, Extra: PipelineCronExtra{
+		NormalLabels: map[string]string{
+			"org":                               "erda",
+			apistructs.LabelPipelineTriggerMode: "dice",
+		},
+	}}
+	now := time.Now()
+	normalLabels := pc.GenCompensateCreatePipelineReqNormalLabels(now)
+	assert.Equal(t, "erda", normalLabels["org"])
+	assert.Equal(t, apistructs.PipelineTriggerModeCron.String(), normalLabels[apistructs.LabelPipelineTriggerMode])
+	assert.Equal(t, strconv.FormatInt(now.UnixNano(), 10), normalLabels[apistructs.LabelPipelineCronTriggerTime])
+}
+
+func TestGenCompensateCreatePipelineReqFilterLabels(t *testing.T) {
+	pc := PipelineCron{ID: 1, Extra: PipelineCronExtra{
+		FilterLabels: map[string]string{
+			"org":                               "erda",
+			apistructs.LabelPipelineTriggerMode: "dice",
+		},
+	}}
+	filterLabels := pc.GenCompensateCreatePipelineReqFilterLabels()
+	assert.Equal(t, "true", filterLabels[apistructs.LabelPipelineCronCompensated])
+	assert.Equal(t, apistructs.PipelineTriggerModeCron.String(), filterLabels[apistructs.LabelPipelineTriggerMode])
+}


### PR DESCRIPTION
#### What type of this PR

Add one of the following kinds:
/kind bugfix

#### What this PR does / why we need it:
cron compensate generate new map when create pipeline to avoid concurrent map problem

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls3NzIsNjgwLDg4MV0sIm1lbWJlciI6WyIxMDAxMjA1Il19&id=267763&iterationID=772&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： cron compensate generate new map when create pipeline to avoid concurrent map problem（修复了pipeline定时补偿时并发读写map panic的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  cron compensate generate new map when create pipeline to avoid concurrent map problem            |
| 🇨🇳 中文    |  修复了pipeline定时补偿时并发读写map panic的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
