### PR TITLE
fix: Modification of branch calculation method

### DIFF
--- a/modules/dop/services/filetree/filetree.go
+++ b/modules/dop/services/filetree/filetree.go
@@ -971,10 +971,22 @@ func getBranchStr(name string) string {
 	}
 
 	rightNameValue := splitValue[3]
-	afterIndex := strings.LastIndex(rightNameValue, "/.dice/")
-	if afterIndex == -1 {
-		afterIndex = strings.LastIndex(rightNameValue, "/.erda/")
+
+	var afterIndex = -1
+	if strings.HasSuffix(rightNameValue, "/.dice") {
+		afterIndex = strings.LastIndex(rightNameValue, "/.dice")
+	} else {
+		afterIndex = strings.LastIndex(rightNameValue, "/.dice/")
 	}
+
+	if afterIndex == -1 {
+		if strings.HasSuffix(rightNameValue, "/.erda") {
+			afterIndex = strings.LastIndex(rightNameValue, "/.erda")
+		} else {
+			afterIndex = strings.LastIndex(rightNameValue, "/.erda/")
+		}
+	}
+
 	if afterIndex == -1 {
 		afterIndex = strings.LastIndex(rightNameValue, "/pipeline.yml")
 	}

--- a/modules/dop/services/filetree/filetree_test.go
+++ b/modules/dop/services/filetree/filetree_test.go
@@ -74,6 +74,41 @@ func Test_getBranchStr(t *testing.T) {
 			},
 			want: "feature/sad",
 		},
+		{
+			name: "test 7",
+			args: args{
+				name: "1/2/tree/feature/.diced",
+			},
+			want: "feature/.diced",
+		},
+		{
+			name: "test 8",
+			args: args{
+				name: "1/2/tree/feature/.dice/.dice",
+			},
+			want: "feature/.dice",
+		},
+		{
+			name: "test 9",
+			args: args{
+				name: "1/2/tree/.dice",
+			},
+			want: ".dice",
+		},
+		{
+			name: "test 10",
+			args: args{
+				name: "1/2/tree/.dice/.diced/.erda",
+			},
+			want: ".dice/.diced",
+		},
+		{
+			name: "test 11",
+			args: args{
+				name: "1/2/tree/develop/.dice",
+			},
+			want: "develop",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
Modification of branch calculation method, If the number of / characters of the branch is calculated incorrectly, the pipelines directory will not be obtained.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://terminus-org.app.terminus.io/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOlsxMDY5LDg4Myw3NzIsMTA5MF0sIm1lbWJlciI6WyIxMDAwNTYwIl19&id=281110&iterationID=772&pId=0&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Modification of branch calculation method       |
| 🇨🇳 中文    |       分支计算方式修改       |

