### PR TITLE
fix: (cherry-pick to release/1.6-alpha.2) hide aggregate button (#4019)

### DIFF
--- a/modules/dop/component-protocol/components/release-manage/releaseFilter/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseFilter/render.go
@@ -47,7 +47,7 @@ func (f *ComponentReleaseFilter) Render(ctx context.Context, component *cptype.C
 	}
 
 	if event.Operation == cptype.InitializeOperation {
-		f.State.Values.Latest = true
+		//f.State.Values.Latest = true
 		if err := f.DecodeURLQuery(); err != nil {
 			return errors.Errorf("failed to decode url query for release filter component, %v", err)
 		}
@@ -236,13 +236,15 @@ func (f *ComponentReleaseFilter) RenderFilter() error {
 	}
 	userCondition.Options = userOptions
 	f.Data.Conditions = append(f.Data.Conditions, userCondition)
-	if !f.State.IsProjectRelease {
-		f.Data.Conditions = append(f.Data.Conditions, Condition{
-			Key:   "latest",
-			Label: f.sdk.I18n("aggregateByBranch"),
-			Type:  "checkbox",
-		})
-	}
+
+	//if !f.State.IsProjectRelease {
+	//	f.Data.Conditions = append(f.Data.Conditions, Condition{
+	//		Key:   "latest",
+	//		Label: f.sdk.I18n("aggregateByBranch"),
+	//		Type:  "checkbox",
+	//	})
+	//}
+
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: (cherry-pick to release/1.6-alpha.2) hide aggregate button (#4019)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)

#### Specified Reviewers:

/assign @sixther-dc 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: (cherry-pick to release/1.6-alpha.2) hide aggregate button (#4019 )
| 🇨🇳 中文    | 在release/1.6中隐藏聚合按钮 |

