### PR TITLE
refactor: disable stats default

### DIFF
--- a/conf/monitor/monitor/monitor.yaml
+++ b/conf/monitor/monitor/monitor.yaml
@@ -324,8 +324,7 @@ prometheus:
 
 monitor-monitoring:
   usage_sync_interval:
-    metric: ${MONITOR_MONITORING_METRIC_SYNC_INTERVAL:1h}
-    log: ${MONITOR_MONITORING_LOG_SYNC_INTERVAL:30m}
+    metric: ${MONITOR_MONITORING_METRIC_SYNC_INTERVAL}
 
 grpc-client@erda.core.services.notify.channel:
   addr: "${CORE_SERVICES_GRPC_ADDR:core-services:9537}"


### PR DESCRIPTION
#### What this PR does / why we need it:
disable stats metric storage

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       disable stats metric storage default      |
| 🇨🇳 中文    |       默认情况下禁用指标容量统计       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
