### PR TITLE
fix: eventbox save notify history is nil pointer dereference

### DIFF
--- a/modules/eventbox/subscriber/common.go
+++ b/modules/eventbox/subscriber/common.go
@@ -25,7 +25,7 @@ import (
 )
 
 func SaveNotifyHistories(request *apistructs.CreateNotifyHistoryRequest, messenger pb.NotifyServiceServer) {
-	var createRequest *pb.CreateNotifyHistoryRequest
+	var createRequest pb.CreateNotifyHistoryRequest
 	data, err := json.Marshal(request)
 	if err != nil {
 		logrus.Errorf("创建通知历史记录失败: %v", err)
@@ -36,7 +36,7 @@ func SaveNotifyHistories(request *apistructs.CreateNotifyHistoryRequest, messeng
 		logrus.Errorf("创建通知历史记录失败: %v", err)
 		return
 	}
-	_, err = messenger.CreateNotifyHistory(context.Background(), createRequest)
+	_, err = messenger.CreateNotifyHistory(context.Background(), &createRequest)
 	if err != nil {
 		logrus.Errorf("创建通知历史记录失败: %v", err)
 	}

--- a/modules/eventbox/subscriber/dingding/dingding.go
+++ b/modules/eventbox/subscriber/dingding/dingding.go
@@ -162,9 +162,13 @@ func (d *DDSubscriber) Publish(dest string, content string, time int64, msg *typ
 		}
 	}
 	if len(errs) > 0 {
-		msg.CreateHistory.Status = "failed"
+		if msg != nil && msg.CreateHistory != nil {
+			msg.CreateHistory.Status = "failed"
+		}
 	}
-	subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	if msg.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	}
 	return errs
 }
 

--- a/modules/eventbox/subscriber/dingtalk_worknotice/dingtalk_worknotice.go
+++ b/modules/eventbox/subscriber/dingtalk_worknotice/dingtalk_worknotice.go
@@ -94,10 +94,14 @@ func (d DingWorkNoticeSubscriber) Publish(dest string, content string, time int6
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
-		m.CreateHistory.Status = "failed"
+		if m != nil && m.CreateHistory != nil {
+			m.CreateHistory.Status = "failed"
+		}
 	}
-	subscriber.SaveNotifyHistories(m.CreateHistory, d.messenger)
-	return nil
+	if m.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(m.CreateHistory, d.messenger)
+	}
+	return errs
 }
 
 func (d DingWorkNoticeSubscriber) Status() interface{} {

--- a/modules/eventbox/subscriber/email/email.go
+++ b/modules/eventbox/subscriber/email/email.go
@@ -125,11 +125,16 @@ func (d *MailSubscriber) Publish(dest string, content string, time int64, msg *t
 	}
 	err = d.sendToMail(mails, &mailData)
 	if err != nil {
-		msg.CreateHistory.Status = "failed"
-		logrus.Errorf("send email err: %v", err)
 		errs = append(errs, err)
 	}
-	subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	if len(errs) > 0 {
+		if msg != nil && msg.CreateHistory != nil {
+			msg.CreateHistory.Status = "failed"
+		}
+	}
+	if msg.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	}
 	return errs
 }
 

--- a/modules/eventbox/subscriber/mbox/mbox.go
+++ b/modules/eventbox/subscriber/mbox/mbox.go
@@ -72,10 +72,16 @@ func (d *MBoxSubscriber) Publish(dest string, content string, time int64, msg *t
 		DeduplicateID: mboxData.DeduplicateID,
 	})
 	if err != nil {
-		msg.CreateHistory.Status = "failed"
 		errs = append(errs, err)
 	}
-	subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	if len(errs) > 0 {
+		if msg != nil && msg.CreateHistory != nil {
+			msg.CreateHistory.Status = "failed"
+		}
+	}
+	if msg.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	}
 	return errs
 }
 

--- a/modules/eventbox/subscriber/sms/sms.go
+++ b/modules/eventbox/subscriber/sms/sms.go
@@ -136,9 +136,13 @@ func (d *MobileSubscriber) Publish(dest string, content string, time int64, msg 
 		errs = append(errs, fmt.Errorf("failed to send sms %s", response.GetHttpContentString()))
 	}
 	if len(errs) > 0 {
-		msg.CreateHistory.Status = "failed"
+		if msg != nil && msg.CreateHistory != nil {
+			msg.CreateHistory.Status = "failed"
+		}
 	}
-	subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	if msg.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	}
 	logrus.Infof("sms send success %s", response.GetHttpContentString())
 	return errs
 }

--- a/modules/eventbox/subscriber/vms/vms.go
+++ b/modules/eventbox/subscriber/vms/vms.go
@@ -148,7 +148,14 @@ func (d *VoiceSubscriber) Publish(dest string, content string, time int64, msg *
 	if len(errs) == 0 {
 		logrus.Info("voice send success")
 	}
-	subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	if len(errs) > 0 {
+		if msg != nil && msg.CreateHistory != nil {
+			msg.CreateHistory.Status = "failed"
+		}
+	}
+	if msg.CreateHistory != nil {
+		subscriber.SaveNotifyHistories(msg.CreateHistory, d.messenger)
+	}
 
 	return errs
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
eventbox save notify history is nil pointer dereference

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       eventbox save notify history is nil pointer dereference       |
| 🇨🇳 中文    |       eventbox存通知记录panic       |
