### PR TITLE
fix(pipeline): Move the api-test code location to fix null pointer exception

### DIFF
--- a/pkg/apitestsv2/apitest.go
+++ b/pkg/apitestsv2/apitest.go
@@ -182,16 +182,17 @@ func (at *APITest) Invoke(httpClient *http.Client, testEnv *apistructs.APITestEn
 			reqBody = fmt.Sprint(at.API.Body.Content)
 		}
 	}
+	// headers
+	if apiReq.Headers == nil {
+		apiReq.Headers = make(http.Header)
+	}
+
 	apiReq.Body.Type = at.API.Body.Type
 	if apiReq.Body.Type != "" && apiReq.Body.Type != apistructs.APIBodyTypeNone {
 		apiReq.Headers.Set("Content-Type", apiReq.Body.Type.String())
 	}
 	apiReq.Body.Content = reqBody
 
-	// headers
-	if apiReq.Headers == nil {
-		apiReq.Headers = make(http.Header)
-	}
 	if testEnv != nil && testEnv.Header != nil {
 		for k, v := range testEnv.Header {
 			apiReq.Headers.Set(strings.TrimSpace(k), strings.TrimSpace(v))


### PR DESCRIPTION
#### What this PR does / why we need it:
Move the api-test code location to fix null pointer exception

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTkwLDExNzQsMTIxOF0sImFzc2lnbmVlIjpbIjEwMDA1NjAiXX0%3D&id=306533&iterationID=1174&pId=0&type=BUG)

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Move the api-test code location to fix null pointer exception        |
| 🇨🇳 中文    |       移动api-test代码位置，修复空指针异常       |

