### PR TITLE
fix: ECI pod fluent-bit container image and env

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -579,6 +579,7 @@ services:
       DEBUG: "false"
       TENANT_GROUP_KEY: "58dcbf490ef3"
       MSP_ADDR: "msp:8080"
+      COLLECTOR_SIDECAR_IMAGE: "registry.erda.cloud/erda/erda-fluent-bit:2.1-alpha-20220329155354-3fcba88"
     resources:
       cpu: ${request_cpu:1}
       max_cpu: 1

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/deployment_test.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/deployment_test.go
@@ -596,6 +596,7 @@ func TestKubernetes_setStatelessServiceVolumes(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
+/*
 func TestGenerateECIPodSidecarContainers(t *testing.T) {
 	wantContainer := apiv1.Container{
 		Name: "fluent-bit",
@@ -628,9 +629,57 @@ func TestGenerateECIPodSidecarContainers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GenerateECIPodSidecarContainers()
+			_, err := GenerateECIPodSidecarContainers(false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateECIPodSidecarContainers() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+*/
+
+func TestGenerateECIPodSidecarContainers(t *testing.T) {
+	type args struct {
+		inEdge bool
+	}
+
+	wantContainer := apiv1.Container{
+		Name: "fluent-bit",
+		//Image: sidecar.Image,
+		Resources: apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("0.1"),
+				apiv1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: apiv1.ResourceList{
+				apiv1.ResourceCPU:    resource.MustParse("1"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		Command:      []string{"./fluent-bit/bin/fluent-bit"},
+		Args:         []string{"-c", "/fluent-bit/etc/sidecar/fluent-bit.conf"},
+		VolumeMounts: []apiv1.VolumeMount{},
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    apiv1.Container
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			args:    args{inEdge: false},
+			want:    wantContainer,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GenerateECIPodSidecarContainers(tt.args.inEdge)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateECIPodSidecarContainers() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 		})
 	}

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/job.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/job.go
@@ -140,7 +140,7 @@ func (k *Kubernetes) newJob(service *apistructs.Service, serviceGroup *apistruct
 	// ECI Pod inject fluent-bit sidecar container
 	useECI := UseECI(job.Labels, job.Spec.Template.Labels)
 	if useECI {
-		sidecar, err := GenerateECIPodSidecarContainers()
+		sidecar, err := GenerateECIPodSidecarContainers(k.DeployInEdgeCluster())
 		if err != nil {
 			logrus.Errorf("%v", err)
 			return nil, err

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -1396,3 +1396,17 @@ func (k *Kubernetes) setImagePullSecrets(namespace string) ([]apiv1.LocalObjectR
 	}
 	return secrets, nil
 }
+
+func (k *Kubernetes) DeployInEdgeCluster() bool {
+	clusterInfo, err := k.ClusterInfo.Get()
+	if err != nil {
+		logrus.Warningf("failed to get cluster info, error: %v", err)
+		return false
+	}
+
+	if clusterInfo[string(apistructs.DICE_IS_EDGE)] != "true" {
+		return false
+	}
+
+	return true
+}

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/statefulset.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/statefulset.go
@@ -192,7 +192,7 @@ func (k *Kubernetes) createStatefulSet(ctx context.Context, info StatefulsetInfo
 	// ECI Pod inject fluent-bit sidecar container
 	useECI := UseECI(set.Labels, set.Spec.Template.Labels)
 	if useECI {
-		sidecar, err := GenerateECIPodSidecarContainers()
+		sidecar, err := GenerateECIPodSidecarContainers(k.DeployInEdgeCluster())
 		if err != nil {
 			logrus.Errorf("%v", err)
 			return err


### PR DESCRIPTION
#### What this PR does / why we need it:
ECI Pod fluent-bit image need set by Env,  ECI Pod fluent-bit container need add env DICE_IS_EDGE for deployed in edge cluster




#### Specified Reviewers:

/assign @sixther-dc @iutx @luobily 


#### ChangeLog
Bugfix： ECI Pod fluent-bit image need set by Env,  ECI Pod fluent-bit container need add env DICE_IS_EDGE for deployed in edge cluster （修复了 ECI Pod fluent-bit 镜像设置参数，对于 Edge 环境部署需要增加环境变量 DICE_IS_EDGE ）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        ECI Pod fluent-bit image need set by Env,  ECI Pod fluent-bit container need add env DICE_IS_EDGE for deployed in edge cluster        |
| 🇨🇳 中文    |     修复了 ECI Pod fluent-bit 镜像设置参数，对于 Edge 环境部署需要增加环境变量 DICE_IS_EDGE          |
