### PR TITLE
fix: panic when parse empty dice yml

### DIFF
--- a/modules/dicehub/release/release.go
+++ b/modules/dicehub/release/release.go
@@ -956,9 +956,15 @@ func (s *ReleaseService) parseReleaseFile(req *pb.ReleaseUploadRequest, file io.
 					return nil, nil, errors.Errorf("failed to get releases by app and version, %v", err)
 				}
 				if len(existedReleases) > 0 {
-					oldDice, err := diceyml.New([]byte(existedReleases[0].Dice), true)
-					if err != nil {
-						return nil, nil, errors.Errorf("dice yml for release %s is invalid, %v", existedReleases[0].ReleaseID, err)
+					var oldDice *diceyml.DiceYaml
+					if len(existedReleases[0].Dice) != 0 {
+						oldDice, err = diceyml.New([]byte(existedReleases[0].Dice), true)
+						if err != nil {
+							return nil, nil, errors.Errorf("dice yml for release %s is invalid, %v", existedReleases[0].ReleaseID, err)
+						}
+					}
+					if dices[appName] == "" {
+						return nil, nil, errors.Errorf("dice yml for app %s release is empty", appName)
 					}
 					newDice, err := diceyml.New([]byte(dices[appName]), true)
 					if err != nil {

--- a/modules/dicehub/release/release.service.go
+++ b/modules/dicehub/release/release.service.go
@@ -1172,6 +1172,9 @@ func (s *ReleaseService) convertToReleaseResponse(release *db.Release) (*pb.Rele
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
+				if len(appReleases[i].Dice) == 0 {
+					return
+				}
 				dice, err := diceyml.New([]byte(appReleases[i].Dice), true)
 				if err != nil {
 					logrus.Errorf("failed to parse diceyml for release %s, %v", appReleases[i].ReleaseID, err)


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: panic when parse empty dice yml

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: panic when parse empty dice yml |
| 🇨🇳 中文    | 修复解析空dice.yml时panic的问题 |

