### PR TITLE
feat(pipeline): reconciler trigger pipeline's next reconcile-loop immediately when one task done

### DIFF
--- a/modules/pipeline/providers/leaderworker/leader_framework.go
+++ b/modules/pipeline/providers/leaderworker/leader_framework.go
@@ -53,6 +53,7 @@ func (p *provider) leaderFramework(ctx context.Context) {
 
 	// before exec on leader
 	for _, l := range listeners {
+		l := l
 		safe.Do(func() { l.BeforeExecOnLeader(ctx) })
 	}
 
@@ -64,6 +65,7 @@ func (p *provider) leaderFramework(ctx context.Context) {
 
 	// after exec on leader
 	for _, l := range listeners {
+		l := l
 		safe.Do(func() { l.AfterExecOnLeader(ctx) })
 	}
 

--- a/modules/pipeline/providers/reconciler/reconcile.go
+++ b/modules/pipeline/providers/reconciler/reconcile.go
@@ -19,6 +19,7 @@ import (
 	"runtime/debug"
 	"sync"
 
+	"github.com/erda-project/erda-infra/pkg/safe"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/providers/reconciler/rutil"
 	"github.com/erda-project/erda/modules/pipeline/providers/reconciler/schedulabletask"
@@ -41,63 +42,32 @@ func (r *provider) ReconcileOnePipeline(ctx context.Context, pipelineID uint64) 
 	// generate pipeline-id-level pr
 	pr := r.generatePipelineReconcilerForEachPipelineID()
 
-	// reconcile
-	rutil.ContinueWorking(ctx, r.Log, func(ctx context.Context) (waitDuration rutil.WaitDuration) {
+	// fetch pipeline detail
+	p := r.mustFetchPipelineDetail(ctx, pipelineID)
 
-		// fetch pipeline detail
-		p := r.mustFetchPipelineDetail(ctx, pipelineID)
-
-		// TODO handle outer stop at reconciler side later
-		if p.Status == apistructs.PipelineStatusStopByUser {
-			// teardown
-			pr.TeardownAfterReconcileDone(ctx, p)
-			return rutil.ContinueWorkingAbort
-		}
-
-		// check need reconcile
-		if !pr.NeedReconcile(ctx, p) {
-			return rutil.ContinueWorkingAbort
-		}
-
-		// prepare before reconcile
-		if err := pr.PrepareBeforeReconcile(ctx, p); err != nil {
-			r.Log.Errorf("failed to prepare before reconcile(auto retry), pipelineID: %d, err: %v", p.ID, err)
-			return rutil.ContinueWorkingWithDefaultInterval
-		}
-
-		// get tasks which can be scheduled
-		schedulableTasks, err := pr.GetTasksCanBeConcurrentlyScheduled(ctx, p)
-		//defer pr.releaseTasksCanBeConcurrentlyScheduled(ctx, p, schedulableTasks)
-		if err != nil {
-			r.Log.Errorf("failed to get tasks can be concurrently scheduled(auto retry), pipelineID: %d, err: %v", p.ID, err)
-			return rutil.ContinueWorkingWithDefaultInterval
-		}
-
-		// reconcile schedulable tasks
-		if err := pr.ReconcileSchedulableTasks(ctx, p, schedulableTasks); err != nil {
-			r.Log.Errorf("failed to reconcile one pipeline schedulable tasks(auto retry), pipelineID: %d, err: %v", p.ID, err)
-			return rutil.ContinueWorkingWithDefaultInterval
-		}
-
-		// calculate and update current reconcile status
-		if err := pr.UpdateCurrentReconcileStatusIfNecessary(ctx, p); err != nil {
-			r.Log.Errorf("failed to calculate pipeline status(auto retry), pipelineID: %d, err: %v", p.ID, err)
-			return rutil.ContinueWorkingWithDefaultInterval
-		}
-
-		// check pipeline reconcile done
-		done := pr.IsReconcileDone(ctx, p)
-		if !done {
-			// not done, enter into next reconcile immediately
-			return rutil.ContinueWorkingImmediately
-		}
-		// done, do teardown and exit loop
+	// TODO handle outer stop at reconciler side later
+	if p.Status == apistructs.PipelineStatusStopByUser {
+		// teardown
 		pr.TeardownAfterReconcileDone(ctx, p)
+		return
+	}
 
-		// all done, exit
-		return rutil.ContinueWorkingAbort
+	// check need reconcile
+	if !pr.NeedReconcile(ctx, p) {
+		return
+	}
 
-	}, rutil.WithContinueWorkingDefaultRetryInterval(r.Cfg.RetryInterval))
+	// prepare before reconcile
+	pr.PrepareBeforeReconcile(ctx, p)
+
+	// continue calculate schedulable tasks
+	safe.Go(func() { pr.continuePushSchedulableTasks(ctx, p) })
+
+	// continue reconcile schedulable tasks
+	safe.Go(func() { pr.continueScheduleTasks(ctx, p) })
+
+	// wait pipeline done and do the teardown
+	safe.Do(func() { pr.waitPipelineDoneAndDoTeardown(ctx, p) })
 }
 
 func (r *provider) generatePipelineReconcilerForEachPipelineID() *defaultPipelineReconciler {
@@ -111,6 +81,9 @@ func (r *provider) generatePipelineReconcilerForEachPipelineID() *defaultPipelin
 		processingTasks:      sync.Map{},
 		defaultRetryInterval: r.Cfg.RetryInterval,
 		calculatedPipelineStatusByAllReconciledTasks: "",
+		chanToTriggerNextLoop:                        make(chan struct{}),
+		schedulableTaskChan:                          make(chan *spec.PipelineTask),
+		doneChan:                                     make(chan struct{}),
 	}
 	return pr
 }
@@ -118,5 +91,72 @@ func (r *provider) generatePipelineReconcilerForEachPipelineID() *defaultPipelin
 func (pr *defaultPipelineReconciler) releaseTasksCanBeConcurrentlyScheduled(ctx context.Context, p *spec.Pipeline, tasks []*spec.PipelineTask) {
 	for _, task := range tasks {
 		pr.processingTasks.Delete(task.NodeName())
+	}
+}
+
+func (pr *defaultPipelineReconciler) waitPipelineDoneAndDoTeardown(ctx context.Context, p *spec.Pipeline) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-pr.doneChan:
+		pr.TeardownAfterReconcileDone(ctx, p)
+		return
+	}
+}
+
+func (pr *defaultPipelineReconciler) continuePushSchedulableTasks(ctx context.Context, p *spec.Pipeline) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-pr.chanToTriggerNextLoop:
+			rutil.ContinueWorking(ctx, pr.log, func(ctx context.Context) rutil.WaitDuration {
+				// set calculated pipeline status by all reconciled tasks from db
+				if err := pr.calculatePipelineStatusByAllReconciledTasks(ctx, p); err != nil {
+					pr.log.Errorf("failed to calculate pipeline status by all reconciled tasks(auto retry), pipelineID: %d, err: %v", p.ID, err)
+					return rutil.ContinueWorkingWithDefaultInterval
+				}
+				schedulableTasks, err := pr.GetTasksCanBeConcurrentlyScheduled(ctx, p)
+				if err != nil {
+					pr.log.Errorf("failed to get tasks can be concurrently scheduled(auto retry), pipelineID: %d, err: %v", p.ID, err)
+					return rutil.ContinueWorkingWithDefaultInterval
+				}
+				for _, task := range schedulableTasks {
+					pr.schedulableTaskChan <- task
+				}
+				// calculate if all done
+				if len(schedulableTasks) == 0 {
+					// calculate and update current reconcile status
+					if err := pr.UpdateCurrentReconcileStatusIfNecessary(ctx, p); err != nil {
+						pr.log.Errorf("failed to calculate pipeline status(auto retry), pipelineID: %d, err: %v", p.ID, err)
+						return rutil.ContinueWorkingWithDefaultInterval
+					}
+
+					// check pipeline reconcile done
+					done := pr.IsReconcileDone(ctx, p)
+					if done && pr.doneChan != nil {
+						pr.doneChan <- struct{}{}
+						close(pr.doneChan)
+						pr.doneChan = nil // set doneChan to nil to guarantee only teardown once
+						return rutil.ContinueWorkingAbort
+					}
+				}
+				return rutil.ContinueWorkingAbort
+			}, rutil.WithContinueWorkingDefaultRetryInterval(pr.defaultRetryInterval))
+		}
+	}
+}
+
+func (pr *defaultPipelineReconciler) continueScheduleTasks(ctx context.Context, p *spec.Pipeline) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok := <-pr.schedulableTaskChan:
+			if !ok {
+				return
+			}
+			safe.Go(func() { pr.ReconcileOneSchedulableTask(ctx, p, task) })
+		}
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

reconciler push in DAG mode

#### Specified Reviewers:

/assign @Effet 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  reconciler trigger pipeline's next reconcile-loop immediately when one task done            |
| 🇨🇳 中文    |  当一个任务结束时，立即触发 pipeline 的下一次推进            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
