### PR TITLE
fix: Update pipeline createRequest commit information and confignamespaces information when the project pipeline executing

### DIFF
--- a/modules/pipeline/providers/definition/pipeline_definition.go
+++ b/modules/pipeline/providers/definition/pipeline_definition.go
@@ -34,6 +34,15 @@ type pipelineDefinition struct {
 	dbClient *db.Client
 }
 
+func GetExtraValue(definition *pb.PipelineDefinition) (*apistructs.PipelineDefinitionExtraValue, error) {
+	var extraValue = apistructs.PipelineDefinitionExtraValue{}
+	err := json.Unmarshal([]byte(definition.Extra.Extra), &extraValue)
+	if err != nil {
+		return nil, err
+	}
+	return &extraValue, nil
+}
+
 func (p pipelineDefinition) Create(ctx context.Context, request *pb.PipelineDefinitionCreateRequest) (*pb.PipelineDefinitionCreateResponse, error) {
 	if err := createPreCheck(request); err != nil {
 		return nil, err


### PR DESCRIPTION
#### What this PR does / why we need it:
If the createrequest commit and confignamespace of the pipeline are not updated, the pre check of the execution pipeline will fail

#### ChangeLog


| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Update the commit and confignamespaces information when the project pipeline is executing     |
| 🇨🇳 中文    |       项目流水线执行的时候更新 commit 和 configNamespaces 信息       |


