### PR TITLE
feat(dop): project pipeline decide whether to turn on or off the cron button according to the yml cron expression

### DIFF
--- a/modules/dop/component-protocol/components/project-pipeline/myPage/tabsTable/pipelineTable/provider.go
+++ b/modules/dop/component-protocol/components/project-pipeline/myPage/tabsTable/pipelineTable/provider.go
@@ -483,7 +483,8 @@ func (p *PipelineTable) SetTableMoreOpItem(definition *pb.PipelineDefinition, de
 			},
 		})
 	}
-	if v, ok := ymlSourceMapCronMap[definitionYmlSourceMap[definition.ID]]; ok {
+
+	if v, ok := ymlSourceMapCronMap[definitionYmlSourceMap[definition.ID]]; ok && strings.TrimSpace(v.CronExpr) != "" {
 		items = append(items, commodel.MoreOpItem{
 			ID: func() string {
 				if *v.Enable {
@@ -497,7 +498,6 @@ func (p *PipelineTable) SetTableMoreOpItem(definition *pb.PipelineDefinition, de
 				}
 				return "cron"
 			}()),
-
 			Icon: func() *commodel.Icon {
 				if *v.Enable {
 					return &commodel.Icon{
@@ -510,17 +510,6 @@ func (p *PipelineTable) SetTableMoreOpItem(definition *pb.PipelineDefinition, de
 			}(),
 			Operations: map[cptype.OperationKey]cptype.Operation{
 				commodel.OpMoreOperationsItemClick{}.OpKey(): build,
-			},
-		})
-	} else {
-		items = append(items, commodel.MoreOpItem{
-			ID:   "cron",
-			Text: cputil.I18n(p.sdk.Ctx, "cron"),
-			Operations: map[cptype.OperationKey]cptype.Operation{
-				commodel.OpMoreOperationsItemClick{}.OpKey(): build,
-			},
-			Icon: &commodel.Icon{
-				Type: "start-timing",
 			},
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
When adding a cron expression to the YML file, the start cron button is turned on. When removing the cron expression, the cron button is hidden

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=275783&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1115&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       When adding a cron expression to the YML file, the start cron button is turned on. When removing the cron expression, the cron button is hidden       |
| 🇨🇳 中文    |       将 cron 表达式添加到YML文件时，cron 按钮处于打开状态。删除 cron 表达式时，cron 按钮将隐藏       |

