### PR TITLE
fix: cherry-pick add console button #3819 to release/1.5

### DIFF
--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/consoleButton/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/consoleButton/render.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consoleButton
+
+import "github.com/erda-project/erda/modules/openapi/component-protocol/components/base"
+
+func init() {
+	base.InitProvider("cmp-dashboard-pods", "consoleButton")
+}

--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/scenario.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/scenario.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/addPodFilter"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/chartContainer"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/charts"
+	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/consoleButton"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/filter"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/page"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsCharts"

--- a/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/consoleButton/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/consoleButton/render.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consoleButton
+
+import "github.com/erda-project/erda/modules/openapi/component-protocol/components/base"
+
+func init() {
+	base.InitProvider("cmp-dashboard-workloads-list", "consoleButton")
+}

--- a/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/scenario.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/scenario.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/addWorkloadFilter"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/chartContainer"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/charts"
+	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/consoleButton"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/page"
 	_ "github.com/erda-project/erda/modules/cmp/component-protocol/components/cmp-dashboard-workloads-list/table"

--- a/modules/cmp/component-protocol/scenarios/cmp-dashboard-pods.yml
+++ b/modules/cmp/component-protocol/scenarios/cmp-dashboard-pods.yml
@@ -21,6 +21,7 @@ hierarchy:
       - podsTotal
       - podsCharts
     topHead:
+      - consoleButton
       - addPodButton
     tableContainer:
       - tabsTable
@@ -41,12 +42,14 @@ components:
     type: FileEditor
   addPodButton:
     type: Button
+  consoleButton:
+    type: Custom
   filter:
     type: ContractiveFilter
   page:
     type: Container
   topHead:
-    type: Container
+    type: RowContainer
   charts:
     type: Container
   chartContainer:

--- a/modules/cmp/component-protocol/scenarios/cmp-dashboard-workloads-list.yml
+++ b/modules/cmp/component-protocol/scenarios/cmp-dashboard-workloads-list.yml
@@ -10,6 +10,7 @@ hierarchy:
       - addWorkloadDrawer
       - yamlDrawer
     workloadHead:
+      - consoleButton
       - addWorkloadButton
     charts:
       - chartContainer
@@ -31,7 +32,7 @@ components:
   page:
     type: Container
   workloadHead:
-    type: Container
+    type: RowContainer
   charts:
     type: Container
   chartContainer:
@@ -54,6 +55,8 @@ components:
     type: Drawer
   addWorkloadButton:
     type: Button
+  consoleButton:
+    type: Custom
   table:
     type: ComposeTable
   yamlDrawer:


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: cherry-pick add console button #3819 to release/1.5

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: cherry-pick add console button #3819 to release/1.5 |
| 🇨🇳 中文    | 在release/1.5版本中修复英文状态下CMP dashboard中控制台按钮与创建按钮重合的问题 |

