### PR TITLE
feat(pipeline): add edgepipeline and register provider for communication between enter and edge

### DIFF
--- a/apistructs/cluster_dialer.go
+++ b/apistructs/cluster_dialer.go
@@ -54,6 +54,11 @@ func (c ClusterDialerClientType) MakeClientKey(clusterKey string) string {
 
 type ClusterDialerClientDetailKey string
 
+var (
+	ClusterDialerDataKeyPipelineHost ClusterDialerClientDetailKey = "pipelineHost"
+	ClusterDialerDataKeyPipelineAddr ClusterDialerClientDetailKey = "pipelineAddr"
+)
+
 type ClusterDialerClientDetail map[ClusterDialerClientDetailKey]string
 
 type ClusterDialerClientMap map[string]ClusterDialerClientDetail

--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -32,6 +32,8 @@ import (
 	_ "github.com/erda-project/erda/modules/pipeline/providers/cron/daemon"
 	_ "github.com/erda-project/erda/modules/pipeline/providers/dbgc"
 	_ "github.com/erda-project/erda/modules/pipeline/providers/definition"
+	_ "github.com/erda-project/erda/modules/pipeline/providers/edgepipeline"
+	_ "github.com/erda-project/erda/modules/pipeline/providers/edgepipeline_register"
 	_ "github.com/erda-project/erda/modules/pipeline/providers/resourcegc"
 	_ "github.com/erda-project/erda/modules/pipeline/providers/source"
 )

--- a/conf/pipeline/pipeline.yaml
+++ b/conf/pipeline/pipeline.yaml
@@ -36,6 +36,10 @@ leader-worker:
     etcd_key_prefix_with_slash: /devops/pipeline/v2/leader-worker/worker/
 reconciler: {}
 clusterinfo: {}
+edgepipeline_register:
+  cluster_dialer_endpoint: "${CLUSTER_DIALER_PUBLIC_URL}/clusteragent/connect"
+  cluster_access_key: "${CLUSTER_ACCESS_KEY}"
+edgepipeline: {}
 resourcegc: {}
 dbgc: {}
 task-policy: {}

--- a/modules/pipeline/endpoints/endpoints.go
+++ b/modules/pipeline/endpoints/endpoints.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/providers/cancel"
 	"github.com/erda-project/erda/modules/pipeline/providers/clusterinfo"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/daemon"
+	"github.com/erda-project/erda/modules/pipeline/providers/edgepipeline"
 	"github.com/erda-project/erda/modules/pipeline/providers/engine"
 	"github.com/erda-project/erda/modules/pipeline/providers/queuemanager"
 	"github.com/erda-project/erda/modules/pipeline/providers/run"
@@ -59,6 +60,7 @@ type Endpoints struct {
 	engine       engine.Interface
 	queueManager queuemanager.Interface
 	clusterInfo  clusterinfo.Interface
+	edgePipeline edgepipeline.Interface
 	mySQL        mysqlxorm.Interface
 	run          run.Interface
 	cancel       cancel.Interface
@@ -164,6 +166,12 @@ func WithQueueManager(qm queuemanager.Interface) Option {
 func WithClusterInfo(clusterInfo clusterinfo.Interface) Option {
 	return func(e *Endpoints) {
 		e.clusterInfo = clusterInfo
+	}
+}
+
+func WithEdgePipeline(edgePipeline edgepipeline.Interface) Option {
+	return func(e *Endpoints) {
+		e.edgePipeline = edgePipeline
 	}
 }
 

--- a/modules/pipeline/initialize.go
+++ b/modules/pipeline/initialize.go
@@ -147,6 +147,7 @@ func (p *provider) do() error {
 	pipelinefunc.CallbackActionFunc = pipelineSvc.DealPipelineCallbackOfAction
 
 	p.Reconciler.InjectLegacyFields(&pipelineFuncs, actionAgentSvc, extMarketSvc)
+	p.EdgePipeline.InjectLegacyFields(pipelineSvc)
 
 	if err := registerSnippetClient(dbClient); err != nil {
 		return err
@@ -175,6 +176,7 @@ func (p *provider) do() error {
 		endpoints.WithQueueManager(p.QueueManager),
 		endpoints.WithEngine(p.Engine),
 		endpoints.WithClusterInfo(p.ClusterInfo),
+		endpoints.WithEdgePipeline(p.EdgePipeline),
 		endpoints.WithMysql(p.MySQL),
 		endpoints.WithRun(p.PipelineRun),
 		endpoints.WithCancel(p.Cancel),

--- a/modules/pipeline/provider.go
+++ b/modules/pipeline/provider.go
@@ -33,6 +33,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/daemon"
 	"github.com/erda-project/erda/modules/pipeline/providers/dbgc"
 	_ "github.com/erda-project/erda/modules/pipeline/providers/dispatcher"
+	"github.com/erda-project/erda/modules/pipeline/providers/edgepipeline"
 	"github.com/erda-project/erda/modules/pipeline/providers/engine"
 	"github.com/erda-project/erda/modules/pipeline/providers/leaderworker"
 	"github.com/erda-project/erda/modules/pipeline/providers/queuemanager"
@@ -56,6 +57,7 @@ type provider struct {
 	Engine       engine.Interface
 	QueueManager queuemanager.Interface
 	Reconciler   reconciler.Interface
+	EdgePipeline edgepipeline.Interface
 	LeaderWorker leaderworker.Interface
 	ClusterInfo  clusterinfo.Interface
 	DBGC         dbgc.Interface

--- a/modules/pipeline/providers/edgepipeline/interface.go
+++ b/modules/pipeline/providers/edgepipeline/interface.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/services/pipelinesvc"
+	"github.com/erda-project/erda/pkg/clusterdialer"
+	"github.com/erda-project/erda/pkg/discover"
+)
+
+type Interface interface {
+	CreatePipeline(ctx context.Context, req *apistructs.PipelineCreateRequestV2) (*apistructs.PipelineDTO, error)
+	InjectLegacyFields(pSvc *pipelinesvc.PipelineSvc)
+}
+
+func (p *provider) InjectLegacyFields(pipelineSvc *pipelinesvc.PipelineSvc) {
+	p.pipelineSvc = pipelineSvc
+}
+
+func (p *provider) ShouldDispatchToEdge(source, clusterName string) bool {
+	if clusterName == "" {
+		return false
+	}
+	if p.Cfg.ClusterName == clusterName {
+		return false
+	}
+	var findInWhitelist bool
+	for _, whiteListSource := range p.Cfg.AllowedSources {
+		if strings.HasPrefix(source, whiteListSource) {
+			findInWhitelist = true
+			break
+		}
+	}
+	if !findInWhitelist {
+		return false
+	}
+	isEdge, err := p.bdl.IsClusterDialerClientRegistered(clusterName, apistructs.ClusterDialerClientTypePipeline.String())
+	if !isEdge || err != nil {
+		return false
+	}
+	return true
+}
+
+func (p *provider) GetDialContextByClusterName(clusterName string) clusterdialer.DialContextFunc {
+	clusterKey := apistructs.ClusterDialerClientTypePipeline.MakeClientKey(clusterName)
+	return clusterdialer.DialContext(clusterKey)
+}
+
+func (p *provider) GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error) {
+	edgeDial := p.GetDialContextByClusterName(clusterName)
+	edgeDetail, err := p.bdl.GetClusterDialerClientData(apistructs.ClusterDialerClientTypePipeline.String(), clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get edge bundle for cluster %s, err: %v", clusterName, err)
+	}
+	pipelineAddr := edgeDetail.Get(apistructs.ClusterDialerDataKeyPipelineAddr)
+	return bundle.New(bundle.WithDialContext(edgeDial), bundle.WithCustom(discover.EnvPipeline, pipelineAddr)), nil
+}
+
+func (p *provider) CreatePipeline(ctx context.Context, req *apistructs.PipelineCreateRequestV2) (*apistructs.PipelineDTO, error) {
+	isEdge := p.ShouldDispatchToEdge(req.PipelineSource.String(), req.ClusterName)
+	if !isEdge {
+		pipeline, err := p.pipelineSvc.CreateV2(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return p.pipelineSvc.ConvertPipeline(pipeline), nil
+	}
+	edgeBundle, err := p.GetEdgeBundleByClusterName(req.ClusterName)
+	if err != nil {
+		return nil, err
+	}
+	pipelineDto, err := edgeBundle.CreatePipeline(req)
+	if err != nil {
+		return nil, err
+	}
+	return pipelineDto, nil
+}

--- a/modules/pipeline/providers/edgepipeline/interface_test.go
+++ b/modules/pipeline/providers/edgepipeline/interface_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/bundle"
+)
+
+func TestSourceWhiteList(t *testing.T) {
+	p := &provider{
+		Cfg: &config{
+			AllowedSources: []string{"cdp-", "recommend-"},
+		},
+	}
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "cdp source",
+			src:  "cdp-123",
+			want: true,
+		},
+		{
+			name: "default source",
+			src:  "default",
+			want: false,
+		},
+		{
+			name: "dice source",
+			src:  "dice",
+			want: false,
+		},
+		{
+			name: "valid source with prefix",
+			src:  "recommend-123",
+			want: true,
+		},
+		{
+			name: "invalid source with prefix",
+			src:  "invalid-123",
+			want: false,
+		},
+	}
+	patch := monkey.PatchInstanceMethod(reflect.TypeOf(p.bdl), "IsClusterDialerClientRegistered", func(_ *bundle.Bundle, _ string, _ string) (bool, error) {
+		return true, nil
+	})
+	defer patch.Unpatch()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.ShouldDispatchToEdge(tt.src, "dev"); got != tt.want {
+				t.Errorf("sourceWhiteList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/pipeline/providers/edgepipeline/provider.go
+++ b/modules/pipeline/providers/edgepipeline/provider.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/services/pipelinesvc"
+)
+
+type config struct {
+	IsEdge         bool     `env:"DICE_IS_EDGE" default:"false"`
+	ClusterName    string   `env:"DICE_CLUSTER_NAME"`
+	AllowedSources []string `env:"EDGE_ALLOW_SOURCES"`
+}
+
+type provider struct {
+	Log logs.Logger
+	Cfg *config
+
+	bdl         *bundle.Bundle
+	pipelineSvc *pipelinesvc.PipelineSvc
+}
+
+func (p *provider) Init(ctx servicehub.Context) error {
+	p.bdl = bundle.New(bundle.WithClusterDialer())
+	return nil
+}
+
+func (p *provider) Run(ctx context.Context) error {
+	return nil
+}
+
+func init() {
+	interfaceType := reflect.TypeOf((*Interface)(nil)).Elem()
+	servicehub.Register("edgepipeline", &servicehub.Spec{
+		Services:     []string{"edgepipeline"},
+		Types:        []reflect.Type{interfaceType},
+		Dependencies: nil,
+		Description:  "edge pipeline",
+		ConfigFunc:   func() interface{} { return &config{} },
+		Creator:      func() servicehub.Provider { return &provider{} },
+	})
+}

--- a/modules/pipeline/providers/edgepipeline_register/interface.go
+++ b/modules/pipeline/providers/edgepipeline_register/interface.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/rancher/remotedialer"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/pkg/discover"
+)
+
+type Interface interface {
+	//RegisterEdgeToDialer(ctx context.Context)
+}
+
+// RegisterEdgeToDialer only registers the edge to the dialer
+func (p *provider) RegisterEdgeToDialer(ctx context.Context) {
+	if !p.Cfg.IsEdge {
+		p.Log.Warnf("current Pipeline is not deployed on edge side, skip register to center dialer")
+		return
+	}
+	if p.Cfg.ClusterAccessKey == "" {
+		p.Log.Panicf("cluster access key is empty, couldn't make edge registration")
+	}
+	headers, err := p.makeEdgeConnHeaders()
+	if err != nil {
+		p.Log.Panicf("failed to make edge connection headers: %v", err)
+	}
+	ep, err := p.parseDialerEndpoint()
+	if err != nil {
+		p.Log.Panicf("failed to parse dialer endpoint: %v", err)
+	}
+	for {
+		// if client connect successfully, will block until client disconnect
+		err = remotedialer.ClientConnect(ctx, ep, headers, nil, p.ConnectAuthorizer, nil)
+		if err != nil {
+			p.Log.Errorf("failed to connect to dialer: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(p.Cfg.RetryConnectDialerInterval):
+			// retry connect dialer
+		}
+	}
+}
+
+func (p *provider) ConnectAuthorizer(proto string, address string) bool {
+	switch proto {
+	case "tcp":
+		return true
+	case "unix":
+		return address == "/var/run/docker.sock"
+	case "npipe":
+		return address == "//./pipe/docker_engine"
+	}
+	return false
+}
+
+func (p *provider) makeEdgeConnDetail() (string, error) {
+	edgeDetail := apistructs.ClusterDialerClientDetail{
+		apistructs.ClusterDialerDataKeyPipelineAddr: p.Cfg.PipelineAddr,
+		apistructs.ClusterDialerDataKeyPipelineHost: p.Cfg.PipelineHost,
+	}
+	edgeDetailBytes, err := edgeDetail.Marshal()
+	if err != nil {
+		return "", err
+	}
+	return string(edgeDetailBytes), nil
+}
+
+func (p *provider) makeEdgeConnHeaders() (http.Header, error) {
+	edgeDetail, err := p.makeEdgeConnDetail()
+	if err != nil {
+		return nil, err
+	}
+	edgeHeaders := http.Header{
+		apistructs.ClusterDialerHeaderKeyClusterKey.String():    {p.Cfg.ClusterName},
+		apistructs.ClusterDialerHeaderKeyClientType.String():    {apistructs.ClusterDialerClientTypePipeline.String()},
+		apistructs.ClusterDialerHeaderKeyAuthorization.String(): {p.Cfg.ClusterAccessKey},
+		apistructs.ClusterDialerHeaderKeyClientDetail.String():  {edgeDetail},
+	}
+	return edgeHeaders, nil
+}
+
+func (p *provider) parseDialerEndpoint() (string, error) {
+	u, err := url.Parse(p.Cfg.ClusterDialEndpoint)
+	if err != nil {
+		return "", err
+	}
+
+	//inCluster, visit dialer inner service first.
+	if !p.Cfg.IsEdge && discover.ClusterDialer() != "" {
+		return "ws://" + discover.ClusterDialer() + u.Path, nil
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	}
+
+	return u.String(), nil
+}

--- a/modules/pipeline/providers/edgepipeline_register/interface_test.go
+++ b/modules/pipeline/providers/edgepipeline_register/interface_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import "testing"
+
+func Test_parseDialerEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "invalid endpoint",
+			endpoint: "xxx",
+			want:     "xxx",
+			wantErr:  false,
+		},
+		{
+			name:     "http endpoint",
+			endpoint: "http://cluster-dialer:80",
+			want:     "ws://cluster-dialer:80",
+			wantErr:  false,
+		},
+		{
+			name:     "https endpoint",
+			endpoint: "https://cluster-dialer:80",
+			want:     "wss://cluster-dialer:80",
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		p := &provider{
+			Cfg: &Config{
+				IsEdge:              true,
+				ClusterDialEndpoint: tt.endpoint,
+			},
+		}
+		got, err := p.parseDialerEndpoint()
+		if (err != nil) != tt.wantErr {
+			t.Errorf("%q. provider.parseDialerEndpoint() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("%q. provider.parseDialerEndpoint() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/modules/pipeline/providers/edgepipeline_register/provider.go
+++ b/modules/pipeline/providers/edgepipeline_register/provider.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/providers/leaderworker"
+)
+
+type Config struct {
+	IsEdge                     bool          `env:"DICE_IS_EDGE" default:"false"`
+	ClusterName                string        `env:"DICE_CLUSTER_NAME"`
+	PipelineAddr               string        `env:"PIPELINE_ADDR"`
+	PipelineHost               string        `env:"PIPELINE_HOST"`
+	ClusterDialEndpoint        string        `file:"cluster_dialer_endpoint" desc:"cluster dialer endpoint"`
+	ClusterAccessKey           string        `file:"cluster_access_key" desc:"cluster access key, if specified will doesn't start watcher"`
+	RetryConnectDialerInterval time.Duration `file:"retry_cluster_hook_interval" default:"1s"`
+}
+
+type provider struct {
+	Log logs.Logger
+	Cfg *Config
+	LW  leaderworker.Interface
+
+	bdl *bundle.Bundle
+}
+
+func (p *provider) Init(ctx servicehub.Context) error {
+	return nil
+}
+
+func (p *provider) Run(ctx context.Context) error {
+	p.LW.OnLeader(p.RegisterEdgeToDialer)
+	return nil
+}
+
+func init() {
+	interfaceType := reflect.TypeOf((*Interface)(nil)).Elem()
+	servicehub.Register("edgepipeline_register", &servicehub.Spec{
+		Services:     []string{"edgepipeline_register"},
+		Types:        []reflect.Type{interfaceType},
+		Dependencies: nil,
+		Description:  "pipeline edgepipeline register agent",
+		ConfigFunc:   func() interface{} { return &Config{} },
+		Creator:      func() servicehub.Provider { return &provider{} },
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
add edgepipeline and dialeragent provider for communication between center and edge

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=304696&iterationID=1174&pId=301655&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support communication between center and edge for pipeline （实现pipeline中心和边缘之间的通讯）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Support communication between center and edge for pipeline           |
| 🇨🇳 中文    |    实现pipeline中心和边缘之间的通讯          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
