### PR TITLE
fix: sourcecov volume config

### DIFF
--- a/modules/orchestrator/services/addon/addon_sourcecov.go
+++ b/modules/orchestrator/services/addon/addon_sourcecov.go
@@ -96,8 +96,8 @@ func (sam *SourcecovAddonManagement) BuildSourceCovServiceItem(
 
 		SetlabelsFromOptions(params.Options, service.Labels)
 
-		//  主要目的是传递 PVC 相关信息
-		vol01 := SetAddonVolumes(params.Options, "", false)
+		//  主要目的是传递 卷配置信息以及标签给后端 sourcecov-agent 对象，本身不会创建卷
+		vol01 := SetAddonVolumes(params.Options, "/for-agent", false)
 		service.Volumes = diceyml.Volumes{vol01}
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
for pass some configurations to sourcecov agent, need set volumes configurations, but did not set volume targetPath, which result to servicegroup can not create  

#### Specified Reviewers:

/assign @sixther-dc


#### ChangeLog
Bugfix： Fix the bug that  sourcecov addon can not create （修复了 sourcecov addon 部署失败的问题）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that  sourcecov addon can not create         |
| 🇨🇳 中文    |      修复了 sourcecov addon 部署失败的问题        |


#### Need cherry-pick to release versions?
/cherry-pick release/1.6-alpha.4

