### PR TITLE
fix(pipeline): k8sspark transfer affinity to node selector

### DIFF
--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/k8sspark.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/k8sspark.go
@@ -517,6 +517,22 @@ func (k *K8sSpark) generateKubeSparkJob(job *apistructs.JobFromUser, conf *apist
 
 	sparkApp.Spec.Executor.SparkPodSpec = k.composePodSpec(job, conf, sparkExecutorType, volMounts)
 	sparkApp.Spec.Executor.Instances = int32ptr(conf.Spec.SparkConf.ExecutorResource.Replica)
+	scheduleInfo2, _, _ := logic.GetScheduleInfo(k.cluster, string(k.Name()), string(Kind), *job)
+
+	// spark-submit doesn't support affinity, so transfer affinity to node selector
+	// in-the-feature, spark-submit will support affinity, and just need to set podSpec.Affinity = &constraintbuilders.K8S(&scheduleInfo2, nil, nil, nil).Affinity
+	affinity := &constraintbuilders.K8S(&scheduleInfo2, nil, nil, nil).Affinity
+	sparkApp.Spec.NodeSelector = make(map[string]string)
+	if affinity != nil && affinity.NodeAffinity != nil && affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil && affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms != nil {
+		nodeTerms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		for _, term := range nodeTerms {
+			for _, expression := range term.MatchExpressions {
+				if expression.Operator == corev1.NodeSelectorOpExists {
+					sparkApp.Spec.NodeSelector[expression.Key] = "true"
+				}
+			}
+		}
+	}
 
 	return sparkApp, nil
 }
@@ -526,7 +542,6 @@ func (k *K8sSpark) composePodSpec(job *apistructs.JobFromUser, conf *apistructs.
 
 	resource := apistructs.BigdataResource{}
 
-	scheduleInfo2, _, _ := logic.GetScheduleInfo(k.cluster, string(k.Name()), string(Kind), *job)
 	switch podType {
 	case sparkDriverType:
 		podSpec.Annotations = map[string]string{
@@ -549,7 +564,7 @@ func (k *K8sSpark) composePodSpec(job *apistructs.JobFromUser, conf *apistructs.
 	k.appendEnvs(&podSpec, &resource, conf.Name, podType)
 	podSpec.Labels = addLabels(conf)
 	podSpec.VolumeMounts = mount
-	podSpec.Affinity = &constraintbuilders.K8S(&scheduleInfo2, nil, nil, nil).Affinity
+
 	return podSpec
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
k8sspark transfer affinity to node selector

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=307044&iterationID=1174&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that k8sspark transfer affinity to node selector （将spark任务的亲和性转换为节点选择器）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that k8sspark transfer affinity to node selector             |
| 🇨🇳 中文    |   将spark任务的亲和性转换为节点选择器           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
