### PR TITLE
feat: manual clean indices support set time duration

### DIFF
--- a/modules/core/monitor/storekit/elasticsearch/index/cleaner/clean.go
+++ b/modules/core/monitor/storekit/elasticsearch/index/cleaner/clean.go
@@ -56,11 +56,14 @@ func (p *provider) runCleanIndices(ctx context.Context) {
 
 // CleanIndices .
 func (p *provider) CleanIndices(ctx context.Context, filter loader.Matcher) error {
+	return p.checkAndDeleteIndices(ctx, time.Now(), filter)
+}
+
+func (p *provider) checkAndDeleteIndices(ctx context.Context, now time.Time, filter loader.Matcher) error {
 	indices := p.loader.AllIndices()
 	if indices == nil {
 		return nil
 	}
-	now := time.Now()
 	removeList := p.getRemoveList(ctx, indices, filter, now)
 	p.Log.Infof("about to remove %d indices: %v", len(removeList), removeList)
 	if len(removeList) > 0 {

--- a/modules/core/monitor/storekit/elasticsearch/index/cleaner/routes.go
+++ b/modules/core/monitor/storekit/elasticsearch/index/cleaner/routes.go
@@ -16,6 +16,7 @@ package cleaner
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/erda-project/erda-infra/providers/httpserver"
 	"github.com/erda-project/erda/modules/core/monitor/storekit/elasticsearch/index/loader"
@@ -25,6 +26,7 @@ func (p *provider) intRoutes(routes httpserver.Router, prefix string) error {
 	routes.GET(prefix+"/cleaner/rollover-body", p.getRolloverBody)
 	routes.GET(prefix+"/cleaner/clean-expired", p.cleanExpiredIndices)
 	routes.GET(prefix+"/cleaner/clean-by-disk", p.cleanByDiskUsage)
+	routes.GET(prefix+"/cleaner/is-leader", p.checkIsLeader)
 	return nil
 }
 
@@ -32,8 +34,22 @@ func (p *provider) getRolloverBody(r *http.Request) interface{} {
 	return p.rolloverBodyForDiskClean
 }
 
-func (p *provider) cleanExpiredIndices(r *http.Request) interface{} {
-	err := p.CleanIndices(r.Context(), func(*loader.IndexEntry) bool { return true })
+func (p *provider) checkIsLeader(r *http.Request) interface{} {
+	return p.election.IsLeader()
+}
+
+func (p *provider) cleanExpiredIndices(r *http.Request, params struct {
+	TimeOffset string `query:"timeOffset"`
+}) interface{} {
+	var duration time.Duration
+	if len(params.TimeOffset) > 0 {
+		d, err := time.ParseDuration(params.TimeOffset)
+		if err != nil {
+			return err
+		}
+		duration = d
+	}
+	err := p.checkAndDeleteIndices(r.Context(), time.Now().Add(duration), func(*loader.IndexEntry) bool { return true })
 	if err != nil {
 		return err
 	}
@@ -41,11 +57,19 @@ func (p *provider) cleanExpiredIndices(r *http.Request) interface{} {
 }
 
 func (p *provider) cleanByDiskUsage(r *http.Request, params struct {
-	TargetUsagePercent float64 `query:"targetPercent"`
+	TargetUsagePercent     float64 `query:"targetPercent"`
+	ThresholdPercent       float64 `query:"thresholdPercent"`
+	MinIndicesStorePercent float64 `query:"minIndicesStorePercent"`
 }) interface{} {
 	config := p.Cfg.DiskClean //deep copy
 	if params.TargetUsagePercent > 0 {
 		config.LowDiskUsagePercent = params.TargetUsagePercent
+	}
+	if params.ThresholdPercent > 0 {
+		config.HighDiskUsagePercent = params.ThresholdPercent
+	}
+	if params.MinIndicesStorePercent > 0 {
+		config.MinIndicesStorePercent = params.MinIndicesStorePercent
 	}
 	err := p.checkDiskUsage(r.Context(), config)
 	if err != nil {

--- a/modules/core/monitor/storekit/elasticsearch/index/cleaner/routes_test.go
+++ b/modules/core/monitor/storekit/elasticsearch/index/cleaner/routes_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleaner
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/modules/core/monitor/storekit/elasticsearch/index/loader"
+)
+
+func Test_cleanExpiredIndices_With_EmptyTimeOffset_Should_UseDefault(t *testing.T) {
+	p := &provider{}
+	nowTime := time.Now()
+	var actualTime time.Time
+
+	monkey.Patch(time.Now, func() time.Time {
+		return nowTime
+	})
+	defer monkey.Unpatch(time.Now)
+	monkey.Patch((*provider).checkAndDeleteIndices, func(p *provider, ctx context.Context, now time.Time, filter loader.Matcher) error {
+		actualTime = now
+		return nil
+	})
+	defer monkey.Unpatch((*provider).checkAndDeleteIndices)
+
+	r, _ := http.NewRequest("GET", "url", nil)
+	result := p.cleanExpiredIndices(r, struct {
+		TimeOffset string `query:"timeOffset"`
+	}{
+		TimeOffset: "",
+	})
+
+	assert.Equal(t, true, result)
+	assert.Equal(t, nowTime, actualTime)
+}
+
+func Test_cleanExpiredIndices_With_ValidTimeOffset_Should_AddTime(t *testing.T) {
+	p := &provider{}
+
+	nowTime := time.Now()
+	var actualTime time.Time
+
+	monkey.Patch(time.Now, func() time.Time {
+		return nowTime
+	})
+	defer monkey.Unpatch(time.Now)
+
+	monkey.Patch((*provider).checkAndDeleteIndices, func(p *provider, ctx context.Context, now time.Time, filter loader.Matcher) error {
+		actualTime = now
+		return nil
+	})
+	defer monkey.Unpatch((*provider).checkAndDeleteIndices)
+
+	r, _ := http.NewRequest("GET", "url", nil)
+	result := p.cleanExpiredIndices(r, struct {
+		TimeOffset string `query:"timeOffset"`
+	}{
+		TimeOffset: "1h",
+	})
+
+	assert.Equal(t, true, result)
+	assert.Equal(t, nowTime.Add(time.Hour), actualTime)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: manual clean indices support set time duration


#### Specified Reviewers:

/assign @liuhaoyang 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        feat: manual clean indices support set time duration      |
| 🇨🇳 中文    |    手动删除过期es索引接口支持传入保留时间参数          |
