### PR TITLE
fix(pipeline): reconciler try-last-result missing provider

### DIFF
--- a/modules/pipeline/providers/reconciler/taskpolicy/provider.go
+++ b/modules/pipeline/providers/reconciler/taskpolicy/provider.go
@@ -43,7 +43,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	p.supportedPolicies = map[apistructs.PolicyType]Interface{
 		apistructs.TryLatestSuccessResultPolicyType: tryLastSuccessResult{p: p},
 		apistructs.NewRunPolicyType:                 newRun{p: p},
-		apistructs.TryLatestResultPolicyType:        tryLastResult{},
+		apistructs.TryLatestResultPolicyType:        tryLastResult{p: p},
 	}
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

inject missing provider field for reconciler try-last-result task-policy

#### Specified Reviewers:

/assign @Effet 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  inject missing provider field for reconciler try-last-result task-policy            |
| 🇨🇳 中文    |  解决 "最近一次执行的结果" 执行策略空指针问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.1-beta.3` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
