### PR TITLE
fix: check user is-existed when add member

### DIFF
--- a/.erda/migrations/cmdb/20220214-delete-empty-userid-member.sql
+++ b/.erda/migrations/cmdb/20220214-delete-empty-userid-member.sql
@@ -1,0 +1,2 @@
+DELETE FROM dice_member WHERE user_id = '';
+DELETE FROM dice_member_extra WHERE user_id = '';

--- a/pkg/ucauth/user_admin.go
+++ b/pkg/ucauth/user_admin.go
@@ -342,7 +342,11 @@ func (c *UCClient) findUsersByQuery(query string, idOrder ...string) ([]User, er
 		}
 		var orderedUsers []User
 		for _, id := range idOrder {
-			orderedUsers = append(orderedUsers, userMap[id])
+			user, ok := userMap[id]
+			if !ok {
+				return nil, fmt.Errorf("failed to find user by id: %s", id)
+			}
+			orderedUsers = append(orderedUsers, user)
 		}
 		return orderedUsers, nil
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
check user is-existed when add member

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOlsxMDY5LDg4Myw4ODEsMTA5MCw3NzJdLCJtZW1iZXIiOlsiMTAwMTIwNSJdfQ%3D%3D&id=282243&iterationID=1090&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that empty user in dice_member （修复了项目成员列表存在空成员的bug）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that empty user in dice_member            |
| 🇨🇳 中文    |  修复了项目成员列表存在空成员的bug            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
