### PR TITLE
fix: agent support limit cache tar file size

### DIFF
--- a/modules/actionagent/define.go
+++ b/modules/actionagent/define.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"sync"
 
+	"github.com/c2h5oh/datasize"
+
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/actionagent/filewatch"
 	"github.com/erda-project/erda/modules/pipeline/spec"
@@ -53,8 +55,8 @@ type Agent struct {
 	Cancel   context.CancelFunc // cancel when logic done
 	ExitCode int
 
-	StdErrRegexpList        []*regexp.Regexp
-	MaxWaitingPathUnlockSec int
+	StdErrRegexpList   []*regexp.Regexp
+	MaxCacheFileSizeMB datasize.ByteSize
 
 	TextBlackList []string // enciphered data will Replaced by '******' when log output
 }

--- a/modules/actionagent/step_sore_test.go
+++ b/modules/actionagent/step_sore_test.go
@@ -19,7 +19,11 @@ import (
 	"os"
 	"testing"
 
+	"bou.ke/monkey"
+	"github.com/c2h5oh/datasize"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/modules/actionagent/agenttool"
 )
 
 func TestStoreAndRestore(t *testing.T) {
@@ -28,11 +32,23 @@ func TestStoreAndRestore(t *testing.T) {
 	tmpDir, err := ioutil.TempDir(tmpCacheDir, tmpCachePrefix)
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
-	agent := Agent{}
+	agent := Agent{MaxCacheFileSizeMB: 1 * datasize.MB}
 	tarFile := "/tmp/abc.tar"
 	err = agent.storeCache(tarFile, tmpDir)
 	assert.NoError(t, err)
 	err = agent.restoreCache(tarFile, tmpDir)
 	assert.NoError(t, err)
 	defer os.Remove(tarFile)
+}
+
+func Test_isCachePathExceedLimit(t *testing.T) {
+	pm1 := monkey.Patch(agenttool.GetDiskSize, func(path string) (datasize.ByteSize, error) {
+		return 1048577 * datasize.B, nil
+	})
+	defer pm1.Unpatch()
+
+	a := Agent{MaxCacheFileSizeMB: 1 * datasize.MB}
+	size, isExceed := a.isCachePathExceedLimit("./erda")
+	assert.Equal(t, true, isExceed)
+	assert.Equal(t, uint64(1048577), size.Bytes())
 }

--- a/modules/actionagent/step_store.go
+++ b/modules/actionagent/step_store.go
@@ -15,6 +15,7 @@
 package actionagent
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,10 @@ func (agent *Agent) store() {
 }
 
 func (agent *Agent) storeCache(tarFile, cachePath string) (err error) {
+	if cachePathSize, isExceed := agent.isCachePathExceedLimit(cachePath); isExceed {
+		return fmt.Errorf("tar path: %s size: %d bytes exceed limit size: %d bytes", cachePath, cachePathSize.Bytes(),
+			agent.MaxCacheFileSizeMB.Bytes())
+	}
 	tmpFile, err := ioutil.TempFile(cacheTempDir, cacheTempPrefix)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What this PR does / why we need it:
agent support limit cache file size

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls3NzIsNjgwLDg4MSw4ODMsNDY3XSwibWVtYmVyIjpbIjEwMDEyMDUiXX0%3D&id=274465&iterationID=772&pId=0&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： agent limit cache file size（pipeline cache大小限制）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   agent limit cache file size           |
| 🇨🇳 中文    |  pipeline cache大小限制            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
