### PR TITLE
fix: polish: parse dice.yml concurrently when get release

### DIFF
--- a/modules/dicehub/release/release.service.go
+++ b/modules/dicehub/release/release.service.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
@@ -1162,29 +1163,39 @@ func (s *ReleaseService) convertToReleaseResponse(release *db.Release) (*pb.Rele
 
 		id2Release := make(map[string]*db.Release)
 		logrus.Infoln("start parse dice yaml")
+
+		wg := sync.WaitGroup{}
+		mux := sync.Mutex{}
 		for i := 0; i < len(appReleases); i++ {
 			id2Release[appReleases[i].ReleaseID] = &appReleases[i]
 
-			dice, err := diceyml.New([]byte(appReleases[i].Dice), true)
-			if err != nil {
-				logrus.Errorf("failed to parse diceyml for release %s, %v", appReleases[i].ReleaseID, err)
-				continue
-			}
-			obj := dice.Obj()
-			if obj == nil || obj.AddOns == nil {
-				continue
-			}
-
-			for name, addon := range obj.AddOns {
-				version := addon.Options["version"]
-				splits := strings.Split(addon.Plan, ":")
-				if len(splits) != 2 {
-					logrus.Errorf("plan field of addon %s for release %s is invalid", name, appReleases[i].ReleaseID)
-					continue
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				dice, err := diceyml.New([]byte(appReleases[i].Dice), true)
+				if err != nil {
+					logrus.Errorf("failed to parse diceyml for release %s, %v", appReleases[i].ReleaseID, err)
+					return
 				}
-				addonSet[strings.Join([]string{splits[0], version, splits[1]}, "_")] = addon
-			}
+				obj := dice.Obj()
+				if obj == nil || obj.AddOns == nil {
+					return
+				}
+
+				for name, addon := range obj.AddOns {
+					version := addon.Options["version"]
+					splits := strings.Split(addon.Plan, ":")
+					if len(splits) != 2 {
+						logrus.Errorf("plan field of addon %s for release %s is invalid", name, appReleases[i].ReleaseID)
+						return
+					}
+					mux.Lock()
+					addonSet[strings.Join([]string{splits[0], version, splits[1]}, "_")] = addon
+					mux.Unlock()
+				}
+			}(i)
 		}
+		wg.Wait()
 		logrus.Infoln("[DEBUG] end parse dice yaml")
 
 		summary = make(map[string]*pb.ModeSummary)


### PR DESCRIPTION
#### What this PR does / why we need it:

polish: parse dice.yml concurrently when get release

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | polish: parse dice.yml concurrently when get release |
| 🇨🇳 中文    | 获取项目制品详情是并发地解析dice.yaml以优化相应时间  |
