### PR TITLE
fix: update and delete k8s executor by factory (#4415)

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/k8s_helper.go
+++ b/modules/pipeline/pipengine/actionexecutor/k8s_helper.go
@@ -23,40 +23,42 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/conf"
+	"github.com/erda-project/erda/modules/pipeline/pipengine/actionexecutor/types"
 	"github.com/erda-project/erda/modules/pipeline/pkg/clusterinfo"
 )
 
 func (m *Manager) deleteK8sExecutor(cluster apistructs.ClusterInfo) {
 	m.Lock()
 	defer m.Unlock()
-	for _, kind := range m.kindsByName {
+	for kind := range m.factory {
 		if kind.IsK8sKind() {
 			name := kind.MakeK8sKindExecutorName(cluster.Name)
-			delete(m.executorsByName, name)
 			delete(m.kindsByName, name)
+			delete(m.executorsByName, name)
 		}
 	}
 }
 
 func (m *Manager) updateK8sExecutor(cluster apistructs.ClusterInfo) error {
-	for _, kind := range m.kindsByName {
+	// create a duplication of k8s kind create fn
+	k8sFactory := make(map[types.Kind]types.CreateFn)
+	m.Lock()
+	for kind, createFn := range m.factory {
 		if kind.IsK8sKind() {
-			m.Lock()
-			create, ok := m.factory[kind]
-			m.Unlock()
-			if !ok {
-				return errors.Errorf("executor creator [%s] not found", kind)
-			}
-			name := kind.MakeK8sKindExecutorName(cluster.Name)
-			actionExecutor, err := create(name, nil)
-			if err != nil {
-				return errors.Errorf("executor [%s] created failed, err: %v", name, err)
-			}
-			m.Lock()
-			m.kindsByName[name] = kind
-			m.executorsByName[actionExecutor.Name()] = actionExecutor
-			m.Unlock()
+			k8sFactory[kind] = createFn
 		}
+	}
+	m.Unlock()
+	for kind, createFn := range k8sFactory {
+		name := kind.MakeK8sKindExecutorName(cluster.Name)
+		actionExecutor, err := createFn(name, nil)
+		if err != nil {
+			return errors.Errorf("executor [%s] created failed, err: %v", name, err)
+		}
+		m.Lock()
+		m.kindsByName[name] = kind
+		m.executorsByName[actionExecutor.Name()] = actionExecutor
+		m.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
(cherry picked from commit 8e81dd38afb9d0a143c54cd9fcf05754b44d1e22)

#### What this PR does / why we need it:
fix k8s executor concurrent interator and write map

#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that update and delete k8s executor by factory （修复了k8sexecutor并发遍历写map的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that update and delete k8s executor by factory           |
| 🇨🇳 中文    |  修复了k8sexecutor并发遍历写map的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
