### PR TITLE
Bug fix: netdatavolume can not 

### DIFF
--- a/modules/volume-provisioner/netdatavolume/provision.go
+++ b/modules/volume-provisioner/netdatavolume/provision.go
@@ -17,7 +17,7 @@ package netdatavolume
 import (
 	"context"
 	"fmt"
-	"os"
+	"os/exec"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -54,7 +54,8 @@ func (p *netDataVolumeProvisioner) Provision(ctx context.Context, options contro
 	if err != nil {
 		return nil, controller.ProvisioningFinished, err
 	}
-	if err := os.MkdirAll(volPath, 0666); err != nil {
+	mkdirCommand := exec.Command("/bin/sh", "-c", fmt.Sprintf("mkdir -p %s", volPath))
+	if _, err := mkdirCommand.Output(); err != nil {
 		return nil, controller.ProvisioningFinished, fmt.Errorf("Failed to mkdir: %v, err: %v", volPath, err)
 	}
 	return &v1.PersistentVolume{


### PR DESCRIPTION
#### What type of this PR

/kind bugfix



#### What this PR does / why we need it:

netdata volume use os.MkdirAll(volPath, 0666) to create directory, if system use umask 022, then created directory volPath with mode 0644, which disabled non-root user write file to directory volPath.




#### Specified Reviewers:

/assign @iutx @luobily 



| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
