### PR TITLE
feat: init env by project package

### DIFF
--- a/tools/cli/cmd/issue_close.go
+++ b/tools/cli/cmd/issue_close.go
@@ -101,6 +101,7 @@ func IssueClose(ctx *command.Context, issueID int, manHour string) error {
 	req := &apistructs.IssueUpdateRequest{}
 	req.ID = uint64(issue.ID)
 	req.State = &nextStateId
+	req.IterationID = &issue.IterationID
 
 	issue.ManHour.ThisElapsedTime = manHourInMinutes
 	if issue.ManHour.EstimateTime == 0 {

--- a/tools/cli/cmd/mr_create.go
+++ b/tools/cli/cmd/mr_create.go
@@ -17,9 +17,8 @@ package cmd
 import (
 	"net/url"
 
-	"github.com/spf13/cobra"
-
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 
 	"github.com/erda-project/erda-proto-go/dop/issue/pb"
 	"github.com/erda-project/erda/apistructs"
@@ -79,6 +78,14 @@ func MrCreateIssueCompletion(ctx *cobra.Command, args []string, toComplete strin
 }
 
 func MrCreate(ctx *command.Context, application, from, to, title, desc string, issueID uint64, remove, open bool) error {
+	if title == "" {
+		return errors.Errorf("No title set, which is required.")
+	}
+
+	if desc == "" {
+		return errors.Errorf("No description set, which is required.")
+	}
+
 	if from == "" {
 		workDir := "."
 		if application != "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
you may init env one by one

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      add --init-env parameter to  create project by package      |
| 🇨🇳 中文    |        使用工程包初始化项目支持指定环境      |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
