### PR TITLE
fix: different ECI pods have duplicated container ID

### DIFF
--- a/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
@@ -529,6 +529,8 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 				ByProjectName(projectName).
 				ByWorkspace(workspace).
 				ByContainerID(prevContainerID).
+				ByRuntimeID(runtimeID).
+				ByApplicationID(applicationID).
 				Do()
 			if err != nil {
 				return orgs, err
@@ -583,7 +585,7 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 				}
 			}
 			// remove dup instances in db
-			instances, err = r.ByContainerID(prevContainerID).Do()
+			instances, err = r.ByContainerID(prevContainerID).ByRuntimeID(runtimeID).ByApplicationID(applicationID).Do()
 			if err != nil {
 				return orgs, err
 			}
@@ -596,7 +598,7 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 			}
 		}
 		if currentContainerID != "" {
-			instances, err := r.ByContainerID(currentContainerID).Do()
+			instances, err := r.ByContainerID(currentContainerID).ByRuntimeID(runtimeID).ByApplicationID(applicationID).Do()
 			if err != nil {
 				return orgs, err
 			}
@@ -657,7 +659,7 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 				}
 			}
 			// remove dup instances in db
-			instances, err = r.ByContainerID(currentContainerID).Do()
+			instances, err = r.ByContainerID(currentContainerID).ByRuntimeID(runtimeID).ByApplicationID(applicationID).Do()
 			if err != nil {
 				return orgs, err
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
Different ECI pods have duplicated container ID result incorrect logic


#### Specified Reviewers:

/assign @sixther-dc @luobily @iutx 


#### ChangeLog
Bugfix： Fix the bug that  different ECI pods have duplicated container ID result incorrect logic
 （修复了 ECI Pod 可能具有相同的 containerID 导致 erda 工作台使用 containerID 展示服务信息失败 ）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that  different ECI pods have duplicated container ID result incorrect logic        |
| 🇨🇳 中文    |      修复了 ECI Pod 可能具有相同的 containerID 导致 erda 工作台使用 containerID 展示服务信息失败        |


