### PR TITLE
feat: clean up pipeline archives

### DIFF
--- a/.erda/migrations/pipeline/20220322-pipeline-archive-add-index.sql
+++ b/.erda/migrations/pipeline/20220322-pipeline-archive-add-index.sql
@@ -1,1 +1,3 @@
-ALTER TABLE `pipeline_archives` ADD INDEX `idx_status_timecreated` (`status`, `time_created`);
+ALTER TABLE `pipeline_archives` ADD INDEX `idx_status_time_created` (`status`, `time_created`);
+ALTER TABLE `pipeline_archives` ADD INDEX `idx_status` (`status`);
+ALTER TABLE `pipeline_archives` ADD INDEX `idx_time_created` (`time_created`);

--- a/.erda/migrations/pipeline/20220322-pipeline-archive-add-index.sql
+++ b/.erda/migrations/pipeline/20220322-pipeline-archive-add-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pipeline_archives` ADD INDEX `idx_status_timecreated` (`status`, `time_created`);

--- a/modules/pipeline/providers/dbgc/provider.go
+++ b/modules/pipeline/providers/dbgc/provider.go
@@ -17,6 +17,7 @@ package dbgc
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
@@ -28,7 +29,12 @@ import (
 	"github.com/erda-project/erda/pkg/jsonstore/etcd"
 )
 
-type config struct{}
+type config struct {
+	// default 1 day
+	AnalyzedPipelineArchiveDefaultRetainHour time.Duration `file:"analyzed_pipeline_archive_default_retain_hour" default:"24h"`
+	// default 30 day
+	FinishedPipelineArchiveDefaultRetainHour time.Duration `file:"finished_pipeline_archive_default_retain_hour" default:"720h"`
+}
 
 type provider struct {
 	Cfg      *config


### PR DESCRIPTION
#### What this PR does / why we need it:
clean up pipeline archives that have exceeded default retention time

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=248988&iterationID=-1&pId=290591&type=TASK)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support clean up pipeline archives （实现了pipeline归档表的自动清理）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Support clean up pipeline archives           |
| 🇨🇳 中文    |  实现了pipeline归档表的自动清理            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
