### PR TITLE
fix(pipeline): must set totalTaskNum

### DIFF
--- a/modules/pipeline/providers/reconciler/pipeline_reconciler.go
+++ b/modules/pipeline/providers/reconciler/pipeline_reconciler.go
@@ -124,6 +124,11 @@ func (pr *defaultPipelineReconciler) PrepareBeforeReconcile(ctx context.Context,
 		return rutil.ContinueWorkingAbort
 	}, rutil.WithContinueWorkingDefaultRetryInterval(pr.defaultRetryInterval))
 
+	// update pipeline status to running
+	pr.UpdatePipelineToRunning(ctx, p)
+}
+
+func (pr *defaultPipelineReconciler) UpdatePipelineToRunning(ctx context.Context, p *spec.Pipeline) {
 	// update pipeline status if necessary
 	// send event in a tx
 	if p.Status.AfterPipelineQueue() {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix the issue that totalTaskNum is unset if pipeline is already in running status


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix the issue that totalTaskNum is unset if pipeline is already in running status            |
| 🇨🇳 中文    |   修复了当流水线状态为运行中时，totalTaskNum 未设置的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
