### PR TITLE
fix: deployment order resp type is empty

### DIFF
--- a/modules/orchestrator/services/deployment_order/deployment_order_get.go
+++ b/modules/orchestrator/services/deployment_order/deployment_order_get.go
@@ -97,7 +97,7 @@ func (d *DeploymentOrder) Get(userId string, orderId string) (*apistructs.Deploy
 			ReleaseInfo: &apistructs.ReleaseInfo{
 				Id:        order.ReleaseId,
 				Version:   curRelease.Version,
-				Type:      covertReleaseType(curRelease.IsProjectRelease),
+				Type:      convertReleaseType(curRelease.IsProjectRelease),
 				Creator:   curRelease.UserId,
 				CreatedAt: curRelease.CreatedAt,
 				UpdatedAt: curRelease.UpdatedAt,
@@ -222,7 +222,7 @@ func convertConfigType(configType string) string {
 	return "kv"
 }
 
-func covertReleaseType(isProjectRelease bool) string {
+func convertReleaseType(isProjectRelease bool) string {
 	if isProjectRelease {
 		return apistructs.ReleaseTypeProject
 	}

--- a/modules/orchestrator/services/deployment_order/deployment_order_list.go
+++ b/modules/orchestrator/services/deployment_order/deployment_order_list.go
@@ -91,15 +91,15 @@ func (d *DeploymentOrder) convertDeploymentOrderToResponseItem(orders []dbclient
 
 		applicationCount := 1
 
-		releaseResp, ok := releasesMap[order.ReleaseId]
+		r, ok := releasesMap[order.ReleaseId]
 		if !ok {
 			logrus.Errorf("failed to get release %s, not found", order.ReleaseId)
 			continue
 		}
 
-		if releaseResp.IsProjectRelease {
+		if r.IsProjectRelease {
 			subReleases := make([]string, 0)
-			if err := json.Unmarshal([]byte(releaseResp.ApplicationReleaseList), &subReleases); err != nil {
+			if err := json.Unmarshal([]byte(r.ApplicationReleaseList), &subReleases); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal release application list, err: %v", err)
 			}
 			applicationCount = len(subReleases)
@@ -113,8 +113,11 @@ func (d *DeploymentOrder) convertDeploymentOrderToResponseItem(orders []dbclient
 			ID:   order.ID,
 			Name: utils.ParseOrderName(order.ID),
 			ReleaseInfo: &apistructs.ReleaseInfo{
-				Id:      order.ReleaseId,
-				Version: releaseResp.Version,
+				Id:        order.ReleaseId,
+				Version:   r.Version,
+				Type:      convertReleaseType(r.IsProjectRelease),
+				CreatedAt: r.CreatedAt,
+				UpdatedAt: r.UpdatedAt,
 			},
 			Type:              order.Type,
 			ApplicationStatus: applicationStatus,

--- a/modules/orchestrator/services/deployment_order/deployment_order_render.go
+++ b/modules/orchestrator/services/deployment_order/deployment_order_render.go
@@ -122,7 +122,7 @@ func (d *DeploymentOrder) RenderDetail(userId, releaseId, workspace string) (*ap
 			ReleaseInfo: &apistructs.ReleaseInfo{
 				Id:        releaseResp.ReleaseID,
 				Version:   releaseResp.Version,
-				Type:      covertReleaseType(releaseResp.IsProjectRelease),
+				Type:      convertReleaseType(releaseResp.IsProjectRelease),
 				Creator:   releaseResp.UserID,
 				CreatedAt: releaseResp.CreatedAt,
 				UpdatedAt: releaseResp.UpdatedAt,


### PR DESCRIPTION
#### What this PR does / why we need it:
fix deployment order resp type is empty

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix deployment order resp type is empty             |
| 🇨🇳 中文    |  修复部署单类型返回是空的情况           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
