### PR TITLE
fix: kms describe api invoke wrong method

### DIFF
--- a/modules/core-services/services/filesvc/svc.go
+++ b/modules/core-services/services/filesvc/svc.go
@@ -16,6 +16,7 @@ package filesvc
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -60,11 +61,20 @@ func New(options ...Option) *FileService {
 			}
 			panic(err)
 		}
-		if len(kv.Value) == 0 {
+		kmsKey = string(kv.Value)
+		if len(kmsKey) == 0 {
 			ApplyKmsCmk(svc)
 			return
+		} else {
+			_, err = svc.bdl.KMSRotateKeyVersion(apistructs.KMSRotateKeyVersionRequest{
+				RotateKeyVersionRequest: kmstypes.RotateKeyVersionRequest{
+					KeyID: kmsKey,
+				},
+			})
+			if err != nil {
+				panic(fmt.Errorf("dop files kms cmk rotate key version failed, keyID: %s", kmsKey))
+			}
 		}
-		kmsKey = string(kv.Value)
 		_, err = svc.bdl.KMSDescribeKey(apistructs.KMSDescribeKeyRequest{
 			DescribeKeyRequest: kmstypes.DescribeKeyRequest{
 				KeyID: kmsKey,

--- a/modules/kms/endpoints/endpoints.go
+++ b/modules/kms/endpoints/endpoints.go
@@ -57,6 +57,6 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 		{Path: "/api/kms/decrypt", Method: http.MethodPost, Handler: e.KmsDecrypt},
 		{Path: "/api/kms/generate-data-key", Method: http.MethodPost, Handler: e.KmsGenerateDataKey},
 		{Path: "/api/kms/rotate-key-version", Method: http.MethodPost, Handler: e.KmsRotateKeyVersion},
-		{Path: "/api/kms/describe-key", Method: http.MethodGet, Handler: e.KmsRotateKeyVersion},
+		{Path: "/api/kms/describe-key", Method: http.MethodGet, Handler: e.KmsDescribeKey},
 	}
 }

--- a/modules/kms/endpoints/kms.go
+++ b/modules/kms/endpoints/kms.go
@@ -43,7 +43,7 @@ func (e *Endpoints) KmsCreateKey(ctx context.Context, r *http.Request, vars map[
 	return httpserver.OkResp(createKeyResp)
 }
 
-func (e *Endpoints) DescribeKey(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
+func (e *Endpoints) KmsDescribeKey(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
 	var req kmstypes.DescribeKeyRequest
 	if err := e.parseRequestBody(r, &req); err != nil {
 		return err.ToResp(), nil

--- a/pkg/kms/kms_test.go
+++ b/pkg/kms/kms_test.go
@@ -68,7 +68,7 @@ package kms
 //
 //	// describe
 //	keyID := createKeyResp.KeyMetadata.KeyID
-//	descKeyResp, err := plugin.DescribeKey(ctx, &kmstypes.DescribeKeyRequest{KeyID: keyID})
+//	descKeyResp, err := plugin.KmsDescribeKey(ctx, &kmstypes.DescribeKeyRequest{KeyID: keyID})
 //	assert.NoError(t, err)
 //	spew.Dump("describe key", descKeyResp.KeyMetadata)
 //


### PR DESCRIPTION
#### What this PR does / why we need it:

- kms describe api invoke wrong method
- fix dop kms action as before (rotate cmk privateKeyVersion at bootstrap)

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=282686&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1069&type=TASK)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix: kms describe api invoke wrong method           |
| 🇨🇳 中文    |     修复了 KMS Describe API 的错误方法调用         |

