### PR TITLE
fix(pipeline): add `terminus_define_tag` annotation on k8sjob flink spark

### DIFF
--- a/apistructs/pipeline_task.go
+++ b/apistructs/pipeline_task.go
@@ -23,7 +23,9 @@ import (
 
 const (
 	// TerminusDefineTag add this tag env to container for collecting logs
-	TerminusDefineTag            = "TERMINUS_DEFINE_TAG"
+	TerminusDefineTag = "TERMINUS_DEFINE_TAG"
+	// MSPTerminusDefineTag after version 2.0, msp use annotation to collecting logs
+	MSPTerminusDefineTag         = "msp.erda.cloud/terminus_define_tag"
 	PipelineTaskMaxRetryLimit    = 144
 	PipelineTaskMaxRetryDuration = 24 * time.Hour
 )

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sflink/util.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sflink/util.go
@@ -161,13 +161,15 @@ func (k *K8sFlink) ComposeFlinkCluster(job apistructs.JobFromUser, data apistruc
 				Affinity:       affinity,
 				Tolerations:    nil,
 				Sidecars:       nil,
-				PodAnnotations: nil,
+				PodAnnotations: map[string]string{
+					apistructs.MSPTerminusDefineTag: containers.MakeFlinkJobManagerID(data.Name),
+				},
 			},
 			TaskManager: flinkoperatorv1beta1.TaskManagerSpec{
 				Replicas:  data.Spec.FlinkConf.TaskManagerResource.Replica,
 				Resources: composeResources(data.Spec.FlinkConf.TaskManagerResource),
 				PodLabels: map[string]string{
-					apistructs.TerminusDefineTag: containers.MakeFLinkTaskManagerID(data.Name),
+					apistructs.TerminusDefineTag: containers.MakeFlinkTaskManagerID(data.Name),
 				},
 				Volumes:        nil,
 				VolumeMounts:   nil,
@@ -176,7 +178,9 @@ func (k *K8sFlink) ComposeFlinkCluster(job apistructs.JobFromUser, data apistruc
 				Affinity:       affinity,
 				Tolerations:    nil,
 				Sidecars:       nil,
-				PodAnnotations: nil,
+				PodAnnotations: map[string]string{
+					apistructs.MSPTerminusDefineTag: containers.MakeFlinkTaskManagerID(data.Name),
+				},
 			},
 			EnvVars:         data.Spec.Envs,
 			FlinkProperties: data.Spec.Properties,
@@ -210,8 +214,10 @@ func (k *K8sFlink) composeFlinkJob(job apistructs.JobFromUser, data apistructs.B
 		},
 		Affinity:        &constraintbuilders.K8S(&scheduleInfo2, nil, nil, nil).Affinity,
 		CancelRequested: nil,
-		PodAnnotations:  nil,
-		Resources:       corev1.ResourceRequirements{},
+		PodAnnotations: map[string]string{
+			apistructs.MSPTerminusDefineTag: containers.MakeFlinkJobID(data.Name),
+		},
+		Resources: corev1.ResourceRequirements{},
 		PodLabels: map[string]string{
 			apistructs.TerminusDefineTag: containers.MakeFlinkJobID(data.Name),
 		},

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
@@ -523,6 +523,14 @@ func (k *K8sJob) generateKubeJob(specObj interface{}, clusterInfo map[string]str
 		container.Command = append(container.Command, []string{"sh", "-c", job.Cmd}...)
 	}
 
+	// annotations
+	// k8sjob only has one container, multi-container is for compatibility with flink, spark
+	if len(job.TaskContainers) > 0 {
+		kubeJob.Spec.Template.Annotations = map[string]string{
+			apistructs.MSPTerminusDefineTag: job.TaskContainers[0].ContainerID,
+		}
+	}
+
 	var buildkitEnable bool
 
 	if clusterInfo[apistructs.BuildkitEnable] != "" {

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/k8sspark.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/k8sspark.go
@@ -498,9 +498,15 @@ func (k *K8sSpark) composePodSpec(job *apistructs.JobFromUser, conf *apistructs.
 	scheduleInfo2, _, _ := logic.GetScheduleInfo(k.cluster, string(k.Name()), string(Kind), *job)
 	switch podType {
 	case sparkDriverType:
+		podSpec.Annotations = map[string]string{
+			apistructs.MSPTerminusDefineTag: containers.MakeSparkTaskDriverID(conf.Name),
+		}
 		resource = conf.Spec.SparkConf.DriverResource
 	case sparkExecutorType:
 		resource = conf.Spec.SparkConf.ExecutorResource
+		podSpec.Annotations = map[string]string{
+			apistructs.MSPTerminusDefineTag: containers.MakeSparkTaskExecutorID(conf.Name),
+		}
 	}
 
 	k.appendResource(&podSpec, &resource)

--- a/modules/pipeline/pkg/containers/task_container.go
+++ b/modules/pipeline/pkg/containers/task_container.go
@@ -65,7 +65,7 @@ func MakeFlinkTaskManagerName(name string) string {
 	return fmt.Sprintf("%s-task-manager", name)
 }
 
-func MakeFLinkTaskManagerID(uuid string) string {
+func MakeFlinkTaskManagerID(uuid string) string {
 	return fmt.Sprintf("%s-task-manager", uuid)
 }
 
@@ -81,7 +81,7 @@ func GenFlinkContainers(task *spec.PipelineTask) []apistructs.TaskContainer {
 	})
 	containers = append(containers, apistructs.TaskContainer{
 		TaskName:    MakeFlinkTaskManagerName(task.Name),
-		ContainerID: MakeFLinkTaskManagerID(task.Extra.UUID),
+		ContainerID: MakeFlinkTaskManagerID(task.Extra.UUID),
 	})
 	return containers
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
add `terminus_define_tag` annotation on k8sjob flink spark

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=290139&iterationID=1115&pId=0&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add `terminus_define_tag` annotation on k8sjob flink spark（将监控新定义的标签添加到annotation）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that add `terminus_define_tag` annotation on k8sjob flink spark             |
| 🇨🇳 中文    |   将监控新定义的标签添加到annotation           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
