### PR TITLE
fix(pipeline): When creating a definition, a cron info is created asynchronously

### DIFF
--- a/modules/dop/providers/projectpipeline/provider.go
+++ b/modules/dop/providers/projectpipeline/provider.go
@@ -55,7 +55,7 @@ type provider struct {
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
-	p.bundle = bundle.New(bundle.WithCoreServices())
+	p.bundle = bundle.New(bundle.WithAllAvailableClients())
 	p.projectPipelineSvc = &ProjectPipelineService{
 		logger: p.Log,
 		db: &dao.DBClient{

--- a/modules/dop/providers/projectpipeline/service.go
+++ b/modules/dop/providers/projectpipeline/service.go
@@ -33,10 +33,9 @@ import (
 )
 
 type ProjectPipelineService struct {
-	logger             logs.Logger
-	db                 *dao.DBClient
-	bundle             *bundle.Bundle
-	pipelineSourceType ProjectSourceType
+	logger logs.Logger
+	db     *dao.DBClient
+	bundle *bundle.Bundle
 
 	pipelineSvc        *pipeline.Pipeline
 	PipelineSource     sourcepb.SourceServiceServer


### PR DESCRIPTION
#### What this PR does / why we need it:
When creating a definition, a scheduled task is created asynchronously

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](paste your link here)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      When creating a definition, a scheduled task is created asynchronously        |
| 🇨🇳 中文    |       创建定义的时候异步创建定时任务       |

