### PR TITLE
refactor(pipeline): add processedTasks syncmap to determine normally done

### DIFF
--- a/modules/pipeline/providers/reconciler/pipeline_reconciler_impl.go
+++ b/modules/pipeline/providers/reconciler/pipeline_reconciler_impl.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/commonutil/statusutil"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+// updateCalculatedPipelineStatusForTaskUseField by:
+// 1. other flags (higher priority)
+// 2. all reconciled tasks
+func (pr *defaultPipelineReconciler) updateCalculatedPipelineStatusForTaskUseField(ctx context.Context, p *spec.Pipeline) error {
+	newStatus := p.Status
+	defer func() {
+		pr.calculatedStatusForTaskUse = newStatus
+	}()
+
+	// check if done
+	if newStatus.IsEndStatus() {
+		return nil
+	}
+
+	// check flags
+	if pr.flagCanceling {
+		newStatus = apistructs.PipelineStatusStopByUser
+		return nil
+	}
+
+	// calculate new status
+	calculatedStatus, err := pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		pr.log.Errorf("failed to calculate new status by reconciled tasks(auto retry), pipelineID: %d, err: %v", p.ID, err)
+		return err
+	}
+	newStatus = calculatedStatus
+	return nil
+}
+
+func (pr *defaultPipelineReconciler) calculatePipelineStatusForTaskUseField(ctx context.Context, p *spec.Pipeline) (apistructs.PipelineStatus, error) {
+	// get all reconciled tasks
+	reconciledDBTasks, err := pr.dbClient.ListPipelineTasksByPipelineID(p.ID)
+	if err != nil {
+		return "", err
+	}
+	var reconciledTasks []*spec.PipelineTask
+	for _, t := range reconciledDBTasks {
+		t := t
+		reconciledTasks = append(reconciledTasks, &t)
+	}
+
+	// calculate new pipeline status
+	calculatedPipelineStatusByAllReconciledTasks := statusutil.CalculatePipelineStatusV2(reconciledTasks)
+	// consider some special cases:
+	// - no reconciled tasks but pipeline actually have tasks (to resolve first time of loop)
+	if calculatedPipelineStatusByAllReconciledTasks.IsSuccessStatus() && len(reconciledTasks) == 0 && *pr.totalTaskNumber > 0 {
+		calculatedPipelineStatusByAllReconciledTasks = apistructs.PipelineStatusRunning
+	}
+
+	// update status
+	return calculatedPipelineStatusByAllReconciledTasks, nil
+}
+
+func (pr *defaultPipelineReconciler) getCalculatedStatusByAllReconciledTasks() apistructs.PipelineStatus {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+	return pr.calculatedStatusForTaskUse
+}
+
+func (pr *defaultPipelineReconciler) getFlagCanceling() bool {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+	return pr.flagCanceling
+}
+
+func (pr *defaultPipelineReconciler) setTotalTaskNumber(num int) {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+	pr.totalTaskNumber = &num
+}
+
+func (pr *defaultPipelineReconciler) setTotalTaskNumberBeforeReconcilePipeline(ctx context.Context, p *spec.Pipeline) error {
+	allTasks, err := pr.r.YmlTaskMergeDBTasks(p)
+	if err != nil {
+		return err
+	}
+	// set processed tasks
+	for _, task := range allTasks {
+		task := task
+		if task.ID > 0 && (task.Status.IsEndStatus() || task.Status.IsDisabledStatus()) {
+			pr.processedTasks.Store(task.NodeName(), struct{}{})
+		}
+	}
+	pr.setTotalTaskNumber(len(allTasks))
+	return nil
+}

--- a/modules/pipeline/providers/reconciler/pipeline_reconciler_impl_test.go
+++ b/modules/pipeline/providers/reconciler/pipeline_reconciler_impl_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/dbclient"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_defaultPipelineReconciler_setTotalTaskNumberBeforeReconcilePipeline(t *testing.T) {
+	p := &spec.Pipeline{
+		PipelineBase: spec.PipelineBase{
+			Status: apistructs.PipelineStatusRunning,
+		},
+	}
+	ctx := context.TODO()
+	r := &provider{}
+	pr := &defaultPipelineReconciler{r: r}
+
+	// two tasks
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "YmlTaskMergeDBTasks",
+		func(_ *provider, pipeline *spec.Pipeline) ([]*spec.PipelineTask, error) {
+			// two tasks
+			tasks := []*spec.PipelineTask{
+				{Name: "s1c1"},
+				{Name: "s2c1"},
+			}
+			return tasks, nil
+		})
+	err := pr.setTotalTaskNumberBeforeReconcilePipeline(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if *pr.totalTaskNumber != 2 {
+		t.Fatalf("should have two tasks, actually %v", *pr.totalTaskNumber)
+	}
+
+	// none tasks
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "YmlTaskMergeDBTasks",
+		func(_ *provider, pipeline *spec.Pipeline) ([]*spec.PipelineTask, error) {
+			// none tasks
+			return nil, nil
+		})
+	err = pr.setTotalTaskNumberBeforeReconcilePipeline(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if *pr.totalTaskNumber != 0 {
+		t.Fatalf("should have none tasks, actually %v", *pr.totalTaskNumber)
+	}
+}
+
+func Test_defaultPipelineReconciler_updateCalculatedPipelineStatusForTaskUseField(t *testing.T) {
+	p := &spec.Pipeline{
+		PipelineBase: spec.PipelineBase{
+			Status: apistructs.PipelineStatusRunning,
+		},
+	}
+	ctx := context.TODO()
+	r := &provider{}
+	pr := &defaultPipelineReconciler{r: r}
+
+	// already end status
+	p.Status = apistructs.PipelineStatusFailed
+	err := pr.updateCalculatedPipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if pr.calculatedStatusForTaskUse != apistructs.PipelineStatusFailed {
+		t.Fatalf("should be failed")
+	}
+
+	// canceled
+	pr = &defaultPipelineReconciler{r: r}
+	p.Status = apistructs.PipelineStatusRunning
+	pr.flagCanceling = true
+	err = pr.updateCalculatedPipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if pr.calculatedStatusForTaskUse != apistructs.PipelineStatusStopByUser {
+		t.Fatalf("should be stopByUser")
+	}
+
+	// running
+	pr = &defaultPipelineReconciler{r: r}
+	dbClient := &dbclient.Client{}
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{
+				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
+			}, nil
+		})
+	p.Status = apistructs.PipelineStatusRunning
+	err = pr.updateCalculatedPipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if pr.calculatedStatusForTaskUse != apistructs.PipelineStatusSuccess {
+		t.Fatalf("should be stopByUser")
+	}
+}
+
+func Test_defaultPipelineReconciler_calculateNewStatusByReconciledTasks(t *testing.T) {
+	p := &spec.Pipeline{
+		PipelineBase: spec.PipelineBase{
+			Status: apistructs.PipelineStatusRunning,
+		},
+	}
+	ctx := context.TODO()
+	r := &provider{}
+	pr := &defaultPipelineReconciler{r: r}
+	dbClient := &dbclient.Client{}
+
+	// no tasks
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{}, nil
+		})
+	pr.totalTaskNumber = &[]int{0}[0]
+	newStatus, err := pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if newStatus != apistructs.PipelineStatusSuccess {
+		t.Fatalf("should be success if no task")
+	}
+
+	// one task but nothing scheduled (first loop)
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{}, nil
+		})
+	pr.totalTaskNumber = &[]int{1}[0]
+	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if newStatus != apistructs.PipelineStatusRunning {
+		t.Fatalf("should be running")
+	}
+
+	// three task and two scheduled (one success, one running) => running
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{
+				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
+				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusRunning},
+			}, nil
+		})
+	pr.totalTaskNumber = &[]int{3}[0]
+	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if newStatus != apistructs.PipelineStatusRunning {
+		t.Fatalf("should be running")
+	}
+
+	// three task and two scheduled (one success, one failed) => failed
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{
+				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
+				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusFailed},
+			}, nil
+		})
+	pr.totalTaskNumber = &[]int{3}[0]
+	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if newStatus != apistructs.PipelineStatusFailed {
+		t.Fatalf("should be failed")
+	}
+
+	// three task and two scheduled (one running, one failed) => running
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
+		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
+			return []spec.PipelineTask{
+				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusRunning},
+				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusFailed},
+			}, nil
+		})
+	pr.totalTaskNumber = &[]int{3}[0]
+	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if err != nil {
+		t.Fatalf("should no err, err: %v", err)
+	}
+	if newStatus != apistructs.PipelineStatusRunning {
+		t.Fatalf("should be running")
+	}
+}

--- a/modules/pipeline/providers/reconciler/pipeline_reconciler_test.go
+++ b/modules/pipeline/providers/reconciler/pipeline_reconciler_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_defaultPipelineReconciler_IsReconcileDone(t *testing.T) {
+	p := &spec.Pipeline{
+		PipelineBase: spec.PipelineBase{
+			Status: apistructs.PipelineStatusRunning,
+		},
+	}
+	pr := &defaultPipelineReconciler{}
+	ctx := context.TODO()
+
+	// pipeline is canceled
+	// tasks: s1c1, s2c1
+	pr.flagCanceling = true
+	pr.calculatedStatusForTaskUse = apistructs.PipelineStatusStopByUser
+	pr.totalTaskNumber = &[]int{2}[0]
+	pr.processedTasks.Store("s1c1", struct{}{})
+	pr.processingTasks.Store("s2c1", struct{}{})
+	done := pr.IsReconcileDone(ctx, p)
+	if !done {
+		t.Fatalf("should done")
+	}
+
+	// pipeline running
+	// tasks: s1c1(done), s2c1(done), s2c2(analyzed)
+	pr = &defaultPipelineReconciler{}
+	pr.flagCanceling = false
+	pr.totalTaskNumber = &[]int{3}[0]
+	pr.processedTasks.Store("s1c1", struct{}{})
+	pr.processedTasks.Store("s2c1", struct{}{})
+	done = pr.IsReconcileDone(ctx, p)
+	if done {
+		t.Fatalf("should running")
+	}
+
+	// pipeline all tasks done
+	// tasks: s1c1(done), s2c1(done), s2c2(failed)
+	pr = &defaultPipelineReconciler{}
+	pr.flagCanceling = false
+	pr.totalTaskNumber = &[]int{3}[0]
+	pr.processedTasks.Store("s1c1", struct{}{})
+	pr.processedTasks.Store("s2c1", struct{}{})
+	pr.processedTasks.Store("s2c2", struct{}{})
+	done = pr.IsReconcileDone(ctx, p)
+	if !done {
+		t.Fatalf("should done")
+	}
+}

--- a/modules/pipeline/providers/reconciler/reconcile.go
+++ b/modules/pipeline/providers/reconciler/reconcile.go
@@ -86,7 +86,7 @@ func (r *provider) generatePipelineReconcilerForEachPipelineID() *defaultPipelin
 
 func (pr *defaultPipelineReconciler) releaseTaskAfterReconciled(ctx context.Context, p *spec.Pipeline, task *spec.PipelineTask) {
 	pr.processingTasks.Delete(task.NodeName())
-	pr.processedTasks.Store(task.Name, struct{}{})
+	pr.processedTasks.Store(task.NodeName(), struct{}{})
 }
 
 func (pr *defaultPipelineReconciler) waitPipelineDoneAndDoTeardown(ctx context.Context, p *spec.Pipeline) {

--- a/modules/pipeline/providers/reconciler/task_reconciler.go
+++ b/modules/pipeline/providers/reconciler/task_reconciler.go
@@ -408,10 +408,10 @@ func (tr *defaultTaskReconciler) tryCorrectFromExecutorBeforeReconcile(ctx conte
 
 func (tr *defaultTaskReconciler) judgeIfExpression(ctx context.Context, p *spec.Pipeline, task *spec.PipelineTask) error {
 	// if calculated pipeline status is failed and current task have no if expression(cannot must run), set task no-need-run
-	if tr.pr.calculatedPipelineStatusByAllReconciledTasks.IsFailedStatus() {
+	if tr.pr.calculatedStatusForTaskUse.IsFailedStatus() {
 		needSetToNoNeedBySystem := false
 		// stopByUser -> force no-need-by-system -> not check if expression
-		if tr.pr.calculatedPipelineStatusByAllReconciledTasks == apistructs.PipelineStatusStopByUser {
+		if tr.pr.calculatedStatusForTaskUse == apistructs.PipelineStatusStopByUser {
 			needSetToNoNeedBySystem = true
 		}
 		// failed but not stopByUser -> check if expression
@@ -425,8 +425,8 @@ func (tr *defaultTaskReconciler) judgeIfExpression(ctx context.Context, p *spec.
 			return err
 		}
 		task.Status = apistructs.PipelineStatusNoNeedBySystem
-		tr.log.Infof("set task status to %s (calculatedPipelineStatusByAllReconciledTasks: %s, action if expression is empty), pipelineID: %d, taskID: %d, taskName: %s",
-			apistructs.PipelineStatusNoNeedBySystem, tr.pr.calculatedPipelineStatusByAllReconciledTasks, p.ID, task.ID, task.Name)
+		tr.log.Infof("set task status to %s (calculatedStatusForTaskUse: %s, action if expression is empty), pipelineID: %d, taskID: %d, taskName: %s",
+			apistructs.PipelineStatusNoNeedBySystem, tr.pr.calculatedStatusForTaskUse, p.ID, task.ID, task.Name)
 	}
 	return nil
 }

--- a/modules/pipeline/providers/reconciler/task_reconciler.go
+++ b/modules/pipeline/providers/reconciler/task_reconciler.go
@@ -348,7 +348,7 @@ func (tr *defaultTaskReconciler) PrepareBeforeReconcileSnippetPipeline(ctx conte
 
 	// set snippetDetail for snippetTask
 	var snippetPipelineTasks []*spec.PipelineTask
-	snippetPipelineTasks, err := tr.r.ymlTaskMergeDBTasks(sp)
+	snippetPipelineTasks, err := tr.r.YmlTaskMergeDBTasks(sp)
 	if err != nil {
 		return err
 	}

--- a/modules/pipeline/providers/reconciler/util.go
+++ b/modules/pipeline/providers/reconciler/util.go
@@ -44,9 +44,10 @@ func (r *provider) mustFetchPipelineDetail(ctx context.Context, pipelineID uint6
 	}
 }
 
+// YmlTaskMergeDBTasks .
 // parse out tasks according to the yml structure, and then query the created tasks from the database,
 // and replace the tasks that already exist in the database with yml tasks
-func (r *provider) ymlTaskMergeDBTasks(pipeline *spec.Pipeline) ([]*spec.PipelineTask, error) {
+func (r *provider) YmlTaskMergeDBTasks(pipeline *spec.Pipeline) ([]*spec.PipelineTask, error) {
 	// get pipeline tasks from db
 	tasks, err := r.dbClient.ListPipelineTasksByPipelineID(pipeline.ID)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

refacotor pipeline reconcile loop, add processedTasks syncmap to determine normally done.

#### Specified Reviewers:

/assign @chengjoey 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add processedTasks syncmap to determine normally done            |
| 🇨🇳 中文    |  增加 已处理的任务 字段来标识正常的推进结束            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
