### PR TITLE
fix(pipeline): The pipeline graph interface displays the croncontroller field

### DIFF
--- a/apistructs/pipeline_yml.go
+++ b/apistructs/pipeline_yml.go
@@ -39,12 +39,12 @@ const (
 
 type PipelineYml struct {
 	// 用于构造 pipeline yml
-	Version         string                 `json:"version"`                   // 版本
-	Envs            map[string]string      `json:"envs,omitempty"`            // 环境变量
-	Cron            string                 `json:"cron,omitempty"`            // 定时配置
-	CronCompensator *CronCompensator       `json:"cronCompensator,omitempty"` // 定时补偿配置
-	Stages          [][]*PipelineYmlAction `json:"stages"`                    // 流水线
-	FlatActions     []*PipelineYmlAction   `json:"flatActions"`               // 展平了的流水线
+	Version         string                 `json:"version"`                                                    // 版本
+	Envs            map[string]string      `json:"envs,omitempty"`                                             // 环境变量
+	Cron            string                 `json:"cron,omitempty"`                                             // 定时配置
+	CronCompensator *CronCompensator       `json:"cronCompensator,omitempty" yaml:"cronCompensator,omitempty"` // 定时补偿配置
+	Stages          [][]*PipelineYmlAction `json:"stages"`                                                     // 流水线
+	FlatActions     []*PipelineYmlAction   `json:"flatActions"`                                                // 展平了的流水线
 
 	Params []*PipelineParam `json:"params,omitempty"` // 流水线输入
 

--- a/pkg/parser/pipelineyml/graph_pipelineyml.go
+++ b/pkg/parser/pipelineyml/graph_pipelineyml.go
@@ -189,6 +189,16 @@ func ConvertToGraphPipelineYml(data []byte) (*apistructs.PipelineYml, error) {
 		Outputs:     pipelineOutputs,
 		On:          on,
 		Triggers:    pipelineYml.Spec().Triggers,
+		CronCompensator: func() *apistructs.CronCompensator {
+			if pipelineYml.Spec().CronCompensator == nil {
+				return nil
+			}
+			return &apistructs.CronCompensator{
+				Enable:               pipelineYml.Spec().CronCompensator.Enable,
+				LatestFirst:          pipelineYml.Spec().CronCompensator.LatestFirst,
+				StopIfLatterExecuted: pipelineYml.Spec().CronCompensator.StopIfLatterExecuted,
+			}
+		}(),
 	}
 
 	var lifecycle []*apistructs.NetworkHookInfo


### PR DESCRIPTION
#### What this PR does / why we need it:
The pipeline graph interface displays the croncontroller field

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc0LDExNjQsMTE0Nl0sImFzc2lnbmVlIjpbIjEwMDA1NjAiXX0%3D&id=303639&iterationID=1164&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The pipeline graph interface displays the croncontroller field       |
| 🇨🇳 中文    |       流水线 graph 接口展示 cronCompensator 字段       |

