### PR TITLE
fix(pipeline): query cluster info from clusterinfo provider instead of orchestrator

### DIFF
--- a/modules/pipeline/commonutil/linkutil/link.go
+++ b/modules/pipeline/commonutil/linkutil/link.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/providers/clusterinfo"
 	"github.com/erda-project/erda/modules/pipeline/spec"
 )
 
@@ -47,11 +48,11 @@ func GetPipelineLink(bdl *bundle.Bundle, p spec.Pipeline) (bool, string) {
 	}
 
 	// get domain protocol
-	clusterInfo, err := bdl.QueryClusterInfo(p.ClusterName)
+	clusterInfo, err := clusterinfo.GetClusterInfoByName(p.ClusterName)
 	if err != nil {
 		return false, ""
 	}
-	protocol := clusterInfo.Get(apistructs.DICE_PROTOCOL)
+	protocol := clusterInfo.CM.Get(apistructs.DICE_PROTOCOL)
 	if protocol == "" {
 		return false, ""
 	}

--- a/modules/pipeline/services/actionagentsvc/script.go
+++ b/modules/pipeline/services/actionagentsvc/script.go
@@ -17,6 +17,7 @@ package actionagentsvc
 import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/providers/clusterinfo"
 )
 
 func RunScript(clusterInfo apistructs.ClusterInfoData, scriptName string, params map[string]string) error {
@@ -24,11 +25,11 @@ func RunScript(clusterInfo apistructs.ClusterInfoData, scriptName string, params
 	// 如果是 edas 集群且指定了打包集群，则去对应集群下载
 	jobClusterName := clusterInfo.Get(apistructs.EDASJOB_CLUSTER_NAME)
 	if clusterInfo.IsEDAS() && jobClusterName != "" {
-		jobClusterInfo, err := bundle.New(bundle.WithScheduler()).QueryClusterInfo(jobClusterName)
+		cluster, err := clusterinfo.GetClusterInfoByName(jobClusterName)
 		if err != nil {
 			return err
 		}
-		return RunScript(jobClusterInfo, scriptName, params)
+		return RunScript(cluster.CM, scriptName, params)
 	}
 
 	return bundle.New(bundle.WithSoldier(clusterInfo.MustGetPublicURL("soldier"))).RunSoldierScript(scriptName, params)

--- a/modules/pipeline/services/pipelinesvc/run.go
+++ b/modules/pipeline/services/pipelinesvc/run.go
@@ -115,11 +115,11 @@ func (s *PipelineSvc) RunPipeline(req *apistructs.PipelineRunRequest) (*spec.Pip
 	now := time.Now()
 	p.TimeBegin = &now
 
-	clusterInfo, err := s.bdl.QueryClusterInfo(p.ClusterName)
+	cluster, err := s.clusterInfo.GetClusterInfoByName(p.ClusterName)
 	if err != nil {
 		return nil, apierrors.ErrRunPipeline.InternalError(err)
 	}
-	container_provider.DealPipelineProviderBeforeRun(&p, clusterInfo)
+	container_provider.DealPipelineProviderBeforeRun(&p, cluster.CM)
 	// update pipeline base
 	if err := s.dbClient.UpdatePipelineBase(p.ID, &p.PipelineBase); err != nil {
 		return nil, apierrors.ErrUpdatePipeline.InternalError(err)


### PR DESCRIPTION
#### What this PR does / why we need it:
query cluster info from provider instead of orchestrator


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that query cluster info from provider instead of orchestrator (解耦了pipeline查询orchestrator集群信息的依赖）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that query cluster info from provider instead of orchestrator           |
| 🇨🇳 中文    |     解耦了pipeline查询orchestrator集群信息的依赖         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
