### PR TITLE
fix: k8s remotecommand support cluster-dialer

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -5,6 +5,8 @@
     "pkg/clientgo/apis/flinkoperator/",
     "pkg/clientgo/apis/openyurt/",
     "pkg/clientgo/clientset/",
+    "pkg/k8s/httpstream/spdy",
+    "pkg/k8s/spdy",
     "pkg/pipe.v2/pipe.go",
     "modules/tools/admin-tools/statik/statik.go",
     "modules/gittar/pkg/gitmodule",

--- a/conf/resources.go
+++ b/conf/resources.go
@@ -43,7 +43,7 @@ var (
 
 	//go:embed monitor/agent-injector/agent-injector.yaml
 	MonitorAgentInjectorDefaultConfig string
-	MonitorAgentInjectorFilePath      string = "conf/monitor/agent-injector.yaml"
+	MonitorAgentInjectorFilePath      string = "conf/monitor/agent-injector/agent-injector.yaml"
 )
 
 // msp

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20201215015655-2e8b733f5ad0
 	github.com/Masterminds/semver v1.5.0
+	github.com/Shopify/sarama v1.19.0
 	github.com/ahmetb/go-linq/v3 v3.2.0
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/colour v0.1.0 // indirect
@@ -35,9 +36,11 @@ require (
 	github.com/coreos/etcd v3.3.25+incompatible
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/spdystream v0.2.0
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/cloud-on-k8s v0.0.0-20210205172912-5ce0eca90c60
+	github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6
 	github.com/erda-project/erda-infra v0.0.0-20220121065448-af236c62e621
 	github.com/erda-project/erda-oap-thirdparty-protocol v0.0.0-20210907135609-15886a136d5b
 	github.com/erda-project/erda-proto-go v0.0.0
@@ -47,6 +50,7 @@ require (
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
 	github.com/fatih/color v1.10.0
+	github.com/fntlnz/mountinfo v0.0.0-20171106231217-40cb42681fad
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/getkin/kin-openapi v0.49.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
@@ -126,11 +130,13 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f
 	github.com/satori/go.uuid v1.2.0
 	github.com/scylladb/gocqlx v1.5.0
+	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.21.3
 	github.com/shogo82148/androidbinary v1.0.2
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sony/sonyflake v1.0.0
+	github.com/spf13/afero v1.6.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
@@ -144,6 +150,7 @@ require (
 	github.com/xormplus/builder v0.0.0-20181220055446-b12ceebee76f
 	github.com/xormplus/core v0.0.0-20181016121923-6bfce2eb8867
 	github.com/xormplus/xorm v0.0.0-20181212020813-da46657160ff
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opentelemetry.io/otel v1.2.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.2.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.2.0
@@ -179,6 +186,7 @@ require (
 	k8s.io/apimachinery v0.21.2
 	k8s.io/apiserver v0.21.2
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.8.0
 	k8s.io/kube-aggregator v0.20.0
 	k8s.io/kubectl v0.21.0
@@ -196,6 +204,7 @@ require (
 
 replace (
 	github.com/coreos/bbolt => go.etcd.io/bbolt v1.3.5
+	github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 	github.com/erda-project/erda-proto-go v0.0.0 => ./api/proto-go
 	github.com/google/gnostic => github.com/googleapis/gnostic v0.4.0
 	github.com/googlecloudplatform/flink-operator => github.com/erda-project/flink-on-k8s-operator v0.0.0-20210828094530-28e003581cf2

--- a/go.sum
+++ b/go.sum
@@ -135,7 +135,9 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/Shopify/sarama v1.19.0 h1:9oksLxC6uxVPHPVYUmq6xhr1BOF/hHobWH2UzO67z1s=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
+github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -445,7 +447,8 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
-github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
@@ -455,8 +458,11 @@ github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e/go.mod h1:CgNC6SGbT+Xb8wGGvzilttZL1mc5sQ/5KkcxsZttMIk=
+github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
@@ -471,6 +477,7 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6 h1:GhNw/V+7mWhxPyD/n7STfwp/MJJ+Z/sa6wmzYXr96Ls=
 github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
@@ -524,6 +531,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fntlnz/mountinfo v0.0.0-20171106231217-40cb42681fad h1:7dkG+DBBIETkv0nraI5oMvN4M5X3i75q7xq68eIq5Ag=
+github.com/fntlnz/mountinfo v0.0.0-20171106231217-40cb42681fad/go.mod h1:OJmEqKcMeJq0teE8CysGMs/5Ulch9FogT/MmOzE1U9o=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -597,8 +606,9 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.4.0 h1:uc1uML3hRYL9/ZZPdgHS/n8Nzo+eaYL/Efxkkamf7OM=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -1524,6 +1534,7 @@ github.com/rancher/wrangler v0.6.2-0.20200714200521-c61fae623942/go.mod h1:8LdIq
 github.com/rancher/wrangler v0.6.2-0.20200820173016-2068de651106/go.mod h1:iKqQcYs4YSDjsme52OZtQU4jHPmLlIiM93aj2c8c/W8=
 github.com/rancher/wrangler v0.8.1-0.20210423003607-f71a90542852 h1:HMvBxqM0edSRzRZSWg0uDPaKy0NJhIoePmkln4ta4bs=
 github.com/rancher/wrangler v0.8.1-0.20210423003607-f71a90542852/go.mod h1:zSV5oh3+YZboilwcJmFHO3J6FZba82BTQft1b6ijx2I=
+github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/recallsong/go-utils v1.1.2-0.20210826100715-fce05eefa294 h1:1CONHJOaZVu3fJv11U+/KSstXi4KK3PvdFNPyf6MjYA=
 github.com/recallsong/go-utils v1.1.2-0.20210826100715-fce05eefa294/go.mod h1:NARLokMUOzyJ55oYXvPcxQh3rBoTBAbolNfqou6AqdY=
@@ -1584,11 +1595,11 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sethvargo/go-password v0.1.3/go.mod h1:2tyaaoHK/AlXwh5WWQDYjqQbHcq4cjPj5qb/ciYvu/Q=
 github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa h1:2cO3RojjYl3hVTbEvJVqrMaFmORhL6O06qdW42toftk=
 github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa/go.mod h1:Yjr3bdWaVWyME1kha7X0jsz3k2DgXNa1Pj3XGyUAbx8=
-github.com/shirou/gopsutil v2.19.10+incompatible h1:lA4Pi29JEVIQIgATSeftHSY0rMGI9CLrl2ZvDLiahto=
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
+github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v3 v3.21.3 h1:wgcdAHZS2H6qy4JFewVTtqfiYxFzCeEJod/mLztdPG8=
 github.com/shirou/gopsutil/v3 v3.21.3/go.mod h1:ghfMypLDrFSWN2c9cDYFLHyynQ+QUht0cv/18ZqVczw=
-github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shogo82148/androidbinary v1.0.2 h1:tjgNUJeZwlIEytmn0u6Gk6b6rinpZSYi9HqRpLX7Obs=
 github.com/shogo82148/androidbinary v1.0.2/go.mod h1:c3BBft4TLXkvqry+EEN8z9ZtyY09r7jLMvFB/L/KrfI=
@@ -1813,6 +1824,8 @@ github.com/yuin/goldmark v1.1.30/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
+github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=

--- a/modules/core/services/filenamager/common.go
+++ b/modules/core/services/filenamager/common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/common/errors"
 	perm "github.com/erda-project/erda/pkg/common/permission"
+	remotecommandexec "github.com/erda-project/erda/pkg/k8s/remotecommand"
 )
 
 const instanceKey = "instance"
@@ -93,7 +94,7 @@ func parseInstanceMetadata(text string) map[string]string {
 	return kvs
 }
 
-func (s *fileManagerService) execInPod(clluster, namespace, podName, container string, command []string, stdin io.Reader, stdout io.Writer) error {
+func (s *fileManagerService) execInPod(ctx context.Context, clluster, namespace, podName, container string, command []string, stdin io.Reader, stdout io.Writer) error {
 	if len(namespace) <= 0 || len(podName) <= 0 {
 		return errors.NewNotFoundError(fmt.Sprintf("pods %s/%s", namespace, podName))
 	}
@@ -114,7 +115,7 @@ func (s *fileManagerService) execInPod(clluster, namespace, podName, container s
 			Stderr:    true,
 			TTY:       false,
 		}, scheme.ParameterCodec)
-	executor, err := remotecommand.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
+	executor, err := remotecommandexec.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
 	if err != nil {
 		return errors.NewInternalServerError(fmt.Errorf("failed to NewSPDYExecutor: %s", err))
 	}

--- a/modules/core/services/filenamager/file.manager.service.go
+++ b/modules/core/services/filenamager/file.manager.service.go
@@ -52,7 +52,7 @@ func (s *fileManagerService) ListFiles(ctx context.Context, req *pb.ListFilesReq
 		return nil, err
 	}
 	stdout := &strings.Builder{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", command,
 		},
@@ -127,7 +127,7 @@ func (s *fileManagerService) ReadFile(ctx context.Context, req *pb.ReadFileReque
 
 	checkFile := func() (*pb.FileInfo, error) {
 		stdout := &strings.Builder{}
-		err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+		err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 			[]string{
 				"sh", "-c", fmt.Sprintf("TIME_STYLE='+%%Y-%%m-%%dT%%H:%%M:%%S.%%N' ls -la %q", noExpandPath(req.Path)),
 			},
@@ -163,7 +163,7 @@ func (s *fileManagerService) ReadFile(ctx context.Context, req *pb.ReadFileReque
 
 	// read file
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", fmt.Sprintf("dd if=%q", noExpandPath(req.Path)),
 		},
@@ -223,7 +223,7 @@ func (s *fileManagerService) WriteFile(ctx context.Context, req *pb.WriteFileReq
 		return nil, err
 	}
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", command,
 		},
@@ -256,7 +256,7 @@ func (s *fileManagerService) MakeDirectory(ctx context.Context, req *pb.MakeDire
 		return nil, err
 	}
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", command,
 		},
@@ -281,7 +281,7 @@ func (s *fileManagerService) MoveFile(ctx context.Context, req *pb.MoveFileReque
 		return nil, err
 	}
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", fmt.Sprintf("mv %q %q", noExpandPath(req.Source), noExpandPath(req.Destination)),
 		},
@@ -308,7 +308,7 @@ func (s *fileManagerService) DeleteFile(ctx context.Context, req *pb.DeleteFileR
 		return nil, err
 	}
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", fmt.Sprintf("rm -rf %q", noExpandPath(req.Path)),
 		},
@@ -343,7 +343,7 @@ func (s *fileManagerService) DownloadFile(rw http.ResponseWriter, req *http.Requ
 	setHeader := true // delay to set header
 	var count int
 	path := noExpandPath(params.Path)
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", fmt.Sprintf("([ -f %q ] || [ -d %q ]) && tar -zcf - %q", path, path, path),
 		},
@@ -401,7 +401,7 @@ func (s *fileManagerService) UploadFile(rw http.ResponseWriter, req *http.Reques
 	}
 	path := noExpandPath(params.Path)
 	stdout := &bytes.Buffer{}
-	err = s.execInPod(instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
+	err = s.execInPod(ctx, instance.ClusterName, instance.Namespace, instance.PodName, instance.ContainerName,
 		[]string{
 			"sh", "-c", fmt.Sprintf("([ ! -f %q ] && [ ! -d %q ]) && dd of=%q", path, path, path),
 		},

--- a/modules/openapi/api/apis/monitor/monitor_filemanager_download.go
+++ b/modules/openapi/api/apis/monitor/monitor_filemanager_download.go
@@ -17,8 +17,8 @@ package monitor
 import "github.com/erda-project/erda/modules/openapi/api/apis"
 
 var MONITOR_FILEMANAGER_DOWNLOAD = apis.ApiSpec{
-	Path:        "/api/container/:containerID/files/download",
-	BackendPath: "/api/container/:containerID/files/download",
+	Path:        "/api/container/<containerID>/files/download",
+	BackendPath: "/api/container/<containerID>/files/download",
 	Host:        "monitor.marathon.l4lb.thisdcos.directory:7096",
 	Scheme:      "http",
 	Method:      "GET",

--- a/modules/openapi/api/apis/monitor/monitor_filemanager_upload.go
+++ b/modules/openapi/api/apis/monitor/monitor_filemanager_upload.go
@@ -17,8 +17,8 @@ package monitor
 import "github.com/erda-project/erda/modules/openapi/api/apis"
 
 var MONITOR_FILEMANAGER_UPLOAD = apis.ApiSpec{
-	Path:        "/api/container/:containerID/files/upload",
-	BackendPath: "/api/container/:containerID/files/upload",
+	Path:        "/api/container/<containerID>/files/upload",
+	BackendPath: "/api/container/<containerID>/files/upload",
 	Host:        "monitor.marathon.l4lb.thisdcos.directory:7096",
 	Scheme:      "http",
 	Method:      "GET",

--- a/pkg/k8s/httpstream/spdy/connection.go
+++ b/pkg/k8s/httpstream/spdy/connection.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/docker/spdystream"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/klog"
+)
+
+// connection maintains state about a spdystream.Connection and its associated
+// streams.
+type connection struct {
+	conn             *spdystream.Connection
+	streams          []httpstream.Stream
+	streamLock       sync.Mutex
+	newStreamHandler httpstream.NewStreamHandler
+}
+
+// NewClientConnection creates a new SPDY client connection.
+func NewClientConnection(conn net.Conn) (httpstream.Connection, error) {
+	spdyConn, err := spdystream.NewConnection(conn, false)
+	if err != nil {
+		defer conn.Close()
+		return nil, err
+	}
+
+	return newConnection(spdyConn, httpstream.NoOpNewStreamHandler), nil
+}
+
+// NewServerConnection creates a new SPDY server connection. newStreamHandler
+// will be invoked when the server receives a newly created stream from the
+// client.
+func NewServerConnection(conn net.Conn, newStreamHandler httpstream.NewStreamHandler) (httpstream.Connection, error) {
+	spdyConn, err := spdystream.NewConnection(conn, true)
+	if err != nil {
+		defer conn.Close()
+		return nil, err
+	}
+
+	return newConnection(spdyConn, newStreamHandler), nil
+}
+
+// newConnection returns a new connection wrapping conn. newStreamHandler
+// will be invoked when the server receives a newly created stream from the
+// client.
+func newConnection(conn *spdystream.Connection, newStreamHandler httpstream.NewStreamHandler) httpstream.Connection {
+	c := &connection{conn: conn, newStreamHandler: newStreamHandler}
+	go conn.Serve(c.newSpdyStream)
+	return c
+}
+
+// createStreamResponseTimeout indicates how long to wait for the other side to
+// acknowledge the new stream before timing out.
+const createStreamResponseTimeout = 30 * time.Second
+
+// Close first sends a reset for all of the connection's streams, and then
+// closes the underlying spdystream.Connection.
+func (c *connection) Close() error {
+	c.streamLock.Lock()
+	for _, s := range c.streams {
+		// calling Reset instead of Close ensures that all streams are fully torn down
+		s.Reset()
+	}
+	c.streams = make([]httpstream.Stream, 0)
+	c.streamLock.Unlock()
+
+	// now that all streams are fully torn down, it's safe to call close on the underlying connection,
+	// which should be able to terminate immediately at this point, instead of waiting for any
+	// remaining graceful stream termination.
+	return c.conn.Close()
+}
+
+// CreateStream creates a new stream with the specified headers and registers
+// it with the connection.
+func (c *connection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	stream, err := c.conn.CreateStream(headers, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	if err = stream.WaitTimeout(createStreamResponseTimeout); err != nil {
+		return nil, err
+	}
+
+	c.registerStream(stream)
+	return stream, nil
+}
+
+// registerStream adds the stream s to the connection's list of streams that
+// it owns.
+func (c *connection) registerStream(s httpstream.Stream) {
+	c.streamLock.Lock()
+	c.streams = append(c.streams, s)
+	c.streamLock.Unlock()
+}
+
+// CloseChan returns a channel that, when closed, indicates that the underlying
+// spdystream.Connection has been closed.
+func (c *connection) CloseChan() <-chan bool {
+	return c.conn.CloseChan()
+}
+
+// newSpdyStream is the internal new stream handler used by spdystream.Connection.Serve.
+// It calls connection's newStreamHandler, giving it the opportunity to accept or reject
+// the stream. If newStreamHandler returns an error, the stream is rejected. If not, the
+// stream is accepted and registered with the connection.
+func (c *connection) newSpdyStream(stream *spdystream.Stream) {
+	replySent := make(chan struct{})
+	err := c.newStreamHandler(stream, replySent)
+	rejectStream := (err != nil)
+	if rejectStream {
+		klog.Warningf("Stream rejected: %v", err)
+		stream.Reset()
+		return
+	}
+
+	c.registerStream(stream)
+	stream.SendReply(http.Header{}, rejectStream)
+	close(replySent)
+}
+
+// SetIdleTimeout sets the amount of time the connection may remain idle before
+// it is automatically closed.
+func (c *connection) SetIdleTimeout(timeout time.Duration) {
+	c.conn.SetIdleTimeout(timeout)
+}

--- a/pkg/k8s/httpstream/spdy/connection_test.go
+++ b/pkg/k8s/httpstream/spdy/connection_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+func runProxy(t *testing.T, backendUrl string, proxyUrl chan<- string, proxyDone chan<- struct{}, errCh chan<- error) {
+	listener, err := net.Listen("tcp4", "localhost:0")
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer listener.Close()
+
+	proxyUrl <- listener.Addr().String()
+
+	clientConn, err := listener.Accept()
+	if err != nil {
+		t.Errorf("proxy: error accepting client connection: %v", err)
+		return
+	}
+
+	backendConn, err := net.Dial("tcp4", backendUrl)
+	if err != nil {
+		t.Errorf("proxy: error dialing backend: %v", err)
+		return
+	}
+	defer backendConn.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		io.Copy(backendConn, clientConn)
+	}()
+
+	go func() {
+		defer wg.Done()
+		io.Copy(clientConn, backendConn)
+	}()
+
+	wg.Wait()
+
+	proxyDone <- struct{}{}
+}
+
+func runServer(t *testing.T, backendUrl chan<- string, serverDone chan<- struct{}, errCh chan<- error) {
+	listener, err := net.Listen("tcp4", "localhost:0")
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer listener.Close()
+
+	backendUrl <- listener.Addr().String()
+
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Errorf("server: error accepting connection: %v", err)
+		return
+	}
+
+	streamChan := make(chan httpstream.Stream)
+	replySentChan := make(chan (<-chan struct{}))
+	spdyConn, err := NewServerConnection(conn, func(stream httpstream.Stream, replySent <-chan struct{}) error {
+		streamChan <- stream
+		replySentChan <- replySent
+		return nil
+	})
+	if err != nil {
+		t.Errorf("server: error creating spdy connection: %v", err)
+		return
+	}
+
+	stream := <-streamChan
+	replySent := <-replySentChan
+	<-replySent
+
+	buf := make([]byte, 1)
+	_, err = stream.Read(buf)
+	if err != io.EOF {
+		t.Errorf("server: unexpected read error: %v", err)
+		return
+	}
+
+	<-spdyConn.CloseChan()
+	raw := spdyConn.(*connection).conn
+	if err := raw.Wait(15 * time.Second); err != nil {
+		t.Errorf("server: timed out waiting for connection closure: %v", err)
+	}
+
+	serverDone <- struct{}{}
+}
+
+func TestConnectionCloseIsImmediateThroughAProxy(t *testing.T) {
+	errCh := make(chan error)
+
+	serverDone := make(chan struct{}, 1)
+	backendUrlChan := make(chan string)
+	go runServer(t, backendUrlChan, serverDone, errCh)
+
+	var backendUrl string
+	select {
+	case err := <-errCh:
+		t.Fatalf("server: error listening: %v", err)
+	case backendUrl = <-backendUrlChan:
+	}
+
+	proxyDone := make(chan struct{}, 1)
+	proxyUrlChan := make(chan string)
+	go runProxy(t, backendUrl, proxyUrlChan, proxyDone, errCh)
+
+	var proxyUrl string
+	select {
+	case err := <-errCh:
+		t.Fatalf("error listening: %v", err)
+	case proxyUrl = <-proxyUrlChan:
+	}
+
+	conn, err := net.Dial("tcp4", proxyUrl)
+	if err != nil {
+		t.Fatalf("client: error connecting to proxy: %v", err)
+	}
+
+	spdyConn, err := NewClientConnection(conn)
+	if err != nil {
+		t.Fatalf("client: error creating spdy connection: %v", err)
+	}
+
+	if _, err := spdyConn.CreateStream(http.Header{}); err != nil {
+		t.Fatalf("client: error creating stream: %v", err)
+	}
+
+	spdyConn.Close()
+	raw := spdyConn.(*connection).conn
+	if err := raw.Wait(15 * time.Second); err != nil {
+		t.Fatalf("client: timed out waiting for connection closure: %v", err)
+	}
+
+	expired := time.NewTimer(15 * time.Second)
+	defer expired.Stop()
+	i := 0
+	for {
+		select {
+		case <-expired.C:
+			t.Fatalf("timed out waiting for proxy and/or server closure")
+		case <-serverDone:
+			i++
+		case <-proxyDone:
+			i++
+		}
+		if i == 2 {
+			break
+		}
+	}
+}

--- a/pkg/k8s/httpstream/spdy/roundtripper.go
+++ b/pkg/k8s/httpstream/spdy/roundtripper.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/third_party/forked/golang/netutil"
+)
+
+// SpdyRoundTripper knows how to upgrade an HTTP request to one that supports
+// multiplexed streams. After RoundTrip() is invoked, Conn will be set
+// and usable. SpdyRoundTripper implements the UpgradeRoundTripper interface.
+type SpdyRoundTripper struct {
+	//tlsConfig holds the TLS configuration settings to use when connecting
+	//to the remote server.
+	tlsConfig *tls.Config
+
+	/* TODO according to http://golang.org/pkg/net/http/#RoundTripper, a RoundTripper
+	   must be safe for use by multiple concurrent goroutines. If this is absolutely
+	   necessary, we could keep a map from http.Request to net.Conn. In practice,
+	   a client will create an http.Client, set the transport to a new insteace of
+	   SpdyRoundTripper, and use it a single time, so this hopefully won't be an issue.
+	*/
+	// conn is the underlying network connection to the remote server.
+	conn net.Conn
+
+	// Dialer is the dialer used to connect.  Used if non-nil.
+	DialerTimeout  time.Duration
+	DialerDeadline time.Time
+	Dialer         func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// proxier knows which proxy to use given a request, defaults to http.ProxyFromEnvironment
+	// Used primarily for mocking the proxy discovery in tests.
+	proxier func(req *http.Request) (*url.URL, error)
+
+	// followRedirects indicates if the round tripper should examine responses for redirects and
+	// follow them.
+	followRedirects bool
+	// requireSameHostRedirects restricts redirect following to only follow redirects to the same host
+	// as the original request.
+	requireSameHostRedirects bool
+}
+
+var _ utilnet.TLSClientConfigHolder = &SpdyRoundTripper{}
+var _ httpstream.UpgradeRoundTripper = &SpdyRoundTripper{}
+var _ utilnet.Dialer = &SpdyRoundTripper{}
+
+// NewRoundTripper creates a new SpdyRoundTripper that will use
+// the specified tlsConfig.
+func NewRoundTripper(tlsConfig *tls.Config, followRedirects, requireSameHostRedirects bool) httpstream.UpgradeRoundTripper {
+	return NewSpdyRoundTripper(tlsConfig, followRedirects, requireSameHostRedirects)
+}
+
+// NewSpdyRoundTripper creates a new SpdyRoundTripper that will use
+// the specified tlsConfig. This function is mostly meant for unit tests.
+func NewSpdyRoundTripper(tlsConfig *tls.Config, followRedirects, requireSameHostRedirects bool) *SpdyRoundTripper {
+	return &SpdyRoundTripper{
+		tlsConfig:                tlsConfig,
+		followRedirects:          followRedirects,
+		requireSameHostRedirects: requireSameHostRedirects,
+	}
+}
+
+// TLSClientConfig implements pkg/util/net.TLSClientConfigHolder for proper TLS checking during
+// proxying with a spdy roundtripper.
+func (s *SpdyRoundTripper) TLSClientConfig() *tls.Config {
+	return s.tlsConfig
+}
+
+// Dial implements k8s.io/apimachinery/pkg/util/net.Dialer.
+func (s *SpdyRoundTripper) Dial(req *http.Request) (net.Conn, error) {
+	conn, err := s.dial(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := req.Write(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// dial dials the host specified by req, using TLS if appropriate, optionally
+// using a proxy server if one is configured via environment variables.
+func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
+	proxier := s.proxier
+	if proxier == nil {
+		proxier = utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
+	}
+	proxyURL, err := proxier(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if proxyURL == nil {
+		return s.dialWithoutProxy(req.Context(), req.URL)
+	}
+
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(req.URL)
+
+	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
+	proxyReq := http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{},
+		Host:   targetHost,
+	}
+
+	if pa := s.proxyAuth(proxyURL); pa != "" {
+		proxyReq.Header = http.Header{}
+		proxyReq.Header.Set("Proxy-Authorization", pa)
+	}
+
+	proxyDialConn, err := s.dialWithoutProxy(req.Context(), proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
+	_, err = proxyClientConn.Do(&proxyReq)
+	if err != nil && err != httputil.ErrPersistEOF {
+		return nil, err
+	}
+
+	rwc, _ := proxyClientConn.Hijack()
+
+	if req.URL.Scheme != "https" {
+		return rwc, nil
+	}
+
+	host, _, err := net.SplitHostPort(targetHost)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := s.tlsConfig
+	switch {
+	case tlsConfig == nil:
+		tlsConfig = &tls.Config{ServerName: host}
+	case len(tlsConfig.ServerName) == 0:
+		tlsConfig = tlsConfig.Clone()
+		tlsConfig.ServerName = host
+	}
+
+	tlsConn := tls.Client(rwc, tlsConfig)
+
+	// need to manually call Handshake() so we can call VerifyHostname() below
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, err
+	}
+
+	// Return if we were configured to skip validation
+	if tlsConfig.InsecureSkipVerify {
+		return tlsConn, nil
+	}
+
+	if err := tlsConn.VerifyHostname(tlsConfig.ServerName); err != nil {
+		return nil, err
+	}
+
+	return tlsConn, nil
+}
+
+// dialWithoutProxy dials the host specified by url, using TLS if appropriate.
+func (s *SpdyRoundTripper) dialWithoutProxy(ctx context.Context, url *url.URL) (net.Conn, error) {
+	dialAddr := netutil.CanonicalAddr(url)
+
+	d := net.Dialer{
+		Timeout:  s.DialerTimeout,
+		Deadline: s.DialerDeadline,
+	}
+	if url.Scheme == "http" {
+		if s.Dialer == nil {
+			return d.DialContext(ctx, "tcp", dialAddr)
+		} else {
+			return s.Dialer(ctx, "tcp", dialAddr)
+		}
+	}
+
+	// TODO validate the TLSClientConfig is set up?
+	var conn *tls.Conn
+	var err error
+	if s.Dialer == nil {
+		conn, err = dialTLS(context.Background(), d.Timeout, d.Deadline, d.DialContext, "tcp", dialAddr, s.tlsConfig)
+	} else {
+		conn, err = dialTLS(context.Background(), s.DialerTimeout, s.DialerDeadline, s.Dialer, "tcp", dialAddr, s.tlsConfig)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Return if we were configured to skip validation
+	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
+		return conn, nil
+	}
+
+	host, _, err := net.SplitHostPort(dialAddr)
+	if err != nil {
+		return nil, err
+	}
+	if s.tlsConfig != nil && len(s.tlsConfig.ServerName) > 0 {
+		host = s.tlsConfig.ServerName
+	}
+	err = conn.VerifyHostname(host)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// proxyAuth returns, for a given proxy URL, the value to be used for the Proxy-Authorization header
+func (s *SpdyRoundTripper) proxyAuth(proxyURL *url.URL) string {
+	if proxyURL == nil || proxyURL.User == nil {
+		return ""
+	}
+	credentials := proxyURL.User.String()
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(credentials))
+	return fmt.Sprintf("Basic %s", encodedAuth)
+}
+
+// RoundTrip executes the Request and upgrades it. After a successful upgrade,
+// clients may call SpdyRoundTripper.Connection() to retrieve the upgraded
+// connection.
+func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	header := utilnet.CloneHeader(req.Header)
+	header.Add(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
+	header.Add(httpstream.HeaderUpgrade, HeaderSpdy31)
+
+	var (
+		conn        net.Conn
+		rawResponse []byte
+		err         error
+	)
+
+	if s.followRedirects {
+		conn, rawResponse, err = utilnet.ConnectWithRedirects(req.Method, req.URL, header, req.Body, s, s.requireSameHostRedirects)
+	} else {
+		clone := utilnet.CloneRequest(req)
+		clone.Header = header
+		conn, err = s.Dial(clone)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	responseReader := bufio.NewReader(
+		io.MultiReader(
+			bytes.NewBuffer(rawResponse),
+			conn,
+		),
+	)
+
+	resp, err := http.ReadResponse(responseReader, nil)
+	if err != nil {
+		if conn != nil {
+			conn.Close()
+		}
+		return nil, err
+	}
+
+	s.conn = conn
+
+	return resp, nil
+}
+
+// NewConnection validates the upgrade response, creating and returning a new
+// httpstream.Connection if there were no errors.
+func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
+	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
+	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
+	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
+		defer resp.Body.Close()
+		responseError := ""
+		responseErrorBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			responseError = "unable to read error from server response"
+		} else {
+			// TODO: I don't belong here, I should be abstracted from this class
+			if obj, _, err := statusCodecs.UniversalDecoder().Decode(responseErrorBytes, nil, &metav1.Status{}); err == nil {
+				if status, ok := obj.(*metav1.Status); ok {
+					return nil, &apierrors.StatusError{ErrStatus: *status}
+				}
+			}
+			responseError = string(responseErrorBytes)
+			responseError = strings.TrimSpace(responseError)
+		}
+
+		return nil, fmt.Errorf("unable to upgrade connection: %s", responseError)
+	}
+
+	return NewClientConnection(s.conn)
+}
+
+// statusScheme is private scheme for the decoding here until someone fixes the TODO in NewConnection
+var statusScheme = runtime.NewScheme()
+
+// ParameterCodec knows about query parameters used with the meta v1 API spec.
+var statusCodecs = serializer.NewCodecFactory(statusScheme)
+
+func init() {
+	statusScheme.AddUnversionedTypes(metav1.SchemeGroupVersion,
+		&metav1.Status{},
+	)
+}

--- a/pkg/k8s/httpstream/spdy/roundtripper_test.go
+++ b/pkg/k8s/httpstream/spdy/roundtripper_test.go
@@ -1,0 +1,583 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elazarl/goproxy"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// be sure to unset environment variable https_proxy (if exported) before testing, otherwise the testing will fail unexpectedly.
+func TestRoundTripAndNewConnection(t *testing.T) {
+	for _, redirect := range []bool{false, true} {
+		t.Run(fmt.Sprintf("redirect = %t", redirect), func(t *testing.T) {
+			localhostPool := x509.NewCertPool()
+			if !localhostPool.AppendCertsFromPEM(localhostCert) {
+				t.Errorf("error setting up localhostCert pool")
+			}
+
+			httpsServerInvalidHostname := func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+				if err != nil {
+					t.Errorf("https (invalid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			}
+
+			httpsServerValidHostname := func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			}
+
+			testCases := map[string]struct {
+				serverFunc             func(http.Handler) *httptest.Server
+				proxyServerFunc        func(http.Handler) *httptest.Server
+				proxyAuth              *url.Userinfo
+				clientTLS              *tls.Config
+				serverConnectionHeader string
+				serverUpgradeHeader    string
+				serverStatusCode       int
+				shouldError            bool
+			}{
+				"no headers": {
+					serverFunc:             httptest.NewServer,
+					serverConnectionHeader: "",
+					serverUpgradeHeader:    "",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true,
+				},
+				"no upgrade header": {
+					serverFunc:             httptest.NewServer,
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true,
+				},
+				"no connection header": {
+					serverFunc:             httptest.NewServer,
+					serverConnectionHeader: "",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true,
+				},
+				"no switching protocol status code": {
+					serverFunc:             httptest.NewServer,
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusForbidden,
+					shouldError:            true,
+				},
+				"http": {
+					serverFunc:             httptest.NewServer,
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"https (invalid hostname + InsecureSkipVerify)": {
+					serverFunc:             httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: true},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"https (invalid hostname + hostname verification)": {
+					serverFunc:             httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: false},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true,
+				},
+				"https (valid hostname + RootCAs)": {
+					serverFunc:             httpsServerValidHostname,
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied http->http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httptest.NewServer,
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https (invalid hostname + InsecureSkipVerify) -> http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: true},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https with auth (invalid hostname + InsecureSkipVerify) -> http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					proxyAuth:              url.UserPassword("proxyuser", "proxypasswd"),
+					clientTLS:              &tls.Config{InsecureSkipVerify: true},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https (invalid hostname + hostname verification) -> http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: false},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true, // fails because the client doesn't trust the proxy
+				},
+				"proxied https (valid hostname + RootCAs) -> http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httpsServerValidHostname,
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https with auth (valid hostname + RootCAs) -> http": {
+					serverFunc:             httptest.NewServer,
+					proxyServerFunc:        httpsServerValidHostname,
+					proxyAuth:              url.UserPassword("proxyuser", "proxypasswd"),
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https (invalid hostname + InsecureSkipVerify) -> https (invalid hostname)": {
+					serverFunc:             httpsServerInvalidHostname,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: true},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false, // works because the test proxy ignores TLS errors
+				},
+				"proxied https with auth (invalid hostname + InsecureSkipVerify) -> https (invalid hostname)": {
+					serverFunc:             httpsServerInvalidHostname,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					proxyAuth:              url.UserPassword("proxyuser", "proxypasswd"),
+					clientTLS:              &tls.Config{InsecureSkipVerify: true},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false, // works because the test proxy ignores TLS errors
+				},
+				"proxied https (invalid hostname + hostname verification) -> https (invalid hostname)": {
+					serverFunc:             httpsServerInvalidHostname,
+					proxyServerFunc:        httpsServerInvalidHostname,
+					clientTLS:              &tls.Config{InsecureSkipVerify: false},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            true, // fails because the client doesn't trust the proxy
+				},
+				"proxied https (valid hostname + RootCAs) -> https (valid hostname + RootCAs)": {
+					serverFunc:             httpsServerValidHostname,
+					proxyServerFunc:        httpsServerValidHostname,
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+				"proxied https with auth (valid hostname + RootCAs) -> https (valid hostname + RootCAs)": {
+					serverFunc:             httpsServerValidHostname,
+					proxyServerFunc:        httpsServerValidHostname,
+					proxyAuth:              url.UserPassword("proxyuser", "proxypasswd"),
+					clientTLS:              &tls.Config{RootCAs: localhostPool},
+					serverConnectionHeader: "Upgrade",
+					serverUpgradeHeader:    "SPDY/3.1",
+					serverStatusCode:       http.StatusSwitchingProtocols,
+					shouldError:            false,
+				},
+			}
+
+			for k, testCase := range testCases {
+				server := testCase.serverFunc(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					if testCase.shouldError {
+						if e, a := httpstream.HeaderUpgrade, req.Header.Get(httpstream.HeaderConnection); e != a {
+							t.Fatalf("%s: Expected connection=upgrade header, got '%s", k, a)
+						}
+
+						w.Header().Set(httpstream.HeaderConnection, testCase.serverConnectionHeader)
+						w.Header().Set(httpstream.HeaderUpgrade, testCase.serverUpgradeHeader)
+						w.WriteHeader(testCase.serverStatusCode)
+
+						return
+					}
+
+					streamCh := make(chan httpstream.Stream)
+
+					responseUpgrader := NewResponseUpgrader()
+					spdyConn := responseUpgrader.UpgradeResponse(w, req, func(s httpstream.Stream, replySent <-chan struct{}) error {
+						streamCh <- s
+						return nil
+					})
+					if spdyConn == nil {
+						t.Fatalf("%s: unexpected nil spdyConn", k)
+					}
+					defer spdyConn.Close()
+
+					stream := <-streamCh
+					io.Copy(stream, stream)
+				}))
+				defer server.Close()
+
+				serverURL, err := url.Parse(server.URL)
+				if err != nil {
+					t.Fatalf("%s: Error creating request: %s", k, err)
+				}
+				req, err := http.NewRequest("GET", server.URL, nil)
+				if err != nil {
+					t.Fatalf("%s: Error creating request: %s", k, err)
+				}
+
+				spdyTransport := NewSpdyRoundTripper(testCase.clientTLS, redirect, redirect)
+
+				var proxierCalled bool
+				var proxyCalledWithHost string
+				var proxyCalledWithAuth bool
+				var proxyCalledWithAuthHeader string
+				if testCase.proxyServerFunc != nil {
+					proxyHandler := goproxy.NewProxyHttpServer()
+
+					proxyHandler.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+						proxyCalledWithHost = host
+
+						proxyAuthHeaderName := "Proxy-Authorization"
+						_, proxyCalledWithAuth = ctx.Req.Header[proxyAuthHeaderName]
+						proxyCalledWithAuthHeader = ctx.Req.Header.Get(proxyAuthHeaderName)
+						return goproxy.OkConnect, host
+					})
+
+					proxy := testCase.proxyServerFunc(proxyHandler)
+
+					spdyTransport.proxier = func(proxierReq *http.Request) (*url.URL, error) {
+						proxierCalled = true
+						proxyURL, err := url.Parse(proxy.URL)
+						if err != nil {
+							return nil, err
+						}
+						proxyURL.User = testCase.proxyAuth
+						return proxyURL, nil
+					}
+					defer proxy.Close()
+				}
+
+				client := &http.Client{Transport: spdyTransport}
+
+				resp, err := client.Do(req)
+				var conn httpstream.Connection
+				if err == nil {
+					conn, err = spdyTransport.NewConnection(resp)
+				}
+				haveErr := err != nil
+				if e, a := testCase.shouldError, haveErr; e != a {
+					t.Fatalf("%s: shouldError=%t, got %t: %v", k, e, a, err)
+				}
+				if testCase.shouldError {
+					continue
+				}
+				defer conn.Close()
+
+				if resp.StatusCode != http.StatusSwitchingProtocols {
+					t.Fatalf("%s: expected http 101 switching protocols, got %d", k, resp.StatusCode)
+				}
+
+				stream, err := conn.CreateStream(http.Header{})
+				if err != nil {
+					t.Fatalf("%s: error creating client stream: %s", k, err)
+				}
+
+				n, err := stream.Write([]byte("hello"))
+				if err != nil {
+					t.Fatalf("%s: error writing to stream: %s", k, err)
+				}
+				if n != 5 {
+					t.Fatalf("%s: Expected to write 5 bytes, but actually wrote %d", k, n)
+				}
+
+				b := make([]byte, 5)
+				n, err = stream.Read(b)
+				if err != nil {
+					t.Fatalf("%s: error reading from stream: %s", k, err)
+				}
+				if n != 5 {
+					t.Fatalf("%s: Expected to read 5 bytes, but actually read %d", k, n)
+				}
+				if e, a := "hello", string(b[0:n]); e != a {
+					t.Fatalf("%s: expected '%s', got '%s'", k, e, a)
+				}
+
+				if testCase.proxyServerFunc != nil {
+					if !proxierCalled {
+						t.Fatalf("%s: Expected to use a proxy but proxier in SpdyRoundTripper wasn't called", k)
+					}
+					if proxyCalledWithHost != serverURL.Host {
+						t.Fatalf("%s: Expected to see a call to the proxy for backend %q, got %q", k, serverURL.Host, proxyCalledWithHost)
+					}
+				}
+
+				var expectedProxyAuth string
+				if testCase.proxyAuth != nil {
+					encodedCredentials := base64.StdEncoding.EncodeToString([]byte(testCase.proxyAuth.String()))
+					expectedProxyAuth = "Basic " + encodedCredentials
+				}
+				if len(expectedProxyAuth) == 0 && proxyCalledWithAuth {
+					t.Fatalf("%s: Proxy authorization unexpected, got %q", k, proxyCalledWithAuthHeader)
+				}
+				if proxyCalledWithAuthHeader != expectedProxyAuth {
+					t.Fatalf("%s: Expected to see a call to the proxy with credentials %q, got %q", k, testCase.proxyAuth, proxyCalledWithAuthHeader)
+				}
+			}
+		})
+	}
+}
+
+func TestRoundTripRedirects(t *testing.T) {
+	tests := []struct {
+		redirects     int32
+		expectSuccess bool
+	}{
+		{0, true},
+		{1, true},
+		{9, true},
+		{10, false},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("with %d redirects", test.redirects), func(t *testing.T) {
+			var redirects int32 = 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if redirects < test.redirects {
+					atomic.AddInt32(&redirects, 1)
+					http.Redirect(w, req, "redirect", http.StatusFound)
+					return
+				}
+				streamCh := make(chan httpstream.Stream)
+
+				responseUpgrader := NewResponseUpgrader()
+				spdyConn := responseUpgrader.UpgradeResponse(w, req, func(s httpstream.Stream, replySent <-chan struct{}) error {
+					streamCh <- s
+					return nil
+				})
+				if spdyConn == nil {
+					t.Fatalf("unexpected nil spdyConn")
+				}
+				defer spdyConn.Close()
+
+				stream := <-streamCh
+				io.Copy(stream, stream)
+			}))
+			defer server.Close()
+
+			req, err := http.NewRequest("GET", server.URL, nil)
+			if err != nil {
+				t.Fatalf("Error creating request: %s", err)
+			}
+
+			spdyTransport := NewSpdyRoundTripper(nil, true, true)
+			client := &http.Client{Transport: spdyTransport}
+
+			resp, err := client.Do(req)
+			if test.expectSuccess {
+				if err != nil {
+					t.Fatalf("error calling Do: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expecting an error")
+				} else if !strings.Contains(err.Error(), "too many redirects") {
+					t.Fatalf("expecting too many redirects, got %v", err)
+				}
+				return
+			}
+
+			conn, err := spdyTransport.NewConnection(resp)
+			if err != nil {
+				t.Fatalf("error calling NewConnection: %v", err)
+			}
+			defer conn.Close()
+
+			if resp.StatusCode != http.StatusSwitchingProtocols {
+				t.Fatalf("expected http 101 switching protocols, got %d", resp.StatusCode)
+			}
+
+			stream, err := conn.CreateStream(http.Header{})
+			if err != nil {
+				t.Fatalf("error creating client stream: %s", err)
+			}
+
+			n, err := stream.Write([]byte("hello"))
+			if err != nil {
+				t.Fatalf("error writing to stream: %s", err)
+			}
+			if n != 5 {
+				t.Fatalf("Expected to write 5 bytes, but actually wrote %d", n)
+			}
+
+			b := make([]byte, 5)
+			n, err = stream.Read(b)
+			if err != nil {
+				t.Fatalf("error reading from stream: %s", err)
+			}
+			if n != 5 {
+				t.Fatalf("Expected to read 5 bytes, but actually read %d", n)
+			}
+			if e, a := "hello", string(b[0:n]); e != a {
+				t.Fatalf("expected '%s', got '%s'", e, a)
+			}
+		})
+	}
+}
+
+// exampleCert was generated from crypto/tls/generate_cert.go with the following command:
+//    go run generate_cert.go  --rsa-bits 2048 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDADCCAeigAwIBAgIQVHG3Fn9SdWayyLOZKCW1vzANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEArTCu9fiIclNgDdWHphewM+JW55dCb5yYGlJgCBvwbOx547M9p+tn
+zm9QOhsdZDHDZsG9tqnWxE2Nc1HpIJyOlfYsOoonpEoG/Ep6nnK91ngj0bn/JlNy
++i/bwU4r97MOukvnOIQez9/D9jAJaOX2+b8/d4lRz9BsqiwJyg+ynZ5tVVYj7aMi
+vXnd6HOnJmtqutOtr3beucJnkd6XbwRkLUcAYATT+ZihOWRbTuKqhCg6zGkJOoUG
+f8sX61JjoilxiURA//ftGVbdTCU3DrmGmardp5NNOHbumMYU8Vhmqgx1Bqxb+9he
+7G42uW5YWYK/GqJzgVPjjlB2dOGj9KrEWQIDAQABo1AwTjAOBgNVHQ8BAf8EBAMC
+AqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAWBgNVHREE
+DzANggtleGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAQEAig4AIi9xWs1+pLES
+eeGGdSDoclplFpcbXANnsYYFyLf+8pcWgVi2bOmb2gXMbHFkB07MA82wRJAUTaA+
+2iNXVQMhPCoA7J6ADUbww9doJX2S9HGyArhiV/MhHtE8txzMn2EKNLdhhk3N9rmV
+x/qRbWAY1U2z4BpdrAR87Fe81Nlj7h45csW9K+eS+NgXipiNTIfEShKgCFM8EdxL
+1WXg7r9AvYV3TNDPWTjLsm1rQzzZQ7Uvcf6deWiNodZd8MOT/BFLclDPTK6cF2Hr
+UU4dq6G4kCwMSxWE4cM3HlZ4u1dyIt47VbkP0rtvkBCXx36y+NXYA5lzntchNFZP
+uvEQdw==
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEArTCu9fiIclNgDdWHphewM+JW55dCb5yYGlJgCBvwbOx547M9
+p+tnzm9QOhsdZDHDZsG9tqnWxE2Nc1HpIJyOlfYsOoonpEoG/Ep6nnK91ngj0bn/
+JlNy+i/bwU4r97MOukvnOIQez9/D9jAJaOX2+b8/d4lRz9BsqiwJyg+ynZ5tVVYj
+7aMivXnd6HOnJmtqutOtr3beucJnkd6XbwRkLUcAYATT+ZihOWRbTuKqhCg6zGkJ
+OoUGf8sX61JjoilxiURA//ftGVbdTCU3DrmGmardp5NNOHbumMYU8Vhmqgx1Bqxb
++9he7G42uW5YWYK/GqJzgVPjjlB2dOGj9KrEWQIDAQABAoIBAQClt4CiYaaF5ltx
+wVDjz6TNcJUBUs3CKE+uWAYFnF5Ii1nyU876Pxj8Aaz9fHZ6Kde0GkwiXY7gFOj1
+YHo2tzcELSKS/SEDZcYbYFTGCjq13g1AH74R+SV6WZLn+5m8kPvVrM1ZWap188H5
+bmuCkRDqVmIvShkbRW7EwhC35J9fiuW3majC/sjmsxtxyP6geWmu4f5/Ttqahcdb
+osPZIgIIPzqAkNtkLTi7+meHYI9wlrGhL7XZTwnJ1Oc/Y67zzmbthLYB5YFSLUew
+rXT58jtSjX4gbiQyheBSrWxW08QE4qYg6jJlAdffHhWv72hJW2MCXhuXp8gJs/Do
+XLRHGwSBAoGBAMdNtsbe4yae/QeHUPGxNW0ipa0yoTF6i+VYoxvqiRMzDM3+3L8k
+dgI1rr4330SivqDahMA/odWtM/9rVwJI2B2QhZLMHA0n9ytH007OO9TghgVB12nN
+xosRYBpKdHXyyvV/MUZl7Jux6zKIzRDWOkF95VVYPcAaxJqd1E5/jJ6JAoGBAN51
+QrebA1w/jfydeqQTz1sK01sbO4HYj4qGfo/JarVqGEkm1azeBBPPRnHz3jNKnCkM
+S4PpqRDased3NIcViXlAgoqPqivZ8mQa/Rb146l7WaTErASHsZ023OGrxsr/Ed6N
+P3GrmvxVJjebaFNaQ9sP80dLkpgeas0t2TY8iQNRAoGATOcnx8TpUVW3vNfx29DN
+FLdxxkrq9/SZVn3FMlhlXAsuva3B799ZybB9JNjaRdmmRNsMrkHfaFvU3JHGmRMS
+kRXa9LHdgRYSwZiNaLMbUyDvlce6HxFPswmZU4u3NGvi9KeHk+pwSgN1BaLTvdNr
+1ymE/FF4QlAR3LdZ3JBK6kECgYEA0wW4/CJ31ZIURoW8SNjh4iMqy0nR8SJVR7q9
+Y/hU2TKDRyEnoIwaohAFayNCrLUh3W5kVAXa8roB+OgDVAECH5sqOfZ+HorofD19
+x8II7ESujLZj1whBXDkm3ovsT7QWZ17lyBZZNvQvBKDPHgKKS8udowv1S4fPGENd
+wS07a4ECgYEAwLSbmMIVJme0jFjsp5d1wOGA2Qi2ZwGIAVlsbnJtygrU/hSBfnu8
+VfyJSCgg3fPe7kChWKlfcOebVKSb68LKRsz1Lz1KdbY0HOJFp/cT4lKmDAlRY9gq
+LB4rdf46lV0mUkvd2/oofIbTrzukjQSnyfLawb/2uJGV1IkTcZcn9CI=
+-----END RSA PRIVATE KEY-----`)
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//     go run generate_cert.go  --rsa-bits 2048 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDGTCCAgGgAwIBAgIRALL5AZcefF4kkYV1SEG6YrMwDQYJKoZIhvcNAQELBQAw
+EjEQMA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2
+MDAwMFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEP
+ADCCAQoCggEBALQ/FHcyVwdFHxARbbD2KBtDUT7Eni+8ioNdjtGcmtXqBv45EC1C
+JOqqGJTroFGJ6Q9kQIZ9FqH5IJR2fOOJD9kOTueG4Vt1JY1rj1Kbpjefu8XleZ5L
+SBwIWVnN/lEsEbuKmj7N2gLt5AH3zMZiBI1mg1u9Z5ZZHYbCiTpBrwsq6cTlvR9g
+dyo1YkM5hRESCzsrL0aUByoo0qRMD8ZsgANJwgsiO0/M6idbxDwv1BnGwGmRYvOE
+Hxpy3v0Jg7GJYrvnpnifJTs4nw91N5X9pXxR7FFzi/6HTYDWRljvTb0w6XciKYAz
+bWZ0+cJr5F7wB7ovlbm7HrQIR7z7EIIu2d8CAwEAAaNoMGYwDgYDVR0PAQH/BAQD
+AgKkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wLgYDVR0R
+BCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZI
+hvcNAQELBQADggEBAFPPWopNEJtIA2VFAQcqN6uJK+JVFOnjGRoCrM6Xgzdm0wxY
+XCGjsxY5dl+V7KzdGqu858rCaq5osEBqypBpYAnS9C38VyCDA1vPS1PsN8SYv48z
+DyBwj+7R2qar0ADBhnhWxvYO9M72lN/wuCqFKYMeFSnJdQLv3AsrrHe9lYqOa36s
+8wxSwVTFTYXBzljPEnSaaJMPqFD8JXaZK1ryJPkO5OsCNQNGtatNiWAf3DcmwHAT
+MGYMzP0u4nw47aRz9shB8w+taPKHx2BVwE1m/yp3nHVioOjXqA1fwRQVGclCJSH1
+D2iq3hWVHRENgjTjANBPICLo9AZ4JfN6PH19mnU=
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAtD8UdzJXB0UfEBFtsPYoG0NRPsSeL7yKg12O0Zya1eoG/jkQ
+LUIk6qoYlOugUYnpD2RAhn0WofkglHZ844kP2Q5O54bhW3UljWuPUpumN5+7xeV5
+nktIHAhZWc3+USwRu4qaPs3aAu3kAffMxmIEjWaDW71nllkdhsKJOkGvCyrpxOW9
+H2B3KjViQzmFERILOysvRpQHKijSpEwPxmyAA0nCCyI7T8zqJ1vEPC/UGcbAaZFi
+84QfGnLe/QmDsYliu+emeJ8lOzifD3U3lf2lfFHsUXOL/odNgNZGWO9NvTDpdyIp
+gDNtZnT5wmvkXvAHui+VubsetAhHvPsQgi7Z3wIDAQABAoIBAGmw93IxjYCQ0ncc
+kSKMJNZfsdtJdaxuNRZ0nNNirhQzR2h403iGaZlEpmdkhzxozsWcto1l+gh+SdFk
+bTUK4MUZM8FlgO2dEqkLYh5BcMT7ICMZvSfJ4v21E5eqR68XVUqQKoQbNvQyxFk3
+EddeEGdNrkb0GDK8DKlBlzAW5ep4gjG85wSTjR+J+muUv3R0BgLBFSuQnIDM/IMB
+LWqsja/QbtB7yppe7jL5u8UCFdZG8BBKT9fcvFIu5PRLO3MO0uOI7LTc8+W1Xm23
+uv+j3SY0+v+6POjK0UlJFFi/wkSPTFIfrQO1qFBkTDQHhQ6q/7GnILYYOiGbIRg2
+NNuP52ECgYEAzXEoy50wSYh8xfFaBuxbm3ruuG2W49jgop7ZfoFrPWwOQKAZS441
+VIwV4+e5IcA6KkuYbtGSdTYqK1SMkgnUyD/VevwAqH5TJoEIGu0pDuKGwVuwqioZ
+frCIAV5GllKyUJ55VZNbRr2vY2fCsWbaCSCHETn6C16DNuTCe5C0JBECgYEA4JqY
+5GpNbMG8fOt4H7hU0Fbm2yd6SHJcQ3/9iimef7xG6ajxsYrIhg1ft+3IPHMjVI0+
+9brwHDnWg4bOOx/VO4VJBt6Dm/F33bndnZRkuIjfSNpLM51P+EnRdaFVHOJHwKqx
+uF69kihifCAG7YATgCveeXImzBUSyZUz9UrETu8CgYARNBimdFNG1RcdvEg9rC0/
+p9u1tfecvNySwZqU7WF9kz7eSonTueTdX521qAHowaAdSpdJMGODTTXaywm6cPhQ
+jIfj9JZZhbqQzt1O4+08Qdvm9TamCUB5S28YLjza+bHU7nBaqixKkDfPqzCyilpX
+yVGGL8SwjwmN3zop/sQXAQKBgC0JMsESQ6YcDsRpnrOVjYQc+LtW5iEitTdfsaID
+iGGKihmOI7B66IxgoCHMTws39wycKdSyADVYr5e97xpR3rrJlgQHmBIrz+Iow7Q2
+LiAGaec8xjl6QK/DdXmFuQBKqyKJ14rljFODP4QuE9WJid94bGqjpf3j99ltznZP
+4J8HAoGAJb4eb4lu4UGwifDzqfAPzLGCoi0fE1/hSx34lfuLcc1G+LEu9YDKoOVJ
+9suOh0b5K/bfEy9KrVMBBriduvdaERSD8S3pkIQaitIz0B029AbE4FLFf9lKQpP2
+KR8NJEkK99Vh/tew6jAMll70xFrE7aF8VLXJVE7w4sQzuvHxl9Q=
+-----END RSA PRIVATE KEY-----
+`)

--- a/pkg/k8s/httpstream/spdy/tls.go
+++ b/pkg/k8s/httpstream/spdy/tls.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spdy
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"strings"
+	"time"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "tls: DialWithDialer timed out" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+var emptyConfig tls.Config
+
+func defaultConfig() *tls.Config {
+	return &emptyConfig
+}
+
+func dialTLS(ctx context.Context, timeout time.Duration, deadline time.Time, dialer func(ctx context.Context, network, address string) (net.Conn, error), network, addr string, config *tls.Config) (*tls.Conn, error) {
+
+	if !deadline.IsZero() {
+		deadlineTimeout := time.Until(deadline)
+		if timeout == 0 || deadlineTimeout < timeout {
+			timeout = deadlineTimeout
+		}
+	}
+
+	// hsErrCh is non-nil if we might not wait for Handshake to complete.
+	var hsErrCh chan error
+	if timeout != 0 || ctx.Done() != nil {
+		hsErrCh = make(chan error, 2)
+	}
+	if timeout != 0 {
+		timer := time.AfterFunc(timeout, func() {
+			hsErrCh <- timeoutError{}
+		})
+		defer timer.Stop()
+	}
+
+	rawConn, err := dialer(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	colonPos := strings.LastIndex(addr, ":")
+	if colonPos == -1 {
+		colonPos = len(addr)
+	}
+	hostname := addr[:colonPos]
+
+	if config == nil {
+		config = defaultConfig()
+	}
+	// If no ServerName is set, infer the ServerName
+	// from the hostname we're connecting to.
+	if config.ServerName == "" {
+		// Make a copy to avoid polluting argument or default.
+		c := config.Clone()
+		c.ServerName = hostname
+		config = c
+	}
+
+	conn := tls.Client(rawConn, config)
+
+	if hsErrCh == nil {
+		err = conn.Handshake()
+	} else {
+		go func() {
+			hsErrCh <- conn.Handshake()
+		}()
+
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case err = <-hsErrCh:
+			if err != nil {
+				// If the error was due to the context
+				// closing, prefer the context's error, rather
+				// than some random network teardown error.
+				if e := ctx.Err(); e != nil {
+					err = e
+				}
+			}
+		}
+	}
+
+	if err != nil {
+		rawConn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}

--- a/pkg/k8s/httpstream/spdy/upgrade.go
+++ b/pkg/k8s/httpstream/spdy/upgrade.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const HeaderSpdy31 = "SPDY/3.1"
+
+// responseUpgrader knows how to upgrade HTTP responses. It
+// implements the httpstream.ResponseUpgrader interface.
+type responseUpgrader struct {
+}
+
+// connWrapper is used to wrap a hijacked connection and its bufio.Reader. All
+// calls will be handled directly by the underlying net.Conn with the exception
+// of Read and Close calls, which will consider data in the bufio.Reader. This
+// ensures that data already inside the used bufio.Reader instance is also
+// read.
+type connWrapper struct {
+	net.Conn
+	closed    int32
+	bufReader *bufio.Reader
+}
+
+func (w *connWrapper) Read(b []byte) (n int, err error) {
+	if atomic.LoadInt32(&w.closed) == 1 {
+		return 0, io.EOF
+	}
+	return w.bufReader.Read(b)
+}
+
+func (w *connWrapper) Close() error {
+	err := w.Conn.Close()
+	atomic.StoreInt32(&w.closed, 1)
+	return err
+}
+
+// NewResponseUpgrader returns a new httpstream.ResponseUpgrader that is
+// capable of upgrading HTTP responses using SPDY/3.1 via the
+// spdystream package.
+func NewResponseUpgrader() httpstream.ResponseUpgrader {
+	return responseUpgrader{}
+}
+
+// UpgradeResponse upgrades an HTTP response to one that supports multiplexed
+// streams. newStreamHandler will be called synchronously whenever the
+// other end of the upgraded connection creates a new stream.
+func (u responseUpgrader) UpgradeResponse(w http.ResponseWriter, req *http.Request, newStreamHandler httpstream.NewStreamHandler) httpstream.Connection {
+	connectionHeader := strings.ToLower(req.Header.Get(httpstream.HeaderConnection))
+	upgradeHeader := strings.ToLower(req.Header.Get(httpstream.HeaderUpgrade))
+	if !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
+		errorMsg := fmt.Sprintf("unable to upgrade: missing upgrade headers in request: %#v", req.Header)
+		http.Error(w, errorMsg, http.StatusBadRequest)
+		return nil
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		errorMsg := fmt.Sprintf("unable to upgrade: unable to hijack response")
+		http.Error(w, errorMsg, http.StatusInternalServerError)
+		return nil
+	}
+
+	w.Header().Add(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
+	w.Header().Add(httpstream.HeaderUpgrade, HeaderSpdy31)
+	w.WriteHeader(http.StatusSwitchingProtocols)
+
+	conn, bufrw, err := hijacker.Hijack()
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("unable to upgrade: error hijacking response: %v", err))
+		return nil
+	}
+
+	connWithBuf := &connWrapper{Conn: conn, bufReader: bufrw.Reader}
+	spdyConn, err := NewServerConnection(connWithBuf, newStreamHandler)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("unable to upgrade: error creating SPDY server connection: %v", err))
+		return nil
+	}
+
+	return spdyConn
+}

--- a/pkg/k8s/httpstream/spdy/upgrade_test.go
+++ b/pkg/k8s/httpstream/spdy/upgrade_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpgradeResponse(t *testing.T) {
+	testCases := []struct {
+		connectionHeader string
+		upgradeHeader    string
+		shouldError      bool
+	}{
+		{
+			connectionHeader: "",
+			upgradeHeader:    "",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "",
+			upgradeHeader:    "SPDY/3.1",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "SPDY/3.1",
+			shouldError:      false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			upgrader := NewResponseUpgrader()
+			conn := upgrader.UpgradeResponse(w, req, nil)
+			haveErr := conn == nil
+			if e, a := testCase.shouldError, haveErr; e != a {
+				t.Fatalf("%d: expected shouldErr=%t, got %t", i, testCase.shouldError, haveErr)
+			}
+			if haveErr {
+				return
+			}
+			if conn == nil {
+				t.Fatalf("%d: unexpected nil conn", i)
+			}
+			defer conn.Close()
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		if err != nil {
+			t.Fatalf("%d: error creating request: %s", i, err)
+		}
+
+		req.Header.Set("Connection", testCase.connectionHeader)
+		req.Header.Set("Upgrade", testCase.upgradeHeader)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%d: unexpected non-nil err from client.Do: %s", i, err)
+		}
+
+		if testCase.shouldError {
+			continue
+		}
+
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("%d: expected status 101 switching protocols, got %d", i, resp.StatusCode)
+		}
+	}
+}

--- a/pkg/k8s/remotecommand/remotecommand.go
+++ b/pkg/k8s/remotecommand/remotecommand.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remotecommand
+
+import (
+	"net/url"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+
+	httpstreamspdy "github.com/erda-project/erda/pkg/k8s/httpstream/spdy"
+	spdy "github.com/erda-project/erda/pkg/k8s/spdy"
+)
+
+// NewSPDYExecutor connects to the provided server and upgrades the connection to
+// multiplexed bidirectional streams.
+func NewSPDYExecutor(config *restclient.Config, method string, url *url.URL) (remotecommand.Executor, error) {
+	wrapper, upgradeRoundTripper, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, err
+	}
+	// request by cluster-dialer
+	if config.Dial != nil {
+		spdyRoundTripper, ok := upgradeRoundTripper.(*httpstreamspdy.SpdyRoundTripper)
+		if ok {
+			spdyRoundTripper.Dialer = config.Dial
+		}
+	}
+	return remotecommand.NewSPDYExecutorForTransports(wrapper, upgradeRoundTripper, method, url)
+}

--- a/pkg/k8s/spdy/spdy.go
+++ b/pkg/k8s/spdy/spdy.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	// "k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	restclient "k8s.io/client-go/rest"
+
+	spdy "github.com/erda-project/erda/pkg/k8s/httpstream/spdy"
+)
+
+// Upgrader validates a response from the server after a SPDY upgrade.
+type Upgrader interface {
+	// NewConnection validates the response and creates a new Connection.
+	NewConnection(resp *http.Response) (httpstream.Connection, error)
+}
+
+// RoundTripperFor returns a round tripper and upgrader to use with SPDY.
+func RoundTripperFor(config *restclient.Config) (http.RoundTripper, Upgrader, error) {
+	tlsConfig, err := restclient.TLSConfigFor(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig, true, false)
+	wrapper, err := restclient.HTTPWrappersForConfig(config, upgradeRoundTripper)
+	if err != nil {
+		return nil, nil, err
+	}
+	return wrapper, upgradeRoundTripper, nil
+}
+
+// dialer implements the httpstream.Dialer interface.
+type dialer struct {
+	client   *http.Client
+	upgrader Upgrader
+	method   string
+	url      *url.URL
+}
+
+var _ httpstream.Dialer = &dialer{}
+
+// NewDialer will create a dialer that connects to the provided URL and upgrades the connection to SPDY.
+func NewDialer(upgrader Upgrader, client *http.Client, method string, url *url.URL) httpstream.Dialer {
+	return &dialer{
+		client:   client,
+		upgrader: upgrader,
+		method:   method,
+		url:      url,
+	}
+}
+
+func (d *dialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	req, err := http.NewRequest(d.method, d.url.String(), nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("error creating request: %v", err)
+	}
+	return Negotiate(d.upgrader, d.client, req, protocols...)
+}
+
+// Negotiate opens a connection to a remote server and attempts to negotiate
+// a SPDY connection. Upon success, it returns the connection and the protocol selected by
+// the server. The client transport must use the upgradeRoundTripper - see RoundTripperFor.
+func Negotiate(upgrader Upgrader, client *http.Client, req *http.Request, protocols ...string) (httpstream.Connection, string, error) {
+	for i := range protocols {
+		req.Header.Add(httpstream.HeaderProtocolVersion, protocols[i])
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+	conn, err := upgrader.NewConnection(resp)
+	if err != nil {
+		return nil, "", err
+	}
+	return conn, resp.Header.Get(httpstream.HeaderProtocolVersion), nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
1、k8s remotecommand support cluster-dialer
2、fix monitor agent injector config path
3、fix filemanager openapi path

#### Specified Reviewers:

/assign @liuhaoyang 

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     k8s remotecommand support cluster-dialer         |
| 🇨🇳 中文    |    支持 通过 cluster-dialer 执行 k8s  pod 命令    |
