### PR TITLE
fix: fix volume without storage, set default volume type

### DIFF
--- a/modules/orchestrator/scheduler/impl/servicegroup/servicegroup.go
+++ b/modules/orchestrator/scheduler/impl/servicegroup/servicegroup.go
@@ -438,6 +438,11 @@ func setServiceVolumes(clusterName string, service *diceyml.Service, clusterinfo
 		if v.Path != "" && v.TargetPath != "" && v.Path != v.TargetPath {
 			return []apistructs.Volume{}, errors.New("if path and taragetPath set in volume, they must same.")
 		}
+
+		if v.TargetPath == "" && v.Path != "" {
+			v.TargetPath = v.Path
+		}
+
 		// 卷映射的容器目录合法性检查
 		if v.TargetPath == "" || v.TargetPath == "/" {
 			return []apistructs.Volume{}, errors.New(fmt.Sprintf("invalid targetPath [%s]", v.TargetPath))

--- a/modules/orchestrator/services/deployment/deployment_context.go
+++ b/modules/orchestrator/services/deployment/deployment_context.go
@@ -1521,7 +1521,7 @@ func (fsm *DeployFSMContext) convertService(serviceName string, service *diceyml
 	oldTypeVolumes := make([]diceyml.Volume, 0)
 	newVolumes := make([]diceyml.Volume, 0)
 	for _, vol := range service.Volumes {
-		if vol.Storage != "" {
+		if vol.Path != "" {
 			oldTypeVolumes = append(oldTypeVolumes, vol)
 		} else {
 			newVolumes = append(newVolumes, vol)

--- a/pkg/k8s/storage/detect_sc.go
+++ b/pkg/k8s/storage/detect_sc.go
@@ -82,7 +82,7 @@ func VolumeTypeToSCName(diskType string, vendor string) (string, error) {
 			}
 	*/
 	case "":
-		return apistructs.DiceLocalVolumeSC, nil
+		return apistructs.DiceNFSVolumeSC, nil
 	//case apistructs.VolumeTypeOSS:
 	default:
 		return "", errors.New(fmt.Sprintf("unsupported disk type %s", diskType))

--- a/pkg/k8s/storage/detect_sc_test.go
+++ b/pkg/k8s/storage/detect_sc_test.go
@@ -37,7 +37,7 @@ func TestVolumeTypeToSCName(t *testing.T) {
 			args: args{
 				vendor: apistructs.CSIVendorAlibaba,
 			},
-			want:    apistructs.DiceLocalVolumeSC,
+			want:    apistructs.DiceNFSVolumeSC,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
#### What this PR does / why we need it:
1. service volumes in old type define may be not set  `storage` filed, need detect it as old volume type by 'path' filed. 
2. Adjust volume with not set storage, set default volume type as dice-nfs-volume

#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
Bugfix： Fix the bug that need detect volume as old volume type by 'path' filed.（修复了 Service 的 volumes 的旧的格式定义可能 storage 字段不设置，导致无法通过 storage 字段识别是否是旧格式的 volume 的问题，同时调整默认 volume 类型）


| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Fix the bug that need detect volume as old volume type by 'path' filed.    |
| 🇨🇳 中文    |     修复了 Service 的 volumes 的旧的格式定义可能 storage 字段不设置，导致无法通过 storage 字段识别是否是旧格式的 volume 的问题，同时调整默认 volume 类型     |


#### Need cherry-pick to release versions?
/cherry-pick   1.6-alpha.4

