### PR TITLE
feat: default 'v1' for kong path handling

### DIFF
--- a/modules/hepa/gateway/assembler/gateway_kong_assembler.go
+++ b/modules/hepa/gateway/assembler/gateway_kong_assembler.go
@@ -51,7 +51,7 @@ func (GatewayKongAssemblerImpl) BuildKongRouteReq(routeId string, dto *gw.ApiDto
 	if dto == nil || len(serviceId) == 0 {
 		return nil, errors.New(ERR_INVALID_ARG)
 	}
-	req := &kong.KongRouteReqDto{}
+	req := kong.NewKongRouteReqDto()
 	req.Service = &kong.Service{}
 	req.Service.Id = serviceId
 	if len(routeId) != 0 {

--- a/modules/hepa/kong/base/kong_adapter.go
+++ b/modules/hepa/kong/base/kong_adapter.go
@@ -177,12 +177,11 @@ func (impl *KongAdapterImpl) TouchRouteOAuthMethod(id string) error {
 		return errors.Errorf("get route info failed: code[%d] msg[%s]", code, body)
 	}
 	if needTouch {
-		reqDto := KongRouteReqDto{
-			Methods: []string{"POST"},
-			Hosts:   respDto.Hosts,
-			Paths:   []string{respDto.Paths[0] + "/oauth2/token", respDto.Paths[0] + "/oauth2/authorize"},
-			Service: &respDto.Service,
-		}
+		reqDto := NewKongRouteReqDto()
+		reqDto.Methods = []string{"POST"}
+		reqDto.Hosts = respDto.Hosts
+		reqDto.Paths = []string{respDto.Paths[0] + "/oauth2/token", respDto.Paths[0] + "/oauth2/authorize"}
+		reqDto.Service = &respDto.Service
 		code, body, err = util.DoCommonRequest(impl.Client, "POST", impl.KongAddr+RouteRoot, reqDto)
 		if code == 201 || code == 200 {
 			return nil

--- a/modules/hepa/kong/dto/kong_route_req_dto.go
+++ b/modules/hepa/kong/dto/kong_route_req_dto.go
@@ -44,6 +44,30 @@ type KongRouteReqDto struct {
 	RegexPriority int `json:"regex_priority,omitempty"`
 	// 真正的路由id，更新时使用
 	RouteId string `json:"-"`
+
+	// Path handling algorithms.
+	// "v0" is the behavior used in Kong 0.x and 2.x. It treats service.path,
+	// route.path and request path as segments of a url. It will always join
+	// them via slashes. Given a service path /s, route path /r and request
+	// path /re, the concatenated path will be /s/re. If the resulting path
+	// is a single slash, no further transformation is done to it. If it’s
+	// longer, then the trailing slash is removed.
+	//
+	// "v1" is the behavior used in Kong 1.x. It treats service.path as a prefix,
+	// and ignores the initial slashes of the request and route paths. Given service
+	// path /s, route path /r and request path /re, the concatenated path will be /sre.
+	//
+	// See more https://docs.konghq.com/enterprise/2.2.x/admin-api/#path-handling-algorithms
+	PathHandling *string `json:"path_handling"`
+}
+
+func NewKongRouteReqDto() *KongRouteReqDto {
+	stripPath := true
+	pathHandling := "v1"
+	return &KongRouteReqDto{
+		StripPath:    &stripPath,
+		PathHandling: &pathHandling,
+	}
 }
 
 // IsEmpty

--- a/modules/hepa/kong/dto/kong_route_req_dto_test.go
+++ b/modules/hepa/kong/dto/kong_route_req_dto_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/modules/hepa/kong/dto"
+)
+
+func TestNewKongRouteReqDto(t *testing.T) {
+	req := dto.NewKongRouteReqDto()
+	if req.StripPath == nil || !*req.StripPath {
+		t.Fatal("err")
+	}
+	if req.PathHandling == nil || *req.PathHandling != "v1" {
+		t.Fatal("err")
+	}
+}

--- a/modules/hepa/services/endpoint_api/impl/impl.go
+++ b/modules/hepa/services/endpoint_api/impl/impl.go
@@ -551,10 +551,9 @@ func (impl GatewayOpenapiServiceImpl) updatePackageApiHost(pack *orm.GatewayPack
 		if route == nil {
 			return errors.Errorf("can't find route of api:%s", api.Id)
 		}
-		req := &kongDto.KongRouteReqDto{
-			RouteId: route.RouteId,
-			Hosts:   hosts,
-		}
+		req := kongDto.NewKongRouteReqDto()
+		req.RouteId = route.RouteId
+		req.Hosts = hosts
 		resp, err := kongAdapter.UpdateRoute(req)
 		if err != nil {
 			return err
@@ -1050,7 +1049,7 @@ func (impl GatewayOpenapiServiceImpl) deleteKongService(adapter kong.KongAdapter
 }
 
 func (impl GatewayOpenapiServiceImpl) createKongRouteReq(dto *gw.OpenapiDto, serviceId string, routeId ...string) *kongDto.KongRouteReqDto {
-	reqDto := &kongDto.KongRouteReqDto{}
+	reqDto := kongDto.NewKongRouteReqDto()
 	if dto.Method != "" {
 		reqDto.Methods = []string{dto.Method}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: default 'v1' for kong path handling

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | default 'v1' for kong path handling |
| 🇨🇳 中文    | 将 API 网关 Kong 的路径处理语法更换为 `v1` |

![image](https://user-images.githubusercontent.com/25881576/157787476-9a45436f-5e9d-4a27-a086-c80a4a675615.png)
change Kong (API Gateway) path handling from red to bule.

#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
