### PR TITLE
fix: manual-test recognize member 'unassigned' as id

### DIFF
--- a/modules/dop/dao/testcase.go
+++ b/modules/dop/dao/testcase.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erda-project/erda/modules/dop/services/apierrors"
 	"github.com/erda-project/erda/pkg/database/dbengine"
 	"github.com/erda-project/erda/pkg/strutil"
+	"github.com/erda-project/erda/pkg/ucauth"
 )
 
 // TestCase 测试用例
@@ -426,4 +427,7 @@ func setDefaultForTestCasePagingRequest(req *apistructs.TestCasePagingRequest) {
 	if req.PageSize == 0 {
 		req.PageSize = 20
 	}
+
+	// set unassigned ids
+	req.UpdaterIDs = ucauth.PolishUnassignedAsEmptyStr(req.UpdaterIDs)
 }

--- a/modules/dop/dao/testplan.go
+++ b/modules/dop/dao/testplan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/database/dbengine"
 	"github.com/erda-project/erda/pkg/strutil"
+	"github.com/erda-project/erda/pkg/ucauth"
 )
 
 // TestPlan 测试计划
@@ -121,6 +122,10 @@ func (client *DBClient) PagingTestPlan(req apistructs.TestPlanPagingRequest) (ui
 		total     uint64
 		testPlans []TestPlan
 	)
+	// set unassigned ids
+	req.OwnerIDs = ucauth.PolishUnassignedAsEmptyStr(req.OwnerIDs)
+	req.PartnerIDs = ucauth.PolishUnassignedAsEmptyStr(req.PartnerIDs)
+	req.UserIDs = ucauth.PolishUnassignedAsEmptyStr(req.UserIDs)
 
 	var tpIDs []uint64
 	var tpIDsAssigned = false

--- a/modules/dop/dao/testplan_testcase_relation.go
+++ b/modules/dop/dao/testplan_testcase_relation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erda-project/erda/modules/dop/services/apierrors"
 	"github.com/erda-project/erda/pkg/database/dbengine"
 	"github.com/erda-project/erda/pkg/strutil"
+	"github.com/erda-project/erda/pkg/ucauth"
 )
 
 // TestPlanCaseRel
@@ -495,5 +496,17 @@ func setDefaultForTestPlanCaseRelPagingRequest(req *apistructs.TestPlanCaseRelPa
 	}
 	if req.PageSize == 0 {
 		req.PageSize = 20
+	}
+
+	// set unassigned ids
+	for i, executorID := range req.ExecutorIDs {
+		if ucauth.USERID(executorID).IsUnassigned() {
+			req.ExecutorIDs[i] = ""
+		}
+	}
+	for i, updaterID := range req.UpdaterIDs {
+		if ucauth.USERID(updaterID).IsUnassigned() {
+			req.UpdaterIDs[i] = ""
+		}
 	}
 }

--- a/modules/dop/dao/testplan_testcase_relation.go
+++ b/modules/dop/dao/testplan_testcase_relation.go
@@ -324,7 +324,7 @@ func (client *DBClient) PagingTestPlanCaseRelations(req apistructs.TestPlanCaseR
 	}
 	// updater
 	if len(req.UpdaterIDs) > 0 {
-		baseSQL = baseSQL.Where("`tc`.`updater_id` IN (?)", req.UpdaterIDs)
+		baseSQL = baseSQL.Where("`rel`.`updater_id` IN (?)", req.UpdaterIDs)
 	}
 	// updatedAtBegin (Left closed Section)
 	if req.TimestampSecUpdatedAtBegin != nil {

--- a/modules/dop/dao/testplan_testcase_relation.go
+++ b/modules/dop/dao/testplan_testcase_relation.go
@@ -499,14 +499,6 @@ func setDefaultForTestPlanCaseRelPagingRequest(req *apistructs.TestPlanCaseRelPa
 	}
 
 	// set unassigned ids
-	for i, executorID := range req.ExecutorIDs {
-		if ucauth.USERID(executorID).IsUnassigned() {
-			req.ExecutorIDs[i] = ""
-		}
-	}
-	for i, updaterID := range req.UpdaterIDs {
-		if ucauth.USERID(updaterID).IsUnassigned() {
-			req.UpdaterIDs[i] = ""
-		}
-	}
+	req.ExecutorIDs = ucauth.PolishUnassignedAsEmptyStr(req.ExecutorIDs)
+	req.UpdaterIDs = ucauth.PolishUnassignedAsEmptyStr(req.UpdaterIDs)
 }

--- a/modules/dop/endpoints/testcase.go
+++ b/modules/dop/endpoints/testcase.go
@@ -212,32 +212,6 @@ func (e *Endpoints) PagingTestCases(ctx context.Context, r *http.Request, vars m
 		return apierrors.ErrPagingTestCases.InvalidParameter(err).ToResp(), nil
 	}
 
-	// TODO: 操作鉴权
-
-	//判断UpdaterIDs在项目内是否有权限
-	if len(req.UpdaterIDs) > 0 {
-		members, _ := e.bdl.ListMembers(apistructs.MemberListRequest{
-			ScopeType: apistructs.ProjectScope,
-			ScopeID:   int64(req.ProjectID),
-			PageNo:    1,
-			PageSize:  300,
-		})
-		mapOfupdaterIDs := make(map[string]bool)
-		for _, updater := range req.UpdaterIDs {
-			mapOfupdaterIDs[updater] = false
-		}
-		for _, member := range members {
-			if _, ok := mapOfupdaterIDs[member.UserID]; ok {
-				mapOfupdaterIDs[member.UserID] = true
-			}
-		}
-		for _, value := range mapOfupdaterIDs {
-			if !value {
-				return nil, apierrors.ErrPagingTestCases.AccessDenied()
-			}
-		}
-	}
-
 	pagingResult, err := e.testcase.PagingTestCases(req)
 	if err != nil {
 		return errorresp.ErrResp(err)

--- a/pkg/ucauth/unassigned.go
+++ b/pkg/ucauth/unassigned.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucauth
+
+import (
+	"strings"
+)
+
+const (
+	UnassignedMemberID USERID = "unassigned"
+	emptyUserID        USERID = ""
+)
+
+func (u USERID) IsUnassigned() bool {
+	return strings.EqualFold(u.String(), UnassignedMemberID.String())
+}
+
+func PolishUnassignedAsEmptyStr(userIDs []string) (result []string) {
+	for _, userID := range userIDs {
+		polishedUserID := userID
+		if strings.EqualFold(userID, UnassignedMemberID.String()) {
+			polishedUserID = emptyUserID.String()
+		}
+		result = append(result, polishedUserID)
+	}
+	return result
+}

--- a/pkg/ucauth/unassigned.go
+++ b/pkg/ucauth/unassigned.go
@@ -30,7 +30,7 @@ func (u USERID) IsUnassigned() bool {
 func PolishUnassignedAsEmptyStr(userIDs []string) (result []string) {
 	for _, userID := range userIDs {
 		polishedUserID := userID
-		if strings.EqualFold(userID, UnassignedUserID.String()) {
+		if USERID(userID).IsUnassigned() {
 			polishedUserID = emptyUserID.String()
 		}
 		result = append(result, polishedUserID)

--- a/pkg/ucauth/unassigned.go
+++ b/pkg/ucauth/unassigned.go
@@ -19,18 +19,18 @@ import (
 )
 
 const (
-	UnassignedMemberID USERID = "unassigned"
-	emptyUserID        USERID = ""
+	UnassignedUserID USERID = "unassigned"
+	emptyUserID      USERID = ""
 )
 
 func (u USERID) IsUnassigned() bool {
-	return strings.EqualFold(u.String(), UnassignedMemberID.String())
+	return strings.EqualFold(u.String(), UnassignedUserID.String())
 }
 
 func PolishUnassignedAsEmptyStr(userIDs []string) (result []string) {
 	for _, userID := range userIDs {
 		polishedUserID := userID
-		if strings.EqualFold(userID, UnassignedMemberID.String()) {
+		if strings.EqualFold(userID, UnassignedUserID.String()) {
 			polishedUserID = emptyUserID.String()
 		}
 		result = append(result, polishedUserID)

--- a/pkg/ucauth/unassigned_test.go
+++ b/pkg/ucauth/unassigned_test.go
@@ -39,7 +39,7 @@ func TestPolishUnassignedAsEmptyStr(t *testing.T) {
 		{
 			name: "have unassigned",
 			args: args{
-				userIDs: []string{"1", UnassignedMemberID.String(), "2"},
+				userIDs: []string{"1", UnassignedUserID.String(), "2"},
 			},
 			wantResult: []string{"1", emptyUserID.String(), "2"},
 		},

--- a/pkg/ucauth/unassigned_test.go
+++ b/pkg/ucauth/unassigned_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolishUnassignedAsEmptyStr(t *testing.T) {
+	type args struct {
+		userIDs []string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantResult []string
+	}{
+		{
+			name: "no unassigned",
+			args: args{
+				userIDs: []string{"1", "2"},
+			},
+			wantResult: []string{"1", "2"},
+		},
+		{
+			name: "have unassigned",
+			args: args{
+				userIDs: []string{"1", UnassignedMemberID.String(), "2"},
+			},
+			wantResult: []string{"1", emptyUserID.String(), "2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.wantResult, PolishUnassignedAsEmptyStr(tt.args.userIDs), "PolishUnassignedAsEmptyStr(%v)", tt.args.userIDs)
+		})
+	}
+}

--- a/pkg/ucauth/unassigned_test.go
+++ b/pkg/ucauth/unassigned_test.go
@@ -43,6 +43,13 @@ func TestPolishUnassignedAsEmptyStr(t *testing.T) {
 			},
 			wantResult: []string{"1", emptyUserID.String(), "2"},
 		},
+		{
+			name: "non users",
+			args: args{
+				userIDs: []string{},
+			},
+			wantResult: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ucauth/user.go
+++ b/pkg/ucauth/user.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -31,7 +32,16 @@ import (
 	"github.com/erda-project/erda/pkg/http/httpclient"
 )
 
+const (
+	UnassignedMemberID USERID = "unassigned"
+)
+
 type USERID string
+
+func (u USERID) String() string { return string(u) }
+func (u USERID) IsUnassigned() bool {
+	return strings.EqualFold(u.String(), UnassignedMemberID.String())
+}
 
 // maybe int or string, unmarshal them to string(USERID)
 func (u *USERID) UnmarshalJSON(b []byte) error {

--- a/pkg/ucauth/user.go
+++ b/pkg/ucauth/user.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,16 +31,9 @@ import (
 	"github.com/erda-project/erda/pkg/http/httpclient"
 )
 
-const (
-	UnassignedMemberID USERID = "unassigned"
-)
-
 type USERID string
 
 func (u USERID) String() string { return string(u) }
-func (u USERID) IsUnassigned() bool {
-	return strings.EqualFold(u.String(), UnassignedMemberID.String())
-}
 
 // maybe int or string, unmarshal them to string(USERID)
 func (u *USERID) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: manual-test recognize member 'unassigned' as id


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=269348&issueFilter__urlQuery=eyJ0aXRsZSI6IuacquaMh%2BWumiIsInN0YXRlcyI6WzQ0MTIsNDUzOCw0NDEzLDQ0MTQsNDQxNSw0NDE2XX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fixed an bug that manual-test could not filter out "unspecified" users          |
| 🇨🇳 中文    |   修复了手动测试无法过滤出"未指定"用户的问题           |

