### PR TITLE
fix: remove metricq-client in dicehub conf

### DIFF
--- a/conf/dicehub/dicehub.yaml
+++ b/conf/dicehub/dicehub.yaml
@@ -34,9 +34,5 @@ mysql:
   password: "${MYSQL_PASSWORD:123456}"
   database: "${MYSQL_DATABASE:dice}"
 
-metricq-client:
-  endpoint: "http://${MONITOR_ADDR:monitor.default.svc.cluster.local:7096}"
-
-
 etcd-election@initExtension:
   root_path: erda/component-leader/dicehub/init_extension


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: remove metricq-client in dicehub conf

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: remove metricq-client in dicehub conf |
| 🇨🇳 中文    | 移除dicehub的conf文件中对msp的依赖 |
