### PR TITLE
chore: check chinese & english changelog before pr merged

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,0 +1,12 @@
+{
+  "body": [
+    {
+      "pattern": "|.*中文.*|.*[^\\s]*.*|",
+      "message": "You need fulfil chinese changelog"
+    },
+    {
+      "pattern": "|.*English.*|.*[^\\s]*.*|",
+      "message": "You need fulfil english changelog"
+    }
+  ]
+}

--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,11 +1,11 @@
 {
   "body": [
     {
-      "pattern": "|.*中文.*|.*[^\\s]*.*|",
+      "pattern": "\\|[^\\|]*中文[^\\|]*\\|[^\\|]*[^\\|\\s]+[^\\|]*\\|",
       "message": "You need fulfil chinese changelog"
     },
     {
-      "pattern": "|.*English.*|.*[^\\s]*.*|",
+      "pattern": "\\|[^\\|]*English[^\\|]*\\|[^\\|]*[^\\|\\s]+[^\\|]*\\|",
       "message": "You need fulfil english changelog"
     }
   ]


### PR DESCRIPTION
#### What this PR does / why we need it:
check chinese & english changelog before pr merged

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     check chinese & english changelog before pr merged as required         |
| 🇨🇳 中文    |   增加 prlint.json 强制要求 pr 必须提供 changelog           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
