### PR TITLE
feat: openapi support specify custom k8s svc addr from env

### DIFF
--- a/modules/openapi/proxy/director_test.go
+++ b/modules/openapi/proxy/director_test.go
@@ -26,4 +26,13 @@ func TestReplaceServiceName(t *testing.T) {
 	defer os.Unsetenv("ERDA_SYSTEM_FQDN")
 	result := replaceServiceName(os.Getenv("ERDA_SYSTEM_FQDN"), "openapi.default.svc.cluster.local")
 	assert.Equal(t, "openapi.erda-system.svc.cluster.local", result)
+
+	// only fdp custom namespace
+	result = replaceServiceName("project-865-dev.svc.cluster.local", "fdp")
+	assert.Equal(t, "fdp.project-865-dev.svc.cluster.local", result)
+}
+
+func Test_getServiceName(t *testing.T) {
+	assert.Equal(t, "fdp", getServiceName("fdp.project-865-dev.svc.cluster.local"))
+	assert.Equal(t, "fdp", getServiceName("fdp"))
 }

--- a/pkg/discover/address.go
+++ b/pkg/discover/address.go
@@ -44,6 +44,7 @@ const (
 	EnvECP            = "ECP_ADDR"
 	EnvClusterManager = "CLUSTER_MANAGER_ADDR"
 	EnvCoreServices   = "CORE_SERVICES_ADDR"
+	EnvFDPMaster      = "FDP_MASTER_ADDR"
 )
 
 // 定义各个服务的 k8s svc 名称
@@ -74,9 +75,10 @@ const (
 	SvcECP            = "ecp"
 	SvcClusterManager = "cluster-manager"
 	SvcCoreServices   = "core-services"
+	SvcFDPMaster      = "fdp-master"
 )
 
-var servicesEnvKeys = map[string]string{
+var ServicesEnvKeys = map[string]string{
 	SvcEventBox:       EnvEventBox,
 	SvcCMDB:           EnvCMDB,
 	SvcScheduler:      EnvScheduler,
@@ -103,11 +105,12 @@ var servicesEnvKeys = map[string]string{
 	SvcECP:            EnvECP,
 	SvcClusterManager: EnvClusterManager,
 	SvcCoreServices:   EnvCoreServices,
+	SvcFDPMaster:      EnvFDPMaster,
 }
 
 func Services() []string {
-	list := make([]string, 0, len(servicesEnvKeys))
-	for key := range servicesEnvKeys {
+	list := make([]string, 0, len(ServicesEnvKeys))
+	for key := range ServicesEnvKeys {
 		list = append(list, key)
 	}
 	sort.Strings(list)

--- a/pkg/discover/resolver.go
+++ b/pkg/discover/resolver.go
@@ -103,7 +103,7 @@ func resolveEndpoint(serviceName string) (endpoint string, err error) {
 }
 
 func GetEndpoint(serviceName string) (endpoint string, err error) {
-	if envKey, ok := servicesEnvKeys[serviceName]; ok {
+	if envKey, ok := ServicesEnvKeys[serviceName]; ok {
 		v := os.Getenv(envKey)
 		if v != "" {
 			return v, nil


### PR DESCRIPTION
#### What this PR does / why we need it:

openapi support specify custom k8s svc addr from env


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=257374&issueFilter__urlQuery=eyJ0aXRsZSI6Im9wZW5hcGkiLCJzdGF0ZXMiOls0NDA2LDQ0MDddfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=883&type=TASK)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | openapi support specify custom service addr from env           |
| 🇨🇳 中文    | OPENAPI 支持从环境变量中获取 k8s 服务的自定义地址            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
