### PR TITLE
fix(pipeline): disable eci for pipelines containing custom tasks

### DIFF
--- a/apistructs/pipeline_container_instance.go
+++ b/apistructs/pipeline_container_instance.go
@@ -35,6 +35,7 @@ func (c ContainerInstanceType) Valid() bool {
 }
 
 type ContainerInstanceProvider struct {
+	IsDisabled              bool `json:"isDisabled"`
 	IsHitted                bool `json:"isHitted"`
 	ContainerInstanceType   `json:"containerInstanceType"`
 	PipelineAppliedResource `json:"pipelineAppliedResource"`

--- a/modules/pipeline/services/pipelinesvc/create_v2.go
+++ b/modules/pipeline/services/pipelinesvc/create_v2.go
@@ -228,7 +228,8 @@ func (s *PipelineSvc) makePipelineFromRequestV2(req *apistructs.PipelineCreateRe
 	}
 
 	// container instance provider
-	p.Extra.ContainerInstanceProvider = container_provider.ConstructContainerProviderByLabel(labels)
+	p.Extra.ContainerInstanceProvider = container_provider.ConstructContainerProvider(container_provider.WithLabels(labels),
+		container_provider.WithStages(pipelineYml.Spec().Stages))
 
 	// pipelineYmlSource
 	p.Extra.PipelineYmlSource = apistructs.PipelineYmlSourceContent


### PR DESCRIPTION
#### What this PR does / why we need it:
disable eci for pipelines containing custom tasks

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMDkwLDExMTVdLCJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=285869&iterationID=1115&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that disable eci for pipelines containing custom tasks（禁止包含自定义任务的流水线使用eci）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that disable eci for pipelines containing custom tasks            |
| 🇨🇳 中文    |  禁止包含自定义任务的流水线使用eci            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
