### PR TITLE
refactor: use standard RFC4122 form of uuid with hyphens

### DIFF
--- a/modules/dicehub/service/release_rule/release_rule.go
+++ b/modules/dicehub/service/release_rule/release_rule.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -27,6 +26,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/dicehub/dbclient"
 	"github.com/erda-project/erda/modules/dicehub/service/apierrors"
+	"github.com/erda-project/erda/pkg/crypto/uuid"
 	"github.com/erda-project/erda/pkg/http/httpserver/errorresp"
 )
 
@@ -74,7 +74,7 @@ func (rule *ReleaseRule) Create(request *apistructs.CreateUpdateDeleteReleaseRul
 		}
 	}
 	var record = &apistructs.BranchReleaseRuleModel{
-		ID:        uuid.New().String(),
+		ID:        uuid.New(),
 		ProjectID: request.ProjectID,
 		Pattern:   request.Body.Pattern,
 		IsEnabled: request.Body.IsEnabled,

--- a/modules/dop/services/apidocsvc/ws_upgrade.go
+++ b/modules/dop/services/apidocsvc/ws_upgrade.go
@@ -19,14 +19,13 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/uuid"
-
 	"github.com/erda-project/erda-infra/providers/i18n"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/modules/dop/services/apierrors"
 	"github.com/erda-project/erda/modules/dop/services/websocket"
 	"github.com/erda-project/erda/modules/orchestrator/scheduler/cache/org"
+	"github.com/erda-project/erda/pkg/crypto/uuid"
 	"github.com/erda-project/erda/pkg/http/httpserver/errorresp"
 )
 
@@ -50,7 +49,7 @@ func (svc *Service) Upgrade(w http.ResponseWriter, r *http.Request, req *apistru
 		filename:  filepath.Base(ft.PathFromRepoRoot()),
 		req:       req,
 		svc:       svc,
-		sessionID: uuid.New().String(),
+		sessionID: uuid.New(),
 		ft:        ft,
 		trans:     svc.trans,
 	}

--- a/modules/eventbox/webhook/impl.go
+++ b/modules/eventbox/webhook/impl.go
@@ -300,7 +300,7 @@ func mkLocationDir(location HookLocation) string {
 }
 
 func genID() string {
-	return uuid.Generate()[0:12]
+	return uuid.UUID()[0:12]
 }
 
 func nowTimestamp() string {

--- a/modules/orchestrator/scheduler/impl/job/job.go
+++ b/modules/orchestrator/scheduler/impl/job/job.go
@@ -186,7 +186,7 @@ func makeJobKey(namespce, name string) string {
 func prepareJob(job *apistructs.JobFromUser) {
 	// job ID may be specified by job owner, e.g. jobflow
 	if job.ID == "" {
-		job.ID = uuid.Generate()
+		job.ID = uuid.UUID()
 	}
 
 	// Do not overwrite environment

--- a/modules/orchestrator/scheduler/impl/volume/volume.go
+++ b/modules/orchestrator/scheduler/impl/volume/volume.go
@@ -71,7 +71,7 @@ func (i VolumeIdentity) String() string {
 // TODO: Need to better distinguish between name and ID
 func (i VolumeIdentity) IsNotUUID() bool {
 	IDLenLock.Do(func() {
-		IDLen = len(uuid.Generate())
+		IDLen = len(uuid.UUID())
 	})
 	return len(i) != IDLen
 }
@@ -104,7 +104,7 @@ func NewVolumeID(config VolumeCreateConfig) (VolumeIdentity, error) {
 	if err != nil {
 		return VolumeIdentity(""), err
 	}
-	id := hex + uuid.Generate()
+	id := hex + uuid.UUID()
 	if len(id) > 40 {
 		return VolumeIdentity(id[:40]), nil
 	}

--- a/modules/orchestrator/scheduler/impl/volume/volume_test.go
+++ b/modules/orchestrator/scheduler/impl/volume/volume_test.go
@@ -60,7 +60,7 @@ func TestNewVolumeID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			generatePatch := monkey.Patch(uuid.Generate, func() string {
+			generatePatch := monkey.Patch(uuid.UUID, func() string {
 				return "7cdf0078cfe74afe95a962572da952"
 			})
 

--- a/modules/pipeline/providers/definition/pipeline_definition.go
+++ b/modules/pipeline/providers/definition/pipeline_definition.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"unicode/utf8"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/providers/definition/db"
 	"github.com/erda-project/erda/modules/pipeline/services/apierrors"
+	"github.com/erda-project/erda/pkg/crypto/uuid"
 	"github.com/erda-project/erda/pkg/encoding/jsonparse"
 	"github.com/erda-project/erda/pkg/time/mysql_time"
 )
@@ -55,7 +55,7 @@ func (p pipelineDefinition) Create(ctx context.Context, request *pb.PipelineDefi
 	pipelineDefinition.PipelineSourceId = request.PipelineSourceID
 	pipelineDefinition.Category = request.Category
 	pipelineDefinition.Creator = request.Creator
-	pipelineDefinition.ID = uuid.New().String()
+	pipelineDefinition.ID = uuid.New()
 	pipelineDefinition.StartedAt = *mysql_time.GetMysqlDefaultTime()
 	pipelineDefinition.EndedAt = *mysql_time.GetMysqlDefaultTime()
 	pipelineDefinition.CostTime = -1
@@ -65,7 +65,7 @@ func (p pipelineDefinition) Create(ctx context.Context, request *pb.PipelineDefi
 	}
 
 	var pipelineDefinitionExtra db.PipelineDefinitionExtra
-	pipelineDefinitionExtra.ID = uuid.New().String()
+	pipelineDefinitionExtra.ID = uuid.New()
 	var extra apistructs.PipelineDefinitionExtraValue
 	err = json.Unmarshal([]byte(request.Extra.Extra), &extra)
 	if err != nil {

--- a/modules/pipeline/providers/source/db/source.go
+++ b/modules/pipeline/providers/source/db/source.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/erda-project/erda-infra/providers/mysqlxorm"
 	"github.com/erda-project/erda-proto-go/core/pipeline/source/pb"
+	"github.com/erda-project/erda/pkg/crypto/uuid"
 )
 
 type PipelineSource struct {
@@ -57,7 +57,7 @@ func (client *Client) CreatePipelineSource(pipelineSource *PipelineSource, ops .
 	session := client.NewSession(ops...)
 	defer session.Close()
 
-	pipelineSource.ID = uuid.New().String()
+	pipelineSource.ID = uuid.New()
 	_, err = session.InsertOne(pipelineSource)
 	return err
 }

--- a/pkg/crypto/uuid/uuid.go
+++ b/pkg/crypto/uuid/uuid.go
@@ -17,16 +17,28 @@ package uuid
 import (
 	"fmt"
 
+	guuid "github.com/google/uuid"
 	uuid "github.com/satori/go.uuid"
 )
 
-// Generate 不要再调用这个函数，太丑了，找时间废除.
-func Generate() string {
-	u := uuid.NewV4()
-	return fmt.Sprintf("%x%x%x%x%x", u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+// New return UUID.
+// see: https://en.wikipedia.org/wiki/Universally_unique_identifier#Format
+//
+// A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC 4122.
+// In its canonical textual representation, the 16 octets of a UUID are represented as 32 hexadecimal (base-16) digits,
+// displayed in five groups separated by hyphens, in the form 8-4-4-4-12 for a total of 36 characters (32 hexadecimal characters and 4 hyphens).
+// For example:
+//   123e4567-e89b-12d3-a456-426614174000
+//   xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
+func New() string {
+	return guuid.New().String()
 }
 
-// UUID 返回 uuid.
+// UUID return uuid.
+// format:
+//   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// Deprecated. Please use New()
 func UUID() string {
-	return Generate()
+	u := uuid.NewV4()
+	return fmt.Sprintf("%x%x%x%x%x", u[:4], u[4:6], u[6:8], u[8:10], u[10:])
 }

--- a/pkg/crypto/uuid/uuid_test.go
+++ b/pkg/crypto/uuid/uuid_test.go
@@ -21,5 +21,9 @@ import (
 )
 
 func TestUuid(t *testing.T) {
-	assert.Equal(t, 32, len(Generate()))
+	assert.Equal(t, 32, len(UUID()))
+}
+
+func TestNew(t *testing.T) {
+	assert.Equal(t, 32+4, len(New()))
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

see: https://en.wikipedia.org/wiki/Universally_unique_identifier#Format
refactor: uuid return form of xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx

#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  UUID use standard RFC4122 format: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx           |
| 🇨🇳 中文    |    UUID 使用 RFC4122 标准格式 ：xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
