### PR TITLE
fix(dop): unexpected render missing create button when delete mysql addon account

### DIFF
--- a/modules/dop/component-protocol/scenarios/addon-mysql-account.yml
+++ b/modules/dop/component-protocol/scenarios/addon-mysql-account.yml
@@ -39,6 +39,7 @@ rendering:
   accountTable:
     - name: viewPasswordModal
     - name: viewPassword
+    - name: addAccountButton
   addAccountButton:
     - name: root
     - name: accountTable


### PR DESCRIPTION
#### What this PR does / why we need it:
render fail when delete mysql addon

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix(dop): unexpected render missing create button when delete mysql addon account          |
| 🇨🇳 中文    |      修复删除mysql 账号时渲染失败缺少创建按钮的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
