### PR TITLE
fix(pipeline): deep copy cluster info when query cluster

### DIFF
--- a/modules/pipeline/providers/clusterinfo/chache_test.go
+++ b/modules/pipeline/providers/clusterinfo/chache_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestGetClusterInfoByName(t *testing.T) {
+	ca := NewClusterInfoCache()
+	ca.cache = map[string]apistructs.ClusterInfo{
+		"dev": {
+			Name: "dev",
+			CM: map[apistructs.ClusterInfoMapKey]string{
+				"host": "localhost",
+			},
+		},
+	}
+
+	c1, ok := ca.GetClusterInfoByName("dev")
+	if !ok {
+		t.Error("Expected to find cluster info")
+	}
+	assert.Equal(t, "dev", c1.Name)
+	c2, ok := ca.GetClusterInfoByName("dev")
+	if !ok {
+		t.Error("Expected to find cluster info")
+	}
+	assert.Equal(t, "dev", c2.Name)
+	delete(c1.CM, "host")
+	if c2.CM["host"] != "localhost" {
+		t.Error("expected to get new clusterinfo data")
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
deep copy cluster info when query cluster from cache


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that concurrent write cluster info map （修复了并发写集群信息的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |Fix the bug that concurrent write cluster info map              |
| 🇨🇳 中文    |   修复了并发写集群信息的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
