### PR TITLE
feat(pipeline): in-cluster pipeline job create k8sclient directly

### DIFF
--- a/modules/cmp/impl/clusters/credential_test.go
+++ b/modules/cmp/impl/clusters/credential_test.go
@@ -133,7 +133,7 @@ func Test_ResetAccessKey_InCluster_Error(t *testing.T) {
 		return nil, csErr
 	})
 
-	monkey.Patch(k8sclient.NewForInCluster, func() (*k8sclient.K8sClient, error) {
+	monkey.Patch(k8sclient.NewForInCluster, func(ops ...k8sclient.Option) (*k8sclient.K8sClient, error) {
 		return nil, csErr
 	})
 

--- a/modules/pipeline/conf/conf.go
+++ b/modules/pipeline/conf/conf.go
@@ -24,9 +24,9 @@ import (
 
 // Conf 定义配置对象.
 type Conf struct {
-	ListenAddr  string `env:"LISTEN_ADDR" default:":3081"`
-	Debug       bool   `env:"DEBUG" default:"false"`
-	DiceCluster string `env:"DICE_CLUSTER" default:"local"` // 服务所在集群
+	ListenAddr      string `env:"LISTEN_ADDR" default:":3081"`
+	Debug           bool   `env:"DEBUG" default:"false"`
+	DiceClusterName string `env:"DICE_CLUSTER_NAME" default:"local"` // 服务所在集群
 
 	// task level
 	TaskDefaultCPU             float64       `env:"TASK_DEFAULT_CPU" default:"0.5"`
@@ -139,9 +139,9 @@ func Debug() bool {
 	return cfg.Debug
 }
 
-// DiceCluster 返回 pipeline 服务所在集群，用于判断 task 运行在 中心 or SaaS 集群.
-func DiceCluster() string {
-	return cfg.DiceCluster
+// DiceClusterName return the cluster where pipeline belong to
+func DiceClusterName() string {
+	return cfg.DiceClusterName
 }
 
 // TaskDefaultCPU 返回 task 默认的 cpu 限制.

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sflink/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sflink/type.go
@@ -34,13 +34,13 @@ type K8sFlink struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sFlink, error) {
-	k, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
 	if err != nil {
 		return nil, err
 	}
 	k8sFlink := &K8sFlink{
 		name:        name,
-		client:      k,
+		client:      client,
 		clusterName: clusterName,
 		cluster:     cluster,
 		errWrapper:  logic.NewErrorWrapper(name.String()),

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
@@ -93,13 +93,13 @@ type K8sJob struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sJob, error) {
-	k, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
 	if err != nil {
 		return nil, err
 	}
 	k8sJob := &K8sJob{
 		name:        name,
-		client:      k,
+		client:      client,
 		clusterName: clusterName,
 		cluster:     cluster,
 		errWrapper:  logic.NewErrorWrapper(name.String()),

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob_test.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob_test.go
@@ -16,7 +16,6 @@ package k8sjob
 
 import (
 	"testing"
-	"time"
 
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +63,7 @@ func Test_isBuildkitHit(t *testing.T) {
 func Test_generateKubeJob(t *testing.T) {
 	defer monkey.UnpatchAll()
 
-	monkey.Patch(k8sclient.NewWithTimeOut, func(_ string, _ time.Duration) (*k8sclient.K8sClient, error) {
+	monkey.Patch(k8sclient.New, func(_ string, _ ...k8sclient.Option) (*k8sclient.K8sClient, error) {
 		return nil, nil
 	})
 

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/type.go
@@ -37,14 +37,14 @@ type K8sSpark struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sSpark, error) {
-	kc, err := k8sclient.NewWithTimeOut(clusterName, time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second)
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
 	if err != nil {
 		return nil, err
 	}
 	k8sSpark := &K8sSpark{
 		name:        name,
 		clusterName: clusterName,
-		client:      kc,
+		client:      client,
 		cluster:     cluster,
 		errWrapper:  logic.NewErrorWrapper(name.String()),
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
in-cluster pipeline job create k8sclient directly


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature:  in-cluster pipeline job create k8sclient directly （当前集群的流水线任务直连k8s）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  in-cluster pipeline job create k8sclient directly            |
| 🇨🇳 中文    |    当前集群的流水线任务直连k8s          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
