### PR TITLE
fix(pipeline): filter out duplicate pipelines when reporting the number of executions

### DIFF
--- a/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
+++ b/modules/pipeline/aop/plugins/pipeline/testplan_after/plugin.go
@@ -297,8 +297,14 @@ func statistics(ctx *aoptypes.TuneContext, pipelineID uint64) (*ApiNumStatistics
 			apiSuccessNum++
 		}
 	}
+	// Filter out duplicate pipelines
+	pipelineIDMap := make(map[uint64]struct{})
 	for id, reports := range snippetReports {
 		for _, report := range reports {
+			if _, ok := pipelineIDMap[report.PipelineID]; ok {
+				continue
+			}
+			pipelineIDMap[report.PipelineID] = struct{}{}
 			meta, err := convertReport(id, report)
 			if err != nil {
 				continue


### PR DESCRIPTION
#### What this PR does / why we need it:
filter out duplicate pipelines when reporting the number of executions

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOls4ODMsNzcyXSwibWVtYmVyIjpbIjEwMDEyNjEiXX0%3D&id=274143&iterationID=772&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      filter out duplicate pipelines when reporting the number of executions        |
| 🇨🇳 中文    |      上报执行数量时过滤掉重复上报的流水线       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
