### PR TITLE
fix: i18n of autotest plan list (#3735)

### DIFF
--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/filter/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/filter/render.go
@@ -22,6 +22,7 @@ import (
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/components/filter"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/type_conversion"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list/i18n"
 )
 
 type AutoTestPlanFilter struct{}
@@ -54,7 +55,7 @@ func (tpm *AutoTestPlanFilter) Render(ctx context.Context, c *apistructs.Compone
 	if c.State == nil {
 		c.State = make(map[string]interface{})
 	}
-	c.State["conditions"] = tpm.setConditions(iterations)
+	c.State["conditions"] = tpm.setConditions(bdl, iterations)
 	if event.Operation.String() == "filter" {
 		if _, ok := c.State["values"]; ok {
 			fiterDataBytes, err := json.Marshal(c.State["values"])
@@ -87,38 +88,39 @@ func (tpm *AutoTestPlanFilter) Render(ctx context.Context, c *apistructs.Compone
 	return nil
 }
 
-func (tpm *AutoTestPlanFilter) setConditions(iterations []apistructs.Iteration) []filter.PropCondition {
+func (tpm *AutoTestPlanFilter) setConditions(ctxBundle protocol.ContextBundle, iterations []apistructs.Iteration) []filter.PropCondition {
+	i18nLocale := ctxBundle.Bdl.GetLocale(ctxBundle.Locale)
 	return []filter.PropCondition{
 		{
 			Key:         "name",
-			Label:       "计划名",
+			Label:       i18nLocale.Get(i18n.I18nKeyPlanName),
 			Fixed:       true,
-			Placeholder: "输入计划名按回车键查询",
+			Placeholder: i18nLocale.Get(i18n.I18nKeyPlanNameRegex),
 			Type:        filter.PropConditionTypeInput,
 		},
 		{
 			Key:         "archive",
-			Label:       "归档",
-			EmptyText:   "全部",
+			Label:       i18nLocale.Get(i18n.I18nKeyArchive),
+			EmptyText:   i18nLocale.Get(i18n.I18nKeyAll),
 			Fixed:       true,
-			Placeholder: "输入计划名按回车键查询",
+			Placeholder: i18nLocale.Get(i18n.I18nKeyPlanNameRegex),
 			Type:        filter.PropConditionTypeSelect,
 			Options: []filter.PropConditionOption{
 				{
-					Label: "进行中",
+					Label: i18nLocale.Get(i18n.I18nKeyInProgress),
 					Value: "inprogress",
 				},
 				{
-					Label: "已归档",
+					Label: i18nLocale.Get(i18n.I18nKeyArchived),
 					Value: "archived",
 				},
 			},
 		},
 		{
-			EmptyText: "全部",
+			EmptyText: i18nLocale.Get(i18n.I18nKeyAll),
 			Fixed:     true,
 			Key:       "iteration",
-			Label:     "迭代",
+			Label:     i18nLocale.Get(i18n.I18nKeyIteration),
 			Options: func() (opts []filter.PropConditionOption) {
 				for _, itr := range iterations {
 					opts = append(opts, filter.PropConditionOption{

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/formModal/render.go
@@ -133,7 +133,7 @@ func (tpm *TestPlanManageFormModal) Render(ctx context.Context, c *apistructs.Co
 		c.State["visible"] = true
 		c.State["formData"] = formData
 		c.State["isUpdate"] = true
-		c.Props = auto_test_plan_list.GenUpdateFormModalProps(tsBytes, iterationsBytes)
+		c.Props = auto_test_plan_list.GenUpdateFormModalProps(bdl, tsBytes, iterationsBytes)
 		(*gs)[protocol.GlobalInnerKeyUserIDs.String()] = resp.Data.Owners
 		return nil
 	}
@@ -179,7 +179,7 @@ func (tpm *TestPlanManageFormModal) Render(ctx context.Context, c *apistructs.Co
 		}
 
 		c.State["isCreate"] = true
-		c.Props = auto_test_plan_list.GenCreateFormModalProps(tsBytes, iterationsBytes)
+		c.Props = auto_test_plan_list.GenCreateFormModalProps(bdl, tsBytes, iterationsBytes)
 		return nil
 	}
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render.go
@@ -25,6 +25,7 @@ import (
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/pkg/type_conversion"
 	auto_test_plan_list "github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list/i18n"
 )
 
 type TestPlanManageTable struct{}
@@ -191,6 +192,7 @@ func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Compo
 	}
 	// data
 	var l []TableItem
+	i18nLocale := bdl.Bdl.GetLocale(bdl.Locale)
 	for _, data := range r.List {
 		item := TableItem{
 			Id:   data.ID,
@@ -216,20 +218,20 @@ func (tpmt *TestPlanManageTable) Render(ctx context.Context, c *apistructs.Compo
 		if data.IsArchived == true {
 			item.Operate.Operations["archive"] = map[string]interface{}{
 				"key":    "archive",
-				"text":   "取消归档",
+				"text":   i18nLocale.Get(i18n.I18nKeyUnarchive),
 				"reload": true,
 				"meta":   map[string]interface{}{"id": data.ID, "isArchived": false},
 			}
 		} else {
 			item.Operate.Operations["archive"] = map[string]interface{}{
 				"key":    "archive",
-				"text":   "归档",
+				"text":   i18nLocale.Get(i18n.I18nKeyArchive),
 				"reload": true,
 				"meta":   map[string]interface{}{"id": data.ID, "isArchived": true},
 			}
 			item.Operate.Operations["edit"] = map[string]interface{}{
 				"key":       "edit",
-				"text":      "编辑",
+				"text":      i18nLocale.Get(i18n.I18nKeyEdit),
 				"reload":    true,
 				"meta":      map[string]interface{}{"id": data.ID},
 				"showIndex": 2,

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/components/table/render_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+	"github.com/erda-project/erda/pkg/i18n"
 )
 
 func TestTestPlanManageTable_Render(t *testing.T) {
@@ -55,12 +56,17 @@ func TestTestPlanManageTable_Render(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var bdl = protocol.ContextBundle{}
-			var dl = bundle.Bundle{}
-			monkey.PatchInstanceMethod(reflect.TypeOf(&dl), "PagingTestPlansV2", func(b *bundle.Bundle, req apistructs.TestPlanV2PagingRequest) (*apistructs.TestPlanV2PagingResponseData, error) {
+			var bdl = protocol.ContextBundle{Locale: "zh"}
+			dl := bundle.New(bundle.WithI18nLoader(&i18n.LocaleResourceLoader{}))
+			m := monkey.PatchInstanceMethod(reflect.TypeOf(dl), "GetLocale",
+				func(bdl *bundle.Bundle, local ...string) *i18n.LocaleResource {
+					return &i18n.LocaleResource{}
+				})
+			defer m.Unpatch()
+			monkey.PatchInstanceMethod(reflect.TypeOf(dl), "PagingTestPlansV2", func(b *bundle.Bundle, req apistructs.TestPlanV2PagingRequest) (*apistructs.TestPlanV2PagingResponseData, error) {
 				return &apistructs.TestPlanV2PagingResponseData{}, nil
 			})
-			bdl.Bdl = &dl
+			bdl.Bdl = dl
 			bdl.InParams = map[string]interface{}{"projectId": 1}
 			tt.args.ctx = context.WithValue(tt.args.ctx, protocol.GlobalInnerKeyCtxBundle.String(), bdl)
 

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/helper.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/helper.go
@@ -16,24 +16,29 @@ package auto_test_plan_list
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
+
+	protocol "github.com/erda-project/erda/modules/openapi/component-protocol"
+	"github.com/erda-project/erda/modules/openapi/component-protocol/scenarios/auto-test-plan-list/i18n"
 )
 
 // GenCreateFormModalProps 生成创建测试计划表单的props
-func GenCreateFormModalProps(testSpace, iteration []byte) interface{} {
-	props := `{
-          "name": "计划",
+func GenCreateFormModalProps(ctxBundle protocol.ContextBundle, testSpace, iteration []byte) interface{} {
+	i18nLocale := ctxBundle.Bdl.GetLocale(ctxBundle.Locale)
+	props := fmt.Sprintf(`{
+          "name": "%s",
           "fields": [
             {
               "component": "input",
               "key": "name",
-              "label": "计划名称",
+              "label": "%s",
               "required": true,
               "rule": [
                 {
                   "pattern": "/^[a-z\u4e00-\u9fa5A-Z0-9_-]*$/",
-                  "msg": "可输入中文、英文、数字、中划线或下划线"
+                  "msg": "%s"
                 }
               ],
               "componentProps": {
@@ -43,26 +48,26 @@ func GenCreateFormModalProps(testSpace, iteration []byte) interface{} {
             {
               "component": "select",
               "key": "spaceId",
-              "label": "测试空间",
+              "label": "%s",
 							"disabled": false,
               "required": true,
               "componentProps": {
-                "options": ` + string(testSpace) +
+                "options": `+string(testSpace)+
 		`}
             },
 			{
               "component": "select",
               "key": "iterationId",
-              "label": "迭代",
+              "label": "%s",
 							"disabled": false,
               "required": true,
               "componentProps": {
-                "options": ` + string(iteration) +
+                "options": `+string(iteration)+
 		`}
             },
             {
               "key": "owners",
-              "label": "负责人",
+              "label": "%s",
               "required": true,
               "component": "memberSelector",
               "componentProps": {
@@ -71,7 +76,9 @@ func GenCreateFormModalProps(testSpace, iteration []byte) interface{} {
               }
             }
           ]
-        }`
+        }`, i18nLocale.Get(i18n.I18nKeyPlan), i18nLocale.Get(i18n.I18nKeyPlanName),
+		i18nLocale.Get(i18n.I18nKeyPlanNameRegex), i18nLocale.Get(i18n.I18nKeyTestSpace),
+		i18nLocale.Get(i18n.I18nKeyIteration), i18nLocale.Get(i18n.I18nKeyPrincipal))
 
 	var propsI interface{}
 	if err := json.Unmarshal([]byte(props), &propsI); err != nil {
@@ -82,19 +89,20 @@ func GenCreateFormModalProps(testSpace, iteration []byte) interface{} {
 }
 
 // GenUpdateFormModalProps 生成更新测试计划表单的props
-func GenUpdateFormModalProps(testSpace, iteration []byte) interface{} {
-	props := `{
-          "name": "计划",
+func GenUpdateFormModalProps(ctxBundle protocol.ContextBundle, testSpace, iteration []byte) interface{} {
+	i18nLocale := ctxBundle.Bdl.GetLocale(ctxBundle.Locale)
+	props := fmt.Sprintf(`{
+          "name": "%s",
           "fields": [
             {
               "component": "input",
               "key": "name",
-              "label": "计划名称",
+              "label": "%s",
               "required": true,
               "rule": [
                 {
                   "pattern": "/^[a-z\u4e00-\u9fa5A-Z0-9_-]*$/",
-                  "msg": "可输入中文、英文、数字、中划线或下划线"
+                  "msg": "%s"
                 }
               ],
               "componentProps": {
@@ -104,25 +112,25 @@ func GenUpdateFormModalProps(testSpace, iteration []byte) interface{} {
             {
               "component": "select",
               "key": "spaceId",
-              "label": "测试空间",
+              "label": "%s",
               "disabled": true,
 							"componentProps": {
-                "options": ` + string(testSpace) +
+                "options": `+string(testSpace)+
 		`}
             },
 			{
               "component": "select",
               "key": "iterationId",
-              "label": "迭代",
+              "label": "%s",
               "required": true,
               "disabled": false,
 							"componentProps": {
-                "options": ` + string(iteration) +
+                "options": `+string(iteration)+
 		`}
             },
             {
               "key": "owners",
-              "label": "负责人",
+              "label": "%s",
               "required": true,
               "component": "memberSelector",
               "componentProps": {
@@ -131,7 +139,9 @@ func GenUpdateFormModalProps(testSpace, iteration []byte) interface{} {
               }
             }
           ]
-        }`
+        }`, i18nLocale.Get(i18n.I18nKeyPlan), i18nLocale.Get(i18n.I18nKeyPlanName),
+		i18nLocale.Get(i18n.I18nKeyPlanNameRegex), i18nLocale.Get(i18n.I18nKeyTestSpace),
+		i18nLocale.Get(i18n.I18nKeyIteration), i18nLocale.Get(i18n.I18nKeyPrincipal))
 
 	var propsI interface{}
 	if err := json.Unmarshal([]byte(props), &propsI); err != nil {

--- a/modules/openapi/component-protocol/scenarios/auto-test-plan-list/i18n/i18n.go
+++ b/modules/openapi/component-protocol/scenarios/auto-test-plan-list/i18n/i18n.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package i18n
+
+const (
+	I18nKeyPlan                     = "autotest.plan.plan"
+	I18nKeyNewPlan                  = "autotest.plan.new.plan"
+	I18nKeyPlanName                 = "autotest.plan.plan.name"
+	I18nKeyPlanNameRegex            = "autotest.plan.plan.regex"
+	I18nKeyTestSpace                = "autotest.plan.test.space"
+	I18nKeyTaskParameter            = "autotest.plan.task.parameter"
+	I18nKeyParameterConfiguration   = "autotest.plan.parameter.configuration"
+	I18nKeySceneSet                 = "autotest.plan.autotest.scene.set"
+	I18nKeyScene                    = "autotest.plan.autotest.scene"
+	I18nKeyIteration                = "autotest.plan.iteration"
+	I18nKeyPrincipal                = "autotest.plan.principal"
+	I18nKeyArchive                  = "autotest.plan.archive"
+	I18nKeyUnarchive                = "autotest.plan.un.archive"
+	I18nKeyInProgress               = "autotest.plan.in.progress"
+	I18nKeyArchived                 = "autotest.plan.archived"
+	I18nKeyAll                      = "autotest.plan.all"
+	I18nKeyPlanID                   = "autotest.plan.id"
+	I18nKeyTotalInterfaces          = "autotest.plan.total.executed.interfaces"
+	I18nKeyPassRate                 = "autotest.plan.execution.pass.rate"
+	I18nKeyExecutionTime            = "autotest.plan.execution.time"
+	I18nKeyOperations               = "autotest.plan.operations"
+	I18nKeyEdit                     = "autotest.plan.edit"
+	I18nKeyExecute                  = "autotest.plan.execute"
+	I18nKeyConfigurationInformation = "autotest.plan.configuration.information"
+)


### PR DESCRIPTION
(cherry picked from commit 459c203eab553eed478d3920e61de2bcd5bd002e)

#### What this PR does / why we need it:
hotfix i18n of autotest plan list (#3735)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： hotfix i18n of autotest plan list (#3735) （自动化测试列表的国际化hotfix）


`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   hotfix i18n of autotest plan list (#3735)            |
| 🇨🇳 中文    |   自动化测试列表的国际化hotfix           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
