### PR TITLE
fix(pipeline): platformSecrets do not use cache

### DIFF
--- a/modules/pipeline/providers/cache/secret.go
+++ b/modules/pipeline/providers/cache/secret.go
@@ -15,7 +15,6 @@
 package cache
 
 type SecretCache struct {
-	PlatformSecrets   map[string]string
 	Secrets           map[string]string
 	CmsDiceFiles      map[string]string
 	HoldOnKeys        []string

--- a/modules/pipeline/services/pipelinesvc/precheck.go
+++ b/modules/pipeline/services/pipelinesvc/precheck.go
@@ -126,7 +126,6 @@ func (s *PipelineSvc) PreCheck(p *spec.Pipeline, stages []spec.PipelineStage, us
 			CmsDiceFiles:      cmsDiceFiles,
 			HoldOnKeys:        holdOnKeys,
 			EncryptSecretKeys: encryptSecretKeys,
-			PlatformSecrets:   platformSecrets,
 		})
 	}
 

--- a/modules/pipeline/services/pipelinesvc/run.go
+++ b/modules/pipeline/services/pipelinesvc/run.go
@@ -79,18 +79,18 @@ func (s *PipelineSvc) RunPipeline(req *apistructs.PipelineRunRequest) (*spec.Pip
 		cmsDiceFiles = secretCache.CmsDiceFiles
 		holdOnKeys = secretCache.HoldOnKeys
 		encryptSecretKeys = secretCache.EncryptSecretKeys
-		platformSecrets = secretCache.PlatformSecrets
 	} else {
 		// fetch secrets
 		secrets, cmsDiceFiles, holdOnKeys, encryptSecretKeys, err = s.FetchSecrets(&p)
 		if err != nil {
 			return nil, apierrors.ErrRunPipeline.InternalError(err)
 		}
-		// fetch platform secrets
-		platformSecrets, err = s.FetchPlatformSecrets(&p, holdOnKeys)
-		if err != nil {
-			return nil, apierrors.ErrRunPipeline.InternalError(err)
-		}
+	}
+
+	// fetch platform secrets
+	platformSecrets, err = s.FetchPlatformSecrets(&p, holdOnKeys)
+	if err != nil {
+		return nil, apierrors.ErrRunPipeline.InternalError(err)
 	}
 
 	for k, v := range req.Secrets {


### PR DESCRIPTION
#### What this PR does / why we need it:
platformSecrets do not use cache

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc0XSwiYXNzaWduZWUiOlsiMTAwMTI2MSJdfQ%3D%3D&id=305483&iterationID=1174&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     platformSecrets do not use cache         |
| 🇨🇳 中文    |   platformSecrets不使用缓存           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
