### PR TITLE
fix(dop): add disabled field for autotest step when import and export

### DIFF
--- a/modules/dop/services/autotest_v2/import.go
+++ b/modules/dop/services/autotest_v2/import.go
@@ -233,7 +233,7 @@ func (a *AutoTestSpaceExcel) SetSceneSteps() error {
 	}
 
 	for _, stepRow := range sheet[1:] {
-		if len(stepRow) != 9 {
+		if len(stepRow) < 9 {
 			return fmt.Errorf("invalid scene step data")
 		}
 		step := apistructs.AutoTestSceneStep{}
@@ -257,6 +257,12 @@ func (a *AutoTestSpaceExcel) SetSceneSteps() error {
 		step.APISpecID, err = convertToUint64PermitZero(stepRow[8])
 		if err != nil {
 			return err
+		}
+		if len(stepRow) > 9 {
+			step.IsDisabled, err = strconv.ParseBool(stepRow[9])
+			if err != nil {
+				return err
+			}
 		}
 		if a.Data.Steps[step.SceneID] == nil {
 			a.Data.Steps[step.SceneID] = []apistructs.AutoTestSceneStep{}

--- a/modules/dop/services/autotest_v2/space_data.go
+++ b/modules/dop/services/autotest_v2/space_data.go
@@ -288,6 +288,7 @@ func (a *AutoTestSpaceData) addSceneStepToExcel(file *excel.XlsxFile) error {
 		excel.NewCell(l.Get(i18n.I18nKeySceneStepSpaceNum)),
 		excel.NewCell(l.Get(i18n.I18nKeySceneStepPreType)),
 		excel.NewCell(l.Get(i18n.I18nKeySceneStepApiSpecNum)),
+		excel.NewCell(l.Get(i18n.I18nKeySceneStepIsDisabled)),
 	}
 
 	allLines := [][]excel.Cell{title}
@@ -304,6 +305,7 @@ func (a *AutoTestSpaceData) addSceneStepToExcel(file *excel.XlsxFile) error {
 				excel.NewCell(strutil.String(step.SpaceID)),
 				excel.NewCell(strutil.String(step.PreType)),
 				excel.NewCell(strutil.String(step.APISpecID)),
+				excel.NewCell(strutil.String(step.IsDisabled)),
 			})
 			for _, pv := range step.Children {
 				stepLines = append(stepLines, []excel.Cell{
@@ -316,6 +318,7 @@ func (a *AutoTestSpaceData) addSceneStepToExcel(file *excel.XlsxFile) error {
 					excel.NewCell(strutil.String(pv.SpaceID)),
 					excel.NewCell(strutil.String(pv.PreType)),
 					excel.NewCell(strutil.String(pv.APISpecID)),
+					excel.NewCell(strutil.String(pv.IsDisabled)),
 				})
 			}
 		}
@@ -709,15 +712,16 @@ func (a *AutoTestSpaceData) CopySceneSteps() error {
 			each.Value = replacePreStepValue(each.Value, a.stepIDAssociationMap)
 
 			newStep := &dao.AutoTestSceneStep{
-				Type:      each.Type,
-				Value:     each.Value,
-				Name:      each.Name,
-				PreID:     head,
-				PreType:   each.PreType,
-				SceneID:   a.sceneIDAssociationMap[oldSceneID],
-				SpaceID:   a.NewSpace.ID,
-				APISpecID: each.APISpecID,
-				CreatorID: a.UserID,
+				Type:       each.Type,
+				Value:      each.Value,
+				Name:       each.Name,
+				PreID:      head,
+				PreType:    each.PreType,
+				SceneID:    a.sceneIDAssociationMap[oldSceneID],
+				SpaceID:    a.NewSpace.ID,
+				APISpecID:  each.APISpecID,
+				IsDisabled: each.IsDisabled,
+				CreatorID:  a.UserID,
 			}
 			if err = a.svc.db.CreateAutoTestSceneStep(newStep); err != nil {
 				return err
@@ -739,15 +743,16 @@ func (a *AutoTestSpaceData) CopySceneSteps() error {
 				pv.Value = replacePreStepValue(pv.Value, a.stepIDAssociationMap)
 
 				newPStep := &dao.AutoTestSceneStep{
-					Type:      pv.Type,
-					Value:     pv.Value,
-					Name:      pv.Name,
-					PreID:     pHead,
-					PreType:   pv.PreType,
-					SceneID:   a.sceneIDAssociationMap[oldSceneID],
-					SpaceID:   a.NewSpace.ID,
-					APISpecID: pv.APISpecID,
-					CreatorID: a.UserID,
+					Type:       pv.Type,
+					Value:      pv.Value,
+					Name:       pv.Name,
+					PreID:      pHead,
+					PreType:    pv.PreType,
+					SceneID:    a.sceneIDAssociationMap[oldSceneID],
+					SpaceID:    a.NewSpace.ID,
+					APISpecID:  pv.APISpecID,
+					IsDisabled: pv.IsDisabled,
+					CreatorID:  a.UserID,
 				}
 
 				if err = a.svc.db.CreateAutoTestSceneStep(newPStep); err != nil {

--- a/modules/dop/services/i18n/i18n.go
+++ b/modules/dop/services/i18n/i18n.go
@@ -90,6 +90,7 @@ const (
 	I18nKeySceneStepSpaceNum   = "tp.export.scene.step.space.num"
 	I18nKeySceneStepPreType    = "tp.export.scene.step.pre.type"
 	I18nKeySceneStepApiSpecNum = "tp.export.scene.step.api.spec.num"
+	I18nKeySceneStepIsDisabled = "tp.export.scene.step.is.disabled"
 
 	I18nKeyConfigSheetName   = "tp.export.config.sheet.name"
 	I18nKeyConfigScopeName   = "tp.export.config.scope.name"

--- a/pkg/erda-configs/i18n/qa.json
+++ b/pkg/erda-configs/i18n/qa.json
@@ -77,6 +77,7 @@
         "tp.export.scene.step.space.num": "测试空间编号",
         "tp.export.scene.step.pre.type": "排序类型",
         "tp.export.scene.step.api.spec.num": "API集市编号",
+        "tp.export.scene.step.is.disabled": "是否禁用",
 
         "tp.export.config.sheet.name": "自动化测试配置",
         "tp.export.config.scope.name": "范围",
@@ -175,6 +176,7 @@
         "tp.export.scene.step.space.num": "space num",
         "tp.export.scene.step.pre.type": "sorting type",
         "tp.export.scene.step.api.spec.num": "api spce num",
+        "tp.export.scene.step.is.disabled": "is disabled",
 
         "tp.export.config.sheet.name": "AutoTest Global Config",
         "tp.export.config.scope.name": "scope",


### PR DESCRIPTION
#### What this PR does / why we need it:
add disabled field for autotest step when import and export

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTQ2XSwiYXNzaWduZWUiOlsiMTAwMTIwNSJdfQ%3D%3D&id=297516&iterationID=1146&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add disabled field for autotest step when import and export（修复了自动化测试复制时禁用功能的丢失）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that add disabled field for autotest step when import and export            |
| 🇨🇳 中文    |    修复了自动化测试复制时禁用功能的丢失          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
