### PR TITLE
fix: Arm64 ignore getting goid

### DIFF
--- a/pkg/goroutine_context/context.go
+++ b/pkg/goroutine_context/context.go
@@ -16,6 +16,7 @@ package goroutine_context
 
 import (
 	"context"
+	"runtime"
 	"sync"
 
 	"github.com/go-eden/routine"
@@ -24,6 +25,8 @@ import (
 const LocaleNameContextKey = "locale_name_context_key"
 
 const bucketsSize = 128
+
+const arm64 = "arm64"
 
 type (
 	contextBucket struct {
@@ -47,6 +50,11 @@ func init() {
 
 // GetContext .
 func GetContext() context.Context {
+	// mac system use goroutine_context.GetContext() will panic
+	if runtime.GOARCH == arm64 {
+		return context.Background()
+	}
+
 	goid := routine.Goid()
 	idx := goid % bucketsSize
 	bucket := goroutineContext.buckets[idx]
@@ -58,6 +66,11 @@ func GetContext() context.Context {
 
 // SetContext .
 func SetContext(ctx context.Context) {
+	// mac system use goroutine_context.GetContext() will panic
+	if runtime.GOARCH == arm64 {
+		return
+	}
+
 	goid := routine.Goid()
 	idx := goid % bucketsSize
 	bucket := goroutineContext.buckets[idx]
@@ -68,6 +81,11 @@ func SetContext(ctx context.Context) {
 
 // ClearContext .
 func ClearContext() {
+	// mac system use goroutine_context.GetContext() will panic
+	if runtime.GOARCH == arm64 {
+		return
+	}
+
 	goid := routine.Goid()
 	idx := goid % bucketsSize
 	bucket := goroutineContext.buckets[idx]

--- a/pkg/i18n/helper.go
+++ b/pkg/i18n/helper.go
@@ -17,7 +17,6 @@ package i18n
 import (
 	"context"
 	"net/http"
-	"runtime"
 
 	"github.com/erda-project/erda/pkg/goroutine_context"
 )
@@ -42,11 +41,6 @@ func GetLocaleNameByRequest(request *http.Request) string {
 }
 
 func GetGoroutineBindLang() string {
-	// mac system use goroutine_context.GetContext() will panic
-	if runtime.GOOS == "darwin" {
-		return ""
-	}
-
 	globalContext := goroutine_context.GetContext()
 	if globalContext == nil {
 		return ""
@@ -64,11 +58,6 @@ func GetGoroutineBindLang() string {
 }
 
 func SetGoroutineBindLang(localeName string) {
-	// mac system use goroutine_context.GetContext() will panic
-	if runtime.GOOS == "darwin" {
-		return
-	}
-
 	ctx := goroutine_context.GetContext()
 	if ctx == nil {
 		ctx = context.Background()


### PR DESCRIPTION
#### What this PR does / why we need it:
Goroutine binds some global context and needs to ignore the arm64 system. The arm64 system uses some open source packages to bind the PA


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The arm64 system ignores the bound global context       |
| 🇨🇳 中文    |       arm64 系统忽略绑定全局的 context       |

