### PR TITLE
feat(pipeline): stop queue when pipeline canceled

### DIFF
--- a/modules/pipeline/providers/reconciler/taskrun/taskop/queue.go
+++ b/modules/pipeline/providers/reconciler/taskrun/taskop/queue.go
@@ -68,7 +68,7 @@ func (q *queue) Processing() (interface{}, error) {
 	}
 	alerted := false
 
-	err := loop.New(loop.WithDeclineRatio(1.5), loop.WithDeclineLimit(time.Second*10)).Do(func() (abort bool, err error) {
+	err := loop.New(loop.WithContext(q.Ctx), loop.WithDeclineRatio(1.5), loop.WithDeclineLimit(time.Second*10)).Do(func() (abort bool, err error) {
 		// 排队超时钉钉告警
 		if !alerted && time.Now().Sub(beginQueue) > conf.TaskQueueAlertTime() {
 			logrus.Errorf("[pipeline] task queue exceed %v, beginTime: %s, now: %s, cluster: %s, pipelineID: %d, taskID: %d, taskName: %s, reason: %s",


### PR DESCRIPTION
#### What this PR does / why we need it:

stop queue when pipeline canceled

#### Specified Reviewers:

/assign @Effet @chengjoey 

before cancel pipeline:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/13919034/163381691-1112e077-894f-4410-9753-956bed768793.png">
after cancel pipeline, queue stopped:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/13919034/163381728-f00eb1ca-dfcf-4b3f-be03-7de87d3b14e3.png">


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   stop queue when pipeline canceled           |
| 🇨🇳 中文    |  当流水线被取消时，任务停止排队            |
