### PR TITLE
feat: cors in rate-limiting

### DIFF
--- a/modules/hepa/apipolicy/policies/server-guard/dto.go
+++ b/modules/hepa/apipolicy/policies/server-guard/dto.go
@@ -86,8 +86,9 @@ func (dto *PolicyDto) AdjustDto() {
 }
 
 func (dto PolicyDto) RefuseResonseCanBeJson() bool {
-	if s, err := strconv.Unquote("\"" + dto.RefuseResponse + "\""); err == nil {
-		return json.Unmarshal([]byte(s), new(interface{})) == nil
-	}
-	return false
+	return json.Unmarshal([]byte(dto.RefuseResponse), new(interface{})) == nil
+}
+
+func (dto PolicyDto) RefuseResponseQuote() string {
+	return strconv.Quote(dto.RefuseResponse)
 }

--- a/modules/hepa/apipolicy/policies/server-guard/dto_test.go
+++ b/modules/hepa/apipolicy/policies/server-guard/dto_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverguard_test
+
+import (
+	"testing"
+
+	serverguard "github.com/erda-project/erda/modules/hepa/apipolicy/policies/server-guard"
+)
+
+func TestPolicyDto_ApplicationJson(t *testing.T) {
+	var dto = serverguard.PolicyDto{RefuseResponse: `{\"success\": true, \"msg\": \"访问频繁\"}`}
+	t.Logf("application/json: %v", dto.RefuseResonseCanBeJson())
+}

--- a/modules/hepa/apipolicy/policies/server-guard/dto_test.go
+++ b/modules/hepa/apipolicy/policies/server-guard/dto_test.go
@@ -22,5 +22,20 @@ import (
 
 func TestPolicyDto_ApplicationJson(t *testing.T) {
 	var dto = serverguard.PolicyDto{RefuseResponse: `{\"success\": true, \"msg\": \"访问频繁\"}`}
-	t.Logf("application/json: %v", dto.RefuseResonseCanBeJson())
+	if dto.RefuseResonseCanBeJson() {
+		t.Fatal("the refuseResponse can not be json")
+	}
+	dto.RefuseResponse = `{"success": true, "msg": "访问频繁"}`
+	if !dto.RefuseResonseCanBeJson() {
+		t.Fatal("the refuseResponse can be json")
+	}
+}
+
+func TestPolicyDto_RefuseResponseQuote(t *testing.T) {
+	var dto = serverguard.PolicyDto{RefuseResponse: `{"success": true, "msg": "访问频繁"}`}
+	t.Logf("quote: %s", dto.RefuseResponseQuote())
+	quoted := `"{\"success\": true, \"msg\": \"访问频繁\"}"`
+	if dto.RefuseResponseQuote() != quoted {
+		t.Fatalf("quote error,\n quote: %s,\nquoted: %s", dto.RefuseResponseQuote(), quoted)
+	}
 }

--- a/modules/hepa/apipolicy/policies/server-guard/dto_test.go
+++ b/modules/hepa/apipolicy/policies/server-guard/dto_test.go
@@ -39,3 +39,34 @@ func TestPolicyDto_RefuseResponseQuote(t *testing.T) {
 		t.Fatalf("quote error,\n quote: %s,\nquoted: %s", dto.RefuseResponseQuote(), quoted)
 	}
 }
+
+func TestPolicyDto_AdjustDto(t *testing.T) {
+	var dto serverguard.PolicyDto
+	{
+	}
+	dto.MaxTps = -1
+	dto.AdjustDto()
+	if dto.Switch {
+		t.Fatal("switch should be false")
+	}
+
+	dto.MaxTps = 100
+	dto.RefuseCode = 99
+	dto.AdjustDto()
+	if dto.RefuseCode != 429 {
+		t.Fatal("refuseCode should be 429")
+	}
+
+	dto.RefuseCode = 302
+	dto.RefuseResponse = "busy"
+	dto.AdjustDto()
+	if dto.RefuseCode != 429 {
+		t.Fatal("refuseCode should be 429")
+	}
+
+	dto.ExtraLatency = 10
+	dto.AdjustDto()
+	if dto.ExtraLatency != 20 {
+		t.Fatalf("expected extraLatency: 20, actual: %v", dto.ExtraLatency)
+	}
+}

--- a/modules/hepa/apipolicy/policies/server-guard/policy.go
+++ b/modules/hepa/apipolicy/policies/server-guard/policy.go
@@ -200,9 +200,9 @@ location @LIMIT-%s {
     more_set_headers 'Access-Control-Allow-Credentials: true';
     more_set_headers 'Access-Control-Max-Age: 86400';
     more_set_headers 'Content-Type: %s';
-    return %d "%s";
+    return %d %s;
 }
-`, id, contentType, policyDto.RefuseCode, policyDto.RefuseResponse)
+`, id, contentType, policyDto.RefuseCode, policyDto.RefuseResponseQuote())
 	}
 	locationSnippet := limitReq + limitReqStatus + errorPage
 	res.IngressAnnotation = &apipolicy.IngressAnnotation{

--- a/modules/hepa/apipolicy/policies/server-guard/policy.go
+++ b/modules/hepa/apipolicy/policies/server-guard/policy.go
@@ -160,6 +160,12 @@ location @LIMIT-%s {
     log_by_lua_block {
         plugins.run()
     }
+    more_set_headers 'Access-Control-Allow-Origin: $from_request_origin_or_referer';
+    more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
+    more_set_headers 'Access-Control-Allow-Headers: $http_access_control_request_headers';
+    more_set_headers 'Access-Control-Allow-Credentials: true';
+    more_set_headers 'Access-Control-Max-Age: 86400';
+    more_set_headers 'Content-Type: text/plain charset=UTF-8';
     return %d;
 }
 `, id, policyDto.RefuseCode)
@@ -169,19 +175,34 @@ location @LIMIT-%s {
     log_by_lua_block {
         plugins.run()
     }
+    more_set_headers 'Access-Control-Allow-Origin: $from_request_origin_or_referer';
+    more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
+    more_set_headers 'Access-Control-Allow-Headers: $http_access_control_request_headers';
+    more_set_headers 'Access-Control-Allow-Credentials: true';
+    more_set_headers 'Access-Control-Max-Age: 86400';
+    more_set_headers 'Content-Type: text/plain charset=UTF-8';
     return %d "%s";
 }
 `, id, policyDto.RefuseCode, policyDto.RefuseResponse)
 	} else {
+		contentType := "text/plain; charset=utf-8"
+		if policyDto.RefuseResonseCanBeJson() {
+			contentType = "application/json"
+		}
 		namedLocation = fmt.Sprintf(`
 location @LIMIT-%s {
     log_by_lua_block {
         plugins.run()
     }
-    more_set_headers 'Content-Type: text/plain; charset=utf-8';
+    more_set_headers 'Access-Control-Allow-Origin: $from_request_origin_or_referer';
+    more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
+    more_set_headers 'Access-Control-Allow-Headers: $http_access_control_request_headers';
+    more_set_headers 'Access-Control-Allow-Credentials: true';
+    more_set_headers 'Access-Control-Max-Age: 86400';
+    more_set_headers 'Content-Type: %s';
     return %d "%s";
 }
-`, id, policyDto.RefuseCode, policyDto.RefuseResponse)
+`, id, contentType, policyDto.RefuseCode, policyDto.RefuseResponse)
 	}
 	locationSnippet := limitReq + limitReqStatus + errorPage
 	res.IngressAnnotation = &apipolicy.IngressAnnotation{


### PR DESCRIPTION
#### What this PR does / why we need it:
When the current limit is triggered, cross-domain is allowed

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | When the current limit is triggered, cross-domain is allowed. When the throttling reject response conforms to JSON format, Content-Type is automatically set to application/json. |
| 🇨🇳 中文    | 当触发限流时，允许跨域。当限流的拒绝响应符合 JSON 格式时，Content-Type 自动设置为 application/json. |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
