### PR TITLE
Add a new reference execution strategy to the automated test reference scenario set

### DIFF
--- a/apistructs/pipeline_yml.go
+++ b/apistructs/pipeline_yml.go
@@ -124,6 +124,7 @@ type PolicyType string
 const (
 	NewRunPolicyType                 PolicyType = "new-run"
 	TryLatestSuccessResultPolicyType PolicyType = "try-latest-success-result"
+	TryLatestResultPolicyType        PolicyType = "try-latest-result"
 )
 
 func (p PolicyType) GetZhName() string {
@@ -131,6 +132,8 @@ func (p PolicyType) GetZhName() string {
 	case NewRunPolicyType:
 		return "重新执行并引用执行结果"
 	case TryLatestSuccessResultPolicyType:
+		return "最近一次执行成功的结果"
+	case TryLatestResultPolicyType:
 		return "最近一次执行的结果"
 	default:
 		return ""
@@ -142,7 +145,7 @@ func (p PolicyType) ToString() string {
 }
 
 func (p PolicyType) IsValid() bool {
-	return p == "" || p == NewRunPolicyType || p == TryLatestSuccessResultPolicyType
+	return p == "" || p == NewRunPolicyType || p == TryLatestSuccessResultPolicyType || p == TryLatestResultPolicyType
 }
 
 type Policy struct {

--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileFormModal/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileFormModal/render.go
@@ -163,6 +163,10 @@ func (a *ComponentFileFormModal) initSceneSetFields(inParams fileTree.InParams) 
 							apistructs.TryLatestSuccessResultPolicyType.GetZhName(),
 							apistructs.TryLatestSuccessResultPolicyType,
 						},
+						PolicyOption{
+							apistructs.TryLatestResultPolicyType.GetZhName(),
+							apistructs.TryLatestResultPolicyType,
+						},
 					},
 				},
 			},
@@ -404,6 +408,10 @@ func (a *ComponentFileFormModal) GetScene(inParams fileTree.InParams) error {
 						PolicyOption{
 							apistructs.TryLatestSuccessResultPolicyType.GetZhName(),
 							apistructs.TryLatestSuccessResultPolicyType,
+						},
+						PolicyOption{
+							apistructs.TryLatestResultPolicyType.GetZhName(),
+							apistructs.TryLatestResultPolicyType,
 						},
 					},
 				},

--- a/modules/pipeline/aop/plugins/pipeline/apitest_report/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/apitest_report/plugin.go
@@ -99,7 +99,7 @@ func (p *provider) Handle(ctx *aoptypes.TuneContext) error {
 
 		if task.Type == apistructs.ActionTypeSnippet {
 			if task.SnippetPipelineID != nil &&
-				task.Extra.CurrentPolicy.Type != apistructs.TryLatestSuccessResultPolicyType {
+				task.Extra.CurrentPolicy.Type != apistructs.TryLatestSuccessResultPolicyType && task.Extra.CurrentPolicy.Type != apistructs.TryLatestResultPolicyType {
 				snippetTaskPipelineIDs = append(snippetTaskPipelineIDs, *task.SnippetPipelineID)
 			}
 			continue


### PR DESCRIPTION
#### What type of this PR

/kind feature


#### What this PR does / why we need it:
A new execution strategy is added to the automated test scenario reference scenario set to reference the results of the last successful execution

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls3NzJdLCJtZW1iZXIiOlsiMTAwMDU2MCJdfQ%3D%3D&id=258470&iterationID=772&pId=0&type=REQUIREMENT)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Pipeline tasks add strategies that reference the results of recent successful execution        |
| 🇨🇳 中文    |        流水线任务增加引用`最近执行成功的结果`的策略      |


