### PR TITLE
fix: create customize alert return id is 0

### DIFF
--- a/modules/core/monitor/alert/alert-apis/adapt/alert.go
+++ b/modules/core/monitor/alert/alert-apis/adapt/alert.go
@@ -415,12 +415,6 @@ func (a *Adapt) getEnabledAlertRulesByScopeAndIndices(lang i18n.LanguageCodes, s
 	if len(indices) == 0 {
 		return nil, nil
 	}
-
-	//rules, err := a.db.AlertRule.QueryEnabledByScopeAndIndices(scope, indices)
-	//if err != nil {
-	//	return nil, err
-	//}
-
 	rules := make([]*db.AlertRule, 0)
 	for _, v := range indices {
 		rule, ok := expression.ExpressionIndex[v]

--- a/modules/core/monitor/alert/alert-apis/adapt/alert.go
+++ b/modules/core/monitor/alert/alert-apis/adapt/alert.go
@@ -423,17 +423,19 @@ func (a *Adapt) getEnabledAlertRulesByScopeAndIndices(lang i18n.LanguageCodes, s
 
 	rules := make([]*db.AlertRule, 0)
 	for _, v := range indices {
-		rule := expression.ExpressionIndex[v]
-		expressionConfig := expression.AlertConfig[v]
-		alertRule := &db.AlertRule{
-			Name:       expressionConfig.Name,
-			AlertScope: expressionConfig.AlertScope,
-			AlertIndex: expressionConfig.Id,
-			Template:   rule.Expression,
-			Attributes: expressionConfig.Attributes,
-			AlertType:  expressionConfig.AlertType,
+		rule, ok := expression.ExpressionIndex[v]
+		if ok {
+			expressionConfig := expression.AlertConfig[v]
+			alertRule := &db.AlertRule{
+				Name:       expressionConfig.Name,
+				AlertScope: expressionConfig.AlertScope,
+				AlertIndex: expressionConfig.Id,
+				Template:   rule.Expression,
+				Attributes: expressionConfig.Attributes,
+				AlertType:  expressionConfig.AlertType,
+			}
+			rules = append(rules, alertRule)
 		}
-		rules = append(rules, alertRule)
 	}
 
 	customizeRules, err := a.db.CustomizeAlertRule.QueryEnabledByScopeAndIndices(scope, scopeID, indices)


### PR DESCRIPTION
#### What this PR does / why we need it:
fix the bug ofcreate customize alert return id is 0

#### Which issue(s) this PR fixes:271065

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      fix the bug ofcreate customize alert return id is 0        |
| 🇨🇳 中文    |       使用自定义告警规则创建告警策略id返回0       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.6` when this PR is merged.