### PR TITLE
fix: deployment order deploy duplicate, app release can't cancel

### DIFF
--- a/modules/orchestrator/endpoints/deployment_order.go
+++ b/modules/orchestrator/endpoints/deployment_order.go
@@ -58,7 +58,11 @@ func (e *Endpoints) CreateDeploymentOrder(ctx context.Context, r *http.Request, 
 	data, err := e.deploymentOrder.Create(ctx, &req)
 	if err != nil {
 		logrus.Errorf("failed to create deployment order: %v", err)
-		return errorresp.ErrResp(err)
+		errCtx := map[string]interface{}{}
+		if data != nil {
+			errCtx["deploymentOrderID"] = data.Id
+		}
+		return errorresp.New().InternalError(err).SetCtx(errCtx).ToResp(), nil
 	}
 
 	if req.Source != apistructs.SourceDeployPipeline {

--- a/modules/orchestrator/services/deployment_order/deployment_order_cancel_test.go
+++ b/modules/orchestrator/services/deployment_order/deployment_order_cancel_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment_order
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/orchestrator/dbclient"
+)
+
+func TestCancel(t *testing.T) {
+	order := New()
+
+	defer monkey.UnpatchAll()
+	monkey.PatchInstanceMethod(reflect.TypeOf(order.db), "GetDeploymentOrder", func(*dbclient.DBClient, string) (*dbclient.DeploymentOrder, error) {
+		return &dbclient.DeploymentOrder{}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(order.db), "UpdateDeploymentOrder", func(*dbclient.DBClient, *dbclient.DeploymentOrder) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(order.db), "GetRuntimeByDeployOrderId", func(*dbclient.DBClient, uint64, string) (*[]dbclient.Runtime, error) {
+		return &[]dbclient.Runtime{}, nil
+	})
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(order.bdl), "CheckPermission", func(*bundle.Bundle, *apistructs.PermissionCheckRequest) (*apistructs.PermissionCheckResponseData, error) {
+		return &apistructs.PermissionCheckResponseData{
+			Access: true,
+		}, nil
+	})
+
+	_, err := order.Cancel(context.Background(), &apistructs.DeploymentOrderCancelRequest{
+		DeploymentOrderId: "demo-order-id",
+	})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix: deployment order deploy duplicate, app release can't cancled

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  deployment order deploy duplicate, app release can't cancel            |
| 🇨🇳 中文    |   修复部署单错误情况下的重复部署，应用制品在错误下无法取消的情况           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
