### PR TITLE
fix(pipeline): remove invalidate oauth2Token after pipeline task tear down

### DIFF
--- a/modules/pipeline/providers/reconciler/task_reconciler.go
+++ b/modules/pipeline/providers/reconciler/task_reconciler.go
@@ -325,9 +325,9 @@ func (tr *defaultTaskReconciler) TeardownAfterReconcileDone(ctx context.Context,
 	}
 
 	// invalidate openapi oauth2 token
+	// TODO Temporarily remove EnvOpenapiToken, this causes the deployment to not be canceled when pipeline is canceled. And its ttl is 3630s,
 	tokens := strutil.DedupSlice([]string{
 		task.Extra.PublicEnvs[apistructs.EnvOpenapiTokenForActionBootstrap],
-		task.Extra.PrivateEnvs[apistructs.EnvOpenapiToken],
 	}, true)
 	for _, token := range tokens {
 		_, err := tr.bdl.InvalidateOAuth2Token(apistructs.OAuth2TokenInvalidateRequest{AccessToken: token})


### PR DESCRIPTION
#### What this PR does / why we need it:
remove invalidate oauth2Token after pipeline task tear down，
this causes the deployment to not be canceled

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMTkwLDEyMThdLCJhc3NpZ25lZSI6WyIxMDAxMjYxIl19&id=309956&iterationID=1190&pId=0&type=BUG)


#### Specified Reviewers:

/assign #sfwn


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       remove invalidate oauth2Token after pipeline task tear down       |
| 🇨🇳 中文    |      pipeline取消的时候，取消删除oauth2Token       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
