### PR TITLE
refactor(dop): Remove setid of automated test scenes stages__urlquery and sceneid__urlquery state

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesSetConfig/scenesStages/model.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesSetConfig/scenesStages/model.go
@@ -84,8 +84,6 @@ type State struct {
 	SceneID               uint64     `json:"sceneId"`
 	SceneSetKey           uint64     `json:"sceneSetKey"`
 	PageNo                int        `json:"pageNo"`
-	SetId__urlQuery       string     `json:"setId__urlQuery"`
-	SceneId__urlQuery     string     `json:"sceneId__urlQuery"`
 	SelectedKeys          []string   `json:"selectedKeys"`
 	IsClickScene          bool       `json:"isClickScene"`
 	IsClickFolderTableRow bool       `json:"isClickFolderTableRow"`


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove setid of automated test scenessstages__ Urlquery and sceneid__urlQuery state

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Remove setid of automated test scenessstages__ Urlquery and sceneid__urlQuery state      |
| 🇨🇳 中文    |       移除自动化测试 scenesStages 的 SetId__urlQuery 和 SceneId__urlQuery state       |

