### PR TITLE
feat(dop): Delete unnecessary keys in project pipeline configuration

### DIFF
--- a/modules/dop/providers/cms/cicdcmsservice.go
+++ b/modules/dop/providers/cms/cicdcmsservice.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erda-project/erda/modules/dop/services/permission"
 	"github.com/erda-project/erda/modules/dop/utils"
 	"github.com/erda-project/erda/modules/pipeline/providers/cms"
+	"github.com/erda-project/erda/modules/pipeline/providers/cms/db"
 	"github.com/erda-project/erda/pkg/common/apis"
 	"github.com/erda-project/erda/providers/audit"
 )
@@ -75,7 +76,7 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 	var keys []string
 
 	for _, config := range req.Configs {
-		if req.Batch && config.Type == "FILE" {
+		if req.Batch && config.Type == db.ConfigTypeDiceFile {
 			continue
 		}
 
@@ -127,11 +128,70 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 		}))
 	}()
 
+	if req.Batch {
+		err := s.deleteNotNeedKeys(ctx, updateRequest.PipelineSource, updateRequest.Ns, keys)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// TODO Use distributed transaction to solve the problem that there is no new addition after deletion
+	// create or update configs
 	if _, err = s.p.PipelineCms.UpdateCmsNsConfigs(utils.WithInternalClientContext(ctx), updateRequest); err != nil {
 		return false, err
 	}
 
 	return true, nil
+}
+
+func (s *CICDCmsService) deleteNotNeedKeys(ctx context.Context, pipelineSource string, ns string, keys []string) error {
+	// get pre configs
+	newContext := apis.WithInternalClientContext(ctx, "dop")
+	preCMS, err := s.p.PipelineCms.GetCmsNsConfigs(newContext, &cmspb.CmsNsConfigsGetRequest{
+		PipelineSource: pipelineSource,
+		Ns:             ns,
+	})
+	if err != nil {
+		return err
+	}
+
+	// get unnecessary keys
+	var deleteKeys []string
+	for _, v := range preCMS.Data {
+		// file type not support change key, so can not delete not find key
+		if v.Type == db.ConfigTypeDiceFile {
+			continue
+		}
+
+		var find = false
+		for _, conf := range keys {
+			if conf != v.Key {
+				continue
+			}
+
+			find = true
+			break
+		}
+		if !find {
+			deleteKeys = append(deleteKeys, v.Key)
+		}
+	}
+
+	if len(deleteKeys) == 0 {
+		return nil
+	}
+
+	// delete unnecessary keys in the project pipeline configs
+	_, err = s.p.PipelineCms.DeleteCmsNsConfigs(newContext, &cmspb.CmsNsConfigsDeleteRequest{
+		Ns:             ns,
+		PipelineSource: pipelineSource,
+		DeleteKeys:     deleteKeys,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *CICDCmsService) CICDCmsUpdate(ctx context.Context, req *pb.CICDCmsUpdateRequest) (*pb.CICDCmsUpdateResponse, error) {

--- a/modules/dop/providers/cms/cicdcmsservice_test.go
+++ b/modules/dop/providers/cms/cicdcmsservice_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cms
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/alecthomas/assert"
+
+	cmspb "github.com/erda-project/erda-proto-go/core/pipeline/cms/pb"
+)
+
+type CmsServiceServerImpl struct {
+}
+
+func (c *CmsServiceServerImpl) CreateNs(ctx context.Context, request *cmspb.CmsCreateNsRequest) (*cmspb.CmsCreateNsResponse, error) {
+	panic("implement me")
+}
+
+func (c *CmsServiceServerImpl) ListCmsNs(ctx context.Context, request *cmspb.CmsListNsRequest) (*cmspb.CmsListNsResponse, error) {
+	panic("implement me")
+}
+
+func (c *CmsServiceServerImpl) UpdateCmsNsConfigs(ctx context.Context, request *cmspb.CmsNsConfigsUpdateRequest) (*cmspb.CmsNsConfigsUpdateResponse, error) {
+	panic("implement me")
+}
+
+func (c *CmsServiceServerImpl) DeleteCmsNsConfigs(ctx context.Context, request *cmspb.CmsNsConfigsDeleteRequest) (*cmspb.CmsNsConfigsDeleteResponse, error) {
+	panic("implement me")
+}
+
+func (c *CmsServiceServerImpl) GetCmsNsConfigs(ctx context.Context, request *cmspb.CmsNsConfigsGetRequest) (*cmspb.CmsNsConfigsGetResponse, error) {
+	panic("implement me")
+}
+
+func (c *CmsServiceServerImpl) BatchGetCmsNsConfigs(ctx context.Context, request *cmspb.CmsNsConfigsBatchGetRequest) (*cmspb.CmsNsConfigsBatchGetResponse, error) {
+	panic("implement me")
+}
+
+func TestCICDCmsService_deleteNotNeedKeys(t *testing.T) {
+	type fields struct {
+		p *provider
+	}
+	type args struct {
+		ctx            context.Context
+		pipelineSource string
+		ns             string
+		keys           []string
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantErr    bool
+		deleteKeys []string
+		dbKeys     []string
+	}{
+		{
+			name: "test key",
+			fields: fields{
+				p: &provider{},
+			},
+			args: args{
+				pipelineSource: "source",
+				ns:             "ns",
+				ctx:            context.Background(),
+				keys:           []string{"a", "c"},
+			},
+			wantErr:    false,
+			deleteKeys: []string{"b", "d"},
+			dbKeys:     []string{"a", "b", "c", "d"},
+		},
+
+		{
+			name: "not find delete keys",
+			fields: fields{
+				p: &provider{},
+			},
+			args: args{
+				pipelineSource: "source",
+				ns:             "ns",
+				ctx:            context.Background(),
+				keys:           []string{"a", "c"},
+			},
+			wantErr:    false,
+			deleteKeys: []string{},
+			dbKeys:     []string{"a", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cms = CmsServiceServerImpl{}
+			patch := monkey.PatchInstanceMethod(reflect.TypeOf(&cms), "GetCmsNsConfigs", func(cms *CmsServiceServerImpl, ctx context.Context, req *cmspb.CmsNsConfigsGetRequest) (*cmspb.CmsNsConfigsGetResponse, error) {
+				assert.Equal(t, req.PipelineSource, tt.args.pipelineSource)
+				assert.Equal(t, req.Ns, tt.args.ns)
+
+				var configs []*cmspb.PipelineCmsConfig
+				for _, key := range tt.dbKeys {
+					configs = append(configs, &cmspb.PipelineCmsConfig{
+						Key: key,
+					})
+				}
+				return &cmspb.CmsNsConfigsGetResponse{
+					Data: configs,
+				}, nil
+			})
+			defer patch.Unpatch()
+
+			patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(&cms), "DeleteCmsNsConfigs", func(cms *CmsServiceServerImpl, ctx context.Context, req *cmspb.CmsNsConfigsDeleteRequest) (*cmspb.CmsNsConfigsDeleteResponse, error) {
+				assert.Equal(t, req.PipelineSource, tt.args.pipelineSource)
+				assert.Equal(t, req.Ns, tt.args.ns)
+				assert.Equal(t, req.DeleteKeys, tt.deleteKeys)
+				return &cmspb.CmsNsConfigsDeleteResponse{}, nil
+			})
+			defer patch1.Unpatch()
+
+			tt.fields.p.PipelineCms = &cms
+			s := &CICDCmsService{
+				p: tt.fields.p,
+			}
+			if err := s.deleteNotNeedKeys(tt.args.ctx, tt.args.pipelineSource, tt.args.ns, tt.args.keys); (err != nil) != tt.wantErr {
+				t.Errorf("deleteNotNeedKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Delete unnecessary keys in project pipeline configuration

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTY0XSwiYXNzaWduZWUiOlsiMTAwMDU2MCJdfQ%3D%3D&id=299271&iterationID=1164&pId=293275&type=TASK)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Delete unnecessary keys in project pipeline configuration        |
| 🇨🇳 中文    |        项目流水线配置删除不需要的key      |

