### PR TITLE
feat(dop): Scene set supports drag and drop

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/model.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/model.go
@@ -42,15 +42,19 @@ type SceneSet struct {
 	Operations    map[string]interface{} `json:"operations"`
 	Children      []Scene                `json:"children"`
 	Type          string                 `json:"type"`
+	Draggable     bool                   `json:"draggable"`
+	DropPosition  []int                  `json:"dropPosition"`
 }
 
 type Scene struct {
-	Key        string                 `json:"key"`
-	Title      string                 `json:"title"`
-	Icon       string                 `json:"icon"`
-	IsLeaf     bool                   `json:"isLeaf"`
-	Operations map[string]interface{} `json:"operations"`
-	Type       string                 `json:"type"`
+	Key          string                 `json:"key"`
+	Title        string                 `json:"title"`
+	Icon         string                 `json:"icon"`
+	IsLeaf       bool                   `json:"isLeaf"`
+	Operations   map[string]interface{} `json:"operations"`
+	Type         string                 `json:"type"`
+	Draggable    bool                   `json:"draggable"`
+	DropPosition []int                  `json:"dropPosition"`
 }
 
 type OperationBase struct {

--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/render.go
@@ -175,7 +175,7 @@ func (i *ComponentFileTree) Render(ctx context.Context, c *cptype.Component, sce
 	i.Operations["drag"] = drag
 
 	i.Props = map[string]interface{}{}
-	i.Props["draggable"] = false
+	i.Props["draggable"] = true
 
 	inParamsBytes, err := json.Marshal(cputil.SDK(ctx).InParams)
 	if err != nil {

--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/scenes.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/scenes.go
@@ -250,6 +250,8 @@ func (i *ComponentFileTree) initSceneSet(s *apistructs.SceneSet) SceneSet {
 	set.Operations["delete"] = delete
 	set.Operations["refSceneSet"] = refSceneSet
 	set.Operations["exportSceneSet"] = export
+	set.Draggable = true
+	set.DropPosition = []int{1, -1}
 	return set
 }
 
@@ -318,6 +320,8 @@ func (i *ComponentFileTree) initScene(scene apistructs.AutoTestScene, setId int)
 		},
 	}
 	s.Operations["delete"] = deleteOperation
+	s.Draggable = false
+	s.DropPosition = nil
 	return s
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
 Scene set supports drag and drop

https://user-images.githubusercontent.com/23724009/158137792-701191db-11ab-40be-a73c-d0be818a58f2.mov



#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTMxLDExNDYsMTExNV0sImFzc2lnbmVlIjpbIjEwMDEyNjEiXX0%3D&id=291519&iterationID=1146&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Scene set supports drag and drop         |
| 🇨🇳 中文    |       场景集支持拖拽       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
