### PR TITLE
fix: release group can not be empty

### DIFF
--- a/modules/dicehub/service/release/release.go
+++ b/modules/dicehub/service/release/release.go
@@ -118,7 +118,13 @@ func (r *Release) Create(req *apistructs.ReleaseCreateRequest) (string, error) {
 	)
 	if req.IsProjectRelease {
 		var list []string
+		if len(req.ApplicationReleaseList) == 0 {
+			return "", errors.New("application release list can not be empty")
+		}
 		for i := 0; i < len(req.ApplicationReleaseList); i++ {
+			if len(req.ApplicationReleaseList[i]) == 0 {
+				return "", errors.New("application release group can not be empty")
+			}
 			sort.Strings(req.ApplicationReleaseList[i])
 			list = append(list, req.ApplicationReleaseList[i]...)
 		}
@@ -451,6 +457,9 @@ func (r *Release) Update(orgID int64, releaseID string, req *apistructs.ReleaseU
 
 		var newList []string
 		for i := 0; i < len(req.ApplicationReleaseList); i++ {
+			if len(req.ApplicationReleaseList[i]) == 0 {
+				return errors.New("application release group can not be empty")
+			}
 			sort.Strings(req.ApplicationReleaseList[i])
 			newList = append(newList, req.ApplicationReleaseList[i]...)
 		}

--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -140,17 +140,17 @@ func (r *ComponentReleaseTable) DecodeURLQuery() error {
 }
 
 func (r *ComponentReleaseTable) EncodeURLQuery() error {
-	query := make(map[string]interface{})
-	query["pageNo"] = r.State.PageNo
-	query["pageSize"] = r.State.PageSize
-	query["sorterData"] = r.State.Sorter
-	data, err := json.Marshal(query)
+	urlQuery := make(map[string]interface{})
+	urlQuery["pageNo"] = r.State.PageNo
+	urlQuery["pageSize"] = r.State.PageSize
+	urlQuery["sorterData"] = r.State.Sorter
+	jsonData, err := json.Marshal(urlQuery)
 	if err != nil {
 		return err
 	}
 
-	encode := base64.StdEncoding.EncodeToString(data)
-	r.State.ReleaseTableURLQuery = encode
+	encoded := base64.StdEncoding.EncodeToString(jsonData)
+	r.State.ReleaseTableURLQuery = encoded
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: release group can not be empty

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: release group can not be empty |
| 🇨🇳 中文    | 修复创建项目制品时引用应用制品组为空后还能创建成功的问题 |


#### Need cherry-pick to release versions?

Need cherry-pick to release/1.6-alpha.3
