### PR TITLE
feat: implement 53-bit snowflake id for js compatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,7 +145,6 @@ require (
 	github.com/shogo82148/androidbinary v1.0.2
 	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.8.1
-	github.com/sony/sonyflake v1.0.0
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
-github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/deislabs/oras v0.11.1 h1:oo2J/3vXdcti8cjFi8ghMOkx0OacONxHC8dhJ17NdJ0=
 github.com/deislabs/oras v0.11.1/go.mod h1:39lCtf8Q6WDC7ul9cnyWXONNzKvabEKk+AX+L0ImnQk=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
@@ -1681,8 +1679,6 @@ github.com/smartystreets/gunit v0.0.0-20180314194857-6f0d6275bdcd/go.mod h1:XUKj
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
-github.com/sony/sonyflake v1.0.0 h1:MpU6Ro7tfXwgn2l5eluf9xQvQJDROTBImNCfRXn/YeM=
-github.com/sony/sonyflake v1.0.0/go.mod h1:Jv3cfhf/UFtolOTTRd3q4Nl6ENqM+KfyZ5PseKfZGF4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/crypto/uuid/snowflake.go
+++ b/pkg/crypto/uuid/snowflake.go
@@ -15,51 +15,23 @@
 package uuid
 
 import (
-	"math/rand"
-	"net"
-	"os"
 	"strconv"
-	"strings"
 
-	"github.com/sony/sonyflake"
+	"github.com/erda-project/erda/pkg/crypto/uuid/snowflake"
 )
 
-var sf = sonyflake.NewSonyflake(sonyflake.Settings{
-	MachineID: func() (uint16, error) { return podIP(), nil },
-})
+var sf = snowflake.NewSnowflake(snowflake.Settings{})
 
 // SnowFlakeIDUint64 return sequence uuid
-// 39 bits for time in units of 10 msec
-// 8 bits for a sequence number
-// 16 bits for a machine id
 func SnowFlakeIDUint64() uint64 {
-	id, _ := sf.NextID()
+	id, err := sf.NextID()
+	if err != nil {
+		panic(err)
+	}
 	return id
 }
 
 // SnowFlakeID is string format SnowFlakeIDUint64
 func SnowFlakeID() string {
 	return strconv.FormatUint(SnowFlakeIDUint64(), 10)
-}
-
-func podIP() uint16 {
-	podIP := os.Getenv("POD_IP")
-	if podIP == "" {
-		podIP = RandomIpV4Address()
-	}
-	ip := net.ParseIP(podIP)
-	return uint16(ip[8])<<7 + uint16(ip[9])<<6 +
-		uint16(ip[10])<<5 + uint16(ip[11])<<4 +
-		uint16(ip[12])<<3 + uint16(ip[13])<<2 +
-		uint16(ip[14])<<1 + uint16(ip[15])
-}
-
-// RandomIpV4Address returns a valid IPv4 address as string
-func RandomIpV4Address() string {
-	var blocks []string
-	for i := 0; i < 4; i++ {
-		number := rand.Intn(255)
-		blocks = append(blocks, strconv.Itoa(number))
-	}
-	return strings.Join(blocks, ".")
 }

--- a/pkg/crypto/uuid/snowflake/machine_id.go
+++ b/pkg/crypto/uuid/snowflake/machine_id.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+const (
+	POD_IP = "POD_IP"
+)
+
+func get12BitMachineID() (uint16, error) {
+	ip, err := tryGetIPv4()
+	if err != nil {
+		return 0, err
+	}
+
+	machineID := get12BitMachineIDByIPv4(ip)
+	return machineID, nil
+}
+
+func get12BitMachineIDByIPv4(ipv4 net.IP) uint16 {
+	ipPart2 := ipv4[2] // from part 0 to 3
+	movedIPPart2 := uint16(ipPart2) << 8
+	fourBitReservedIPPart2 := movedIPPart2 & (0b00001111 << 8)
+	ipPart3 := ipv4[3]
+	machineID := fourBitReservedIPPart2 | uint16(ipPart3)
+	return machineID
+}
+
+func tryGetIPv4() (net.IP, error) {
+	podIP, ok := tryPodIP()
+	if ok {
+		return podIP, nil
+	}
+
+	as, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range as {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+
+		ip := ipnet.IP.To4()
+		if ip != nil {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("no ipv4 address")
+}
+
+func tryPodIP() (net.IP, bool) {
+	podIP := os.Getenv(POD_IP)
+	if podIP == "" {
+		return nil, false
+	}
+	ip := net.ParseIP(podIP)
+	if ip == nil {
+		return nil, false
+	}
+	return ip.To4(), true
+}
+
+func isPrivateIPv4(ip net.IP) bool {
+	return ip != nil &&
+		(ip[0] == 10 || ip[0] == 172 && (ip[1] >= 16 && ip[1] < 32) || ip[0] == 192 && ip[1] == 168)
+}

--- a/pkg/crypto/uuid/snowflake/machine_id_test.go
+++ b/pkg/crypto/uuid/snowflake/machine_id_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func Test_get12BitMachineIDByIPv4(t *testing.T) {
+	// last 12-bit: 1000 00111001
+	ipsWithSameLast12Bits := []string{
+		"30.43.40.57",
+		"30.43.8.57",
+		"1.1.24.57",
+	}
+
+	var machineID uint16
+	for i, ipStr := range ipsWithSameLast12Bits {
+		ip := net.ParseIP(ipStr).To4()
+		calMachineID := get12BitMachineIDByIPv4(ip)
+		if i == 0 {
+			machineID = calMachineID
+			continue
+		}
+		if calMachineID != machineID {
+			panic(fmt.Errorf("machineID not same, ip: %s", ipStr))
+		}
+	}
+}
+
+func TestDecompose(t *testing.T) {
+	id := uint64(1154715486265)
+	fmt.Println(Decompose(id))
+
+	id = uint64(1154715490361)
+	fmt.Println(Decompose(id))
+}

--- a/pkg/crypto/uuid/snowflake/snowflake.go
+++ b/pkg/crypto/uuid/snowflake/snowflake.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snowflake
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Inspired by Sonyflake.
+
+// A Snowflake ID is composed of below parts:
+//     35 bits for time in units of 10 msec (lifetime: 10 years)
+//      6 bits for a sequence number (64 IDs/10msec)
+//     12 bits for a machine id (4096 machines/thread)
+const (
+	BitTotal        = 53                                     // bit length of Snowflake ID
+	BitLenTime      = 35                                     // bit length of time
+	BitLenSequence  = 6                                      // bit length of sequence number
+	BitLenMachineID = BitTotal - BitLenTime - BitLenSequence // bit length of machine id ; 12
+)
+
+// Settings configures Snowflake:
+//
+// StartTime is the time since which the Snowflake time is defined as the elapsed time.
+// If StartTime is 0, the start time of the Snowflake is set to "2022-04-19 00:00:00 +0000 UTC".
+// If StartTime is ahead of the current time, Snowflake is not created.
+//
+// MachineID returns the unique ID of the Snowflake instance.
+// If MachineID returns an error, Snowflake is not created.
+// If MachineID is nil, default MachineID is used.
+// Default MachineID returns the lower 16 bits of the private IP address.
+//
+// CheckMachineID validates the uniqueness of the machine ID.
+// If CheckMachineID returns false, Snowflake is not created.
+// If CheckMachineID is nil, no validation is done.
+type Settings struct {
+	StartTime      time.Time
+	MachineID      func() (uint16, error)
+	CheckMachineID func(uint16) bool
+}
+
+// Snowflake is a distributed unique ID generator.
+type Snowflake struct {
+	mutex       *sync.Mutex
+	startTime   int64
+	elapsedTime int64
+	sequence    uint16
+	machineID   uint16
+}
+
+// NewSnowflake returns a new Snowflake configured with the given Settings.
+// NewSnowflake returns nil in the following cases:
+// - Settings.StartTime is ahead of the current time.
+// - Settings.MachineID returns an error.
+// - Settings.CheckMachineID returns false.
+func NewSnowflake(st Settings) *Snowflake {
+	sf := new(Snowflake)
+	sf.mutex = new(sync.Mutex)
+	sf.sequence = uint16(1<<BitLenSequence - 1)
+
+	if st.StartTime.After(time.Now()) {
+		return nil
+	}
+	if st.StartTime.IsZero() {
+		sf.startTime = toSnowflakeTime(time.Date(2022, 4, 19, 0, 0, 0, 0, time.UTC))
+	} else {
+		sf.startTime = toSnowflakeTime(st.StartTime)
+	}
+
+	var err error
+	if st.MachineID == nil {
+		sf.machineID, err = get12BitMachineID()
+	} else {
+		sf.machineID, err = st.MachineID()
+	}
+	if err != nil {
+		panic(err)
+	}
+	if st.CheckMachineID != nil && !st.CheckMachineID(sf.machineID) {
+		panic(fmt.Errorf("failed to check machineID"))
+	}
+
+	return sf
+}
+
+// NextID generates a next unique ID.
+// After the Snowflake time overflows, NextID returns an error.
+func (sf *Snowflake) NextID() (uint64, error) {
+	const maskSequence = uint16(1<<BitLenSequence - 1)
+
+	sf.mutex.Lock()
+	defer sf.mutex.Unlock()
+
+	current := currentElapsedTime(sf.startTime)
+	if sf.elapsedTime < current {
+		sf.elapsedTime = current
+		sf.sequence = 0
+	} else { // sf.elapsedTime >= current
+		sf.sequence = (sf.sequence + 1) & maskSequence
+		if sf.sequence == 0 {
+			sf.elapsedTime++
+			overtime := sf.elapsedTime - current
+			time.Sleep(sleepTime(overtime))
+		}
+	}
+
+	return sf.toID()
+}
+
+const snowflakeTimeUnit = 1e7 // nsec, i.e. 10 msec
+
+func toSnowflakeTime(t time.Time) int64 {
+	return t.UTC().UnixNano() / snowflakeTimeUnit
+}
+
+func currentElapsedTime(startTime int64) int64 {
+	return toSnowflakeTime(time.Now()) - startTime
+}
+
+func sleepTime(overtime int64) time.Duration {
+	return time.Duration(overtime)*10*time.Millisecond -
+		time.Duration(time.Now().UTC().UnixNano()%snowflakeTimeUnit)*time.Nanosecond
+}
+
+func (sf *Snowflake) toID() (uint64, error) {
+	if sf.elapsedTime >= 1<<BitLenTime {
+		return 0, errors.New("over the time limit")
+	}
+
+	return uint64(sf.elapsedTime)<<(BitLenSequence+BitLenMachineID) |
+		uint64(sf.sequence)<<BitLenMachineID |
+		uint64(sf.machineID), nil
+}
+
+// Decompose returns a set of Snowflake ID parts.
+func Decompose(id uint64) map[string]uint64 {
+	const maskSequence = uint64((1<<BitLenSequence - 1) << BitLenMachineID)
+	const maskMachineID = uint64(1<<BitLenMachineID - 1)
+
+	msb := id >> BitTotal
+	time := id >> (BitLenSequence + BitLenMachineID)
+	sequence := id & maskSequence >> BitLenMachineID
+	machineID := id & maskMachineID
+	return map[string]uint64{
+		"id":         id,
+		"msb":        msb,
+		"time":       time,
+		"sequence":   sequence,
+		"machine-id": machineID,
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

implement 53-bit snowflake id for js compatible.

SnowFlakeIDUint64 return sequence uuid:
- 38 bits for time in units of 10 msec
- 7 bits for a sequence number
- 8 bits for a machine id

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=306508&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1174&type=TASK)

#### Specified Reviewers:

/assign @Effet @littlejiancc 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   implement 53-bit snowflake id for js compatible           |
| 🇨🇳 中文    |  实现 53-bit 雪花 ID 以兼容 JS Number 最大值问题            |

