### PR TITLE
fix(dop): The scene set does not expand when dragging

### DIFF
--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/render.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/render.go
@@ -199,7 +199,7 @@ func (i *ComponentFileTree) Render(ctx context.Context, c *cptype.Component, sce
 				return err
 			}
 		} else {
-			if err := i.RenderSceneSets(inParams); err != nil {
+			if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 				return err
 			}
 		}
@@ -209,7 +209,7 @@ func (i *ComponentFileTree) Render(ctx context.Context, c *cptype.Component, sce
 				return err
 			}
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.ExpandSceneSetOperationKey:
@@ -241,35 +241,35 @@ func (i *ComponentFileTree) Render(ctx context.Context, c *cptype.Component, sce
 		if err := i.RenderDeleteSceneSet(event, inParams); err != nil {
 			return err
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.DeleteSceneOperationKey:
 		if err := i.RenderDeleteScene(event); err != nil {
 			return err
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.ExportSceneSetOperationKey:
 		if err := i.RenderExportSceneSet(event, inParams); err != nil {
 			return err
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.DragSceneSetOperationKey:
 		if err := i.RenderDragHelper(inParams); err != nil {
 			return err
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.CopySceneOperationKey:
 		if err := i.RenderCopyScene(inParams, event); err != nil {
 			return err
 		}
-		if err := i.RenderSceneSets(inParams); err != nil {
+		if err := i.RenderSceneSets(inParams, apistructs.OperationKey(event.Operation)); err != nil {
 			return err
 		}
 	case apistructs.RefSceneSetOperationKey:

--- a/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/scenes.go
+++ b/modules/dop/component-protocol/components/auto-test-scenes/leftPage/fileTree/scenes.go
@@ -96,7 +96,7 @@ func (i *ComponentFileTree) findScene(setId uint64, sceneId uint64) ([]Scene, bo
 	return res, find, nil
 }
 
-func (i *ComponentFileTree) RenderSceneSets(inParams InParams) error {
+func (i *ComponentFileTree) RenderSceneSets(inParams InParams, operationKey apistructs.OperationKey) error {
 	req := apistructs.SceneSetRequest{
 		SpaceID: inParams.SpaceId,
 	}
@@ -122,7 +122,9 @@ func (i *ComponentFileTree) RenderSceneSets(inParams InParams) error {
 	}
 
 	// selectKey, expandedKeys := findSelectedKeysExpandedKeys(res, inParams.SelectedKeys)
-	if i.State.SceneSetKey != 0 {
+
+	// Do not expand when dragging
+	if i.State.SceneSetKey != 0 && operationKey != apistructs.DragSceneSetOperationKey {
 		i.State.ExpandedKeys = append(i.State.ExpandedKeys, "sceneset-"+strconv.Itoa(i.State.SceneSetKey))
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
 Do not expand when dragging

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTQ2XSwiYXNzaWduZWUiOlsiMTAwMTI2MSJdfQ%3D%3D&id=294297&iterationID=1146&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      The scene set does not expand when dragging       |
| 🇨🇳 中文    |     场景集拖拽的时候不去展开         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
