### PR TITLE
fix(dop): add is disable for step when copy autotest scene

### DIFF
--- a/modules/dop/services/autotest_v2/scene.go
+++ b/modules/dop/services/autotest_v2/scene.go
@@ -1231,15 +1231,16 @@ func (svc *Service) CopyAutotestScene(req apistructs.AutotestSceneCopyRequest, i
 		v.Value = replacePreStepValue(v.Value, replaceIdMap)
 
 		newStep := &dao.AutoTestSceneStep{
-			Type:      v.Type,
-			Value:     v.Value,
-			Name:      v.Name,
-			PreID:     head,
-			PreType:   v.PreType,
-			SceneID:   newId,
-			SpaceID:   req.SpaceID,
-			APISpecID: v.APISpecID,
-			CreatorID: req.UserID,
+			Type:       v.Type,
+			Value:      v.Value,
+			Name:       v.Name,
+			PreID:      head,
+			PreType:    v.PreType,
+			SceneID:    newId,
+			SpaceID:    req.SpaceID,
+			APISpecID:  v.APISpecID,
+			CreatorID:  req.UserID,
+			IsDisabled: v.IsDisabled,
 		}
 		if err := svc.db.CreateAutoTestSceneStep(newStep); err != nil {
 			return newScene.ID, err
@@ -1252,15 +1253,16 @@ func (svc *Service) CopyAutotestScene(req apistructs.AutotestSceneCopyRequest, i
 			pv.Value = replacePreStepValue(pv.Value, replaceIdMap)
 
 			newPStep := &dao.AutoTestSceneStep{
-				Type:      pv.Type,
-				Value:     pv.Value,
-				Name:      pv.Name,
-				PreID:     pHead,
-				PreType:   pv.PreType,
-				SceneID:   newId,
-				SpaceID:   req.SpaceID,
-				APISpecID: pv.APISpecID,
-				CreatorID: req.UserID,
+				Type:       pv.Type,
+				Value:      pv.Value,
+				Name:       pv.Name,
+				PreID:      pHead,
+				PreType:    pv.PreType,
+				SceneID:    newId,
+				SpaceID:    req.SpaceID,
+				APISpecID:  pv.APISpecID,
+				CreatorID:  req.UserID,
+				IsDisabled: pv.IsDisabled,
 			}
 
 			if err := svc.db.CreateAutoTestSceneStep(newPStep); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
add is disable for step when copy autotest scene

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTQ2XSwiYXNzaWduZWUiOlsiMTAwMTIwNSJdfQ%3D%3D&id=297516&iterationID=1146&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add is disable for step when copy autotest scene（修复了复制场景时步骤禁用的丢失）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that add is disable for step when copy autotest scene             |
| 🇨🇳 中文    |   修复了复制场景时步骤禁用的丢失           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
