### PR TITLE
fix(dop): .erda/ pipelines and The pipeline yml in the .dice/pipelines folder supports on push events

### DIFF
--- a/bundle/filetree.go
+++ b/bundle/filetree.go
@@ -405,8 +405,8 @@ func (b *Bundle) ListFileTreeNodes(req apistructs.UnifiedFileTreeNodeListRequest
 
 func (b *Bundle) GetPipelineGittarFolder(userID string, appID uint64, branch string) string {
 	gittarPrefix := "/wb"
-	defaultPath := ".erda/pipelines"
-	compatiblePath := ".dice/pipelines"
+	defaultPath := apistructs.ErdaPipelinePath
+	compatiblePath := apistructs.DicePipelinePath
 	app, err := b.GetApp(appID)
 	if err != nil {
 		return defaultPath

--- a/modules/dop/endpoints/pipeline.go
+++ b/modules/dop/endpoints/pipeline.go
@@ -669,11 +669,12 @@ func (e *Endpoints) checkrunCreate(ctx context.Context, r *http.Request, vars ma
 	}
 	result := pipeline.GetPipelineYmlList(req, e.bdl, gitEvent.Content.AuthorId)
 	find := false
+
+	app, err := e.bdl.GetApp(uint64(appID))
+	if err != nil {
+		return nil, apierrors.ErrGetApp.InternalError(err)
+	}
 	for _, each := range result {
-		app, err := e.bdl.GetApp(uint64(appID))
-		if err != nil {
-			return nil, apierrors.ErrGetApp.InternalError(err)
-		}
 		strPipelineYml, err := e.pipeline.FetchPipelineYml(app.GitRepo, gitEvent.Content.SourceBranch, each, gitEvent.Content.AuthorId)
 		if err != nil {
 			continue

--- a/modules/dop/endpoints/release_test.go
+++ b/modules/dop/endpoints/release_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import "testing"
+
+func Test_getSourcePathAndName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantPath     string
+		wantFileName string
+	}{
+		{
+			name: "test pipeline.yml",
+			args: args{
+				name: "pipeline.yml",
+			},
+			wantFileName: "pipeline.yml",
+			wantPath:     "",
+		},
+		{
+			name: "test .erda/pipelines/push.yml",
+			args: args{
+				name: ".erda/pipelines/push.yml",
+			},
+			wantFileName: "push.yml",
+			wantPath:     ".erda/pipelines",
+		},
+		{
+			name: "test .dice/pipelines/push.yml",
+			args: args{
+				name: ".dice/pipelines/push.yml",
+			},
+			wantFileName: "push.yml",
+			wantPath:     ".dice/pipelines",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotFileName := getSourcePathAndName(tt.args.name)
+			if gotPath != tt.wantPath {
+				t.Errorf("getSourcePathAndName() gotPath = %v, want %v", gotPath, tt.wantPath)
+			}
+			if gotFileName != tt.wantFileName {
+				t.Errorf("getSourcePathAndName() gotFileName = %v, want %v", gotFileName, tt.wantFileName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
.erda/ pipelines and The pipeline yml in the .dice/pipelines folder supports on push events

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTY0XSwiYXNzaWduZWUiOlsiMTAwMDU2MCJdfQ%3D%3D&id=299403&iterationID=1164&pId=295915&type=TASK)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      .erda/ pipelines and The pipeline yml in the .dice/pipelines folder supports on push events       |
| 🇨🇳 中文    |       .erda/pipelines 和 .dice/pipelines  文件夹下的流水线文件支持 on push 事件      |


