### PR TITLE
fix: pipeline creates k8s executors concurrently when initializing

### DIFF
--- a/modules/pipeline/conf/conf.go
+++ b/modules/pipeline/conf/conf.go
@@ -112,6 +112,9 @@ type Conf struct {
 	// scheduler executor refresh interval
 	ExecutorRefreshIntervalMinute uint64 `env:"EXECUTOR_REFRESH_INTERVAL_MINUTE" default:"20"`
 	SpecifyImagePullPolicy        string `env:"SPECIFY_IMAGE_PULL_POLICY" default:"IfNotPresent"`
+
+	// k8s executor goroutine pool size
+	K8SExecutorPoolSize int `env:"K8S_EXECUTOR_POOL_SIZE" default:"50"`
 }
 
 var cfg Conf
@@ -362,4 +365,9 @@ func ExecutorRefreshIntervalMinute() uint64 {
 // SpecifyImagePullPolicy return default image pull policy
 func SpecifyImagePullPolicy() string {
 	return cfg.SpecifyImagePullPolicy
+}
+
+// K8SExecutorPoolSize return default k8s executor pool size
+func K8SExecutorPoolSize() int {
+	return cfg.K8SExecutorPoolSize
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline creates k8s executors concurrently when initializing

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb24iOlsxMDkwXSwibWVtYmVyIjpbIjEwMDEyMDUiXX0%3D&id=283781&iterationID=1090&pId=0&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that pipeline create k8s executor concurrency （pipeline启动时并发的去创建k8s executor）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that pipeline creates k8s executors concurrently when initializing           |
| 🇨🇳 中文    |     pipeline启动时并发的去创建k8s executor         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).