### PR TITLE
fix(openapi): the manual review action needs to be added with scopeID props

### DIFF
--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
@@ -324,9 +324,17 @@ func registerActionTypeRender() {
 	one.Do(func() {
 		actionTypeRender = make(map[string]func(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, globalStateData *apistructs.GlobalStateData) (err error))
 		actionTypeRender["manual-review"] = func(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, globalStateData *apistructs.GlobalStateData) (err error) {
+			bdl := ctx.Value(protocol.GlobalInnerKeyCtxBundle.String()).(protocol.ContextBundle)
 			action := ctx.Value(DataValueKey).(*apistructs.PipelineYmlAction)
 			if action == nil {
 				return nil
+			}
+
+			if c.Props != nil {
+				value, ok := c.Props.(map[string]interface{})
+				if ok {
+					value["scopeID"] = bdl.InParams["scopeID"]
+				}
 			}
 
 			params := action.Params


### PR DESCRIPTION
#### What this PR does / why we need it:
The project pipeline is special, and the manual review action needs to be added with scopeID props

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     the manual review action needs to be added with scopeID props       |
| 🇨🇳 中文    |      人工审核 action 需要额外加上 scopeID props        |

