### PR TITLE
fix: k8sclient new-func support some custom options

### DIFF
--- a/modules/cmp/component-protocol/cputil/util.go
+++ b/modules/cmp/component-protocol/cputil/util.go
@@ -263,7 +263,7 @@ func GetImpersonateClient(steveServer cmp.SteveServer, userID, orgID, clusterNam
 	config.Impersonate.Groups = user.GetGroups()
 	config.Impersonate.Extra = user.GetExtra()
 
-	client, err := k8sclient.NewForRestConfig(config, scheme.LocalSchemeBuilder...)
+	client, err := k8sclient.NewForRestConfig(config, k8sclient.WithSchemes(scheme.LocalSchemeBuilder...))
 	if err != nil {
 		return nil, errors.Errorf("failed to get k8s client, %v", err)
 	}

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -304,7 +304,7 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 
 	rc.Timeout = conf.ExecutorClientTimeout()
 
-	k8sClient, err := k8sclient.NewForRestConfig(rc, scheme.LocalSchemeBuilder...)
+	k8sClient, err := k8sclient.NewForRestConfig(rc, k8sclient.WithSchemes(scheme.LocalSchemeBuilder...))
 	if err != nil {
 		return nil, errors.Errorf("failed to get k8s client for cluster %s, %v", clusterName, err)
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sflink/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sflink/type.go
@@ -34,7 +34,9 @@ type K8sFlink struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sFlink, error) {
-	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
+	// we could operate normal resources (job, pod, deploy,pvc,pv,crd and so on) by default config permissions(injected by kubernetes, /var/run/secrets/kubernetes.io/serviceaccount)
+	// so WithPreferredToUseInClusterConfig it's enough for pipeline and orchestrator
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second), k8sclient.WithPreferredToUseInClusterConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
@@ -93,7 +93,9 @@ type K8sJob struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sJob, error) {
-	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
+	// we could operate normal resources (job, pod, deploy,pvc,pv,crd and so on) by default config permissions(injected by kubernetes, /var/run/secrets/kubernetes.io/serviceaccount)
+	// so WithPreferredToUseInClusterConfig it's enough for pipeline and orchestrator
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second), k8sclient.WithPreferredToUseInClusterConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/type.go
+++ b/modules/pipeline/pipengine/actionexecutor/plugins/k8sspark/type.go
@@ -37,7 +37,9 @@ type K8sSpark struct {
 }
 
 func New(name types.Name, clusterName string, cluster apistructs.ClusterInfo) (*K8sSpark, error) {
-	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second))
+	// we could operate normal resources (job, pod, deploy,pvc,pv,crd and so on) by default config permissions(injected by kubernetes, /var/run/secrets/kubernetes.io/serviceaccount)
+	// so WithPreferredToUseInClusterConfig it's enough for pipeline and orchestrator
+	client, err := k8sclient.New(clusterName, k8sclient.WithTimeout(time.Duration(conf.K8SExecutorMaxInitializationSec())*time.Second), k8sclient.WithPreferredToUseInClusterConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -30,6 +30,12 @@ import (
 )
 
 type K8sClient struct {
+	// custom options
+	timeout              *time.Duration
+	priorityUseInCluster bool
+	schemes              []func(scheme *runtime.Scheme) error
+
+	// client for kubernetes
 	ClientSet *kubernetes.Clientset
 	CRClient  client.Client
 }
@@ -38,9 +44,13 @@ type K8sClient struct {
 func New(clusterName string, ops ...Option) (*K8sClient, error) {
 	var rc *rest.Config
 	var err error
+	var kc K8sClient
+	for _, op := range ops {
+		op(&kc)
+	}
 
 	inClusterName := os.Getenv(string(apistructs.DICE_CLUSTER_NAME))
-	if inClusterName == clusterName {
+	if inClusterName == clusterName && kc.priorityUseInCluster {
 		rc, err = config.GetInClusterRestConfig()
 	} else {
 		rc, err = GetRestConfig(clusterName)
@@ -49,12 +59,9 @@ func New(clusterName string, ops ...Option) (*K8sClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	ops = append(ops, WithSchemes(scheme.LocalSchemeBuilder...))
 
-	for _, op := range ops {
-		op(rc)
-	}
-
-	return NewForRestConfig(rc, scheme.LocalSchemeBuilder...)
+	return NewForRestConfig(rc, ops...)
 }
 
 // NewWithTimeOut new k8sClient with timeout
@@ -75,13 +82,20 @@ func NewWithTimeOut(clusterName string, timeout time.Duration) (*K8sClient, erro
 
 	rc.Timeout = timeout
 
-	return NewForRestConfig(rc, scheme.LocalSchemeBuilder...)
+	return NewForRestConfig(rc, WithSchemes(scheme.LocalSchemeBuilder...))
 }
 
 // NewForRestConfig new K8sClient with rest.Config, you can register your custom runtime.Scheme.
-func NewForRestConfig(c *rest.Config, schemes ...func(scheme *runtime.Scheme) error) (*K8sClient, error) {
+func NewForRestConfig(c *rest.Config, ops ...Option) (*K8sClient, error) {
 	var kc K8sClient
 	var err error
+
+	for _, op := range ops {
+		op(&kc)
+	}
+	if kc.timeout != nil {
+		c.Timeout = *kc.timeout
+	}
 
 	if kc.ClientSet, err = kubernetes.NewForConfig(c); err != nil {
 		return nil, err
@@ -90,7 +104,7 @@ func NewForRestConfig(c *rest.Config, schemes ...func(scheme *runtime.Scheme) er
 	sc := runtime.NewScheme()
 	schemeBuilder := &runtime.SchemeBuilder{}
 
-	for _, s := range schemes {
+	for _, s := range kc.schemes {
 		schemeBuilder.Register(s)
 	}
 
@@ -105,11 +119,25 @@ func NewForRestConfig(c *rest.Config, schemes ...func(scheme *runtime.Scheme) er
 	return &kc, nil
 }
 
-type Option func(*rest.Config)
+type Option func(*K8sClient)
 
 func WithTimeout(timeout time.Duration) Option {
-	return func(rc *rest.Config) {
-		rc.Timeout = timeout
+	return func(k *K8sClient) {
+		k.timeout = &timeout
+	}
+}
+
+func WithSchemes(schemes ...func(scheme *runtime.Scheme) error) Option {
+	return func(k *K8sClient) {
+		k.schemes = schemes
+	}
+}
+
+// WithPreferredToUseInClusterConfig set whether priority to use in cluster config
+// if not set this option, we will get and use config set by cluster agent
+func WithPreferredToUseInClusterConfig() Option {
+	return func(k *K8sClient) {
+		k.priorityUseInCluster = true
 	}
 }
 
@@ -119,10 +147,7 @@ func NewForInCluster(ops ...Option) (*K8sClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, op := range ops {
-		op(rc)
-	}
-	return NewForRestConfig(rc, scheme.LocalSchemeBuilder...)
+	return NewForRestConfig(rc, WithSchemes(scheme.LocalSchemeBuilder...))
 }
 
 // GetRestConfig get rest config with clusterName

--- a/providers/k8s-client-manager/provider.go
+++ b/providers/k8s-client-manager/provider.go
@@ -59,7 +59,7 @@ func (p *provider) Init(ctx servicehub.Context) (err error) {
 		if err != nil {
 			return nil, err
 		}
-		client, err := k8sclient.NewForRestConfig(rc, scheme.LocalSchemeBuilder...)
+		client, err := k8sclient.NewForRestConfig(rc, k8sclient.WithSchemes(scheme.LocalSchemeBuilder...))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
k8sclient new-func support some custom options

in [this pr](https://github.com/erda-project/erda/pull/4633), i make new k8sclient directly by erda-operator injected conf  if in-cluster, but in-cluster is insufficient permissons for cmp, so i add `priorityUseInCluster` option for pipeline

#### Specified Reviewers:

/assign @sfwn  @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that k8sclient new-func support some custom options（修复了多云管理平台k8sclient的权限不足）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that k8sclient new-func support some custom options             |
| 🇨🇳 中文    |  修复了多云管理平台k8sclient的权限不足            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
