### PR TITLE
feat(pipeline): clusterinfo provider support get current cluster from configmap

### DIFF
--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -23,6 +23,11 @@ import (
 )
 
 const (
+	ConfigMapNameOfClusterInfo = "dice-cluster-info" // ConfigMapNameOfClusterInfo cluster info configmap name
+	ConfigMapNameOfAddons      = "dice-addons-info"  // ConfigMapNameOfAddons addon configmap name
+)
+
+const (
 	ETCD_ENDPOINTS          ClusterInfoMapKey = "ETCD_ENDPOINTS"          // k8s etcd的rs ip地址，逗号分割
 	DICE_INSIDE             ClusterInfoMapKey = "DICE_INSIDE"             // bool值, true表示当前集群是离线部署的
 	DICE_CLUSTER_TYPE       ClusterInfoMapKey = "DICE_CLUSTER_TYPE"       // 集群类型

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/clusterinfo/clusterinfo.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/clusterinfo/clusterinfo.go
@@ -41,10 +41,6 @@ import (
 const (
 	// diceCMNamespace dice configmap namespace
 	diceCMNamespace = "default"
-	// clusterInfoConfigMapName cluster info configmap name
-	clusterInfoConfigMapName = "dice-cluster-info"
-	// addonsConfigMapName addon configmap name
-	addonsConfigMapName = "dice-addons-info"
 	// clusterInfoPrefix 是集群配置信息在 etcd 中的路径前缀
 	clusterInfoPrefix = "/dice/scheduler/clusterinfo/"
 	// dlockKeyPrefix 分布式锁前缀，每个集群一把锁
@@ -174,17 +170,17 @@ func (ci *ClusterInfo) Load() error {
 		err     error
 	)
 	if ci.k8sClient != nil {
-		cm, err = ci.k8sClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), clusterInfoConfigMapName, metav1.GetOptions{})
+		cm, err = ci.k8sClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), apistructs.ConfigMapNameOfClusterInfo, metav1.GetOptions{})
 	} else {
 		if ci.ConfigMap == nil {
 			return errors.New("configMap is nil")
 		}
-		cm, err = ci.ConfigMap.Get(namespace, clusterInfoConfigMapName)
+		cm, err = ci.ConfigMap.Get(namespace, apistructs.ConfigMapNameOfClusterInfo)
 	}
 
 	if err != nil {
 		return errors.Errorf("failed to get %s configMap, clusterName: %s, (%v)",
-			clusterInfoConfigMapName, ci.clusterName, err)
+			apistructs.ConfigMapNameOfClusterInfo, ci.clusterName, err)
 	}
 
 	// 忽略指定的字段
@@ -193,13 +189,13 @@ func (ci *ClusterInfo) Load() error {
 	}
 	ci.data = cm.Data
 	if ci.k8sClient != nil {
-		addonCM, err = ci.k8sClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), addonsConfigMapName, metav1.GetOptions{})
+		addonCM, err = ci.k8sClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), apistructs.ConfigMapNameOfAddons, metav1.GetOptions{})
 	} else {
-		addonCM, err = ci.ConfigMap.Get(namespace, addonsConfigMapName)
+		addonCM, err = ci.ConfigMap.Get(namespace, apistructs.ConfigMapNameOfAddons)
 	}
 	if err != nil {
 		return errors.Errorf("failed to get %s configMap, clusterName: %s, (%v)",
-			addonsConfigMapName, ci.clusterName, err)
+			apistructs.ConfigMapNameOfAddons, ci.clusterName, err)
 	}
 
 	// add registry addr

--- a/modules/pipeline/providers/clusterinfo/interface_test.go
+++ b/modules/pipeline/providers/clusterinfo/interface_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterinfo
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-infra/base/logs/logrusx"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+)
+
+func TestGetClusterInfoByNameEdge(t *testing.T) {
+	type args struct {
+		name        string
+		clusterName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "get current cluster info",
+			args: args{
+				name: "dev",
+			},
+			wantErr: false,
+		},
+		{
+			name: "get current cluster info failed",
+			args: args{
+				name:        "op",
+				clusterName: "op",
+			},
+			wantErr: true,
+		},
+		{
+			name: "get edge cluster info",
+			args: args{
+				name: "edge",
+			},
+			wantErr: false,
+		},
+	}
+	bdl := bundle.New()
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetCluster", func(_ *bundle.Bundle, idOrName string) (*apistructs.ClusterInfo, error) {
+		if idOrName == "edge" {
+			return &apistructs.ClusterInfo{
+				Name: "edge",
+			}, nil
+		}
+		return nil, fmt.Errorf("not found for cluster: %s", idOrName)
+	})
+	defer pm1.Unpatch()
+	p := provider{
+		Cfg: &config{
+			ClusterName: "dev",
+			IsEdge:      true,
+		},
+		cache: NewClusterInfoCache(),
+		bdl:   bdl,
+	}
+	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(&p), "GetCurrentClusterInfoFromK8sConfigMap", func(_ *provider) (apistructs.ClusterInfo, error) {
+		if p.Cfg.ClusterName == "op" {
+			return apistructs.ClusterInfo{}, fmt.Errorf("not found for cluster: %s", p.Cfg.ClusterName)
+		}
+		return apistructs.ClusterInfo{
+			Name: "dev",
+		}, nil
+	})
+	defer pm2.Unpatch()
+	for _, tt := range tests {
+		if tt.args.clusterName != "" {
+			p.Cfg.ClusterName = tt.args.clusterName
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.GetClusterInfoByName(tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetClusterInfoByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_batchUpdateClusterInfo(t *testing.T) {
+	bdl := bundle.New()
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "ListClusters", func(_ *bundle.Bundle, clusterType string, orgID ...uint64) ([]apistructs.ClusterInfo, error) {
+		return []apistructs.ClusterInfo{
+			{
+				Name: "dev",
+			},
+			{
+				Name: "edge",
+			},
+		}, nil
+	})
+	defer pm1.Unpatch()
+	p := provider{
+		Cfg: &config{
+			ClusterName: "dev",
+		},
+		cache: NewClusterInfoCache(),
+		bdl:   bdl,
+	}
+	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(&p), "GetCurrentClusterInfoFromK8sConfigMap", func(_ *provider) (apistructs.ClusterInfo, error) {
+		return apistructs.ClusterInfo{
+			Name: "dev",
+		}, nil
+	})
+	defer pm2.Unpatch()
+	t.Run("batch update cluster info", func(t *testing.T) {
+		os.Setenv(string(apistructs.DICE_CLUSTER_NAME), "dev")
+		p.batchUpdateClusterInfo()
+	})
+	devClusterInfo, err := p.GetClusterInfoByName("dev")
+	assert.NoError(t, err)
+	assert.Equal(t, "dev", devClusterInfo.Name)
+
+	edgeClusterInfo, err := p.GetClusterInfoByName("edge")
+	assert.NoError(t, err)
+	assert.Equal(t, "edge", edgeClusterInfo.Name)
+}
+
+func Test_registerClusterHook(t *testing.T) {
+	bdl := bundle.New()
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "CreateWebhook", func(_ *bundle.Bundle, r apistructs.CreateHookRequest) error {
+		return fmt.Errorf("create hook error")
+	})
+	defer pm1.Unpatch()
+	p := provider{
+		Cfg: &config{
+			ClusterName: "dev",
+		},
+		cache: NewClusterInfoCache(),
+		bdl:   bdl,
+		Log:   logrusx.New(),
+	}
+	err := p.registerClusterHook()
+	assert.Equal(t, true, err != nil)
+}

--- a/modules/pipeline/providers/clusterinfo/provider.go
+++ b/modules/pipeline/providers/clusterinfo/provider.go
@@ -27,6 +27,9 @@ import (
 var pd *provider
 
 type config struct {
+	ClusterName              string        `env:"DICE_CLUSTER_NAME"`
+	ErdaNamespace            string        `env:"DICE_NAMESPACE"`
+	IsEdge                   bool          `env:"DICE_IS_EDGE" default:"false"`
 	RetryClusterHookInterval time.Duration `file:"retry_cluster_hook_interval" default:"5s"`
 	RefreshClustersInterval  time.Duration `file:"refresh_clusters_interval" default:"20m"`
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
clusterinfo provider support get current cluster from configmap, because could't get clusterinfo from cluster-manager when edge deploying

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=306739&iterationID=1190&pId=306714&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: clusterinfo provider support get current cluster from configmap （支持边缘部署的pipeline解耦cluster-manager）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | clusterinfo provider support get current cluster from configmap             |
| 🇨🇳 中文    |   支持边缘部署的pipeline解耦cluster-manage           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
