### PR TITLE
fix: i18n of test report

### DIFF
--- a/conf/dop/i18n/cp/scenarios/test-report.yaml
+++ b/conf/dop/i18n/cp/scenarios/test-report.yaml
@@ -1,0 +1,28 @@
+zh:
+  createProject: 创建报告
+  edit: 编辑
+  preview: 预览
+  filterByName: 按名称过滤
+  iteration: 迭代
+  all: 全部
+  testReportName: 测试报告名称
+  creator: 生成者
+  qualityScore: 总体质量分
+  creationTime: 生成时间
+  operations: 操作
+  download: 下载
+  belongIteration: 所属迭代
+en:
+  createProject: Create report
+  edit: Edit
+  preview: Preview
+  filterByName: Filter by name
+  iteration: Iteration
+  all: All
+  testReportName: Test report name
+  creator: Creator
+  qualityScore: Quality score
+  creationTime: Creation time
+  operations: Operations
+  download: Download
+  belongIteration: Iteration

--- a/modules/dop/component-protocol/components/test-report/createReportButton/render.go
+++ b/modules/dop/component-protocol/components/test-report/createReportButton/render.go
@@ -82,7 +82,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		return err
 	}
 	ca.Props = map[string]interface{}{
-		"text":    "创建报告",
+		"text":    cputil.I18n(ctx, "createProject"),
 		"type":    "primary",
 		"visible": access.Access,
 	}

--- a/modules/dop/component-protocol/components/test-report/filter/render.go
+++ b/modules/dop/component-protocol/components/test-report/filter/render.go
@@ -117,14 +117,14 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		map[string]interface{}{
 			"fixed":       true,
 			"key":         "name",
-			"placeholder": "按名称过滤",
+			"placeholder": cputil.I18n(ctx, "filterByName"),
 			"type":        "input",
 		},
 		map[string]interface{}{
-			"emptyText": "全部",
+			"emptyText": cputil.I18n(ctx, "all"),
 			"fixed":     true,
 			"key":       "iteration",
-			"label":     "迭代",
+			"label":     cputil.I18n(ctx, "iteration"),
 			"options":   iterationOptions,
 			"type":      "select",
 		},

--- a/modules/dop/component-protocol/components/test-report/table/render.go
+++ b/modules/dop/component-protocol/components/test-report/table/render.go
@@ -113,7 +113,7 @@ func (i *ComponentAction) GenComponentState(c *cptype.Component) error {
 	return nil
 }
 
-func (ca *ComponentAction) setData() error {
+func (ca *ComponentAction) setData(ctx context.Context) error {
 	var req apistructs.TestReportRecordListRequest
 	req.UserID = ca.sdk.Identity.UserID
 	req.ProjectID = ca.InParams.ProjectID
@@ -172,7 +172,7 @@ func (ca *ComponentAction) setData() error {
 							"reportId": record.ID,
 						},
 						"reload": false,
-						"text":   "下载",
+						"text":   cputil.I18n(ctx, "download"),
 					},
 				},
 				"renderType": "tableOperation",
@@ -210,29 +210,29 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		"columns": []interface{}{
 			map[string]interface{}{
 				"dataIndex": "name",
-				"title":     "测试报告名称",
+				"title":     cputil.I18n(ctx, "testReportName"),
 			},
 			map[string]interface{}{
 				"dataIndex": "iteration",
-				"title":     "所属迭代",
+				"title":     cputil.I18n(ctx, "belongIteration"),
 			},
 			map[string]interface{}{
 				"dataIndex": "creator",
-				"title":     "生成者",
+				"title":     cputil.I18n(ctx, "creator"),
 			},
 			map[string]interface{}{
 				"dataIndex": "quality",
 				"sorter":    true,
-				"title":     "总体质量分",
+				"title":     cputil.I18n(ctx, "qualityScore"),
 			},
 			map[string]interface{}{
 				"dataIndex": "createTime",
 				"sorter":    true,
-				"title":     "生成时间",
+				"title":     cputil.I18n(ctx, "creationTime"),
 			},
 			map[string]interface{}{
 				"dataIndex": "operate",
-				"title":     "操作",
+				"title":     cputil.I18n(ctx, "operations"),
 				"fixed":     "right",
 				"width":     120,
 			},
@@ -240,7 +240,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		"rowKey":          "id",
 		"pageSizeOptions": []interface{}{"10", "20", "50", "100"},
 	}
-	if err := ca.setData(); err != nil {
+	if err := ca.setData(ctx); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it:
i18n of test report component

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=272293&issueFilter__urlQuery=eyJ0aXRsZSI6IuOAkOWbvemZheWMluOAkVRlc3QgbWFuYWdlbWVudC9UZXN0IHJlcG9ydCIsInN0YXRlcyI6WzQ0MDYsNDQwN119&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=772&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that i18n of test report （修复了测试报告国际化）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that i18n of test report            |
| 🇨🇳 中文    |  修复了测试报告国际化            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
