### PR TITLE
fix(dop): app cannot be continuously integrated

### DIFF
--- a/modules/dop/endpoints/release.go
+++ b/modules/dop/endpoints/release.go
@@ -76,7 +76,12 @@ func (e *Endpoints) ReleaseCallback(ctx context.Context, r *http.Request, vars m
 	if err != nil {
 		return nil, apierrors.ErrGetApp.InternalError(err)
 	}
-	rules, err := e.branchRule.Query(apistructs.ProjectScope, int64(app.ProjectID))
+	rules, err := e.branchRule.Query(apistructs.AppScope, int64(app.ID))
+	if err != nil {
+		return nil, apierrors.ErrFetchConfigNamespace.InternalError(err)
+	}
+
+	projectRules, err := e.branchRule.Query(apistructs.ProjectScope, int64(app.ProjectID))
 	if err != nil {
 		return nil, apierrors.ErrFetchConfigNamespace.InternalError(err)
 	}
@@ -131,7 +136,7 @@ func (e *Endpoints) ReleaseCallback(ctx context.Context, r *http.Request, vars m
 			logrus.Errorf("error convert to pipelineV2 %s, (%+v)", strPipelineYml, err)
 			continue
 		}
-		validBranch := diceworkspace.GetValidBranchByGitReference(reqPipeline.Branch, rules)
+		validBranch := diceworkspace.GetValidBranchByGitReference(reqPipeline.Branch, projectRules)
 		workspace := validBranch.Workspace
 		v2.ForceRun = true
 		v2.DefinitionID = definitionID


### PR DESCRIPTION
#### What this PR does / why we need it:
The repair app cannot be continuously integrated

#### Which issue(s) this PR fixes:
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc0LDExNjQsMTE0Nl0sImFzc2lnbmVlIjpbIjEwMDA1NjAiXX0%3D&id=303196&iterationID=1164&pId=0&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix the issue that app cannot be continuously integrated      |
| 🇨🇳 中文    |      修复应用无法进行持续集成        |
