### PR TITLE
feat: basic addon surpport stop/start

### DIFF
--- a/apistructs/addon.go
+++ b/apistructs/addon.go
@@ -553,6 +553,8 @@ type AddonFetchResponseData struct {
 	CustomAddonType string `json:"customAddonType"`
 	// TenantOwner addon 租户owner的 instancerouting id
 	TenantOwner string `json:"tenantOwner"`
+	// IsInsideAddon addon 是否是 inside addon（如 kafka addon 中的 inside addon 是 zookeeper addon）
+	IsInsideAddon string `json:"isInsideAddon`
 }
 
 // ReferenceInfo 引用信息

--- a/apistructs/runtime_dto.go
+++ b/apistructs/runtime_dto.go
@@ -213,3 +213,32 @@ type BatchRuntimeReDeployResults struct {
 	UnReDeployedIds []uint64           `json:"reDeployedFailedIds,omitempty"`
 	ErrMsg          []string           `json:"errorMsgs,omitempty"`
 }
+
+// AddonScaleRecords 表示 Addon 的 scale 请求群信息
+type AddonScaleRecords struct {
+	// Addons 不为空则无需设置 AddonRoutingIDs, 二者必选其一
+	// 格式: map[{addon instance's routing ID}]AddonScaleRecord
+	Addons map[string]AddonScaleRecord `json:"addonScaleRecords,omitempty"`
+	// AddonRoutingIDs is the list of addon instance's routing ID
+	AddonRoutingIDs []string `json:"ids,omitempty"`
+}
+
+// AddonScaleRecord is the addon
+type AddonScaleRecord struct {
+	AddonName                   string                                      `json:"addonName,omitempty"`
+	ServiceResourcesAndReplicas map[string]AddonServiceResourcesAndReplicas `json:"services,omitempty"`
+}
+
+// AddonServiceResourcesAndReplicas set the desired resources and replicas for addon services
+type AddonServiceResourcesAndReplicas struct {
+	Resources Resources `json:"resources,omitempty"`
+	Replicas  int32     `json:"replicas,omitempty"`
+}
+
+type AddonScaleResults struct {
+	Total     int `json:"total"`
+	Successed int `json:"successed"`
+	Faild     int `json:"failed"`
+	// FailedInfo   map[{addon routingID}]errMsg
+	FailedInfo map[string]string `json:"errors,omitempty"`
+}

--- a/modules/orchestrator/dbclient/addon_instance_routing.go
+++ b/modules/orchestrator/dbclient/addon_instance_routing.go
@@ -436,7 +436,7 @@ func (db *DBClient) GetRoutingInstancesByProject(orgID, projectID uint64, catego
 		Where("project_id = ?", projectID).
 		Where("category != ?", "discovery").
 		Where("is_deleted = ?", apistructs.AddonNotDeleted).
-		Where("status in (?)", []apistructs.AddonStatus{apistructs.AddonAttached, apistructs.AddonAttaching, apistructs.AddonAttachFail})
+		Where("status in (?)", []apistructs.AddonStatus{apistructs.AddonAttached, apistructs.AddonAttaching, apistructs.AddonAttachFail, apistructs.AddonOffline})
 	if category != "" {
 		client = client.Where("category = ?", category)
 	}

--- a/modules/orchestrator/endpoints/addon.go
+++ b/modules/orchestrator/endpoints/addon.go
@@ -17,6 +17,7 @@ package endpoints
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -26,14 +27,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/orchestrator/services/addon"
+	"github.com/erda-project/erda/modules/orchestrator/services/apierrors"
+	"github.com/erda-project/erda/modules/orchestrator/utils"
 	"github.com/erda-project/erda/modules/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
 	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/pkg/parser/diceyml"
 	"github.com/erda-project/erda/pkg/strutil"
-
-	"github.com/erda-project/erda/modules/orchestrator/services/addon"
-	"github.com/erda-project/erda/modules/orchestrator/services/apierrors"
 )
 
 func (e *Endpoints) CreateAddonDirectly(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
@@ -192,6 +193,69 @@ func (e *Endpoints) GetAddon(ctx context.Context, r *http.Request, vars map[stri
 		return apierrors.ErrFetchAddon.InternalError(err).ToResp(), nil
 	}
 	return httpserver.OkResp(addonInfo)
+}
+
+// ScaleAddon 设置 addon 服务停止（副本数 N--->0）/启动（副本数 0--->N）
+func (e *Endpoints) ScaleAddon(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+
+	action := r.URL.Query().Get(apistructs.ScaleAction)
+	if action != apistructs.ScaleActionUp && action != apistructs.ScaleActionDown {
+		return apierrors.ErrScaleAddon.InvalidParameter("no parameter " + apistructs.ScaleAction + " or invalid parameter value for parameter " + apistructs.ScaleAction).ToResp(), nil
+	}
+
+	userID, err := user.GetUserID(r)
+	if err != nil {
+		return apierrors.ErrScaleAddon.NotLogin().ToResp(), nil
+	}
+
+	orgID := r.Header.Get(httputil.OrgHeader)
+	if orgID == "" {
+		return apierrors.ErrScaleAddon.MissingParameter("ORG-ID").ToResp(), nil
+	}
+
+	var addonScaleRecords apistructs.AddonScaleRecords
+	if err := json.NewDecoder(r.Body).Decode(&addonScaleRecords); err != nil {
+		return utils.ErrRespIllegalParam(err, "failed to batch update Overlay, failed to parse req")
+	}
+
+	if len(addonScaleRecords.Addons) == 0 && len(addonScaleRecords.AddonRoutingIDs) == 0 {
+		return utils.ErrRespIllegalParam(err, "failed to batch update Overlay, no addonScaleRecords or ids provided in request body")
+	}
+
+	if len(addonScaleRecords.Addons) != 0 && len(addonScaleRecords.AddonRoutingIDs) != 0 {
+		return utils.ErrRespIllegalParam(err, "failed to batch update Overlay, addonScaleRecords and ids must only one with non-empty values in request body")
+	}
+
+	var result apistructs.AddonScaleResults
+	if len(addonScaleRecords.AddonRoutingIDs) > 0 {
+		// scale addon from N--->0 or 0--->N
+		result.Total = len(addonScaleRecords.AddonRoutingIDs)
+		for _, addonRoutingId := range addonScaleRecords.AddonRoutingIDs {
+			if err := e.addon.Scale(userID.String(), addonRoutingId, action); err != nil {
+				logrus.Errorf("Do %s for addon %s failed. error: %v", action, addonRoutingId, err)
+				msg := fmt.Sprintf("Do %s for addon %s failed. error: %v", action, addonRoutingId, err)
+				if result.FailedInfo == nil {
+					result.FailedInfo = make(map[string]string)
+				}
+				result.Faild++
+				result.FailedInfo[addonRoutingId] = msg
+			} else {
+				logrus.Infof("Do %s for addon %s successfully.", action, vars["addonID"])
+				result.Successed++
+			}
+		}
+	}
+
+	if len(addonScaleRecords.Addons) > 0 {
+		// ToDo: scale addon for replicas or/and resources
+	}
+
+	if result.Faild > 0 {
+		return httpserver.NotOkResp(result, http.StatusInternalServerError)
+	}
+	logrus.Infof("scale all addons successfully")
+
+	return httpserver.OkResp(result)
 }
 
 // DeleteAddon 删除 addon

--- a/modules/orchestrator/endpoints/endpoints.go
+++ b/modules/orchestrator/endpoints/endpoints.go
@@ -262,6 +262,7 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 		{Path: "/api/addons/{addonID}", Method: http.MethodGet, Handler: e.GetAddon},
 		{Path: "/api/addons/{addonID}/actions/references", Method: http.MethodGet, Handler: e.GetAddonReferences},
 		{Path: "/api/addons", Method: http.MethodGet, Handler: e.ListAddon},
+		{Path: "/api/addons", Method: http.MethodPost, Handler: e.ScaleAddon},
 		{Path: "/api/addons/actions/list-extension", Method: http.MethodGet, Handler: e.ListExtensionAddon},
 		{Path: "/api/addons/types/{addonName}", Method: http.MethodGet, Handler: e.ListByAddonName},
 		{Path: "/api/addons/actions/list-available", Method: http.MethodGet, Handler: e.ListAvailableAddon},

--- a/modules/orchestrator/services/addon/addon_test.go
+++ b/modules/orchestrator/services/addon/addon_test.go
@@ -16,6 +16,7 @@ package addon
 
 import (
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/modules/orchestrator/dbclient"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
 )
 
 const count = 20
@@ -117,4 +119,402 @@ func Test_GetAddonConfig(t *testing.T) {
 	cfg, err := GetAddonConfig(cfgStr)
 	assert.NoError(t, err)
 	assert.Equal(t, "fake1", cfg["MYSQL_PASSWORD"].(string))
+}
+
+func Test_addonCanScale(t *testing.T) {
+	type args struct {
+		addonName    string
+		addonId      string
+		action       string
+		status       string
+		addonPlan    string
+		addonVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "Test_01",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionDown,
+				status:       string(apistructs.AddonAttached),
+				addonPlan:    "basic",
+				addonVersion: "5.7.29",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_02",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonAttached),
+				addonPlan:    "basic",
+				addonVersion: "5.7.29",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_03",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonAttached),
+				addonPlan:    "basic",
+				addonVersion: "5.7.29",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_04",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "basic",
+				addonVersion: "5.7.29",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_05",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "professional",
+				addonVersion: "5.7.29",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_06",
+			args: args{
+				addonName:    "redis",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "professional",
+				addonVersion: "5.7.29",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_07",
+			args: args{
+				addonName:    "terminus-elasticsearch",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "professional",
+				addonVersion: "5.7.29",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_08",
+			args: args{
+				addonName:    "terminus-elasticsearch",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionUp,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "professional",
+				addonVersion: "6.8.9",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_09",
+			args: args{
+				addonName:    "mysql",
+				addonId:      "z44f5f6543f004d54ac2a2538efd4e9ec",
+				action:       apistructs.ScaleActionDown,
+				status:       string(apistructs.AddonOffline),
+				addonPlan:    "professional",
+				addonVersion: "5.7.29",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := addonCanScale(tt.args.addonName, tt.args.addonId, tt.args.addonPlan, tt.args.addonVersion, tt.args.status, tt.args.action); (err != nil) != tt.wantErr {
+				t.Errorf("addonCanScale() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddon_doAddonScale(t *testing.T) {
+	a := Addon{
+		db:  &dbclient.DBClient{},
+		bdl: &bundle.Bundle{},
+	}
+
+	addonInstance := &dbclient.AddonInstance{
+		ID:                  "z44f5f6543f004d54ac2a2538efd4e9ec",
+		Name:                "mysql",
+		AddonName:           "mysql",
+		Category:            "database",
+		Namespace:           "addon-mysql",
+		ScheduleName:        "z44f5f6543f004d54ac2a2538efd4e9ec",
+		Plan:                "professional",
+		Version:             "5.7.29",
+		Options:             "{\"applicationId\":\"21\",\"clusterName\":\"test\",\"orgId\":\"1\",\"projectId\":\"1\",\"runtimeId\":\"192\",\"runtimeName\":\"feature/develop\",\"version\":\"5.7.29\",\"workspace\":\"DEV\"}",
+		Status:              "ATTACHED",
+		ShareScope:          "PROJECT",
+		OrgID:               "1",
+		Cluster:             "test",
+		ProjectID:           "1",
+		ApplicationID:       "21",
+		AppID:               "1",
+		Workspace:           "DEV",
+		Deleted:             "N",
+		PlatformServiceType: 0,
+		KmsKey:              "f2dcc7b3761d4244898303cb0104a584",
+		CpuRequest:          0.4,
+		CpuLimit:            4,
+		MemRequest:          17204,
+		MemLimit:            17204,
+	}
+
+	addonInstanceRoutings := make([]dbclient.AddonInstanceRouting, 0)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(&a), "GetAddonExtention",
+		func(a *Addon, params *apistructs.AddonHandlerCreateItem) (*apistructs.AddonExtension, *diceyml.Object, error) {
+			return &apistructs.AddonExtension{}, &diceyml.Object{}, nil
+		},
+	)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(&a), "BuildAddonScaleRequestGroup",
+		func(a *Addon, params *apistructs.AddonHandlerCreateItem, addonIns *dbclient.AddonInstance, scaleAction string, addonSpec *apistructs.AddonExtension, addonDice *diceyml.Object) (*apistructs.UpdateServiceGroupScaleRequst, error) {
+			services := make(map[string]*diceyml.Service)
+			services["mysql-1"] = &diceyml.Service{
+				Image: "registry.erda.cloud/erda-addons-enterprise/addon-mysql:5.7.29-1.0.1-init",
+				Ports: make([]diceyml.ServicePort, 0),
+				Envs:  make(map[string]string),
+				Resources: diceyml.Resources{
+					CPU: 1,
+					Mem: 4301,
+				},
+				Labels:      make(map[string]string),
+				Annotations: make(map[string]string),
+				Binds:       make([]string, 0),
+				Deployments: diceyml.Deployments{
+					Replicas: 1,
+				},
+			}
+
+			services["mysql-1"].Ports = append(services["mysql-1"].Ports, diceyml.ServicePort{
+				Port:       3306,
+				Protocol:   "TCP",
+				L4Protocol: "TCP",
+				Expose:     false,
+				Default:    false,
+			})
+
+			services["mysql-1"].Envs = diceyml.EnvMap{
+				"ADDON_GROUPS":        "2",
+				"ADDON_ID":            "z44f5f6543f004d54ac2a2538efd4e9ec",
+				"ADDON_NODE_ID":       "f54fc4ff4197e4c4fa1cdc5b929ca5849",
+				"ADDON_TYPE":          "mysql",
+				"DICE_ADDON":          "z44f5f6543f004d54ac2a2538efd4e9ec",
+				"DICE_ADDON_TYPE":     "mysql",
+				"DICE_CLUSTER_NAME":   "test",
+				"MYSQL_ROOT_PASSWORD": "cR7yf6zEBVFQ8WgE",
+				"SERVER_ID":           "1",
+				"SERVICE_TYPE":        "ADDONS",
+			}
+
+			services["mysql-1"].Labels = map[string]string{
+				"ADDON_GROUP_ID": "mysql-master",
+			}
+
+			services["mysql-1"].Binds = []string{
+				"/netdata/addon/mysql/backup/z44f5f6543f004d54ac2a2538efd4e9ec_1:/var/backup/mysql:rw",
+				"z44f5f6543f004d54ac2a2538efd4e9ec_1:/var/lib/mysql:rw",
+			}
+
+			services["mysql-2"] = &diceyml.Service{
+				Image: "registry.erda.cloud/erda-addons-enterprise/addon-mysql:5.7.29-1.0.1-init",
+				Ports: make([]diceyml.ServicePort, 0),
+				Envs:  make(map[string]string),
+				Resources: diceyml.Resources{
+					CPU: 1,
+					Mem: 4301,
+				},
+				Labels:      make(map[string]string),
+				Annotations: make(map[string]string),
+				Binds:       make([]string, 0),
+				Deployments: diceyml.Deployments{
+					Replicas: 1,
+				},
+			}
+
+			services["mysql-2"].Ports = append(services["mysql-2"].Ports, diceyml.ServicePort{
+				Port:       3306,
+				Protocol:   "TCP",
+				L4Protocol: "TCP",
+				Expose:     false,
+				Default:    false,
+			})
+
+			services["mysql-2"].Envs = diceyml.EnvMap{
+				"ADDON_GROUPS":        "2",
+				"ADDON_ID":            "z44f5f6543f004d54ac2a2538efd4e9ec",
+				"ADDON_NODE_ID":       "m6475b57e54884af59e4147382964f7ab",
+				"ADDON_TYPE":          "mysql",
+				"DICE_ADDON":          "z44f5f6543f004d54ac2a2538efd4e9ec",
+				"DICE_ADDON_TYPE":     "mysql",
+				"DICE_CLUSTER_NAME":   "test",
+				"MYSQL_ROOT_PASSWORD": "cR7yf6zEBVFQ8WgE",
+				"SERVER_ID":           "2",
+				"SERVICE_TYPE":        "ADDONS",
+			}
+
+			services["mysql-2"].Labels = map[string]string{
+				"ADDON_GROUP_ID": "mysql-slave",
+			}
+
+			services["mysql-2"].Binds = []string{
+				"/netdata/addon/mysql/backup/z44f5f6543f004d54ac2a2538efd4e9ec_2:/var/backup/mysql:rw",
+				"z44f5f6543f004d54ac2a2538efd4e9ec_2:/var/lib/mysql:rw",
+			}
+
+			req := &apistructs.ServiceGroupCreateV2Request{
+				DiceYml: diceyml.Object{
+					Version:  "2.0",
+					Services: services,
+				},
+				ClusterName: "test",
+				ID:          addonIns.ID,
+				Type:        strings.Join([]string{"addon-", strings.Replace(strings.Replace(addonIns.AddonName, "terminus-", "", 1), "-operator", "", 1)}, ""),
+				GroupLabels: make(map[string]string),
+				Volumes:     make(map[string]apistructs.RequestVolumeInfo),
+			}
+
+			ret := &apistructs.UpdateServiceGroupScaleRequst{
+				Namespace:   addonIns.Namespace,
+				Name:        addonIns.ScheduleName,
+				ClusterName: params.ClusterName,
+				Labels:      make(map[string]string),
+				Services:    make([]apistructs.Service, 0),
+			}
+			ret.Labels = req.GroupLabels
+
+			for svcName, svc := range req.DiceYml.Services {
+				scale := 0
+				if scaleAction == apistructs.ScaleActionDown {
+					scale = 0
+				}
+				if scaleAction == apistructs.ScaleActionUp {
+					// TODO: 从数据库表获取前一次 scaleUp 成功之后的 replicas
+					scale = svc.Deployments.Replicas
+				}
+
+				ret.Services = append(ret.Services, apistructs.Service{
+					Name:  svcName,
+					Scale: scale,
+					Resources: apistructs.Resources{
+						Cpu:  svc.Resources.CPU,
+						Mem:  float64(svc.Resources.Mem),
+						Disk: float64(svc.Resources.Disk),
+					},
+				})
+			}
+			return ret, nil
+		},
+	)
+
+	//var bdl = &bundle.Bundle{}
+	monkey.PatchInstanceMethod(reflect.TypeOf(a.bdl), "ScaleServiceGroup",
+		func(_ *bundle.Bundle, sg apistructs.UpdateServiceGroupScaleRequst) error {
+			return nil
+		},
+	)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(a.db), "UpdateAddonInstanceStatus",
+		func(_ *dbclient.DBClient, ID, status string) error {
+			return nil
+		},
+	)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(a.db), "UpdateInstanceRouting",
+		func(db *dbclient.DBClient, routing *dbclient.AddonInstanceRouting) error {
+			return nil
+		},
+	)
+
+	err := a.doAddonScale(addonInstance, &addonInstanceRoutings, apistructs.ScaleActionDown)
+	assert.Equal(t, err, nil)
+}
+
+func TestAddon_insideAddonCanNotScale(t *testing.T) {
+	type fields struct {
+		db *dbclient.DBClient
+	}
+	type args struct {
+		routingIns *dbclient.AddonInstanceRouting
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test_01",
+			fields: fields{
+				db: &dbclient.DBClient{},
+			},
+			args: args{
+				routingIns: &dbclient.AddonInstanceRouting{
+					AddonName:    "terminus-zookeeper",
+					RealInstance: "y6f6485f7d9974c32b47c3a1ecd244109",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Addon{
+				db: tt.fields.db,
+			}
+
+			monkey.PatchInstanceMethod(reflect.TypeOf(a.db), "GetByInSideInstanceID",
+				func(db *dbclient.DBClient, instanceID string) (*dbclient.AddonInstanceRelation, error) {
+					return &dbclient.AddonInstanceRelation{
+						OutsideInstanceID: "c32a40074138a4910af97cff325f8bcd5",
+						InsideInstanceID:  "y6f6485f7d9974c32b47c3a1ecd244109",
+					}, nil
+				},
+			)
+
+			monkey.PatchInstanceMethod(reflect.TypeOf(a.db), "GetInstanceRoutingByRealInstance",
+				func(db *dbclient.DBClient, realIns string) (*[]dbclient.AddonInstanceRouting, error) {
+					ars := make([]dbclient.AddonInstanceRouting, 0)
+					ars = append(ars, dbclient.AddonInstanceRouting{
+						Name: "kafka",
+						ID:   "g3dd89da1f63245a3b2b174d9610661bd",
+					})
+					return &ars, nil
+				},
+			)
+
+			if err := a.insideAddonCanNotScale(tt.args.routingIns); (err != nil) != tt.wantErr {
+				t.Errorf("insideAddonCanNotScale() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/modules/orchestrator/services/apierrors/errors.go
+++ b/modules/orchestrator/services/apierrors/errors.go
@@ -68,6 +68,7 @@ var (
 	ErrFetchAddon      = err("ErrFetchAddon", "获取 addon 详情失败")
 	ErrDeleteAddon     = err("ErrDeleteAddon", "删除 addon 失败")
 	ErrListAddon       = err("ErrListAddon", "获取 addon 列表失败")
+	ErrScaleAddon      = err("ErrScaleAddon", "扩缩 addon 实例副本失败")
 	ErrListAddonMetris = err("ErrListAddonMetris", "获取 addon 监控失败")
 )
 

--- a/modules/scheduler/executor/plugins/k8s/addon/redis/redis.go
+++ b/modules/scheduler/executor/plugins/k8s/addon/redis/redis.go
@@ -293,9 +293,76 @@ func (ro *RedisOperator) Remove(sg *apistructs.ServiceGroup) error {
 	return nil
 }
 
+// Update 支持镜像、环境变量、资源、副本数(不能为0) 等更新
+// 副本数限制参考: https://github.com/spotahome/redis-operator/blob/master/api/redisfailover/v1/validate.go
 func (ro *RedisOperator) Update(k8syml interface{}) error {
-	// TODO:
-	return fmt.Errorf("redisoperator not impl Update yet")
+	// TODO: scale replicas to 0 not work，will change to default value(3)：  https://github.com/spotahome/redis-operator/blob/master/api/redisfailover/v1/validate.go
+	redisAndSecret, ok := k8syml.(redisFailoverAndSecret)
+	if !ok {
+		return fmt.Errorf("[BUG] this k8syml should be redisFailoverAndSecret")
+	}
+
+	redis := redisAndSecret.RedisFailover
+	if err := ro.ns.Exists(redis.Namespace); err != nil {
+		return fmt.Errorf("namespace %s for redisoperator is not existed", redis.Namespace)
+	}
+
+	if redis.Spec.Redis.Replicas == 0 || redis.Spec.Sentinel.Replicas == 0 {
+		return fmt.Errorf("failed to update redisfailover, %s/%s, redisfailover do not surpport set replicas to 0", redis.Namespace, redis.Name)
+	}
+
+	// 更新  RedisFailover (副本数不能为 0，否则将)
+	var oldRedis RedisFailover
+	resp, err := ro.client.Get(ro.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/databases.spotahome.com/v1/namespaces/%s/redisfailovers/%s", redis.Namespace, redis.Name)).
+		Do().JSON(&oldRedis)
+	if err != nil {
+		return fmt.Errorf("failed to update redisfailover, %s/%s, get redisfailover failed, err: %v, body: %v ", redis.Namespace, redis.Name, err, string(resp.Body()))
+	}
+	if !resp.IsOK() {
+		return fmt.Errorf("failed to update redisfailover, %s/%s, get redisfailover is not OK, err: %v, body: %v ", redis.Namespace, redis.Name, err, string(resp.Body()))
+	}
+
+	// update redis
+	if redis.Spec.Redis.Replicas != 0 {
+		oldRedis.Spec.Redis.Replicas = redis.Spec.Redis.Replicas
+	}
+	oldRedis.Spec.Redis.Resources = redis.Spec.Redis.Resources
+	oldRedis.Spec.Redis.Image = redis.Spec.Redis.Image
+	oldRedis.Spec.Redis.CustomConfig = redis.Spec.Redis.CustomConfig
+	oldRedis.Spec.Redis.Command = redis.Spec.Redis.Command
+	oldRedis.Spec.Redis.ShutdownConfigMap = redis.Spec.Redis.ShutdownConfigMap
+	oldRedis.Spec.Redis.Exporter = redis.Spec.Redis.Exporter
+	oldRedis.Spec.Redis.ImagePullSecrets = redis.Spec.Redis.ImagePullSecrets
+	oldRedis.Spec.Redis.Envs = redis.Spec.Redis.Envs
+
+	// update sentinels
+	if redis.Spec.Sentinel.Replicas != 0 {
+		oldRedis.Spec.Redis.Replicas = redis.Spec.Redis.Replicas
+	}
+	oldRedis.Spec.Sentinel.Resources = redis.Spec.Sentinel.Resources
+	oldRedis.Spec.Sentinel.Resources = redis.Spec.Sentinel.Resources
+	oldRedis.Spec.Sentinel.Image = redis.Spec.Sentinel.Image
+	oldRedis.Spec.Sentinel.CustomConfig = redis.Spec.Sentinel.CustomConfig
+	oldRedis.Spec.Sentinel.Command = redis.Spec.Sentinel.Command
+	oldRedis.Spec.Sentinel.Exporter = redis.Spec.Sentinel.Exporter
+	oldRedis.Spec.Sentinel.ImagePullSecrets = redis.Spec.Sentinel.ImagePullSecrets
+	oldRedis.Spec.Sentinel.Envs = redis.Spec.Sentinel.Envs
+
+	var b bytes.Buffer
+	resp, err = ro.client.Put(ro.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/databases.spotahome.com/v1/namespaces/%s/redisfailovers/%s", oldRedis.Namespace, oldRedis.Name)).
+		JSONBody(oldRedis).
+		Do().
+		Body(&b)
+	if err != nil {
+		return fmt.Errorf("failed to update redisfailover, %s/%s, err: %v, body: %v ", oldRedis.Namespace, oldRedis.Name, err, b.String())
+	}
+	if !resp.IsOK() {
+		return fmt.Errorf("failed to update redisfailover, %s/%s, statuscode: %v, body: %v", oldRedis.Namespace, oldRedis.Name, resp.StatusCode(), b.String())
+	}
+
+	return nil
 }
 
 func (ro *RedisOperator) convertRedis(svc apistructs.Service, affinity *corev1.Affinity) RedisSettings {


### PR DESCRIPTION
#### What this PR does / why we need it:

when erda deployment deleted, the addon pods will always running unless you delete addon,but addon may be reused for next deployment, so to release resources (cpu/memorys), can stop addon by scale addon services replicas to 0, this can retain addon services's PVC for reused，If you want reuse addon adgin,  can start addon by scale addon services replicas  original values 





#### Specified Reviewers:

/assign @sixther-dc @luobily @iutx 


#### ChangeLog
Added an API for scale down or scale up addon

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Added an API for scale down or scale up addon    |
| 🇨🇳 中文    |        addon scale API 支持停止/启动 addon      |

