### PR TITLE
feat: support comstom date format

### DIFF
--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -50,6 +50,23 @@ func TestGetTime(t *testing.T) {
 	t.Log("ns-after-hour:", getTime(TimeStampNsAfterHour))
 	t.Log("ns-day:", getTime(TimeStampNsDay))
 	t.Log("ns-after-day:", getTime(TimeStampNsAfterDay))
+
+	t.Log(DateTimeCustom+"ANSIC"+":", getTime(DateTimeCustom+"ANSIC"))
+	t.Log(DateTimeCustom+"UnixDate"+":", getTime(DateTimeCustom+"UnixDate"))
+	t.Log(DateTimeCustom+"RubyDate"+":", getTime(DateTimeCustom+"RubyDate"))
+	t.Log(DateTimeCustom+"RFC822"+":", getTime(DateTimeCustom+"RFC822"))
+	t.Log(DateTimeCustom+"RFC822Z"+":", getTime(DateTimeCustom+"RFC822Z"))
+	t.Log(DateTimeCustom+"RFC850"+":", getTime(DateTimeCustom+"RFC850"))
+	t.Log(DateTimeCustom+"RFC1123"+":", getTime(DateTimeCustom+"RFC1123"))
+	t.Log(DateTimeCustom+"RFC1123Z"+":", getTime(DateTimeCustom+"RFC1123Z"))
+	t.Log(DateTimeCustom+"RFC3339"+":", getTime(DateTimeCustom+"RFC3339"))
+	t.Log(DateTimeCustom+"RFC3339Nano"+":", getTime(DateTimeCustom+"RFC3339Nano"))
+	t.Log(DateTimeCustom+"Kitchen"+":", getTime(DateTimeCustom+"Kitchen"))
+	t.Log(DateTimeCustom+"Stamp"+":", getTime(DateTimeCustom+"Stamp"))
+	t.Log(DateTimeCustom+"StampMilli"+":", getTime(DateTimeCustom+"StampMilli"))
+	t.Log(DateTimeCustom+"StampMicro"+":", getTime(DateTimeCustom+"StampMicro"))
+	t.Log(DateTimeCustom+"StampNano"+":", getTime(DateTimeCustom+"StampNano"))
+	t.Log(DateTimeCustom+"20060102150405"+":", getTime(DateTimeCustom+"20060102150405"))
 }
 
 func Test_randIntegerByLength(t *testing.T) {

--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -51,22 +51,9 @@ func TestGetTime(t *testing.T) {
 	t.Log("ns-day:", getTime(TimeStampNsDay))
 	t.Log("ns-after-day:", getTime(TimeStampNsAfterDay))
 
-	t.Log(DateTimeCustom+"ANSIC"+":", getTime(DateTimeCustom+"ANSIC"))
-	t.Log(DateTimeCustom+"UnixDate"+":", getTime(DateTimeCustom+"UnixDate"))
-	t.Log(DateTimeCustom+"RubyDate"+":", getTime(DateTimeCustom+"RubyDate"))
-	t.Log(DateTimeCustom+"RFC822"+":", getTime(DateTimeCustom+"RFC822"))
-	t.Log(DateTimeCustom+"RFC822Z"+":", getTime(DateTimeCustom+"RFC822Z"))
-	t.Log(DateTimeCustom+"RFC850"+":", getTime(DateTimeCustom+"RFC850"))
-	t.Log(DateTimeCustom+"RFC1123"+":", getTime(DateTimeCustom+"RFC1123"))
-	t.Log(DateTimeCustom+"RFC1123Z"+":", getTime(DateTimeCustom+"RFC1123Z"))
-	t.Log(DateTimeCustom+"RFC3339"+":", getTime(DateTimeCustom+"RFC3339"))
-	t.Log(DateTimeCustom+"RFC3339Nano"+":", getTime(DateTimeCustom+"RFC3339Nano"))
-	t.Log(DateTimeCustom+"Kitchen"+":", getTime(DateTimeCustom+"Kitchen"))
-	t.Log(DateTimeCustom+"Stamp"+":", getTime(DateTimeCustom+"Stamp"))
-	t.Log(DateTimeCustom+"StampMilli"+":", getTime(DateTimeCustom+"StampMilli"))
-	t.Log(DateTimeCustom+"StampMicro"+":", getTime(DateTimeCustom+"StampMicro"))
-	t.Log(DateTimeCustom+"StampNano"+":", getTime(DateTimeCustom+"StampNano"))
-	t.Log(DateTimeCustom+"20060102150405"+":", getTime(DateTimeCustom+"20060102150405"))
+	for k := range dateTimeCustoms {
+		t.Log(DateTimeCustom+k+":", getTime(DateTimeCustom+k))
+	}
 }
 
 func Test_randIntegerByLength(t *testing.T) {

--- a/pkg/mock/time.go
+++ b/pkg/mock/time.go
@@ -49,6 +49,24 @@ const (
 	DateTimeCustom       = "datetime_custom_"        //  当前时间自定义格式
 )
 
+var dateTimeCustoms = map[string]string{
+	"ANSIC":       time.ANSIC,
+	"UnixDate":    time.UnixDate,
+	"RubyDate":    time.RubyDate,
+	"RFC822":      time.RFC822,
+	"RFC822Z":     time.RFC822Z,
+	"RFC850":      time.RFC850,
+	"RFC1123":     time.RFC1123,
+	"RFC1123Z":    time.RFC1123Z,
+	"RFC3339":     time.RFC3339,
+	"RFC3339Nano": time.RFC3339Nano,
+	"Kitchen":     time.Kitchen,
+	"Stamp":       time.Stamp,
+	"StampMilli":  time.StampMilli,
+	"StampMicro":  time.StampMicro,
+	"StampNano":   time.StampNano,
+}
+
 func getTime(timeType string) string {
 	hour, _ := time.ParseDuration("-1h")
 	day, _ := time.ParseDuration("-24h")
@@ -98,39 +116,9 @@ func getTime(timeType string) string {
 		return ""
 	}
 
-	format := strings.TrimPrefix(timeType, DateTimeCustom)
-	switch format {
-	case "ANSIC":
-		return currentTime.Format(time.ANSIC)
-	case "UnixDate":
-		return currentTime.Format(time.UnixDate)
-	case "RubyDate":
-		return currentTime.Format(time.RubyDate)
-	case "RFC822":
-		return currentTime.Format(time.RFC822)
-	case "RFC822Z":
-		return currentTime.Format(time.RFC822Z)
-	case "RFC850":
-		return currentTime.Format(time.RFC850)
-	case "RFC1123":
-		return currentTime.Format(time.RFC1123)
-	case "RFC1123Z":
-		return currentTime.Format(time.RFC1123Z)
-	case "RFC3339":
-		return currentTime.Format(time.RFC3339)
-	case "RFC3339Nano":
-		return currentTime.Format(time.RFC3339Nano)
-	case "Kitchen":
-		return currentTime.Format(time.Kitchen)
-	case "Stamp":
-		return currentTime.Format(time.Stamp)
-	case "StampMilli":
-		return currentTime.Format(time.StampMilli)
-	case "StampMicro":
-		return currentTime.Format(time.StampMicro)
-	case "StampNano":
-		return currentTime.Format(time.StampNano)
+	key := strings.TrimPrefix(timeType, DateTimeCustom)
+	if format, ok := dateTimeCustoms[key]; ok {
+		return currentTime.Format(format)
 	}
-
-	return currentTime.Format(format)
+	return currentTime.Format(key)
 }

--- a/pkg/mock/time.go
+++ b/pkg/mock/time.go
@@ -16,6 +16,7 @@ package mock
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -45,6 +46,7 @@ const (
 	DateDay              = "date_day"                // 1天前日期格式：2006-01-01
 	DateTime             = "datetime"                // 当前带时间的格式：2006-01-02 15:04:05
 	DateTimeHour         = "datetime_hour"           // 1小时前带时间的格式：2006-01-02 14:04:05
+	DateTimeCustom       = "datetime_custom_"        //  当前时间自定义格式
 )
 
 func getTime(timeType string) string {
@@ -92,5 +94,43 @@ func getTime(timeType string) string {
 		return currentTime.Add(hour).Format("2006-01-02 15:04:05")
 	}
 
-	return ""
+	if !strings.HasPrefix(timeType, DateTimeCustom) {
+		return ""
+	}
+
+	format := strings.TrimPrefix(timeType, DateTimeCustom)
+	switch format {
+	case "ANSIC":
+		return currentTime.Format(time.ANSIC)
+	case "UnixDate":
+		return currentTime.Format(time.UnixDate)
+	case "RubyDate":
+		return currentTime.Format(time.RubyDate)
+	case "RFC822":
+		return currentTime.Format(time.RFC822)
+	case "RFC822Z":
+		return currentTime.Format(time.RFC822Z)
+	case "RFC850":
+		return currentTime.Format(time.RFC850)
+	case "RFC1123":
+		return currentTime.Format(time.RFC1123)
+	case "RFC1123Z":
+		return currentTime.Format(time.RFC1123Z)
+	case "RFC3339":
+		return currentTime.Format(time.RFC3339)
+	case "RFC3339Nano":
+		return currentTime.Format(time.RFC3339Nano)
+	case "Kitchen":
+		return currentTime.Format(time.Kitchen)
+	case "Stamp":
+		return currentTime.Format(time.Stamp)
+	case "StampMilli":
+		return currentTime.Format(time.StampMilli)
+	case "StampMicro":
+		return currentTime.Format(time.StampMicro)
+	case "StampNano":
+		return currentTime.Format(time.StampNano)
+	}
+
+	return currentTime.Format(format)
 }

--- a/pkg/mock/time.go
+++ b/pkg/mock/time.go
@@ -46,7 +46,7 @@ const (
 	DateDay              = "date_day"                // 1天前日期格式：2006-01-01
 	DateTime             = "datetime"                // 当前带时间的格式：2006-01-02 15:04:05
 	DateTimeHour         = "datetime_hour"           // 1小时前带时间的格式：2006-01-02 14:04:05
-	DateTimeCustom       = "datetime_custom_"        //  当前时间自定义格式
+	DateTimeCustom       = "datetime_custom_"        // custom datetime format
 )
 
 var dateTimeCustoms = map[string]string{


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: support comstom date format

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | support comstom date format in pipeline |
| 🇨🇳 中文    | 支持在流水线中输入格式更丰富的时间格式 |

```yaml
version: "1.1"
stages:
  - stage:
      - custom-script:
          alias: custom-script
          description: 运行自定义命令
          version: "1.0"
          image: registry.erda.cloud/erda-actions/custom-script-action:1.0-20211216-b1d5635
          commands:
            - echo "action meta:ANSIC=${{ random.datetime_custom_ANSIC }}"
            - echo "action meta:UnixDate=${{ random.datetime_custom_UnixDate }}"
            - echo "action meta:RubyDate=${{ random.datetime_custom_RubyDate }}"
            - echo "action meta:RFC822=${{ random.datetime_custom_RFC822 }}"
            - echo "action meta:RFC822Z=${{ random.datetime_custom_RFC822Z }}"
            - echo "action meta:RFC850=${{ random.datetime_custom_RFC850 }}"
            - echo "action meta:RFC1123=${{ random.datetime_custom_RFC1123 }}"
            - echo "action meta:RFC1123Z=${{ random.datetime_custom_RFC1123Z }}"
            - echo "action meta:RFC3339=${{ random.datetime_custom_RFC3339 }}"
            - echo "action meta:RFC3339Nano=${{ random.datetime_custom_RFC3339Nano }}"
            - echo "action meta:Kitchen=${{ random.datetime_custom_Kitchen }}"
            - echo "action meta:Stamp=${{ random.datetime_custom_Stamp }}"
            - echo "action meta:StampMilli=${{ random.datetime_custom_StampMilli }}"
            - echo "action meta:StampMicro=${{ random.datetime_custom_StampMicro }}"
            - echo "action meta:StampNano=${{ random.datetime_custom_StampNano }}"
            - echo "action meta:COMPRESS=${{ random.datetime_custom_20060102150405 }}"
```
output
```text
ANSIC
Tue Mar  8 16:33:06 2022
UnixDate
Tue Mar  8 16:33:06 CST 2022
RubyDate
Tue Mar 08 16:33:06 +0800 2022
RFC822
08 Mar 22 16:33 CST
RFC822Z
08 Mar 22 16:33 +0800
RFC850
Tuesday, 08-Mar-22 16:33:06 CST
RFC1123
Tue, 08 Mar 2022 16:33:06 CST
RFC1123Z
Tue, 08 Mar 2022 16:33:06 +0800
RFC3339
2022-03-08T16:33:06+08:00
RFC3339Nano
2022-03-08T16:33:06.629310528+08:00
Kitchen
4:33PM
Stamp
Mar  8 16:33:06
StampMilli
Mar  8 16:33:06.629
StampMicro
Mar  8 16:33:06.629326
StampNano
Mar  8 16:33:06.629330204
COMPRESS
20220308163306
```

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
