### PR TITLE
fix: records support fuzzy matching and add defaultrendering

### DIFF
--- a/modules/dop/component-protocol/scenarios/project-pipeline-exec-list.yml
+++ b/modules/dop/component-protocol/scenarios/project-pipeline-exec-list.yml
@@ -28,3 +28,12 @@ components:
     type: ContractiveFilter
   customFilter:
     type: ConfigurableFilter
+
+rendering:
+  __DefaultRendering__:
+    - name: myPage
+    - name: tabsTable
+    - name: filterContainer
+    - name: inputFilter
+    - name: customFilter
+    - name: pipelineTable

--- a/modules/pipeline/dbclient/op_pipeline.go
+++ b/modules/pipeline/dbclient/op_pipeline.go
@@ -392,7 +392,7 @@ func (client *Client) PageListPipelines(req apistructs.PipelinePageListRequest, 
 			baseSQL.Join("INNER", definitiondb.PipelineDefinition{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_definition_id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
 			baseSQL.Join("INNER", sourcedb.PipelineSource{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_source_id", sourcedb.PipelineSource{}.TableName(), definitiondb.PipelineDefinition{}.TableName()))
 			if len(definitionReq.Name) > 0 {
-				baseSQL.Where(fmt.Sprintf("%v.name like ?", definitiondb.PipelineDefinition{}.TableName()), definitionReq.Name+"%")
+				baseSQL.Where(fmt.Sprintf("%v.name like ?", definitiondb.PipelineDefinition{}.TableName()), "%"+definitionReq.Name+"%")
 			}
 			if len(definitionReq.SourceRemotes) > 0 {
 				baseSQL.In(tableFieldName(sourcedb.PipelineSource{}.TableName(), "remote"), definitionReq.SourceRemotes)


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: records support fuzzy matching and add defaultrendering
#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODMsNzcyXSwibWVtYmVyIjpbIjEwMDEyNjEiXX0%3D&id=276032&iterationID=772&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      fix: records support fuzzy matching and add defaultrendering        |
| 🇨🇳 中文    |     项目级流水线执行记录支持名称模糊匹配         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
