### PR TITLE
chore: set pipeline replicas default to 2

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -653,7 +653,7 @@ services:
       - "${nfs_root:/netdata}/dice-ops/dice-config/certificates/etcd-client.pem:/certs/etcd-client.pem:ro"
       - "${nfs_root:/netdata}/dice-ops/dice-config/certificates/etcd-client-key.pem:/certs/etcd-client-key.pem:ro"
     deployments:
-      replicas: ${replicas:1}
+      replicas: ${replicas:2}
       labels:
         GROUP: "devops"
     health_check:


### PR DESCRIPTION
#### What this PR does / why we need it:

set pipeline replicas default to 2


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=282421&issueFilter__urlQuery=eyJ0aXRsZSI6IuawtOW5s%2BaJqeWxlSIsInN0YXRlcyI6WzQ0MDIsNzEwNCw3MTA1LDQ0MDMsNDQwNCw3MTA2LDQ0MDYsNDQwNyw0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNiw0NDA1XSwiYXNzaWduZWVJRHMiOlsiOTIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1115&type=REQUIREMENT)


#### Specified Reviewers:

/assign @luobily @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   set pipeline replicas default to 2           |
| 🇨🇳 中文    |   pipeline 组件的副本数默认设置为 2           |

