### PR TITLE
fix: autotest configsheet datasource addon search

### DIFF
--- a/modules/orchestrator/endpoints/addon.go
+++ b/modules/orchestrator/endpoints/addon.go
@@ -306,7 +306,7 @@ func (e *Endpoints) ListAddon(ctx context.Context, r *http.Request, vars map[str
 
 			var find = false
 			for _, displayName := range displayNames {
-				if v.AddonDisplayName == displayName {
+				if v.AddonName == strings.ToLower(displayName) {
 					find = true
 					break
 				}


### PR DESCRIPTION
#### What this PR does / why we need it:
The addon creation interface has been changed, and the query of automatic test configuration sheet needs to be changed


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The addon creation interface has been changed, and the query of automatic test configuration sheet needs to be changed       |
| 🇨🇳 中文    |        addon 创建接口有变更，需要变更下自动化测试配置单的查询      |

