### PR TITLE
fix: check user is-existed in member service

### DIFF
--- a/modules/core-services/services/member/member.go
+++ b/modules/core-services/services/member/member.go
@@ -93,6 +93,9 @@ func (m *Member) CreateOrUpdate(userID string, req apistructs.MemberAddRequest) 
 		logrus.Warnf("failed to get user info, (%v)", err)
 		return errors.Errorf("failed to get user info")
 	}
+	if err := m.checkUCUserInfo(users); err != nil {
+		return err
+	}
 
 	for _, role := range req.Roles {
 		if types.CheckIfRoleIsOwner(role) {
@@ -910,4 +913,13 @@ func (m *Member) getMember(scopeType apistructs.ScopeType, scopeID int64) (map[s
 	}
 
 	return members, nil
+}
+
+func (m *Member) checkUCUserInfo(users []ucauth.User) error {
+	for _, user := range users {
+		if user.ID == "" {
+			return errors.Errorf("failed to get user info")
+		}
+	}
+	return nil
 }

--- a/modules/core-services/services/member/member_test.go
+++ b/modules/core-services/services/member/member_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/core-services/dao"
+	"github.com/erda-project/erda/pkg/ucauth"
 )
 
 func Test_checkCreateParam(t *testing.T) {
@@ -50,4 +51,12 @@ func Test_CheckPermission(t *testing.T) {
 	m.db = db
 	err := m.CheckPermission("1", apistructs.SysScope, 0)
 	assert.NoError(t, err)
+}
+
+func Test_checkUCUserInfo(t *testing.T) {
+	emptyUsers := make([]ucauth.User, 0)
+	emptyUsers = append(emptyUsers, ucauth.User{})
+	m := New()
+	err := m.checkUCUserInfo(emptyUsers)
+	assert.Equal(t, "failed to get user info", err.Error())
 }

--- a/pkg/ucauth/user_admin.go
+++ b/pkg/ucauth/user_admin.go
@@ -342,11 +342,7 @@ func (c *UCClient) findUsersByQuery(query string, idOrder ...string) ([]User, er
 		}
 		var orderedUsers []User
 		for _, id := range idOrder {
-			user, ok := userMap[id]
-			if !ok {
-				return nil, fmt.Errorf("failed to find user by id: %s", id)
-			}
-			orderedUsers = append(orderedUsers, user)
+			orderedUsers = append(orderedUsers, userMap[id])
 		}
 		return orderedUsers, nil
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
check user is-existed in member service

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=e30%3D&id=282243&iterationID=1090&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that check user is-existed in member service（用户是否存在的校验放在上层service中）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that check user is-existed in member service             |
| 🇨🇳 中文    |   用户是否存在的校验放在上层service中           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
