### PR TITLE
revert: "dop remove workspace label"

### DIFF
--- a/modules/dop/services/pipeline/pipeline.go
+++ b/modules/dop/services/pipeline/pipeline.go
@@ -368,8 +368,7 @@ func (p *Pipeline) ConvertPipelineToV2(pv1 *apistructs.PipelineCreateRequest) (*
 	pv2.ConfigManageNamespaces = append(pv2.ConfigManageNamespaces, ns...)
 
 	// label
-	// orchestrator judge the branch to get workspace,so dop don't need add workspace to labels
-	//labels[apistructs.LabelDiceWorkspace] = workspace
+	labels[apistructs.LabelDiceWorkspace] = workspace
 	labels[apistructs.LabelBranch] = pv1.Branch
 	labels[apistructs.LabelOrgID] = strconv.FormatUint(app.OrgID, 10)
 	labels[apistructs.LabelProjectID] = strconv.FormatUint(app.ProjectID, 10)


### PR DESCRIPTION
This reverts commit 5eef37267208a558d56f74d923335b8c55fc8a05.

#### What this PR does / why we need it:
revert: "dop remove workspace label"

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： revert commit of workspace label （回退workspace标签的去除）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | revert commit of workspace label              |
| 🇨🇳 中文    |   回退workspace标签的去除           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
