### PR TITLE
feat: the repeated call interface of automatic test scenario input parameters

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/inParamsForm/inParamsForm.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/inParamsForm/inParamsForm.go
@@ -16,16 +16,21 @@ package inParamsForm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/expression"
 )
 
-func (i *ComponentInParamsForm) SetProps() {
+func (i *ComponentInParamsForm) SetProps(props cptype.ComponentProps) {
+	// default temp value
 	paramsNameProp := PropColumn{
 		Title: i.sdk.I18n("paramName"),
 		Key:   PropsKeyParamsName,
@@ -84,6 +89,7 @@ func (i *ComponentInParamsForm) SetProps() {
 			Operations: make(map[string]interface{}),
 		},
 	}
+
 	o := OperationInfo{}
 	o.Key = apistructs.AutoTestSceneInputOnSelectOperationKey.String()
 	o.Reload = true
@@ -96,6 +102,26 @@ func (i *ComponentInParamsForm) SetProps() {
 		Width:    200,
 	}
 	i.Props["temp"] = []PropColumn{paramsNameProp, descProp, defaultValueProp, valueProp}
+
+	// set request props temp value
+	if props == nil || props["temp"] == nil {
+		return
+	}
+	tempValue, err := json.Marshal(props["temp"])
+	if err != nil {
+		logrus.Errorf("Marshal temp %v error %v", props["temp"], err)
+		return
+	}
+	var reqPropColumn []PropColumn
+	err = json.Unmarshal(tempValue, &reqPropColumn)
+	if err != nil {
+		logrus.Errorf("Unmarshal tempValue error %v", err)
+		return
+	}
+	if reqPropColumn == nil {
+		return
+	}
+	i.Props["temp"] = reqPropColumn
 }
 
 func (i *ComponentInParamsForm) RenderListInParamsForm() error {

--- a/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/inParamsForm/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/inParamsForm/render.go
@@ -144,7 +144,13 @@ func (i *ComponentInParamsForm) Render(ctx context.Context, c *cptype.Component,
 	}
 	i.Props = visible
 
-	i.SetProps()
+	// change scene reset temp value
+	if c.State["isChangeScene"] != nil {
+		i.SetProps(nil)
+		c.State["isChangeScene"] = nil
+	} else {
+		i.SetProps(c.Props)
+	}
 	switch apistructs.OperationKey(event.Operation) {
 	case apistructs.InitializeOperation:
 		err = i.RenderListInParamsForm()

--- a/modules/dop/component-protocol/scenarios/auto-test-scenes.yml
+++ b/modules/dop/component-protocol/scenarios/auto-test-scenes.yml
@@ -335,7 +335,7 @@ components:
     type: Button
   referSceneSetButton:
     type: Button
-    
+
 rendering:
   # 前端触发组件
   # 先渲染前端触发组件，再渲染关联组件
@@ -372,6 +372,8 @@ rendering:
       state:
         - name: "setId"
           value: "{{ fileTree.sceneSetKey }}"
+        - name: "isChangeScene"
+          value: "{{ fileTree.isClickScene }}"
     - name: stages
     - name: outPutTitle
     - name: outPutForm


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the repeated call interface of automatic test scenario input parameters

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODMsNzcyXSwibWVtYmVyIjpbIjEwMDA1NjAiXX0%3D&id=278894&iterationID=772&pId=0&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Fix the repeated call interface of automatic test scenario input parameters      |
| 🇨🇳 中文    |       修复自动化测试场景入参重复调用接口       |

