### PR TITLE
fix: edge register bundle `IsClusterDialerClientRegistered` force use client type

### DIFF
--- a/bundle/cluster_dialer.go
+++ b/bundle/cluster_dialer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/erda-project/erda/bundle/apierrors"
 )
 
-func (b *Bundle) IsClusterDialerClientRegistered(clientType string, clusterKey string) (bool, error) {
+func (b *Bundle) IsClusterDialerClientRegistered(clientType apistructs.ClusterDialerClientType, clusterKey string) (bool, error) {
 	host, err := b.urls.ClusterDialer()
 	if err != nil {
 		return false, err
@@ -32,7 +32,7 @@ func (b *Bundle) IsClusterDialerClientRegistered(clientType string, clusterKey s
 	var getResp bool
 	resp, err := hc.Get(host).
 		Path("/clusteragent/check").
-		Param("clientType", clientType).
+		Param("clientType", clientType.String()).
 		Param("clusterKey", clusterKey).
 		Do().
 		JSON(&getResp)
@@ -45,7 +45,7 @@ func (b *Bundle) IsClusterDialerClientRegistered(clientType string, clusterKey s
 	return getResp, nil
 }
 
-func (b *Bundle) GetClusterDialerClientData(clientType string, clusterKey string) (apistructs.ClusterDialerClientDetail, error) {
+func (b *Bundle) GetClusterDialerClientData(clientType apistructs.ClusterDialerClientType, clusterKey string) (apistructs.ClusterDialerClientDetail, error) {
 	host, err := b.urls.ClusterDialer()
 	if err != nil {
 		return apistructs.ClusterDialerClientDetail{}, err

--- a/modules/pipeline/providers/edgepipeline_register/interface.go
+++ b/modules/pipeline/providers/edgepipeline_register/interface.go
@@ -60,7 +60,7 @@ func (p *provider) ShouldDispatchToEdge(source, clusterName string) bool {
 	if !findInWhitelist {
 		return false
 	}
-	isEdge, err := p.bdl.IsClusterDialerClientRegistered(clusterName, apistructs.ClusterDialerClientTypePipeline.String())
+	isEdge, err := p.bdl.IsClusterDialerClientRegistered(apistructs.ClusterDialerClientTypePipeline, clusterName)
 	if !isEdge || err != nil {
 		return false
 	}
@@ -75,7 +75,7 @@ func (p *provider) GetDialContextByClusterName(clusterName string) clusterdialer
 
 func (p *provider) GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error) {
 	edgeDial := p.GetDialContextByClusterName(clusterName)
-	edgeDetail, err := p.bdl.GetClusterDialerClientData(apistructs.ClusterDialerClientTypePipeline.String(), clusterName)
+	edgeDetail, err := p.bdl.GetClusterDialerClientData(apistructs.ClusterDialerClientTypePipeline, clusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get edge bundle for cluster %s, err: %v", clusterName, err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
edge register bundle `IsClusterDialerClientRegistered` force use client type


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that edge register bundle `IsClusterDialerClientRegistered` force use client type（强制dialer的一些bundle使用类型参数）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that edge register bundle `IsClusterDialerClientRegistered` force use client type           |
| 🇨🇳 中文    |     强制dialer的一些bundle使用类型参数         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
