### PR TITLE
feat: Automated testing, the request is proxied to the edge cluster regardless of whether it is an internal address or not

### DIFF
--- a/pkg/apitestsv2/apitest_test.go
+++ b/pkg/apitestsv2/apitest_test.go
@@ -67,17 +67,9 @@ func TestAPITest_Invoke(t *testing.T) {
 				testEnv:    &apistructs.APITestEnvData{},
 				caseParams: nil,
 			},
-			want: &apistructs.APIRequestInfo{
-				URL:     "http://www.erda.cloud",
-				Method:  "GET",
-				Headers: map[string][]string{"Accept-Encoding": {"identity"}},
-				Params:  map[string][]string{},
-				Body: apistructs.APIBody{
-					Content: "",
-				},
-			},
+			want:    nil,
 			want1:   &apistructs.APIResp{},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:
Automated testing, the request is proxied to the edge cluster regardless of whether it is an internal address or not

#### Specified Reviewers:

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Automated testing, the request is proxied to the edge cluster regardless of whether it is an internal address or not         |
| 🇨🇳 中文    |       通过自动测试，无论请求是否为内部地址，都会将其代理到边缘群集       |
