### PR TITLE
fix(dop): set api-spec-id  zero when export scene step

### DIFF
--- a/modules/dop/services/autotest_v2/space_data.go
+++ b/modules/dop/services/autotest_v2/space_data.go
@@ -304,7 +304,8 @@ func (a *AutoTestSpaceData) addSceneStepToExcel(file *excel.XlsxFile) error {
 				excel.NewCell(strutil.String(step.SceneID)),
 				excel.NewCell(strutil.String(step.SpaceID)),
 				excel.NewCell(strutil.String(step.PreType)),
-				excel.NewCell(strutil.String(step.APISpecID)),
+				// set api spec id zero because api test markets are not exported
+				excel.NewCell("0"),
 				excel.NewCell(strutil.String(step.IsDisabled)),
 			})
 			for _, pv := range step.Children {
@@ -317,7 +318,8 @@ func (a *AutoTestSpaceData) addSceneStepToExcel(file *excel.XlsxFile) error {
 					excel.NewCell(strutil.String(pv.SceneID)),
 					excel.NewCell(strutil.String(pv.SpaceID)),
 					excel.NewCell(strutil.String(pv.PreType)),
-					excel.NewCell(strutil.String(pv.APISpecID)),
+					// set api spec id zero because api test markets are not exported
+					excel.NewCell("0"),
 					excel.NewCell(strutil.String(pv.IsDisabled)),
 				})
 			}

--- a/modules/dop/services/autotest_v2/space_data_test.go
+++ b/modules/dop/services/autotest_v2/space_data_test.go
@@ -23,8 +23,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/modules/dop/dao"
 	"github.com/erda-project/erda/pkg/database/dbengine"
+	"github.com/erda-project/erda/pkg/excel"
+	"github.com/erda-project/erda/pkg/i18n"
 )
 
 func TestCopy(t *testing.T) {
@@ -156,5 +159,28 @@ func TestCopyScenes(t *testing.T) {
 	a.svc = autotestSvc
 
 	err := a.CopyScenes()
+	assert.NoError(t, err)
+}
+
+func Test_addSceneStepToExcel(t *testing.T) {
+	bdl := bundle.New(bundle.WithI18nLoader(&i18n.LocaleResourceLoader{}))
+	m := monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetLocale",
+		func(bdl *bundle.Bundle, local ...string) *i18n.LocaleResource {
+			return &i18n.LocaleResource{}
+		})
+	defer m.Unpatch()
+	ad := &AutoTestSpaceData{
+		svc: New(WithBundle(bdl)),
+		Steps: map[uint64][]apistructs.AutoTestSceneStep{
+			1: []apistructs.AutoTestSceneStep{
+				{
+					Name:      "step1",
+					APISpecID: 2,
+				},
+			},
+		},
+	}
+	f := excel.NewXLSXFile()
+	err := ad.addSceneStepToExcel(f)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
set api-spec-id  zero when export scene step

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=309640&iterationID=1174&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that autotest show step  api market error （修复了查看步骤详情错误）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that autotest show step  api market error             |
| 🇨🇳 中文    |  修复了查看步骤详情错误            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
