### PR TITLE
fix(openapi): the manual review action needs to be added with scopeID props

### DIFF
--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render.go
@@ -330,12 +330,9 @@ func registerActionTypeRender() {
 				return nil
 			}
 
-			if c.Props != nil {
-				value, ok := c.Props.(map[string]interface{})
-				if ok {
-					value["scopeID"] = bdl.InParams["scopeID"]
-				}
-			}
+			defer func() {
+				c.Props = setMemberSelectorComponentScopeIDFieldWithAppID(c.Props, bdl.InParams["appId"])
+			}()
 
 			params := action.Params
 			if params == nil || params["processor"] == nil {
@@ -362,6 +359,34 @@ func registerActionTypeRender() {
 
 		//actionTypeRender["mysql-cli"] = mysqlCliRender
 	})
+}
+
+func setMemberSelectorComponentScopeIDFieldWithAppID(props interface{}, appID interface{}) (resultProps interface{}) {
+	if props == nil {
+		return
+	}
+
+	value, ok := props.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	fields, ok := value["fields"].([]apistructs.FormPropItem)
+	if !ok {
+		return
+	}
+
+	for _, field := range fields {
+		if field.Component != "memberSelector" {
+			continue
+		}
+		props, ok := field.ComponentProps.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		props["scopeId"] = appID
+	}
+	return props
 }
 
 func (a *ComponentAction) Render(ctx context.Context, c *apistructs.Component, scenario apistructs.ComponentProtocolScenario, event apistructs.ComponentEvent, globalStateData *apistructs.GlobalStateData) (err error) {

--- a/modules/openapi/component-protocol/scenarios/action/components/actionForm/render_test.go
+++ b/modules/openapi/component-protocol/scenarios/action/components/actionForm/render_test.go
@@ -64,3 +64,71 @@ func TestGenTimeoutProps1(t *testing.T) {
 		})
 	}
 }
+
+func Test_setMemberSelectorComponentScopeIDFieldWithAppID1(t *testing.T) {
+	type args struct {
+		props interface{}
+		appID interface{}
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantResultProps interface{}
+	}{
+		{
+			name: "test_not_find_appId",
+			args: args{
+				props: map[string]interface{}{
+					"fields": []apistructs.FormPropItem{
+						{
+							Component:      "memberSelector",
+							ComponentProps: map[string]interface{}{},
+						},
+					},
+				},
+				appID: nil,
+			},
+			wantResultProps: map[string]interface{}{
+				"fields": []apistructs.FormPropItem{
+					{
+						Component: "memberSelector",
+						ComponentProps: map[string]interface{}{
+							"scopeId": nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test_appId_set_to_scopeId",
+			args: args{
+				props: map[string]interface{}{
+					"fields": []apistructs.FormPropItem{
+						{
+							Component:      "memberSelector",
+							ComponentProps: map[string]interface{}{},
+						},
+					},
+				},
+				appID: 10,
+			},
+			wantResultProps: map[string]interface{}{
+				"fields": []apistructs.FormPropItem{
+					{
+						Component: "memberSelector",
+						ComponentProps: map[string]interface{}{
+							"scopeId": 10,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotResultProps := setMemberSelectorComponentScopeIDFieldWithAppID(tt.args.props, tt.args.appID); !reflect.DeepEqual(gotResultProps, tt.wantResultProps) {
+				t.Errorf("setMemberSelectorComponentScopeIDFieldWithAppID() = %v, want %v", gotResultProps, tt.wantResultProps)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
The project pipeline is special, and the manual review action needs to be added with scopeID props

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     the manual review action needs to be added with scopeID props       |
| 🇨🇳 中文    |      人工审核 action 需要额外加上 scopeID props        |

