### PR TITLE
fix(pipeline): allow the handler to be null when the worker is not used to process logical task

### DIFF
--- a/modules/pipeline/providers/leaderworker/worker/worker.go
+++ b/modules/pipeline/providers/leaderworker/worker/worker.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -87,9 +88,6 @@ func New(ops ...OpFunc) Worker {
 	for _, op := range ops {
 		op(&dw)
 	}
-	if len(dw.handlers) == 0 {
-		panic("no handler specified")
-	}
 	return &dw
 }
 
@@ -137,6 +135,10 @@ func (dw *defaultWorker) Handle(ctx context.Context, task LogicTask) {
 	handlers := make([]handler, len(dw.handlers))
 	copy(handlers, dw.handlers)
 	dw.lock.Unlock()
+
+	if len(handlers) == 0 {
+		panic(fmt.Errorf("worker have no handler to handle task, workerID: %s, logicTaskID: %s", dw.GetID(), task.GetLogicID()))
+	}
 
 	finishChan := make(chan struct{}, len(handlers))
 	finishedNum := 0


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow the handler to be null when the worker is not used to process logical task.
If you new a worker but not use it to handle task, no handler is acceptable.

tested on erda daily:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/13919034/159457394-69495779-f644-4907-a6ab-781e2eb4d106.png">

task dispatch key delete correctly:
<img width="125" alt="image" src="https://user-images.githubusercontent.com/13919034/159457636-b9f34ab1-3afb-4b62-a332-5d17d575af07.png">



#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Allow the handler to be null when the worker is not used to process logical task    |
| 🇨🇳 中文    |  当 worker 不用于处理逻辑任务时，允许 handler 为空            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.1-beta.2` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
