### PR TITLE
fix(pipeline): optimization of pipeline k8s executor initialization

### DIFF
--- a/modules/pipeline/conf/conf.go
+++ b/modules/pipeline/conf/conf.go
@@ -114,6 +114,9 @@ type Conf struct {
 
 	// external market refresh interval
 	ExtensionVersionRefreshIntervalMinute uint64 `env:"EXTENSION_VERSION_REFRESH_INTERVAL_MINUTE" default:"1"`
+
+	// k8s type executor max timeout second
+	K8SExecutorMaxInitializationSec uint64 `env:"K8S_EXECUTOR_MAX_INITIALIZATION_SEC" default:"5"`
 }
 
 var cfg Conf
@@ -369,4 +372,9 @@ func K8SExecutorPoolSize() int {
 // ExtensionVersionRefreshIntervalMinute external market refresh interval
 func ExtensionVersionRefreshIntervalMinute() uint64 {
 	return cfg.ExtensionVersionRefreshIntervalMinute
+}
+
+// K8SExecutorMaxInitializationSec k8s type executor max timeout second
+func K8SExecutorMaxInitializationSec() uint64 {
+	return cfg.K8SExecutorMaxInitializationSec
 }

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sflink/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sflink/type.go
@@ -15,7 +15,10 @@
 package k8sflink
 
 import (
+	"time"
+
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/types"
 	"github.com/erda-project/erda/pkg/k8sclient"
 )
@@ -28,7 +31,7 @@ type K8sFlink struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sFlink, error) {
-	k, err := k8sclient.New(clusterName)
+	k, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/events"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/types"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/logic"
 	"github.com/erda-project/erda/modules/pipeline/pkg/container_provider"
@@ -90,7 +91,7 @@ type K8sJob struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sJob, error) {
-	k, err := k8sclient.New(clusterName)
+	k, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob_test.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sjob/k8sjob_test.go
@@ -16,6 +16,7 @@ package k8sjob
 
 import (
 	"testing"
+	"time"
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func Test_isBuildkitHit(t *testing.T) {
 func Test_generateKubeJob(t *testing.T) {
 	defer monkey.UnpatchAll()
 
-	monkey.Patch(k8sclient.New, func(_ string) (*k8sclient.K8sClient, error) {
+	monkey.Patch(k8sclient.NewWithTimeOut, func(_ string, _ time.Duration) (*k8sclient.K8sClient, error) {
 		return nil, nil
 	})
 

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/plugins/k8sspark/type.go
@@ -15,7 +15,10 @@
 package k8sspark
 
 import (
+	"time"
+
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/executor/types"
 	"github.com/erda-project/erda/pkg/k8sclient"
 )
@@ -30,7 +33,7 @@ type K8sSpark struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sSpark, error) {
-	kc, err := k8sclient.New(clusterName)
+	kc, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler.go
@@ -91,7 +91,7 @@ func (s *Sched) Name() types.Name {
 // GetTaskExecutor return bool, task exectuor, error, bool means should it be dispatch to scheduler
 func (s *Sched) GetTaskExecutor(executorType string, clusterName string, task *spec.PipelineTask) (bool, tasktypes.TaskExecutor, error) {
 	var executorName string
-	cluster, err := s.taskManager.GetCluster(clusterName)
+	cluster, err := s.taskManager.TryGetCluster(clusterName)
 	if err != nil {
 		return false, nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/scheduler/scheduler_test.go
@@ -66,7 +66,7 @@ func init() {
 }
 
 func Test_GetTaskExecutor(t *testing.T) {
-	p := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "GetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
+	p := monkey.PatchInstanceMethod(reflect.TypeOf(taskManager), "TryGetCluster", func(_ *executor.Manager, clusterName string) (apistructs.ClusterInfo, error) {
 		if len(clusterName) == 0 {
 			return apistructs.ClusterInfo{}, errors.Errorf("clusterName is empty")
 		}
@@ -90,7 +90,7 @@ func Test_GetTaskExecutor(t *testing.T) {
 	})
 	defer m.Unpatch()
 
-	_, err := s.taskManager.GetCluster("terminus-dev")
+	_, err := s.taskManager.TryGetCluster("terminus-dev")
 	assert.NoError(t, err)
 
 	k8sjobTask := &spec.PipelineTask{

--- a/modules/pipeline/pkg/clusterinfo/clusterinfo.go
+++ b/modules/pipeline/pkg/clusterinfo/clusterinfo.go
@@ -48,6 +48,14 @@ func ListAllClusters() ([]apistructs.ClusterInfo, error) {
 	return bdl.ListClusters("", 0)
 }
 
+func GetClusterByName(clusterName string) (apistructs.ClusterInfo, error) {
+	cluster, err := bdl.GetCluster(clusterName)
+	if err != nil {
+		return apistructs.ClusterInfo{}, err
+	}
+	return *cluster, nil
+}
+
 // DispatchClusterEvent dispatch every cluster event to registered chan
 func DispatchClusterEvent(js jsonstore.JsonStore, clusterEvent apistructs.ClusterEvent) error {
 	return js.Put(context.Background(), ClusterEventEtcdKey, clusterEvent)


### PR DESCRIPTION
#### What this PR does / why we need it:
optimization of pipeline k8s executor initialization

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=286324&iterationID=1115&pId=0&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that optimization of pipeline k8s executor initialization（修复pipeline启动时多集群耗时慢的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |Fix the bug that optimization of pipeline k8s executor initialization              |
| 🇨🇳 中文    |     修复pipeline启动时多集群耗时慢的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
