### PR TITLE
fix(pipeline): Fix the problem that the cron compensates that the action of git-checkout cannot get the git information

### DIFF
--- a/modules/pipeline/providers/cron/compensator/provider.go
+++ b/modules/pipeline/providers/cron/compensator/provider.go
@@ -393,6 +393,7 @@ func (p *provider) doCronCompensate(compensator apistructs.CronCompensator, notR
 
 	_, err := p.pipelineFunc.RunPipeline(&apistructs.PipelineRunRequest{
 		PipelineID:   firstOrLastPipeline.ID,
+		Secrets:      firstOrLastPipeline.Extra.IncomingSecrets,
 		IdentityInfo: apistructs.IdentityInfo{InternalClient: firstOrLastPipeline.Extra.InternalClient},
 	})
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the problem that the cron compensates that the action of git-checkout cannot get the git information

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc0LDExNjQsMTE0Nl0sImFzc2lnbmVlIjpbIjEwMDA1NjAiXX0%3D&id=303665&iterationID=1164&pId=0&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Fix the problem that the cron compensates that the action of git-checkout cannot get the git information    |
| 🇨🇳 中文    |       修复定时补偿执行 git-checkout action, 无法拿到仓库信息       |

