### PR TITLE
fix: Add member project owner error i18n, fix duplicate i18n key

### DIFF
--- a/conf/core-services/i18n/i18n.yaml
+++ b/conf/core-services/i18n/i18n.yaml
@@ -19,6 +19,7 @@ zh:
   FailedDeleteProject: "删除项目失败"
   PROJECT: 项目
   APPLICATION: 应用
+  ErrAddMemberOwner: "添加所有者失败，数量超过上限"
 
 en:
   AvailableIsLessThanQuota: The actual available resource on this workspace in the cluster is less than the quota. Please ask the Ops to allocate project resources reasonably
@@ -41,3 +42,4 @@ en:
   FailedDeleteProject: "failed to delete project"
   PROJECT: project
   APPLICATION: application
+  ErrAddMemberOwner: "failed to add project owner, quantity exceeds limit"

--- a/conf/dop/i18n/cp/scenarios/auto-test-scenes.yaml
+++ b/conf/dop/i18n/cp/scenarios/auto-test-scenes.yaml
@@ -93,7 +93,7 @@ zh:
   try-latest-result: 最近一次执行的结果
   sceneSetRefer: 场景集引用
   configForm: 配置单
-  configInfo: 配置单信息
+  configFormInfo: 配置单信息
   apiInfo: 接口信息
   nestedScene: 嵌套场景
   nestedSceneInfo: 嵌套场景信息
@@ -238,7 +238,7 @@ en:
   try-latest-result: Result of last execution
   sceneSetRefer: Scene set reference
   configForm: Configuration form
-  configInfo: Configuration form info
+  configFormInfo: Configuration form info
   apiInfo: Interface info
   nestedScene: Nested scene
   nestedSceneInfo: Nested scene info

--- a/modules/core-services/endpoints/member.go
+++ b/modules/core-services/endpoints/member.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/erda-project/erda-infra/providers/legacy/httpendpoints/i18n"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/core-services/services/apierrors"
 	"github.com/erda-project/erda/modules/core-services/types"
@@ -53,10 +52,9 @@ func (e *Endpoints) CreateOrUpdateMember(ctx context.Context, r *http.Request, v
 		return apierrors.ErrAddMember.InvalidParameter(err).ToResp(), nil
 	}
 	logrus.Infof("create request: %+v", memberCreateReq)
-	ctx = context.WithValue(ctx, "lang_codes", i18n.Language(r))
 
 	// 创建/更新成员信息至DB
-	if err := e.member.CreateOrUpdate(ctx, userID.String(), memberCreateReq); err != nil {
+	if err := e.member.CreateOrUpdate(userID.String(), memberCreateReq); err != nil {
 		return apierrors.ErrAddMember.InternalError(err).ToResp(), nil
 	}
 	return httpserver.OkResp("add members succ")
@@ -415,9 +413,8 @@ func (e *Endpoints) CreateMemberByInviteCode(ctx context.Context, r *http.Reques
 		return apierrors.ErrAddMember.ErrorVerificationCode(err).ToResp(), nil
 	}
 
-	ctx = context.WithValue(ctx, "lang_codes", i18n.Language(r))
 	// 创建/更新成员信息至DB
-	if err := e.member.CreateOrUpdate(ctx, userID, apistructs.MemberAddRequest{
+	if err := e.member.CreateOrUpdate(userID, apistructs.MemberAddRequest{
 		Scope: apistructs.Scope{
 			Type: apistructs.OrgScope,
 			ID:   req.OrgID,

--- a/modules/core-services/endpoints/member.go
+++ b/modules/core-services/endpoints/member.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/erda-project/erda-infra/providers/legacy/httpendpoints/i18n"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/core-services/services/apierrors"
 	"github.com/erda-project/erda/modules/core-services/types"
@@ -52,9 +53,10 @@ func (e *Endpoints) CreateOrUpdateMember(ctx context.Context, r *http.Request, v
 		return apierrors.ErrAddMember.InvalidParameter(err).ToResp(), nil
 	}
 	logrus.Infof("create request: %+v", memberCreateReq)
+	ctx = context.WithValue(ctx, "lang_codes", i18n.Language(r))
 
 	// 创建/更新成员信息至DB
-	if err := e.member.CreateOrUpdate(userID.String(), memberCreateReq); err != nil {
+	if err := e.member.CreateOrUpdate(ctx, userID.String(), memberCreateReq); err != nil {
 		return apierrors.ErrAddMember.InternalError(err).ToResp(), nil
 	}
 	return httpserver.OkResp("add members succ")
@@ -413,8 +415,9 @@ func (e *Endpoints) CreateMemberByInviteCode(ctx context.Context, r *http.Reques
 		return apierrors.ErrAddMember.ErrorVerificationCode(err).ToResp(), nil
 	}
 
+	ctx = context.WithValue(ctx, "lang_codes", i18n.Language(r))
 	// 创建/更新成员信息至DB
-	if err := e.member.CreateOrUpdate(userID, apistructs.MemberAddRequest{
+	if err := e.member.CreateOrUpdate(ctx, userID, apistructs.MemberAddRequest{
 		Scope: apistructs.Scope{
 			Type: apistructs.OrgScope,
 			ID:   req.OrgID,

--- a/modules/core-services/initialize.go
+++ b/modules/core-services/initialize.go
@@ -202,6 +202,7 @@ func (p *provider) initEndpoints() (*endpoints.Endpoints, error) {
 		member.WithDBClient(db),
 		member.WithUCClient(uc),
 		member.WithRedisClient(redisCli),
+		member.WithTranslator(p.Tran),
 	)
 	mr := manual_review.New(
 		manual_review.WithDBClient(db),

--- a/modules/core-services/services/member/member.go
+++ b/modules/core-services/services/member/member.go
@@ -16,7 +16,6 @@
 package member
 
 import (
-	"context"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -85,14 +84,13 @@ func WithTranslator(tran i18n.Translator) Option {
 }
 
 // CreateOrUpdate 创建/更新成员
-func (m *Member) CreateOrUpdate(ctx context.Context, userID string, req apistructs.MemberAddRequest) error {
+func (m *Member) CreateOrUpdate(userID string, req apistructs.MemberAddRequest) error {
 	// 参数校验
 	if err := m.checkCreateParam(req); err != nil {
 		return err
 	}
 
-	langCodes := ctx.Value("lang_codes").(i18n.LanguageCodes)
-
+	langCodes, _ := i18n.ParseLanguageCode(locale.GetGoroutineBindLang())
 	scopeID, err := strconv.ParseInt(req.Scope.ID, 10, 64)
 	if err != nil {
 		return errors.Errorf("failed to create permission(invalid scope id)")

--- a/modules/dop/component-protocol/scenarios/auto-test-scenes.yml
+++ b/modules/dop/component-protocol/scenarios/auto-test-scenes.yml
@@ -286,7 +286,7 @@ components:
     state:
       visible: false
     props:
-      title: ${{ i18n.configInfo }}
+      title: ${{ i18n.configFormInfo }}
       size: "l"
   apiEditorDrawer:
     type: Drawer

--- a/pkg/erda-configs/i18n/cmdb.json
+++ b/pkg/erda-configs/i18n/cmdb.json
@@ -234,6 +234,7 @@
     "ErrDeleteLabel": "Failed to delete label",
     "ErrUpdateLabel": "Failed to update label",
     "ErrGetLabels": "Failed to get label list",
-    "ErrCreateAudit": "Failed to create audit event"
-  }
+    "ErrCreateAudit": "Failed to create audit event",
+    "ErrAddMember": "Failed to add member"
+  }                 
 }

--- a/pkg/erda-configs/i18n/orchestrator.json
+++ b/pkg/erda-configs/i18n/orchestrator.json
@@ -7,7 +7,7 @@
     "ErrListAddon": "获取 addon 列表失败",
     "ErrListAddonMetris": "获取 addon 监控失败",
 
-    "basicPlan": "基础板",
+    "basicPlan": "基础版",
     "professionalPlan": "专业版"
   },
   "en-US": {


### PR DESCRIPTION
#### What this PR does / why we need it:
 Add member project owner error i18n, fix duplicate i18n key

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOls3NzIsNjgwLDg4MSw4ODMsMTA2OSwxMDkwXSwiYXNzaWduZWUiOlsiMTAwMTA3MyJdfQ%3D%3D&id=279903&iterationID=1090&pId=0&type=BUG)
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOls3NzIsNjgwLDg4MSw4ODMsMTA2OSwxMDkwXSwiYXNzaWduZWUiOlsiMTAwMTA3MyJdfQ%3D%3D&id=285086&iterationID=1090&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Add member project owner error i18n, fix duplicate i18n key             |
| 🇨🇳 中文    |    添加项目所有者错误国际化          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
