### PR TITLE
refactor: adjust erda-cli config and project-deployment logic

### DIFF
--- a/tools/cli/cmd/clone.go
+++ b/tools/cli/cmd/clone.go
@@ -73,7 +73,7 @@ func Clone(ctx *command.Context, ustr string, cloneApps bool) error {
 		return errors.Errorf("Invalid erda url.")
 	}
 
-	org, orgID, err = getOrgID(ctx, org)
+	org, orgID, err = common.GetOrgID(ctx, org)
 	if err != nil {
 		return err
 	}
@@ -204,41 +204,4 @@ func cloneApplication(pInfo *command.ProjectInfo, a apistructs.ApplicationDTO, r
 	}
 
 	return nil
-}
-
-func getOrgID(ctx *command.Context, org string) (string, uint64, error) {
-	var orgID uint64
-	if org != "" {
-		o, err := common.GetOrgDetail(ctx, org)
-		if err != nil {
-			return org, orgID, err
-		}
-		orgID = o.ID
-	}
-
-	if org == "" && ctx.CurrentOrg.Name == "" {
-		return org, orgID, errors.New("Invalid organization name. You may clone a project first.")
-	}
-
-	if org == "" && ctx.CurrentOrg.Name != "" {
-		org = ctx.CurrentOrg.Name
-	}
-
-	if orgID <= 0 && ctx.CurrentOrg.ID <= 0 && org != "" {
-		o, err := common.GetOrgDetail(ctx, org)
-		if err != nil {
-			return org, orgID, err
-		}
-		ctx.CurrentOrg.ID = o.ID
-		orgID = o.ID
-	}
-	if orgID <= 0 && ctx.CurrentOrg.ID <= 0 {
-		return org, orgID, errors.New("Invalid organization id.")
-	}
-
-	if orgID == 0 && ctx.CurrentOrg.ID > 0 {
-		orgID = ctx.CurrentOrg.ID
-	}
-
-	return org, orgID, nil
 }

--- a/tools/cli/cmd/config_get.go
+++ b/tools/cli/cmd/config_get.go
@@ -15,13 +15,10 @@
 package cmd
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 
-	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 
@@ -30,60 +27,26 @@ var CONFIGGET = command.Command{
 	ParentName: "CONFIG",
 	ShortHelp:  "get project workspace config",
 	Example: `
-  $ erda-cli config get --orgName xxx --projectName yyy --workspace DEV
+  $ erda-cli config get --org xxx --project yyy --workspace DEV
 `,
 	Flags: []command.Flag{
-		command.StringFlag{Name: "orgName", Doc: "[required]which org the project belongs", DefaultValue: ""},
-		command.StringFlag{Name: "projectName", Doc: "[required]which project's feature to delete", DefaultValue: ""},
+		command.StringFlag{Name: "org", Doc: "[required]which org the project belongs", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "[required]which project's feature to delete", DefaultValue: ""},
 		command.StringFlag{Name: "workspace", Doc: "[optional]which workspace's feature to delete", DefaultValue: ""},
 	},
 	Run: RunFeaturesGet,
 }
 
-func RunFeaturesGet(ctx *command.Context, orgName, projectName, workspace string) error {
-	var resp apistructs.ProjectWorkSpaceAbilityResponse
-	var b bytes.Buffer
-
-	if projectName == "" || workspace == "" || orgName == "" {
+func RunFeaturesGet(ctx *command.Context, org, project, workspace string) error {
+	if project == "" || workspace == "" || org == "" {
 		return fmt.Errorf(
-			utils.FormatErrMsg("config get", "failed to get configd, one of the flags [orgName, projectName, workspace] not set", true))
+			utils.FormatErrMsg("config get", "failed to get configd, one of the flags [org, project, workspace] not set", true))
 	}
 
-	uop, err := GetUserOrgProjID(ctx, orgName, projectName)
-	if err != nil {
-		return fmt.Errorf(
-			utils.FormatErrMsg("config get", "failed to get configs, can not get orgID or userID or projectID: "+err.Error(), true))
+	if err := common.GetProjectWorkspaceConfigs(ctx, org, project, workspace); err != nil {
+		return err
 	}
 
-	urlPath := "/api/project-workspace-abilities/" + uop.ProjectId + "/" + workspace
-
-	response, err := ctx.Get().Path(urlPath).
-		Header(httputil.OrgHeader, uop.OrgId).
-		Do().Body(&b)
-
-	if err != nil {
-		return fmt.Errorf(
-			utils.FormatErrMsg("config get", "failed to request ("+err.Error()+")", false))
-	}
-
-	if !response.IsOK() {
-		return fmt.Errorf(utils.FormatErrMsg("config get",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-	}
-
-	if err = json.Unmarshal(b.Bytes(), &resp); err != nil {
-		return fmt.Errorf(utils.FormatErrMsg("config get",
-			fmt.Sprintf("failed to unmarshal get config response ("+err.Error()+")"), false))
-	}
-
-	if !resp.Success {
-		return fmt.Errorf(utils.FormatErrMsg("config get",
-			fmt.Sprintf("failed to request, error code: %s, error message: %s",
-				resp.Error.Code, resp.Error.Msg), false))
-	}
-
-	ctx.Info("Configs get result: %s\n", resp.Data.Abilities)
 	ctx.Succ("config get success\n")
 	return nil
 }

--- a/tools/cli/cmd/config_set.go
+++ b/tools/cli/cmd/config_set.go
@@ -15,15 +15,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
-	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 
@@ -32,97 +27,30 @@ var CONFIGSET = command.Command{
 	ParentName: "CONFIG",
 	ShortHelp:  "set project workspace config",
 	Example: `
-  $ erda-cli config set HPA=enable --orgName xxx --projectName yyy --workspace DEV
+  $ erda-cli config set HPA=enable --org xxx --project yyy --workspace DEV
 `,
 	Args: []command.Arg{
 		command.StringArg{}.Name("feature"),
 	},
 	Flags: []command.Flag{
-		command.StringFlag{Name: "orgName", Doc: "[required]which org the project belongs", DefaultValue: ""},
-		command.StringFlag{Name: "projectName", Doc: "[required]which project's feature to delete", DefaultValue: ""},
+		command.StringFlag{Name: "org", Doc: "[required]which org the project belongs", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "[required]which project's feature to delete", DefaultValue: ""},
 		command.StringFlag{Name: "workspace", Doc: "[optional]which workspace's feature to delete", DefaultValue: ""},
 	},
 	Run: RunFeaturesSet,
 }
 
-func RunFeaturesSet(ctx *command.Context, feature, orgName, projectName, workspace string) error {
-	if projectName == "" || workspace == "" || orgName == "" {
+func RunFeaturesSet(ctx *command.Context, feature, org, project, workspace string) error {
+	if project == "" || workspace == "" || org == "" {
 		return fmt.Errorf(
-			utils.FormatErrMsg("config set", "failed to set config, one of the flags [orgName, projectName, workspace] not set", true))
+			utils.FormatErrMsg("config set", "failed to set config, one of the flags [org, project, workspace] not set", true))
 	}
 
-	if err := SetProjectWorkspaceFeatures(ctx, feature, orgName, projectName, workspace); err != nil {
+	if err := common.SetProjectWorkspaceConfigs(ctx, feature, org, project, workspace); err != nil {
 		ctx.Error("failed to set config: " + err.Error() + "\n")
 		return fmt.Errorf(utils.FormatErrMsg("config set", "failed to set configs: "+err.Error(), true))
 	}
 
 	ctx.Succ("config set success\n")
 	return nil
-}
-
-// SetProjectWorkspaceFeatures 为指定项目的指定环境设置 features
-func SetProjectWorkspaceFeatures(ctx *command.Context, feature, orgName, projectName, workspace string) error {
-	var resp apistructs.ProjectWorkSpaceAbilityResponse
-
-	uop, err := GetUserOrgProjID(ctx, orgName, projectName)
-	if err != nil {
-		return errors.New("can not get orgID or userID or projectID: " + err.Error())
-	}
-
-	prjId, _ := strconv.ParseUint(uop.ProjectId, 10, 64)
-	abilities, err := ParseProjectWorkspaceFeatures(feature)
-	if err != nil {
-		return errors.New("parse config list failed: " + err.Error())
-	}
-
-	req := apistructs.ProjectWorkSpaceAbility{
-		ProjectID: prjId,
-		Workspace: workspace,
-		Abilities: abilities,
-	}
-
-	response, err := ctx.Post().Path("/api/project-workspace-abilities").
-		Header(httputil.OrgHeader, uop.OrgId).
-		JSONBody(req).Do().JSON(&resp)
-
-	if err != nil {
-		return errors.New("failed to request set project workspace config: " + err.Error())
-	}
-
-	if !response.IsOK() {
-		return errors.New(fmt.Sprintf("ailed to request set project workspace configs, status-code: %d, content-type: %s, raw bod: %s",
-			response.StatusCode(), response.ResponseHeader("Content-Type"), string(response.Body())))
-	}
-
-	if !resp.Success {
-		return errors.New(fmt.Sprintf("failed to request, error code: %s, raw bod: %s, error message: %s", resp.Error.Code, string(response.Body()), resp.Error.Msg))
-	}
-	return nil
-}
-
-// ParseProjectWorkspaceFeatures 解析 project workspace 的 feature list
-func ParseProjectWorkspaceFeatures(featureList string) (string, error) {
-	features := make(map[string]string)
-
-	fts := strings.Split(featureList, ",")
-
-	if len(fts) > 0 {
-		for _, f := range fts {
-			kv := strings.Split(f, "=")
-			switch {
-			case len(kv) > 2:
-				return "", errors.New(fmt.Sprintf("set configs with invalid parameter %s", f))
-			case len(kv) == 2:
-				features[kv[0]] = kv[1]
-			case len(kv) == 1:
-				features[kv[0]] = "enable"
-			}
-		}
-	}
-
-	featureStr, err := json.Marshal(features)
-	if err != nil {
-		return "", errors.New(fmt.Sprintf("set config failed to Marshal request, error: %v ", err))
-	}
-	return string(featureStr), nil
 }

--- a/tools/cli/cmd/create.go
+++ b/tools/cli/cmd/create.go
@@ -50,7 +50,7 @@ var PROJECTCREATE = command.Command{
 }
 
 func ProjectCreate(ctx *command.Context, org, project, desc, pkg string, waitImport int) error {
-	org, orgID, err := getOrgID(ctx, org)
+	org, orgID, err := common.GetOrgID(ctx, org)
 	if err != nil {
 		return err
 	}

--- a/tools/cli/cmd/project_deployment_start.go
+++ b/tools/cli/cmd/project_deployment_start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 
@@ -30,23 +31,23 @@ var PROJECTDEPLOYMENTSTART = command.Command{
 	ParentName: "PROJECTDEPLOYMENT",
 	ShortHelp:  "start project's runtimes and addons",
 	Example: `
-  $ erda-cli project-deployment start --orgName xxx --projectName yyy --workspace DEV
+  $ erda-cli project-deployment start --org xxx --project yyy --workspace DEV
 `,
 	Flags: []command.Flag{
-		command.StringFlag{Name: "orgName", Doc: "[required] the org name the project belongs to", DefaultValue: ""},
-		command.StringFlag{Name: "projectName", Doc: "[required] which project's runtimes to stop", DefaultValue: ""},
+		command.StringFlag{Name: "org", Doc: "[required] the org name the project belongs to", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "[required] which project's runtimes to stop", DefaultValue: ""},
 		command.StringFlag{Name: "workspace", Doc: "[required] which workspace's runtimes to stop", DefaultValue: ""},
 	},
 	Run: RunStartProjectInWorkspace,
 }
 
-func RunStartProjectInWorkspace(ctx *command.Context, orgName, projectName, workspace string) error {
-	if projectName == "" || workspace == "" || orgName == "" {
+func RunStartProjectInWorkspace(ctx *command.Context, org, project, workspace string) error {
+	if project == "" || workspace == "" || org == "" {
 		return fmt.Errorf(
-			utils.FormatErrMsg("project-deployment start", "failed to start project deployments, one of the flags [orgName, projectName, workspace] not set", true))
+			utils.FormatErrMsg("project-deployment start", "failed to start project deployments, one of the flags [org, project, workspace] not set", true))
 	}
 
-	uop, err := GetUserOrgProjID(ctx, orgName, projectName)
+	uop, err := common.GetUserOrgProjID(ctx, org, project)
 	if err != nil {
 		return fmt.Errorf(
 			utils.FormatErrMsg("project-deployment start", "failed to start project deployments, can not get orgID or userID or projectID: "+err.Error(), true))
@@ -105,8 +106,10 @@ func RunStartProjectInWorkspace(ctx *command.Context, orgName, projectName, work
 		ctx.Info("Waitting %d minutes for project's addons to Running\n", ADDONS_RESTART_WAITTING_DELAY)
 		tick := time.Tick(1 * time.Second)
 		for waits := ADDONS_RESTART_WAITTING_DELAY * 60; waits > 0; waits-- {
-			fmt.Printf("\r%3d", waits)
-			<-tick
+			select {
+			case <-tick:
+				fmt.Printf("\r%3d", waits)
+			}
 		}
 
 		err = waitProjectAddonsComplete(ctx, params)

--- a/tools/cli/cmd/push.go
+++ b/tools/cli/cmd/push.go
@@ -73,7 +73,7 @@ func Push(ctx *command.Context, urlstr string, applications []string, configfile
 	org = paths[1]
 	projectID, err = strconv.ParseUint(paths[4], 10, 64)
 
-	org, orgID, err = getOrgID(ctx, org)
+	org, orgID, err = common.GetOrgID(ctx, org)
 	if err != nil {
 		return err
 	}

--- a/tools/cli/common/config.go
+++ b/tools/cli/common/config.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/pkg/http/httputil"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/utils"
+)
+
+// SetProjectWorkspaceConfigss 为指定项目的指定环境设置 features
+func SetProjectWorkspaceConfigs(ctx *command.Context, feature, orgName, projectName, workspace string) error {
+	var resp apistructs.ProjectWorkSpaceAbilityResponse
+
+	uop, err := GetUserOrgProjID(ctx, orgName, projectName)
+	if err != nil {
+		return errors.New("can not get orgID or userID or projectID: " + err.Error())
+	}
+
+	prjId, _ := strconv.ParseUint(uop.ProjectId, 10, 64)
+	abilities, err := ParseProjectWorkspaceConfigs(feature)
+	if err != nil {
+		return errors.New("parse config list failed: " + err.Error())
+	}
+
+	req := apistructs.ProjectWorkSpaceAbility{
+		ProjectID: prjId,
+		Workspace: workspace,
+		Abilities: abilities,
+	}
+
+	response, err := ctx.Post().Path("/api/project-workspace-abilities").
+		Header(httputil.OrgHeader, uop.OrgId).
+		JSONBody(req).Do().JSON(&resp)
+
+	if err != nil {
+		return errors.New("failed to request set project workspace config: " + err.Error())
+	}
+
+	if !response.IsOK() {
+		return errors.New(fmt.Sprintf("ailed to request set project workspace configs, status-code: %d, content-type: %s, raw bod: %s",
+			response.StatusCode(), response.ResponseHeader("Content-Type"), string(response.Body())))
+	}
+
+	if !resp.Success {
+		return errors.New(fmt.Sprintf("failed to request, error code: %s, raw bod: %s, error message: %s", resp.Error.Code, string(response.Body()), resp.Error.Msg))
+	}
+	return nil
+}
+
+// UpdateProjectWorkspaceConfigs 为指定项目的指定环境更新 features
+func UpdateProjectWorkspaceConfigs(ctx *command.Context, feature, org, project, workspace string) error {
+	var resp apistructs.ProjectWorkSpaceAbilityResponse
+
+	uop, err := GetUserOrgProjID(ctx, org, project)
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config update", "failed to update config, can not get orgID or userID or projectID: "+err.Error(), true))
+	}
+
+	prjId, _ := strconv.ParseUint(uop.ProjectId, 10, 64)
+	abilities, err := ParseProjectWorkspaceConfigs(feature)
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config update", fmt.Sprintf("failed to update config, parse config list failed: %v", err), true))
+	}
+
+	updateReq := apistructs.ProjectWorkSpaceAbility{
+		ProjectID: prjId,
+		Workspace: workspace,
+		Abilities: abilities,
+	}
+
+	response, err := ctx.Put().Path("/api/project-workspace-abilities").
+		Header(httputil.OrgHeader, uop.OrgId).
+		JSONBody(updateReq).Do().JSON(&resp)
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config update", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return fmt.Errorf(utils.FormatErrMsg("config update",
+			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
+				response.StatusCode(), response.ResponseHeader("Content-Type"), string(response.Body())), false))
+	}
+
+	if !resp.Success {
+		return fmt.Errorf(utils.FormatErrMsg("config update",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return nil
+}
+
+// GetProjectWorkspaceConfigs 获取指定项目的指定环境支持的 features
+func GetProjectWorkspaceConfigs(ctx *command.Context, org, project, workspace string) error {
+	var resp apistructs.ProjectWorkSpaceAbilityResponse
+	var b bytes.Buffer
+
+	uop, err := GetUserOrgProjID(ctx, org, project)
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config get", "failed to get configs, can not get orgID or userID or projectID: "+err.Error(), true))
+	}
+
+	urlPath := "/api/project-workspace-abilities/" + uop.ProjectId + "/" + workspace
+
+	response, err := ctx.Get().Path(urlPath).
+		Header(httputil.OrgHeader, uop.OrgId).
+		Do().Body(&b)
+
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config get", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return fmt.Errorf(utils.FormatErrMsg("config get",
+			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
+				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
+	}
+
+	if err = json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return fmt.Errorf(utils.FormatErrMsg("config get",
+			fmt.Sprintf("failed to unmarshal get config response ("+err.Error()+")"), false))
+	}
+
+	if !resp.Success {
+		return fmt.Errorf(utils.FormatErrMsg("config get",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	ctx.Info("Configs get result: %s\n", resp.Data.Abilities)
+	return nil
+}
+
+func DelelteProjectWorkspaceConfigs(ctx *command.Context, org, project, workspace string) error {
+	var resp apistructs.ExtensionVersionGetResponse
+	var b bytes.Buffer
+
+	uop, err := GetUserOrgProjID(ctx, org, project)
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config delete", "failed to delete config, can not get orgID or userID or projectID: "+err.Error(), true))
+	}
+
+	urlPath := ""
+	if workspace != "" {
+		urlPath = fmt.Sprintf("/api/project-workspace-abilities?projectID=%s&workspace=%s", uop.ProjectId, workspace)
+	} else {
+		urlPath = fmt.Sprintf("/api/project-workspace-abilities?projectID=%s", uop.ProjectId)
+	}
+
+	response, err := ctx.Delete().Path(urlPath).
+		Header(httputil.OrgHeader, uop.OrgId).
+		Do().Body(&b)
+
+	if err != nil {
+		return fmt.Errorf(
+			utils.FormatErrMsg("config delete", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return fmt.Errorf(utils.FormatErrMsg("config delete",
+			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
+				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
+	}
+
+	if err = json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return fmt.Errorf(utils.FormatErrMsg("config delete",
+			fmt.Sprintf("failed to unmarshal config delete response ("+err.Error()+")"), false))
+	}
+
+	if !resp.Success {
+		return fmt.Errorf(utils.FormatErrMsg("config delete",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return nil
+}
+
+// ParseProjectWorkspaceConfigs 解析 project workspace 的 feature list
+func ParseProjectWorkspaceConfigs(featureList string) (string, error) {
+	features := make(map[string]string)
+
+	fts := strings.Split(featureList, ",")
+
+	if len(fts) > 0 {
+		for _, f := range fts {
+			kv := strings.Split(f, "=")
+			switch {
+			case len(kv) > 2:
+				return "", errors.New(fmt.Sprintf("set configs with invalid parameter %s", f))
+			case len(kv) == 2:
+				features[kv[0]] = kv[1]
+			case len(kv) == 1:
+				features[kv[0]] = "enable"
+			}
+		}
+	}
+
+	featureStr, err := json.Marshal(features)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("set config failed to Marshal request, error: %v ", err))
+	}
+	return string(featureStr), nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adjust erda-cli config and project-deployment logic for consistency with other erda-cli commands




#### Specified Reviewers:

/assign @sixther-dc @jferic 


#### ChangeLog
Feature: Optimize erda-cli config and project-deployment logic for consistency with other erda-cli commands（优化 erda-cli config 和 erda-cli project-deployment 命令逻辑）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Optimize erda-cli config and project-deployment logic for consistency with other erda-cli commands       |
| 🇨🇳 中文    |    优化 erda-cli config 和 erda-cli project-deployment 命令逻辑         |



