### PR TITLE
feat(cluster-dialer): cluster-dialer support record and query client data

### DIFF
--- a/apistructs/cluster_dialer.go
+++ b/apistructs/cluster_dialer.go
@@ -14,7 +14,10 @@
 
 package apistructs
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type ClusterDialerHeaderKey string
 
@@ -23,6 +26,7 @@ var (
 	ClusterDialerHeaderKeyClientType    ClusterDialerHeaderKey = "X-Erda-Client-Type"
 	ClusterDialerHeaderKeyClusterInfo   ClusterDialerHeaderKey = "X-Erda-Cluster-Info"
 	ClusterDialerHeaderKeyAuthorization ClusterDialerHeaderKey = "Authorization"
+	ClusterDialerHeaderKeyClientDetail  ClusterDialerHeaderKey = "X-Erda-Client-Detail"
 )
 
 func (c ClusterDialerHeaderKey) String() string {
@@ -46,4 +50,22 @@ func (c ClusterDialerClientType) MakeClientKey(clusterKey string) string {
 		return clusterKey
 	}
 	return fmt.Sprintf("%s-client-type-%s", clusterKey, c)
+}
+
+type ClusterDialerClientDetailKey string
+
+type ClusterDialerClientDetail map[ClusterDialerClientDetailKey]string
+
+type ClusterDialerClientMap map[string]ClusterDialerClientDetail
+
+func (detail ClusterDialerClientDetail) Get(key ClusterDialerClientDetailKey) string {
+	return detail[key]
+}
+
+func (detail ClusterDialerClientDetail) Marshal() ([]byte, error) {
+	return json.Marshal(detail)
+}
+
+func (m ClusterDialerClientMap) GetClientDetail(clientKey string) ClusterDialerClientDetail {
+	return m[clientKey]
 }

--- a/modules/cluster-dialer/server/client_data.go
+++ b/modules/cluster-dialer/server/client_data.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"sync"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+var (
+	clientMutex sync.Mutex
+	clientDatas = map[apistructs.ClusterDialerClientType]apistructs.ClusterDialerClientMap{}
+)
+
+func updateClientDetail(clientType apistructs.ClusterDialerClientType, clusterKey string, data apistructs.ClusterDialerClientDetail) {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+	if clusterKey == "" || clientType == "" {
+		return
+	}
+	if _, ok := clientDatas[clientType]; !ok {
+		clientDatas[clientType] = apistructs.ClusterDialerClientMap{}
+	}
+	clientDatas[clientType][clusterKey] = data
+}
+
+func getClientDetail(clientType apistructs.ClusterDialerClientType, clusterKey string) (apistructs.ClusterDialerClientDetail, bool) {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+	if data, ok := clientDatas[clientType]; ok {
+		if clientData, existed := data[clusterKey]; existed {
+			return clientData, true
+		}
+	}
+	return apistructs.ClusterDialerClientDetail{}, false
+}

--- a/modules/cluster-dialer/server/client_data_test.go
+++ b/modules/cluster-dialer/server/client_data_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestGetUpdateClientData(t *testing.T) {
+	type args struct {
+		clusterKey string
+		clientType apistructs.ClusterDialerClientType
+		data       apistructs.ClusterDialerClientDetail
+	}
+	type test struct {
+		name       string
+		args       args
+		want       apistructs.ClusterDialerClientDetail
+		wantExists bool
+	}
+	tests := []test{
+		{
+			name: "test pipeline client data",
+			args: args{
+				clusterKey: "erda-dev",
+				clientType: apistructs.ClusterDialerClientTypePipeline,
+				data: apistructs.ClusterDialerClientDetail{
+					"host": "localhost",
+				},
+			},
+			want: apistructs.ClusterDialerClientDetail{
+				"host": "localhost",
+			},
+			wantExists: true,
+		},
+		{
+			name: "test cluster agent client data",
+			args: args{
+				clusterKey: "erda-dev",
+				clientType: apistructs.ClusterDialerClientTypeCluster,
+				data: apistructs.ClusterDialerClientDetail{
+					"namespace": "erda-dev",
+				},
+			},
+			want: apistructs.ClusterDialerClientDetail{
+				"namespace": "erda-dev",
+			},
+			wantExists: true,
+		},
+		{
+			name: "test cluster agent client data",
+			args: args{
+				clusterKey: "terminus-dev",
+				clientType: apistructs.ClusterDialerClientTypeCluster,
+				data: apistructs.ClusterDialerClientDetail{
+					"namespace": "erda-dev",
+				},
+			},
+			want: apistructs.ClusterDialerClientDetail{
+				"namespace": "erda-dev",
+			},
+			wantExists: true,
+		},
+		{
+			name: "test empty cluster key",
+			args: args{
+				clusterKey: "",
+				clientType: apistructs.ClusterDialerClientTypeCluster,
+				data:       apistructs.ClusterDialerClientDetail{},
+			},
+			want:       apistructs.ClusterDialerClientDetail{},
+			wantExists: false,
+		},
+	}
+	wait := sync.WaitGroup{}
+	wait.Add(len(tests))
+	for _, tt := range tests {
+		go func(t test) {
+			updateClientDetail(t.args.clientType, t.args.clusterKey, t.args.data)
+			wait.Done()
+		}(tt)
+	}
+	wait.Wait()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := getClientDetail(tt.args.clientType, tt.args.clusterKey)
+			if ok != tt.wantExists {
+				t.Errorf("getClientDetail() exist = %v, wantExist %v", ok, tt.wantExists)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getClientDetail() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
cluster-dialer support record and query client data


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: cluster-dialer support record and query client data （cluster-dialer支持记录查询客户端信息）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    cluster-dialer support record and query client data          |
| 🇨🇳 中文    |   cluster-dialer支持记录查询客户端信息           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
