### PR TITLE
fix: use old release dice if conflict when upload

### DIFF
--- a/modules/dicehub/release/release.go
+++ b/modules/dicehub/release/release.go
@@ -699,7 +699,8 @@ func (s *ReleaseService) parseReleaseFile(req *pb.ReleaseUploadRequest, file io.
 					return nil, nil, errors.Errorf("dice yml for app %s release is invalid, %v", appName, err)
 				}
 				if !reflect.DeepEqual(oldDice.Obj(), newDice.Obj()) {
-					return nil, nil, errors.Errorf("app release %s was already existed but has different dice yml", version)
+					logrus.Warningf("app release %s (ID: %s) to upload was already existed but has different dice yml. Use old dice yml instead. Old: %v. New:%v",
+						version, existedReleases[0].ReleaseID, oldDice.Obj(), newDice.Obj())
 				}
 				appReleaseList[i][j] = existedReleases[0].ReleaseID
 				continue

--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -435,12 +435,12 @@ func (r *ComponentReleaseTable) SetComponentValue() {
 	}
 }
 
-func (r *ComponentReleaseTable) Transfer(c *cptype.Component) {
-	c.Props = cputil.MustConvertProps(r.Props)
-	c.Data = map[string]interface{}{
+func (r *ComponentReleaseTable) Transfer(component *cptype.Component) {
+	component.Props = cputil.MustConvertProps(r.Props)
+	component.Data = map[string]interface{}{
 		"list": r.Data.List,
 	}
-	c.State = map[string]interface{}{
+	component.State = map[string]interface{}{
 		"releaseTable__urlQuery": r.State.ReleaseTableURLQuery,
 		"pageNo":                 r.State.PageNo,
 		"pageSize":               r.State.PageSize,
@@ -453,7 +453,7 @@ func (r *ComponentReleaseTable) Transfer(c *cptype.Component) {
 		"applicationID":          r.State.ApplicationID,
 		"filterValues":           r.State.FilterValues,
 	}
-	c.Operations = r.Operations
+	component.Operations = r.Operations
 }
 
 func (r *ComponentReleaseTable) formalReleases(ctx context.Context, releaseID []string) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: use old release dice if conflict when upload

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: use old release dice if conflict when upload |
| 🇨🇳 中文    | 上传制品时如果存在相同version且不同dice.yml的应用制品，使用旧制品的dice.yml而不是上传文件中的dice.yml |


#### Need cherry-pick to release versions?

Need cherry-pick to release/1.6-alpha.4
