### PR TITLE
fix(dop,pipeline): fix autotest can not set Content-Type header and can not get result that not a json

### DIFF
--- a/pkg/apitestsv2/apitest.go
+++ b/pkg/apitestsv2/apitest.go
@@ -143,19 +143,6 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 	}
 	apiReq.Params = params
 
-	// headers
-	if apiReq.Headers == nil {
-		apiReq.Headers = make(http.Header)
-	}
-	if testEnv != nil && testEnv.Header != nil {
-		for k, v := range testEnv.Header {
-			apiReq.Headers.Set(strings.TrimSpace(k), strings.TrimSpace(v))
-		}
-	}
-	for _, h := range at.API.Headers {
-		apiReq.Headers.Set(h.Key, h.Value)
-	}
-
 	// request body
 	var reqBody string
 	if at.API.Body.Content != nil && fmt.Sprint(at.API.Body.Content) != "" {
@@ -200,6 +187,19 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 		apiReq.Headers.Set("Content-Type", apiReq.Body.Type.String())
 	}
 	apiReq.Body.Content = reqBody
+
+	// headers
+	if apiReq.Headers == nil {
+		apiReq.Headers = make(http.Header)
+	}
+	if testEnv != nil && testEnv.Header != nil {
+		for k, v := range testEnv.Header {
+			apiReq.Headers.Set(strings.TrimSpace(k), strings.TrimSpace(v))
+		}
+	}
+	for _, h := range at.API.Headers {
+		apiReq.Headers.Set(h.Key, h.Value)
+	}
 
 	// use netportal
 	customReq, err := handleCustomNetportalRequest(&apiReq, at.opt.netportalOption)

--- a/pkg/encoding/jsonparse/parse.go
+++ b/pkg/encoding/jsonparse/parse.go
@@ -57,6 +57,10 @@ func FilterJson(jsonValue []byte, express string, expressType string) interface{
 	d.UseNumber()
 	err := d.Decode(&body)
 	if err != nil {
+		// resp not a json and express mean get all result, so return all resp
+		if express == "." {
+			return string(jsonValue)
+		}
 		return ""
 	}
 

--- a/pkg/encoding/jsonparse/parse_test.go
+++ b/pkg/encoding/jsonparse/parse_test.go
@@ -16,6 +16,7 @@ package jsonparse
 
 import (
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -45,6 +46,45 @@ func TestJsonOneLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := JsonOneLine(tt.i); got != tt.want {
 				t.Errorf("JsonOneLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterJson(t *testing.T) {
+	type args struct {
+		jsonValue   []byte
+		express     string
+		expressType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "test . and not result json",
+			args: args{
+				jsonValue:   []byte("test"),
+				express:     ".",
+				expressType: "",
+			},
+			want: "test",
+		},
+		{
+			name: "test '' and not result json",
+			args: args{
+				jsonValue:   []byte("test"),
+				express:     ".",
+				expressType: "",
+			},
+			want: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterJson(tt.args.jsonValue, tt.args.express, tt.args.expressType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterJson() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
1. Fix that the automated test could not customize the content type header
2. Fix that the automated test cannot get a result that is not JSON

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc4LDExOTAsMTIxOCwxMTc0XSwiYXNzaWduZWUiOlsiMTAwMDU2MCJdfQ%3D%3D&id=306533&iterationID=1174&pId=0&type=BUG)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix autotest can not set Content-Type header，and can not get result that not a json        |
| 🇨🇳 中文    |      修复自动测试无法设置 Content-Type header，和无法得到非 json 的结果        |
