### PR TITLE
feat: Legacy component default render support i18n

### DIFF
--- a/modules/openapi/component-protocol/generate/gen_auto_register.go
+++ b/modules/openapi/component-protocol/generate/gen_auto_register.go
@@ -100,6 +100,9 @@ func main() {
 	buf.WriteString("\t\t\tpanic(err)\n")
 	buf.WriteString("\t\t}\n")
 	buf.WriteString("\t\tprotocol.DefaultProtocols[pName] = p\n")
+	buf.WriteString("\t\tif protocol.CpPlaceHolderRe.Match([]byte(pStr)) {\n")
+	buf.WriteString("\t\t\tprotocol.DefaultProtocolsRaw[pName] = pStr\n")
+	buf.WriteString("\t\t}\n")
 	buf.WriteString("\t}\n")
 
 	buf.WriteString("}\n")

--- a/modules/openapi/component-protocol/scenario_render.go
+++ b/modules/openapi/component-protocol/scenario_render.go
@@ -183,7 +183,7 @@ func RunScenarioRender(ctx context.Context, req *apistructs.ComponentProtocolReq
 
 	if req.Protocol == nil || req.Event.Component == "" {
 		isDefaultProtocol = true
-		p, err := LoadDefaultProtocol(sk)
+		p, err := LoadDefaultProtocol(ctx, sk)
 		if err != nil {
 			logrus.Errorf("load default protocol failed, scenario:%+v, err:%v", req.Scenario, err)
 			return err


### PR DESCRIPTION
#### What this PR does / why we need it:
Legacy component default render support i18n

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Legacy component default render support i18n            |
| 🇨🇳 中文    |     组件化 默认定义 国际化         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
