### PR TITLE
fix: Pipline loop declineratio and declinelimitsec default settings modified

### DIFF
--- a/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
+++ b/modules/pipeline/pipengine/reconciler/taskrun/taskop/prepare.go
@@ -726,15 +726,27 @@ func getLoopOptions(actionSpec apistructs.ActionSpec, taskLoop *apistructs.Pipel
 		// 默认策略
 		opt.CalculatedLoop.Strategy = &apistructs.PipelineTaskDefaultLoopStrategy
 	}
+
 	if opt.CalculatedLoop.Strategy.IntervalSec == 0 {
 		opt.CalculatedLoop.Strategy.IntervalSec = apistructs.PipelineTaskDefaultLoopStrategy.IntervalSec
 	}
+
 	if opt.CalculatedLoop.Strategy.DeclineRatio <= 0 {
-		opt.CalculatedLoop.Strategy.DeclineRatio = apistructs.PipelineTaskDefaultLoopStrategy.DeclineRatio
+		if opt.CalculatedLoop.Strategy.IntervalSec == 0 {
+			opt.CalculatedLoop.Strategy.DeclineRatio = apistructs.PipelineTaskDefaultLoopStrategy.DeclineRatio
+		} else {
+			opt.CalculatedLoop.Strategy.DeclineRatio = 1
+		}
 	}
+
 	if opt.CalculatedLoop.Strategy.DeclineLimitSec == 0 {
-		opt.CalculatedLoop.Strategy.DeclineLimitSec = apistructs.PipelineTaskDefaultLoopStrategy.DeclineLimitSec
+		if opt.CalculatedLoop.Strategy.IntervalSec == 0 {
+			opt.CalculatedLoop.Strategy.DeclineLimitSec = apistructs.PipelineTaskDefaultLoopStrategy.DeclineLimitSec
+		} else {
+			opt.CalculatedLoop.Strategy.DeclineLimitSec = int64(opt.CalculatedLoop.Strategy.IntervalSec)
+		}
 	}
+
 	return &opt
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When the default value of the loop field declineratio declinelimitsec of the original pipeline is empty, the value set is wrong and does not meet the user's expectations


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls3NzJdLCJtZW1iZXIiOlsiMTAwMDU2MCJdfQ%3D%3D&id=270607&iterationID=772&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Pipline loop declineratio and declinelimitsec default settings modified        |
| 🇨🇳 中文    |      修改了 pipeline loop 的 declineratio和declinelimitsec默认设置        |

