### PR TITLE
feat: only set `path_handling` on Kong 2.x to be compatible with different versions of Kong

### DIFF
--- a/modules/hepa/kong/base/kong_adapter.go
+++ b/modules/hepa/kong/base/kong_adapter.go
@@ -98,6 +98,7 @@ func (impl *KongAdapterImpl) UpdateRoute(req *KongRouteReqDto) (*KongRouteRespDt
 	if req == nil || req.RouteId == "" {
 		return nil, errors.New(ERR_INVALID_ARG)
 	}
+	req.Adjust(Versioning(impl))
 	url := impl.KongAddr + RouteRoot + req.RouteId
 	code, body, err := util.DoCommonRequest(impl.Client, "PATCH", url, req)
 	if err != nil {
@@ -126,6 +127,7 @@ func (impl *KongAdapterImpl) CreateOrUpdateRoute(req *KongRouteReqDto) (*KongRou
 	if req == nil {
 		return nil, errors.New(ERR_INVALID_ARG)
 	}
+	req.Adjust(Versioning(impl))
 	url := impl.KongAddr + RouteRoot
 	method := "POST"
 	if len(req.RouteId) != 0 {

--- a/modules/hepa/kong/dto/kong_route_req_dto_test.go
+++ b/modules/hepa/kong/dto/kong_route_req_dto_test.go
@@ -29,3 +29,28 @@ func TestNewKongRouteReqDto(t *testing.T) {
 		t.Fatal("err")
 	}
 }
+
+type versioning struct {
+	version string
+}
+
+func (v versioning) GetVersion() (string, error) {
+	return v.version, nil
+}
+
+func TestKongRouteReqDto_Adjust(t *testing.T) {
+	var (
+		req = dto.NewKongRouteReqDto()
+		v   versioning
+	)
+	req.Adjust(dto.Versioning(v))
+	if req.PathHandling != nil {
+		t.Fatal("req.PathHandling should be nil")
+	}
+
+	v.version = "2.2.0"
+	req.Adjust(dto.Versioning(v))
+	if req.PathHandling == nil || *req.PathHandling != "v1" {
+		t.Fatal("req.PathHandling should be v1")
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: only set path_handling "v2" on Kong 2.x

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | only set `path_handling` on Kong 2.x to be compatible with different versions of Kong |
| 🇨🇳 中文    | 仅在 Kong 为 2.x 版本时设置 `path_handling` 参数以兼容不同版本的 Kong |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
