### PR TITLE
fix: Project pipeline inode access pipeline details access failed

### DIFF
--- a/modules/dop/component-protocol/components/project-pipeline/myPage/tabsTable/pipelineTable/provider.go
+++ b/modules/dop/component-protocol/components/project-pipeline/myPage/tabsTable/pipelineTable/provider.go
@@ -408,10 +408,9 @@ func (p *PipelineTable) SetTableRows() []table.Row {
 							inode = fmt.Sprintf("%v/%v/tree/%v/%v/%v", p.InParams.ProjectID, appNameIDMap.AppNameToID[appName], v.Ref, v.Path, v.FileName)
 						}
 					}
-
 					build.ServerData = &cptype.OpServerData{
 						"pipelineID": v.PipelineId,
-						"inode":      base64.StdEncoding.EncodeToString([]byte(inode)),
+						"inode":      base64.URLEncoding.EncodeToString([]byte(inode)),
 						"appName":    appName,
 					}
 					return build


### PR DESCRIPTION
#### What this PR does / why we need it:
Project pipeline inode access pipeline details access failed

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODMsNzcyXSwibWVtYmVyIjpbIjEwMDA1NjAiXX0%3D&id=278442&iterationID=772&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Modify the inode base64 method, use urlEncode       |
| 🇨🇳 中文    |      修改inode base64方法, 使用 urlEncode        |


#### test image
![image](https://user-images.githubusercontent.com/28723047/150715485-f943acc8-a0fb-4aa7-a6a7-bc40f77735cf.png)
![image](https://user-images.githubusercontent.com/28723047/150715513-498f1976-ec82-4eab-a17d-fd845e3cdb87.png)


