### PR TITLE
fix: deployment outdate when runtime is deleted

### DIFF
--- a/modules/orchestrator/services/runtime/runtime.go
+++ b/modules/orchestrator/services/runtime/runtime.go
@@ -1112,6 +1112,7 @@ func (r *Runtime) Delete(operator user.ID, orgID uint64, runtimeID uint64) (*api
 	if err := r.db.UpdateRuntime(runtime); err != nil {
 		return nil, apierrors.ErrDeleteRuntime.InternalError(err)
 	}
+
 	event := events.RuntimeEvent{
 		EventName: events.RuntimeDeleting,
 		Runtime:   dbclient.ConvertRuntimeDTO(runtime, app),
@@ -1856,7 +1857,7 @@ func (r *Runtime) ReferCluster(clusterName string) bool {
 
 // MarkOutdatedForDelete 将删除的应用实例，他们的所有部署单，标记为废弃
 func (r *Runtime) MarkOutdatedForDelete(runtimeID uint64) {
-	deployments, err := r.db.FindNotOutdatedOlderThan(runtimeID, math.MaxUint64)
+	deployments, err := r.db.FindNotOutdatedOlderThan(runtimeID, math.MaxUint32)
 	if err != nil {
 		logrus.Errorf("[alert] failed to query all not outdated deployment before delete runtime: %v, (%v)",
 			runtimeID, err)


### PR DESCRIPTION
#### What this PR does / why we need it:

fix deployment outdate when runtime is deleted

#### Which issue(s) this PR fixes:



#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |         fix deployment outdate when runtime is deleted     |
| 🇨🇳 中文    |         删除runtime同时将runtime关联的deployment过期掉    |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
