### PR TITLE
fix: DOP failed to initialize mobile app

### DIFF
--- a/modules/dop/conf/conf.go
+++ b/modules/dop/conf/conf.go
@@ -46,6 +46,7 @@ type Conf struct {
 	SonarAdminToken   string `env:"SONAR_ADMIN_TOKEN" required:"true"` // dice.yml 里依赖了 sonar，由工具链注入 SONAR_ADMIN_TOKEN
 	GolangCILintImage string `env:"GOLANGCI_LINT_IMAGE" default:"registry.cn-hangzhou.aliyuncs.com/terminus/terminus-golangci-lint:1.27"`
 	UIPublicURL       string `env:"UI_PUBLIC_URL" required:"true"`
+	UIDomain          string `env:"UI_PUBLIC_ADDR" required:"true"`
 
 	// ory/kratos config
 	OryEnabled           bool   `default:"false" env:"ORY_ENABLED"`
@@ -164,6 +165,10 @@ func CMDBAddr() string {
 
 func UIPublicURL() string {
 	return cfg.UIPublicURL
+}
+
+func UIDomain() string {
+	return cfg.UIDomain
 }
 
 func OryEnabled() bool {

--- a/modules/dop/services/application/application.go
+++ b/modules/dop/services/application/application.go
@@ -27,7 +27,7 @@ import (
 	cmspb "github.com/erda-project/erda-proto-go/core/pipeline/cms/pb"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
-	"github.com/erda-project/erda/modules/core-services/conf"
+	"github.com/erda-project/erda/modules/dop/conf"
 	"github.com/erda-project/erda/modules/dop/dao"
 	"github.com/erda-project/erda/modules/dop/services/apierrors"
 	"github.com/erda-project/erda/pkg/common/apis"


### PR DESCRIPTION
#### What this PR does / why we need it:
The push code failed due to a problem with the generated action params address

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODMsNzcyXSwibWVtYmVyIjpbIjEwMDA1NjAiXX0%3D&id=276871&iterationID=772&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix mobile app initialization failure        |
| 🇨🇳 中文    |        修复移动应用初始化失败的问题      |

