### PR TITLE
fix: fix get containerID out of range fatal

### DIFF
--- a/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
@@ -491,9 +491,12 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 		} else {
 			currentTerminatedContainer := mainContainer.State.Terminated
 			if currentTerminatedContainer != nil {
-				//currentContainerID = strutil.TrimPrefixes(mainContainer.ContainerID, "docker://")
-				runtimeAndId := strings.Split(mainContainer.ContainerID, "://")
-				currentContainerID = runtimeAndId[1]
+				if len(strings.Split(mainContainer.ContainerID, "://")) == 2 {
+					runtimeAndId := strings.Split(mainContainer.ContainerID, "://")
+					currentContainerID = runtimeAndId[1]
+				} else {
+					currentContainerID = strutil.TrimPrefixes(mainContainer.ContainerID, "docker://")
+				}
 				currentContainerStartedAt = mainContainer.State.Terminated.StartedAt.Time
 				currentContainerFinishedAt = &mainContainer.State.Terminated.FinishedAt.Time
 				if currentContainerFinishedAt.Year() < 2000 {


### PR DESCRIPTION
#### What this PR does / why we need it:
Get containerID from Pod Status may get unknown container which containerID may be nil. 

#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that get containerID from Pod Status may get unknown container which containerID is nil.,which result in out of range fatal （修复了 Pod Status 中包含未知状态的容器导致容器ID为空触发数组越界）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |         Fix the bug that get containerID from Pod Status may get unknown container which containerID is nil.,which result in out of range fatal     |
| 🇨🇳 中文    |      修复了 Pod Status 中包含未知状态的容器导致容器ID为空触发数组越界        |


#### Need cherry-pick to release versions?
/cherry-pick 1.6-alpha.4

