### PR TITLE
feat: merge port of http-server in admin self and erda-infra

### DIFF
--- a/conf/admin/admin.yaml
+++ b/conf/admin/admin.yaml
@@ -2,7 +2,7 @@ admin:
   debug: ${DEBUG:false}
 
 http-server:
-  addr: ":9096"
+  addr: ":9095"
   allow_cors: true
 
 

--- a/conf/openapi/openapi.yaml
+++ b/conf/openapi/openapi.yaml
@@ -104,7 +104,7 @@ openapi-v1-routes:
           - cmp-dashboard-pods
           - cmp-dashboard-podDetail
           - cmp-cluster-list
-      - addr: admin:9096
+      - addr: admin:9095
         scenarios:
           - personal-workbench
       - addr: msp:8080

--- a/erda.yml
+++ b/erda.yml
@@ -98,9 +98,6 @@ services:
       - port: 9095
         protocol: TCP
         l4_protocol: TCP
-      - port: 9096
-        protocol: TCP
-        l4_protocol: TCP
       - port: 8096
         protocol: TCP
         l4_protocol: TCP

--- a/modules/openapi/api/apis/admin/admin_dingtalk.go
+++ b/modules/openapi/api/apis/admin/admin_dingtalk.go
@@ -23,7 +23,7 @@ import (
 var ADMIN_DINGTALK_TEST = apis.ApiSpec{
 	Path:        "/api/admin/notify/dingtalk-test",
 	BackendPath: "/api/admin/notify/dingtalk-test",
-	Host:        "admin.marathon.l4lb.thisdcos.directory:9096",
+	Host:        "admin.marathon.l4lb.thisdcos.directory:9095",
 	Scheme:      "http",
 	Method:      http.MethodPost,
 	CheckLogin:  true,

--- a/pkg/parser/diceyml/diceyml_test.go
+++ b/pkg/parser/diceyml/diceyml_test.go
@@ -294,9 +294,6 @@ services:
       port: 9095
       protocol: TCP
     - l4_protocol: TCP
-      port: 9096
-      protocol: TCP
-    - l4_protocol: TCP
       port: 8096
       protocol: TCP
     resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

merge port of http-server in admin self and erda-infra

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       feat: merge port of http-server in admin self and erda-infra       |
| 🇨🇳 中文    |        合并erda-infra跟admin组件自己的端口      |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
