### PR TITLE
feat(pipeline): pipeline edge cron

### DIFF
--- a/.erda/migrations/pipeline/20220427-pipeline-edge-cron.sql
+++ b/.erda/migrations/pipeline/20220427-pipeline-edge-cron.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pipeline_crons` ADD COLUMN `is_edge` TINYINT(1) COMMENT '是否是边缘集群';

--- a/apistructs/pipeline.go
+++ b/apistructs/pipeline.go
@@ -611,16 +611,6 @@ type PipelineCronListResponse struct {
 	Data []PipelineCronDTO `json:"data"`
 }
 
-type PipelineCronStartResponse struct {
-	Header
-	Data *PipelineCronDTO `json:"data"`
-}
-
-type PipelineCronStopResponse struct {
-	Header
-	Data *PipelineCronDTO `json:"data"`
-}
-
 // pipeline operate
 
 type PipelineGetBranchRuleResponse struct {
@@ -764,11 +754,6 @@ type PipelineStatisticResponseData struct {
 
 type PipelineDeleteResponse struct {
 	Header
-}
-
-type PipelineCronGetResponse struct {
-	Header
-	Data *PipelineCronDTO `json:"data"`
 }
 
 type PipelineDefinitionExtraValue struct {

--- a/apistructs/pipeline_cron.go
+++ b/apistructs/pipeline_cron.go
@@ -16,6 +16,8 @@ package apistructs
 
 import (
 	"time"
+
+	"github.com/erda-project/erda-proto-go/core/pipeline/pb"
 )
 
 type PipelineCronPagingRequest struct {
@@ -62,9 +64,28 @@ type PipelineCronDTO struct {
 
 type PipelineCronCreateResponse struct {
 	Header
-	Data uint64 `json:"data"` // cronID
+	Data *pb.Cron `json:"data"`
+}
+
+type PipelineCronUpdateResponse struct {
+	Header
+}
+
+type PipelineCronGetResponse struct {
+	Header
+	Data *pb.Cron `json:"data"`
 }
 
 type PipelineCronDeleteResponse struct {
 	Header
+}
+
+type PipelineCronStartResponse struct {
+	Header
+	Data *pb.Cron `json:"data"`
+}
+
+type PipelineCronStopResponse struct {
+	Header
+	Data *pb.Cron `json:"data"`
 }

--- a/bundle/pipeline_cron.go
+++ b/bundle/pipeline_cron.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"fmt"
+
+	cronpb "github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
+	"github.com/erda-project/erda-proto-go/core/pipeline/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle/apierrors"
+	"github.com/erda-project/erda/pkg/http/httputil"
+)
+
+func (b *Bundle) CronCreate(req *cronpb.CronCreateRequest) (*pb.Cron, error) {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return nil, err
+	}
+	hc := b.hc
+
+	var createResp apistructs.PipelineCronCreateResponse
+	resp, err := hc.Post(host).Path("/api/pipeline-crons").
+		Header(httputil.InternalHeader, "bundle").JSONBody(req).Do().JSON(&createResp)
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !createResp.Success {
+		return nil, toAPIError(resp.StatusCode(), createResp.Error)
+	}
+
+	return createResp.Data, nil
+}
+
+func (b *Bundle) CronUpdate(req *cronpb.CronUpdateRequest) error {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return err
+	}
+	hc := b.hc
+
+	var createResp apistructs.PipelineCronUpdateResponse
+	resp, err := hc.Put(host).Path(fmt.Sprintf("/api/pipeline-crons/%v", req.CronID)).
+		Header(httputil.InternalHeader, "bundle").JSONBody(req).Do().JSON(&createResp)
+	if err != nil {
+		return apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !createResp.Success {
+		return toAPIError(resp.StatusCode(), createResp.Error)
+	}
+
+	return nil
+}
+
+func (b *Bundle) CronStart(req *cronpb.CronStartRequest) (*pb.Cron, error) {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return nil, err
+	}
+	hc := b.hc
+
+	var result apistructs.PipelineCronStartResponse
+	resp, err := hc.Put(host).Path(fmt.Sprintf("/api/pipeline-crons/%v/actions/start", req.CronID)).
+		Header(httputil.InternalHeader, "bundle").JSONBody(req).Do().JSON(&result)
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !result.Success {
+		return nil, toAPIError(resp.StatusCode(), result.Error)
+	}
+
+	return result.Data, nil
+}
+
+func (b *Bundle) CronStop(req *cronpb.CronStopRequest) (*pb.Cron, error) {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return nil, err
+	}
+	hc := b.hc
+
+	var result apistructs.PipelineCronStopResponse
+	resp, err := hc.Put(host).Path(fmt.Sprintf("/api/pipeline-crons/%v/actions/stop", req.CronID)).
+		Header(httputil.InternalHeader, "bundle").JSONBody(req).Do().JSON(&result)
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !result.Success {
+		return nil, toAPIError(resp.StatusCode(), result.Error)
+	}
+
+	return result.Data, nil
+}
+
+func (b *Bundle) GetCron(cronID uint64) (*pb.Cron, error) {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return nil, err
+	}
+	hc := b.hc
+
+	var cronResp apistructs.PipelineCronGetResponse
+	resp, err := hc.Get(host).Path(fmt.Sprintf("/api/pipeline-crons/%v", cronID)).
+		Header(httputil.InternalHeader, "bundle").Do().JSON(&cronResp)
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !cronResp.Success {
+		return nil, toAPIError(resp.StatusCode(), cronResp.Error)
+	}
+
+	return cronResp.Data, nil
+}
+
+func (b *Bundle) DeleteCron(cronID uint64) error {
+	host, err := b.urls.Pipeline()
+	if err != nil {
+		return err
+	}
+	hc := b.hc
+
+	var cronResp apistructs.PipelineCronDeleteResponse
+	resp, err := hc.Delete(host).Path(fmt.Sprintf("/api/pipeline-crons/%v", cronID)).
+		Header(httputil.InternalHeader, "bundle").Do().JSON(&cronResp)
+	if err != nil {
+		return apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() || !cronResp.Success {
+		return toAPIError(resp.StatusCode(), cronResp.Error)
+	}
+
+	return nil
+}

--- a/modules/pipeline/providers/cron/compensator/provider.go
+++ b/modules/pipeline/providers/cron/compensator/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/dbclient"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/db"
+	"github.com/erda-project/erda/modules/pipeline/providers/edgepipeline_register"
 	"github.com/erda-project/erda/modules/pipeline/providers/leaderworker"
 	"github.com/erda-project/erda/modules/pipeline/spec"
 	"github.com/erda-project/erda/pkg/jsonstore"
@@ -50,11 +51,12 @@ type config struct {
 
 // +provider
 type provider struct {
-	Log          logs.Logger
-	LeaderWorker leaderworker.Interface `autowired:"leader-worker"`
-	ETCD         etcd.Interface         // autowired
-	EtcdClient   *v3.Client
-	MySQL        mysqlxorm.Interface `autowired:"mysql-xorm"`
+	Log                  logs.Logger
+	LeaderWorker         leaderworker.Interface `autowired:"leader-worker"`
+	ETCD                 etcd.Interface         // autowired
+	EtcdClient           *v3.Client
+	MySQL                mysqlxorm.Interface `autowired:"mysql-xorm"`
+	EdgePipelineRegister edgepipeline_register.Interface
 
 	jsonStore    jsonstore.JsonStore
 	dbClient     *dbclient.Client
@@ -511,8 +513,13 @@ func (p *provider) createCronCompensatePipeline(ctx context.Context, pc db.Pipel
 	})
 }
 
-// isCronShouldIgnore if trigger time before cron start from time, should ignore cron at this trigger time
+// isCronShouldIgnore If the cron trigger time is not triggered at this time or does not belong to this edge cluster, it should be skipped
 func (p *provider) isCronShouldBeIgnored(pc db.PipelineCron) bool {
+	ok := p.EdgePipelineRegister.ShouldDispatchToEdge(pc.PipelineSource.String(), pc.Extra.ClusterName)
+	if ok {
+		return true
+	}
+
 	if pc.Extra.CronStartFrom == nil {
 		return false
 	}

--- a/modules/pipeline/providers/cron/cron.service.go
+++ b/modules/pipeline/providers/cron/cron.service.go
@@ -89,6 +89,12 @@ func (s *provider) CronCreate(ctx context.Context, req *pb.CronCreateRequest) (*
 	}
 
 	err = Transaction(s.dbClient, func(op mysqlxorm.SessionOption) error {
+
+		toEdge := s.EdgePipelineRegister.ShouldDispatchToEdge(createCron.PipelineSource.String(), createCron.Extra.ClusterName)
+		if toEdge || s.EdgePipelineRegister.IsEdge() {
+			createCron.IsEdge = true
+		}
+
 		if req.CronExpr != "" {
 			err = s.InsertOrUpdatePipelineCron(createCron, op)
 		} else {
@@ -97,10 +103,25 @@ func (s *provider) CronCreate(ctx context.Context, req *pb.CronCreateRequest) (*
 		if err != nil {
 			return err
 		}
+
 		req.ID = createCron.ID
 		if err := s.Daemon.AddIntoPipelineCrond(createCron); err != nil {
 			return err
 		}
+
+		if toEdge {
+			bdl, err := s.EdgePipelineRegister.GetEdgeBundleByClusterName(createCron.Extra.ClusterName)
+			if err != nil {
+				s.Log.Errorf("GetEdgeBundleByClusterName error %v", err)
+				return err
+			}
+			_, err = bdl.CronCreate(req)
+			if err != nil {
+				s.Log.Errorf("edge bdl CronCreate error %v", err)
+				return err
+			}
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -189,12 +210,37 @@ func (s *provider) operate(cronID uint64, enable bool) (*common.Cron, error) {
 	}
 
 	err = Transaction(s.dbClient, func(option mysqlxorm.SessionOption) error {
+
 		if err = s.dbClient.UpdatePipelineCron(cron.ID, &cron, option); err != nil {
 			return apierrors.ErrOperatePipeline.InternalError(err)
 		}
 
 		if err := s.Daemon.AddIntoPipelineCrond(&cron); err != nil {
 			return apierrors.ErrReloadCrond.InternalError(err)
+		}
+
+		toEdge := s.EdgePipelineRegister.ShouldDispatchToEdge(cron.PipelineSource.String(), cron.Extra.ClusterName)
+
+		if toEdge {
+			bdl, err := s.EdgePipelineRegister.GetEdgeBundleByClusterName(cron.Extra.ClusterName)
+			if err != nil {
+				s.Log.Errorf("GetEdgeBundleByClusterName error %v", err)
+				return err
+			}
+
+			if enable {
+				_, err = bdl.CronStart(&pb.CronStartRequest{
+					CronID: cron.ID,
+				})
+			} else {
+				_, err = bdl.CronStop(&pb.CronStopRequest{
+					CronID: cron.ID,
+				})
+			}
+			if err != nil {
+				s.Log.Errorf("edge bdl operate error %v enable %v", err, enable)
+				return err
+			}
 		}
 		return nil
 	})
@@ -207,27 +253,47 @@ func (s *provider) operate(cronID uint64, enable bool) (*common.Cron, error) {
 func (s *provider) CronDelete(ctx context.Context, req *pb.CronDeleteRequest) (*pb.CronDeleteResponse, error) {
 
 	err := Transaction(s.dbClient, func(option mysqlxorm.SessionOption) error {
-		cron, found, err := s.dbClient.GetPipelineCron(req.CronID, option)
-		if err != nil {
-			return apierrors.ErrDeletePipelineCron.InvalidParameter(err)
-		}
-		if !found {
-			return apierrors.ErrDeletePipelineCron.InvalidParameter(fmt.Errorf("not found"))
-		}
-
-		if err := s.dbClient.DeletePipelineCron(cron.ID, option); err != nil {
-			return apierrors.ErrDeletePipelineCron.InternalError(err)
-		}
-
-		if err := s.Daemon.DeleteFromPipelineCrond(&cron); err != nil {
-			return apierrors.ErrDeletePipelineCron.InternalError(err)
-		}
-		return nil
+		return s.delete(req, option)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return &pb.CronDeleteResponse{}, nil
+}
+
+func (s *provider) delete(req *pb.CronDeleteRequest, option mysqlxorm.SessionOption) error {
+	cron, found, err := s.dbClient.GetPipelineCron(req.CronID, option)
+	if err != nil {
+		return apierrors.ErrDeletePipelineCron.InvalidParameter(err)
+	}
+	if !found {
+		return apierrors.ErrDeletePipelineCron.InvalidParameter(fmt.Errorf("not found"))
+	}
+
+	if err := s.dbClient.DeletePipelineCron(cron.ID, option); err != nil {
+		return apierrors.ErrDeletePipelineCron.InternalError(err)
+	}
+
+	if err := s.Daemon.DeleteFromPipelineCrond(&cron); err != nil {
+		return apierrors.ErrDeletePipelineCron.InternalError(err)
+	}
+
+	toEdge := s.EdgePipelineRegister.ShouldDispatchToEdge(cron.PipelineSource.String(), cron.Extra.ClusterName)
+
+	if toEdge {
+		bdl, err := s.EdgePipelineRegister.GetEdgeBundleByClusterName(cron.Extra.ClusterName)
+		if err != nil {
+			s.Log.Errorf("GetEdgeBundleByClusterName error %v", err)
+			return err
+		}
+
+		err = bdl.DeleteCron(cron.ID)
+		if err != nil {
+			s.Log.Errorf("edge bdl DeleteCron error %v", err)
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *provider) CronGet(ctx context.Context, req *pb.CronGetRequest) (*pb.CronGetResponse, error) {
@@ -277,20 +343,45 @@ func (s *provider) CronUpdate(ctx context.Context, req *pb.CronUpdateRequest) (*
 	}
 
 	err = Transaction(s.dbClient, func(option mysqlxorm.SessionOption) error {
-		err = s.dbClient.UpdatePipelineCronWillUseDefault(cron.ID, &cron, fields, option)
-		if err != nil {
-			return apierrors.ErrUpdatePipelineCron.InternalError(err)
-		}
-
-		if err := s.Daemon.AddIntoPipelineCrond(&cron); err != nil {
-			return apierrors.ErrUpdatePipelineCron.InternalError(err)
-		}
-		return nil
+		return s.update(req, cron, fields, option)
 	})
 	if err != nil {
 		return nil, err
 	}
 	return &pb.CronUpdateResponse{}, nil
+}
+
+func (s *provider) update(req *pb.CronUpdateRequest, cron db.PipelineCron, fields []string, option mysqlxorm.SessionOption) error {
+	toEdge := s.EdgePipelineRegister.ShouldDispatchToEdge(cron.PipelineSource.String(), cron.Extra.ClusterName)
+
+	if toEdge || s.EdgePipelineRegister.IsEdge() {
+		fields = append(fields, spec.PipelineCronIsEdge)
+		cron.IsEdge = true
+	}
+
+	err := s.dbClient.UpdatePipelineCronWillUseDefault(cron.ID, &cron, fields, option)
+	if err != nil {
+		return apierrors.ErrUpdatePipelineCron.InternalError(err)
+	}
+
+	if err := s.Daemon.AddIntoPipelineCrond(&cron); err != nil {
+		return apierrors.ErrUpdatePipelineCron.InternalError(err)
+	}
+
+	if toEdge {
+		bdl, err := s.EdgePipelineRegister.GetEdgeBundleByClusterName(cron.Extra.ClusterName)
+		if err != nil {
+			s.Log.Errorf("GetEdgeBundleByClusterName error %v", err)
+			return err
+		}
+
+		err = bdl.CronUpdate(req)
+		if err != nil {
+			s.Log.Errorf("edge bdl CronUpdate error %v", err)
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *provider) InsertOrUpdatePipelineCron(new *db.PipelineCron, ops ...mysqlxorm.SessionOption) error {
@@ -348,8 +439,10 @@ func (s *provider) InsertOrUpdatePipelineCron(new *db.PipelineCron, ops ...mysql
 func (s *provider) disable(cron *db.PipelineCron, option mysqlxorm.SessionOption) error {
 	var disable = false
 	var updateCron = &db.PipelineCron{}
-	var columns = []string{spec.PipelineCronCronExpr, spec.PipelineCronEnable}
+	var columns = []string{spec.PipelineCronCronExpr, spec.PipelineCronEnable, spec.PipelineCronIsEdge}
 	var err error
+
+	updateCron.IsEdge = cron.IsEdge
 
 	queryV1 := &db.PipelineCron{
 		ApplicationID:   cron.ApplicationID,

--- a/modules/pipeline/providers/cron/cron.service_test.go
+++ b/modules/pipeline/providers/cron/cron.service_test.go
@@ -16,6 +16,7 @@ package cron
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -30,8 +31,71 @@ import (
 	"github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
 	. "github.com/erda-project/erda-proto-go/core/pipeline/pb"
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/modules/pipeline/providers/cron/daemon"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/db"
 )
+
+type daemonInterface struct {
+}
+
+func (d daemonInterface) AddIntoPipelineCrond(cron *db.PipelineCron) error {
+	return nil
+}
+
+func (d daemonInterface) DeleteFromPipelineCrond(cron *db.PipelineCron) error {
+	return nil
+}
+
+func (d daemonInterface) ReloadCrond(ctx context.Context) ([]string, error) {
+	panic("implement me")
+}
+
+func (d daemonInterface) CrondSnapshot() []string {
+	panic("implement me")
+}
+
+func (d daemonInterface) WithPipelineFunc(createPipelineFunc daemon.CreatePipelineFunc) {
+	panic("implement me")
+}
+
+type EdgePipelineRegisterImpl struct {
+	ShouldDispatchToEdgeResult    bool
+	GetEdgeBundleByClusterNameBdl *bundle.Bundle
+	GetEdgeBundleByClusterNameErr error
+}
+
+func (e EdgePipelineRegisterImpl) GetAccessToken(req apistructs.OAuth2TokenGetRequest) (*apistructs.OAuth2Token, error) {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) GetOAuth2Token(req apistructs.OAuth2TokenGetRequest) (*apistructs.OAuth2Token, error) {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) GetEdgePipelineEnvs() apistructs.ClusterDialerClientDetail {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) CheckAccessToken(token string) error {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) CheckAccessTokenFromHttpRequest(req *http.Request) error {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) IsEdge() bool {
+	panic("implement me")
+}
+
+func (e EdgePipelineRegisterImpl) ShouldDispatchToEdge(source, clusterName string) bool {
+	return e.ShouldDispatchToEdgeResult
+}
+
+func (e EdgePipelineRegisterImpl) GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error) {
+	return e.GetEdgeBundleByClusterNameBdl, e.GetEdgeBundleByClusterNameErr
+}
 
 func Test_provider_CronCreate(t *testing.T) {
 	type args struct {
@@ -499,7 +563,7 @@ func Test_provider_CronUpdate(t *testing.T) {
 		{
 			name: "cron not find",
 			result: result{
-				bool: false,
+				bool: true,
 			},
 			args: args{
 				ctx: nil,
@@ -530,6 +594,121 @@ func Test_provider_CronUpdate(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CronUpdate() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_provider_cronDelete(t *testing.T) {
+	type args struct {
+		req    *pb.CronDeleteRequest
+		option mysqlxorm.SessionOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test to edege",
+			args: args{
+				req: &pb.CronDeleteRequest{
+					CronID: 1,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &provider{}
+
+			var dbClient db.Client
+			patch2 := monkey.PatchInstanceMethod(reflect.TypeOf(&dbClient), "GetPipelineCron", func(dbClient *db.Client, id interface{}, ops ...mysqlxorm.SessionOption) (cron db.PipelineCron, bool bool, err error) {
+				cron.ID = tt.args.req.CronID
+				return cron, true, nil
+			})
+			defer patch2.Unpatch()
+
+			patch3 := monkey.PatchInstanceMethod(reflect.TypeOf(&dbClient), "DeletePipelineCron", func(dbClient *db.Client, id interface{}, ops ...mysqlxorm.SessionOption) error {
+				return nil
+			})
+			defer patch3.Unpatch()
+			s.dbClient = &dbClient
+
+			var bdl bundle.Bundle
+			patch4 := monkey.PatchInstanceMethod(reflect.TypeOf(&bdl), "DeleteCron", func(bdl *bundle.Bundle, cronID uint64) error {
+				assert.EqualValues(t, cronID, tt.args.req.CronID)
+				return nil
+			})
+			defer patch4.Unpatch()
+
+			var daemonInterface daemonInterface
+			s.Daemon = daemonInterface
+			s.EdgePipelineRegister = EdgePipelineRegisterImpl{
+				ShouldDispatchToEdgeResult:    true,
+				GetEdgeBundleByClusterNameBdl: &bdl,
+				GetEdgeBundleByClusterNameErr: nil,
+			}
+
+			if err := s.delete(tt.args.req, tt.args.option); (err != nil) != tt.wantErr {
+				t.Errorf("cronDelete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_provider_update(t *testing.T) {
+	type args struct {
+		req    *pb.CronUpdateRequest
+		cron   db.PipelineCron
+		fields []string
+		option mysqlxorm.SessionOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test to edge",
+			args: args{
+				req: &pb.CronUpdateRequest{
+					CronID: 2,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &provider{}
+
+			var dbClient db.Client
+			patch2 := monkey.PatchInstanceMethod(reflect.TypeOf(&dbClient), "UpdatePipelineCronWillUseDefault", func(dbClient *db.Client, id interface{}, cron *db.PipelineCron, columns []string, ops ...mysqlxorm.SessionOption) error {
+				return nil
+			})
+			defer patch2.Unpatch()
+			s.dbClient = &dbClient
+
+			var daemonInterface daemonInterface
+			s.Daemon = daemonInterface
+
+			var bdl bundle.Bundle
+			patch3 := monkey.PatchInstanceMethod(reflect.TypeOf(&bdl), "CronUpdate", func(bdl *bundle.Bundle, req *pb.CronUpdateRequest) error {
+				assert.EqualValues(t, req, tt.args.req)
+				return nil
+			})
+			defer patch3.Unpatch()
+
+			s.EdgePipelineRegister = EdgePipelineRegisterImpl{
+				ShouldDispatchToEdgeResult:    true,
+				GetEdgeBundleByClusterNameBdl: &bdl,
+				GetEdgeBundleByClusterNameErr: nil,
+			}
+
+			if err := s.update(tt.args.req, tt.args.cron, tt.args.fields, tt.args.option); (err != nil) != tt.wantErr {
+				t.Errorf("update() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/modules/pipeline/providers/cron/daemon/cron_task.go
+++ b/modules/pipeline/providers/cron/daemon/cron_task.go
@@ -24,7 +24,10 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	cronpb "github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/modules/pipeline/conf"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/db"
@@ -275,6 +278,19 @@ func (s *provider) reloadCrond(ctx context.Context) ([]string, error) {
 	for i := range pcs {
 		pc := pcs[i]
 		if pc.Enable != nil && *pc.Enable && pc.CronExpr != "" {
+
+			ok := s.EdgePipelineRegister.ShouldDispatchToEdge(pc.PipelineSource.String(), pc.Extra.ClusterName)
+			if ok {
+				err := s.syncCronToEdge(pc)
+				if err != nil {
+					logrus.Errorf("failed to syncCronToEdge error %v", err)
+				}
+				continue
+			}
+			if pc.IsEdge != s.EdgePipelineRegister.IsEdge() {
+				continue
+			}
+
 			if err = s.crond.AddFunc(pc.CronExpr, func() { s.runCronPipelineFunc(ctx, pc.ID) }, makePipelineCronName(pc.ID)); err != nil {
 				l := fmt.Sprintf("failed to load pipeline cron item: %s, cronExpr: %v, err: %v", makePipelineCronName(pc.ID), pc.CronExpr, err)
 				logs = append(logs, l)
@@ -299,6 +315,47 @@ func (s *provider) reloadCrond(ctx context.Context) ([]string, error) {
 	logs = append(logs, s.crondSnapshot()...)
 
 	return logs, nil
+}
+
+func (s *provider) syncCronToEdge(dbCron db.PipelineCron) error {
+	pc := dbCron
+	bdl, err := s.EdgePipelineRegister.GetEdgeBundleByClusterName(dbCron.Extra.ClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to GetEdgeBundleByClusterName error %v", err)
+	}
+
+	edgeCron, err := bdl.GetCron(pc.ID)
+	if err != nil {
+		return fmt.Errorf("failed to GetCron error %v", err)
+	}
+
+	if edgeCron == nil {
+		_, err := bdl.CronCreate(&cronpb.CronCreateRequest{
+			ID:                     pc.ID,
+			CronExpr:               pc.CronExpr,
+			PipelineYmlName:        pc.PipelineYmlName,
+			PipelineSource:         pc.PipelineSource.String(),
+			Enable:                 wrapperspb.Bool(*pc.Enable),
+			PipelineYml:            pc.Extra.PipelineYml,
+			ClusterName:            pc.Extra.ClusterName,
+			FilterLabels:           pc.Extra.FilterLabels,
+			NormalLabels:           pc.Extra.NormalLabels,
+			Envs:                   pc.Extra.Envs,
+			ConfigManageNamespaces: pc.Extra.ConfigManageNamespaces,
+			CronStartFrom: func() *timestamppb.Timestamp {
+				if pc.Extra.CronStartFrom == nil {
+					return nil
+				}
+				return timestamppb.New(*pc.Extra.CronStartFrom)
+			}(),
+			IncomingSecrets:      pc.Extra.IncomingSecrets,
+			PipelineDefinitionID: pc.PipelineDefinitionID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to CreateCron error %v", err)
+		}
+	}
+	return nil
 }
 
 func (s *provider) cleanBuildCacheImages() {

--- a/modules/pipeline/providers/cron/db/define.go
+++ b/modules/pipeline/providers/cron/db/define.go
@@ -46,6 +46,8 @@ type PipelineCron struct {
 	BasePipelineID uint64 `json:"basePipelineID"` // 用于记录最开始创建出这条 cron 记录的 pipeline id
 	// definition id
 	PipelineDefinitionID string `json:"pipelineDefinitionID"`
+
+	IsEdge bool `json:"is_edge"`
 }
 
 // PipelineCronExtra cron 扩展信息, 不参与过滤
@@ -114,6 +116,7 @@ func (pc *PipelineCron) Convert2DTO() *pb.Cron {
 		OrgID:                  pc.GetOrgID(),
 		PipelineDefinitionID:   pc.PipelineDefinitionID,
 		PipelineSource:         pc.PipelineSource.String(),
+		IsEdge:                 wrapperspb.Bool(pc.IsEdge),
 	}
 
 	extra := &pb.CronExtra{

--- a/modules/pipeline/providers/cron/db/define_test.go
+++ b/modules/pipeline/providers/cron/db/define_test.go
@@ -105,6 +105,7 @@ func TestPipelineCron_Convert2DTO(t *testing.T) {
 				Branch:               "test",
 				BasePipelineID:       1,
 				PipelineDefinitionID: "test",
+				IsEdge:               true,
 			},
 			want: &pb.Cron{
 				ID:                     1,
@@ -126,6 +127,7 @@ func TestPipelineCron_Convert2DTO(t *testing.T) {
 				Secrets: map[string]string{
 					"test": "test",
 				},
+				IsEdge: wrapperspb.Bool(true),
 				Extra: &pb.CronExtra{
 					PipelineYml: "test",
 					ClusterName: "test",

--- a/modules/pipeline/providers/cron/provider.go
+++ b/modules/pipeline/providers/cron/provider.go
@@ -22,6 +22,7 @@ import (
 	pb "github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/daemon"
 	"github.com/erda-project/erda/modules/pipeline/providers/cron/db"
+	"github.com/erda-project/erda/modules/pipeline/providers/edgepipeline_register"
 	"github.com/erda-project/erda/modules/pipeline/providers/leaderworker"
 )
 
@@ -37,8 +38,9 @@ type provider struct {
 	MySQL        mysqlxorm.Interface    `autowired:"mysql-xorm"`
 	LeaderWorker leaderworker.Interface `autowired:"leader-worker"`
 
-	Daemon   daemon.Interface
-	dbClient *db.Client
+	Daemon               daemon.Interface
+	dbClient             *db.Client
+	EdgePipelineRegister edgepipeline_register.Interface
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {

--- a/modules/pipeline/spec/pipeline_cron.go
+++ b/modules/pipeline/spec/pipeline_cron.go
@@ -27,6 +27,7 @@ const (
 	PipelineDefinitionID = "pipeline_definition_id"
 	PipelineCronEnable   = "enable"
 	Extra                = "extra"
+	PipelineCronIsEdge   = "is_edge"
 )
 
 type PipelineCron struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
The pipeline edge cron, synchronizes the cron data between the pipeline at the center and the pipeline at the edge

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc4LDExNzQsMTE5MF0sImFzc2lnbmVlIjpbIjEwMDA1NjAiXX0%3D&id=300218&iterationID=1174&pId=301655&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Synchronize cron information between center pipeline and edge pipeline      |
| 🇨🇳 中文    |        中心 pipeline 和边缘 pipeline 同步 cron 信息      |

