### PR TITLE
fix: display NaN% when total number of pod is 0

### DIFF
--- a/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsCharts/render.go
+++ b/modules/cmp/component-protocol/components/cmp-dashboard-pods/podsCharts/render.go
@@ -80,7 +80,10 @@ func (p *PodsCharts) Render(ctx context.Context, c *cptype.Component, s cptype.S
 }
 
 func (p *PodsCharts) ParsePodStatus(ctx context.Context, state string, count, total int) []Pie {
-	percent := float64(count) / float64(total) * 100
+	var percent float64
+	if total != 0 {
+		percent = float64(count) / float64(total) * 100
+	}
 	status := Pie{
 		Name:  cputil.I18n(ctx, state),
 		Value: count,
@@ -96,8 +99,8 @@ func (p *PodsCharts) ParsePodStatus(ctx context.Context, state string, count, to
 	return []Pie{status}
 }
 
-func (p *PodsCharts) Transfer(c *cptype.Component) {
-	c.Data = map[string]interface{}{
+func (p *PodsCharts) Transfer(component *cptype.Component) {
+	component.Data = map[string]interface{}{
 		"group": p.Data.Group,
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: display NaN% when total number of pod is 0

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: display NaN% when total number of pod is 0 |
| 🇨🇳 中文    | 修复CMP dashboard在pod总数为0时Pod chart显示NaN%的问题 |

