### PR TITLE
Add bug reopen count in issue table and export excel, set bug owner b…

### DIFF
--- a/apistructs/issue.go
+++ b/apistructs/issue.go
@@ -64,6 +64,7 @@ type Issue struct {
 
 	TestPlanCaseRels []TestPlanCaseRel `json:"testPlanCaseRels"`
 	relatedIssueIDs  []uint64
+	ReopenCount      int
 }
 
 // GetStage 获取任务状态或者Bug阶段

--- a/conf/dop/i18n/cp/common.yaml
+++ b/conf/dop/i18n/cp/common.yaml
@@ -320,6 +320,7 @@ zh:
   sourceFile: 源文件
   updateName: 编辑名称
   update: 编辑
+  reopenCount: 重新打开次数
 
 en:
   issue-manage: issue manage
@@ -650,3 +651,4 @@ en:
   running duration: Deployment time
   deployTime: Deployment time
   restart: Restart
+  reopenCount: Reopen count

--- a/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
+++ b/modules/dop/component-protocol/components/issue-manage/issueTable/render.go
@@ -126,11 +126,17 @@ type TableItem struct {
 	Complexity  Complexity `json:"complexity,omitempty"`
 	State       State      `json:"state"`
 	// Title       Title      `json:"title"`
-	Type     string   `json:"type"`
-	Deadline Deadline `json:"deadline"`
-	Assignee Assignee `json:"assignee"`
-	ClosedAt ClosedAt `json:"closedAt"`
-	Name     Name     `json:"name"`
+	Type        string    `json:"type"`
+	Deadline    Deadline  `json:"deadline"`
+	Assignee    Assignee  `json:"assignee"`
+	ClosedAt    ClosedAt  `json:"closedAt"`
+	Name        Name      `json:"name"`
+	ReopenCount TextBlock `json:"reopenCount,omitempty"`
+}
+
+type TextBlock struct {
+	Value      string `json:"value"`
+	RenderType string `json:"renderType"`
 }
 
 type Name struct {
@@ -484,9 +490,11 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 	}
 
 	severityCol, closedAtCol := "", ""
+	reopenCountCol := ""
 	if len(cond.Type) == 1 && cond.Type[0] == apistructs.IssueTypeBug {
 		severityCol = `{ "title": "` + cputil.I18n(ctx, "severity") + `", "dataIndex": "severity", "hidden": false },`
 		closedAtCol = `,{ "title": "` + cputil.I18n(ctx, "closed-at") + `", "dataIndex": "closedAt", "hidden": true }`
+		reopenCountCol = `,{ "title": "` + cputil.I18n(ctx, "reopenCount") + `", "dataIndex": "reopenCount", "hidden": true }`
 	}
 	props := `{
     "columns": [
@@ -522,7 +530,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
             "dataIndex": "deadline",
             "title": "` + cputil.I18n(ctx, "deadline") + `"
         }` +
-		closedAtCol +
+		closedAtCol + reopenCountCol +
 		`],
     "rowKey": "id",
 	"pageSizeOptions": ["10", "20", "50", "100"]
@@ -790,6 +798,10 @@ func (ca *ComponentAction) buildTableItem(ctx context.Context, data *apistructs.
 		Name:     nameColumn,
 		Deadline: deadline,
 		ClosedAt: closedAt,
+		ReopenCount: TextBlock{
+			RenderType: "text",
+			Value:      fmt.Sprintf("%d", data.ReopenCount),
+		},
 	}
 }
 

--- a/modules/dop/services/issue/convert.go
+++ b/modules/dop/services/issue/convert.go
@@ -196,6 +196,7 @@ func (svc *Issue) ConvertWithoutButton(model dao.Issue,
 		BugStage:       bugStage,
 		TaskType:       taskType,
 		FinishTime:     model.FinishTime,
+		ReopenCount:    model.ReopenCount,
 	}
 }
 
@@ -331,6 +332,7 @@ func (svc *Issue) convertIssueToExcelList(issues []apistructs.Issue, property []
 			i.ManHour.GetFormartTime("EstimateTime"),
 			finishTime,
 			planStartedAt,
+			fmt.Sprintf("%d", i.ReopenCount),
 		}))
 		relations := propertyMap[i.ID]
 		// 获取每个自定义字段的值
@@ -515,12 +517,14 @@ func (svc *Issue) decodeFromExcelFile(req apistructs.IssueImportExcelRequest, r 
 			issue.PlanStartedAt = &planStartAt
 		}
 
+		// row[20] reopen count, jump over
+
 		// 获取自定义字段
 		relation := apistructs.IssuePropertyRelationCreateRequest{
 			OrgID:     req.OrgID,
 			ProjectID: int64(req.ProjectID),
 		}
-		if len(row) >= 21 {
+		if len(row) >= 22 {
 			for indexx, line := range row[20:] {
 				index := indexx + 20
 				// 获取字段名对应的字段

--- a/pkg/erda-configs/i18n/issue.json
+++ b/pkg/erda-configs/i18n/issue.json
@@ -1,12 +1,12 @@
 
 {
     "zh-CN": {
-      "IssueExportTitle": "ID,标题,内容,状态,创建人,处理人,负责人,任务类型或缺陷引入源,优先级,所属迭代,复杂度,严重程度,标签,类型,截止时间,创建时间,被以下事项关联,预估时间,关闭时间,开始时间",
-      "IssueExportSample": ",样例标题,样例内容,待处理,2,2, ,设计,中,1.0,中,一般,,任务,2021-02-01 00:00:00,2021-01-01 09:30:42,,,,"
+      "IssueExportTitle": "ID,标题,内容,状态,创建人,处理人,负责人,任务类型或缺陷引入源,优先级,所属迭代,复杂度,严重程度,标签,类型,截止时间,创建时间,被以下事项关联,预估时间,关闭时间,开始时间,重新打开次数",
+      "IssueExportSample": ",样例标题,样例内容,待处理,2,2, ,设计,中,1.0,中,一般,,任务,2021-02-01 00:00:00,2021-01-01 09:30:42,,,,,"
 
     },
     "en-US": {
-        "IssueExportTitle": "ID,Title,Content,State,Creator,Assignee,Director,Task Type,Priority,Iteration,Complexity,Severity,Label,Type,End Time,Created Time,Associated by the following,Estimate time,Closing time,Start time",
-        "IssueExportSample": ",Sample Title,Sample Content,OPENING,2,2,,Design,Medium,1.0,Medium,Ordinary,,Task,2021-02-01 00:00:00,2021-01-01 09:30:42,,,,"
+        "IssueExportTitle": "ID,Title,Content,State,Creator,Assignee,Director,Task Type,Priority,Iteration,Complexity,Severity,Label,Type,End Time,Created Time,Associated by the following,Estimate time,Closing time,Start time,Reopen count",
+        "IssueExportSample": ",Sample Title,Sample Content,OPENING,2,2,,Design,Medium,1.0,Medium,Ordinary,,Task,2021-02-01 00:00:00,2021-01-01 09:30:42,,,,,"
     }
   }


### PR DESCRIPTION
…y state.

#### What this PR does / why we need it:
Add bug reopen count in issue table and export excel, set bug owner by state.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTc4LDExNzQsMTE5MCwxMjE4LDEyMjRdLCJhc3NpZ25lZSI6WyIxMDAxMDczIl19&id=307297&iterationID=1190&pId=0&type=REQUIREMENT)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Add bug reopen count in issue table and export excel, set bug owner by state.          |
| 🇨🇳 中文    |     事项列表和导出增加缺陷重新打开数， 缺陷责任人根据状态变化         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
