### PR TITLE
fix: print error rather than return if unmarshal release list failed

### DIFF
--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -308,7 +308,7 @@ func (r *ComponentReleaseTable) RenderTable(gs *cptype.GlobalStateData) error {
 
 			var refReleasedList [][]string
 			if err := json.Unmarshal([]byte(release.ApplicationReleaseList), &refReleasedList); err != nil {
-				return err
+				logrus.Errorf("failed to unmarshal application release list for release %s, %v", release.ReleaseID, err)
 			}
 			var list []string
 			for i := 0; i < len(refReleasedList); i++ {
@@ -426,12 +426,12 @@ func (r *ComponentReleaseTable) SetComponentValue() {
 	}
 }
 
-func (r *ComponentReleaseTable) Transfer(component *cptype.Component) {
-	component.Props = cputil.MustConvertProps(r.Props)
-	component.Data = map[string]interface{}{
+func (r *ComponentReleaseTable) Transfer(c *cptype.Component) {
+	c.Props = cputil.MustConvertProps(r.Props)
+	c.Data = map[string]interface{}{
 		"list": r.Data.List,
 	}
-	component.State = map[string]interface{}{
+	c.State = map[string]interface{}{
 		"releaseTable__urlQuery": r.State.ReleaseTableURLQuery,
 		"pageNo":                 r.State.PageNo,
 		"pageSize":               r.State.PageSize,
@@ -444,7 +444,7 @@ func (r *ComponentReleaseTable) Transfer(component *cptype.Component) {
 		"applicationID":          r.State.ApplicationID,
 		"filterValues":           r.State.FilterValues,
 	}
-	component.Operations = r.Operations
+	c.Operations = r.Operations
 }
 
 func (r *ComponentReleaseTable) formalReleases(releaseID []string) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: print error rather than return if unmarshal release list failed

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: print error rather than return if unmarshal release list failed |
| 🇨🇳 中文    | 对项目制品的引用列表反序列化失败时只打印错误而不是直接返回 |


#### Need cherry-pick to release versions?

Need cherry-pick to release/1.6-alpha.3
