### PR TITLE
fix: Revert fix set volume without storage, set default volume type

### DIFF
--- a/modules/orchestrator/scheduler/impl/servicegroup/servicegroup.go
+++ b/modules/orchestrator/scheduler/impl/servicegroup/servicegroup.go
@@ -438,11 +438,6 @@ func setServiceVolumes(clusterName string, service *diceyml.Service, clusterinfo
 		if v.Path != "" && v.TargetPath != "" && v.Path != v.TargetPath {
 			return []apistructs.Volume{}, errors.New("if path and taragetPath set in volume, they must same.")
 		}
-
-		if v.TargetPath == "" && v.Path != "" {
-			v.TargetPath = v.Path
-		}
-
 		// 卷映射的容器目录合法性检查
 		if v.TargetPath == "" || v.TargetPath == "/" {
 			return []apistructs.Volume{}, errors.New(fmt.Sprintf("invalid targetPath [%s]", v.TargetPath))

--- a/modules/orchestrator/services/deployment/deployment_context.go
+++ b/modules/orchestrator/services/deployment/deployment_context.go
@@ -1522,7 +1522,7 @@ func (fsm *DeployFSMContext) convertService(serviceName string, service *diceyml
 	oldTypeVolumes := make([]diceyml.Volume, 0)
 	newVolumes := make([]diceyml.Volume, 0)
 	for _, vol := range service.Volumes {
-		if vol.Path != "" {
+		if vol.Storage != "" {
 			oldTypeVolumes = append(oldTypeVolumes, vol)
 		} else {
 			newVolumes = append(newVolumes, vol)

--- a/pkg/k8s/storage/detect_sc.go
+++ b/pkg/k8s/storage/detect_sc.go
@@ -82,7 +82,7 @@ func VolumeTypeToSCName(diskType string, vendor string) (string, error) {
 			}
 	*/
 	case "":
-		return apistructs.DiceNFSVolumeSC, nil
+		return apistructs.DiceLocalVolumeSC, nil
 	//case apistructs.VolumeTypeOSS:
 	default:
 		return "", errors.New(fmt.Sprintf("unsupported disk type %s", diskType))

--- a/pkg/k8s/storage/detect_sc_test.go
+++ b/pkg/k8s/storage/detect_sc_test.go
@@ -37,7 +37,7 @@ func TestVolumeTypeToSCName(t *testing.T) {
 			args: args{
 				vendor: apistructs.CSIVendorAlibaba,
 			},
-			want:    apistructs.DiceNFSVolumeSC,
+			want:    apistructs.DiceLocalVolumeSC,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
…(#4180)"

This reverts commit 96a4fc2b5ad4e896db6ce28f3982cca00c67c9db.

#### What this PR does / why we need it:

回退适配ECI的设置默认存储类型逻辑

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      revert    fix set volume without storage, set default volume type      |
| 🇨🇳 中文    |      回退适配ECI的设置默认存储类型逻辑        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
