### PR TITLE
feat: runtime instance return pod meta info

### DIFF
--- a/apistructs/container.go
+++ b/apistructs/container.go
@@ -14,6 +14,20 @@
 
 package apistructs
 
+const (
+	K8sNamespace     = "k8snamespace"
+	K8sPodName       = "k8spodname"
+	K8sPodUid        = "k8spoduid"
+	K8sContainerName = "k8scontainername"
+)
+
+type K8sInstanceMetaInfo struct {
+	PodUid        string `json:"podUid"`
+	PodName       string `json:"podName"`
+	PodNamespace  string `json:"podNamespace"`
+	ContainerName string `json:"containerName"`
+}
+
 type CmContainersFetchResponse struct {
 	Header
 	Data []ContainerFetchResponseData `json:"data"`
@@ -99,6 +113,8 @@ func (c Containers) Less(i, j int) bool { return c[i].StartedAt < c[j].StartedAt
 
 // Container 容器信息
 type Container struct {
+	K8sInstanceMetaInfo
+
 	ID          string  `json:"id,omitempty"`          // Task Id
 	ContainerID string  `json:"containerId,omitempty"` // Container Id
 	IPAddress   string  `json:"ipAddress,omitempty"`

--- a/modules/orchestrator/endpoints/instance_test.go
+++ b/modules/orchestrator/endpoints/instance_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestParseMeta(t *testing.T) {
+	var (
+		metaNamespace     = "namespace"
+		metaPodUid        = "5e352011-f819-4dbb-bfea-3060cb866b53"
+		metaPodName       = "test-pod"
+		metaContainerName = "test-container"
+	)
+	tests := []struct {
+		name  string
+		input string
+		want  apistructs.K8sInstanceMetaInfo
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  apistructs.K8sInstanceMetaInfo{},
+		},
+		{
+			name:  "no meta",
+			input: "hello world",
+			want:  apistructs.K8sInstanceMetaInfo{},
+		},
+		{
+			name: "one meta",
+			input: strings.Join([]string{
+				fmt.Sprintf("%s=%s", apistructs.K8sNamespace, metaNamespace),
+				fmt.Sprintf("%s=%s", apistructs.K8sPodUid, metaPodUid),
+				fmt.Sprintf("%s=%s", apistructs.K8sPodName, metaPodName),
+				fmt.Sprintf("%s=%s", apistructs.K8sContainerName, metaContainerName),
+			}, ","),
+			want: apistructs.K8sInstanceMetaInfo{
+				PodUid:        metaPodUid,
+				PodName:       metaPodName,
+				PodNamespace:  metaNamespace,
+				ContainerName: metaContainerName,
+			},
+		},
+		{
+			name:  "invalid meta",
+			input: "hello world:meta1=value1:meta2=value2:",
+			want:  apistructs.K8sInstanceMetaInfo{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInstanceMeta(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseInstanceMeta() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
@@ -286,6 +286,7 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 			k8snamespace     string
 			k8spodname       string
 			k8scontainername string
+			k8spoduid        string
 
 			diceComponent string
 
@@ -340,6 +341,7 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 
 		k8snamespace = pod.Namespace
 		k8spodname = pod.Name
+		k8spoduid = string(pod.UID)
 		k8scontainername = container.Name
 
 		// The namespace and name of the servicegroup are written into ENV, so that they cannot be obtained directly from the pod information.
@@ -517,13 +519,18 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 		// -------------------------------
 		// 2. Update and create InstanceInfo records
 		// -------------------------------
-		meta := strutil.Join([]string{
-			"k8snamespace=" + k8snamespace,
-			"k8spodname=" + k8spodname,
-			"k8scontainername=" + k8scontainername}, ",")
-		if diceComponent != "" {
-			meta += fmt.Sprintf(",dice_component=%s", diceComponent)
+		kvFormat := "%s=%s"
+		metaSlice := []string{
+			fmt.Sprintf(kvFormat, apistructs.K8sNamespace, k8snamespace),
+			fmt.Sprintf(kvFormat, apistructs.K8sPodName, k8spodname),
+			fmt.Sprintf(kvFormat, apistructs.K8sContainerName, k8scontainername),
+			fmt.Sprintf(kvFormat, apistructs.K8sPodUid, k8spoduid),
 		}
+		if diceComponent != "" {
+			metaSlice = append(metaSlice, fmt.Sprintf(kvFormat, "dice_component", diceComponent))
+		}
+
+		meta := strings.Join(metaSlice, ",")
 		if prevContainerID != "" {
 			instances, err := r.ByOrgName(orgName).
 				ByProjectName(projectName).


### PR DESCRIPTION
#### What this PR does / why we need it:
runtime instance return pod meta info
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/31346321/164605322-2bb212fd-ed8d-4424-9efd-e59b2911028b.png">

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign # @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  runtime instance return pod meta info            |
| 🇨🇳 中文    |     runtime 实例返回 pod 元信息         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
