### PR TITLE
fix(dop): When the pipeline is GC, if the definition is bound to the pipeline_ ID does not perform GC operations

### DIFF
--- a/modules/pipeline/dbclient/op_pipeline_definition.go
+++ b/modules/pipeline/dbclient/op_pipeline_definition.go
@@ -38,6 +38,24 @@ func (client *Client) GetPipelineDefinition(id string, ops ...SessionOption) (*d
 	return &pipelineDefinition, nil
 }
 
+func (client *Client) GetPipelineDefinitionByPipelineID(pipelineID uint64, ops ...SessionOption) (*db.PipelineDefinition, bool, error) {
+	session := client.NewSession(ops...)
+	defer session.Close()
+
+	var pipelineDefinition db.PipelineDefinition
+	var has bool
+	var err error
+	if has, _, err = session.Where("pipeline_id = ? and soft_deleted_at = 0", pipelineID).GetFirst(&pipelineDefinition).GetResult(); err != nil {
+		return nil, false, err
+	}
+
+	if !has {
+		return nil, false, nil
+	}
+
+	return &pipelineDefinition, true, nil
+}
+
 func (client *Client) UpdatePipelineDefinition(id string, pipelineDefinition *db.PipelineDefinition, ops ...SessionOption) error {
 	session := client.NewSession(ops...)
 	defer session.Close()


### PR DESCRIPTION

#### What this PR does / why we need it:
Solve the problem that the pipeline bound by the definition is GC, which causes the user to view the execution details and report an error

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=289045&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA1NjAiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1115&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Solve the problem that the pipeline bound by the definition is GC, which causes the user to view the execution details and report an error       |
| 🇨🇳 中文    |       解决由于 definition 绑定的 pipeline 被 gc，导致用户查看执行明细报错       |

test image:

change bind pipeline_id time info:
![image](https://user-images.githubusercontent.com/28723047/156710758-a8cf3cb0-93ab-4ec0-b3fa-8fe447db13d6.png)

restart pipeline gc info:
![image](https://user-images.githubusercontent.com/28723047/156710828-82155876-1bad-4b4c-8b65-c90de1a0279d.png)



