### PR TITLE
fix(pipeline): The edge pipeline does not query the extension on dicehub

### DIFF
--- a/modules/pipeline/providers/actionmgr/common_test.go
+++ b/modules/pipeline/providers/actionmgr/common_test.go
@@ -132,3 +132,51 @@ func Test_provider_updateExtensionCache(t *testing.T) {
 		t.Fatalf("1.0 is default")
 	}
 }
+
+func Test_getActionNameVersion(t *testing.T) {
+	type args struct {
+		nameVersion string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 string
+	}{
+		{
+			name: "test default",
+			args: args{
+				nameVersion: "test@default",
+			},
+			want:  "test",
+			want1: "",
+		},
+		{
+			name: "test version",
+			args: args{
+				nameVersion: "test@1.0",
+			},
+			want1: "1.0",
+			want:  "test",
+		},
+		{
+			name: "test empty version",
+			args: args{
+				nameVersion: "test@",
+			},
+			want:  "test",
+			want1: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := getActionNameVersion(tt.args.nameVersion)
+			if got != tt.want {
+				t.Errorf("getActionNameVersion() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("getActionNameVersion() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/modules/pipeline/providers/actionmgr/db/client.go
+++ b/modules/pipeline/providers/actionmgr/db/client.go
@@ -256,7 +256,7 @@ func (client *Client) ListPipelineAction(req *pb.PipelineActionListRequest, ops 
 		engine = engine.Where(sqlBuild, args...)
 	}
 
-	engine = engine.OrderBy("created_at desc")
+	engine = engine.OrderBy("version_info desc")
 	err = engine.Find(&pipelineActions)
 	if err != nil {
 		return nil, err

--- a/modules/pipeline/providers/actionmgr/impl.go
+++ b/modules/pipeline/providers/actionmgr/impl.go
@@ -54,24 +54,7 @@ func (s *provider) SearchActions(items []string, locations []string, ops ...OpOp
 	}
 
 	// search from dicehub
-	notFindActionMap := make(map[string]apistructs.ExtensionVersion)
-	worker := limit_sync_group.NewWorker(5)
-	for _, nameVersion := range notFindNameVersion {
-		worker.AddFunc(func(locker *limit_sync_group.Locker, i ...interface{}) error {
-			nameVersion := i[0].(string)
-			action, ok := s.getOrUpdateExtensionFromCache(nameVersion)
-
-			locker.Lock()
-			defer locker.Unlock()
-
-			if ok {
-				notFindActionMap[nameVersion] = action
-			}
-			return nil
-		}, nameVersion)
-	}
-	worker.Do()
-
+	notFindActionMap := s.searchFromDiceHub(notFindNameVersion)
 	for key, notFindAction := range notFindActionMap {
 		pipelineActionMap[key] = notFindAction
 	}
@@ -81,9 +64,7 @@ func (s *provider) SearchActions(items []string, locations []string, ops ...OpOp
 	for _, nameVersion := range items {
 		action, ok := pipelineActionMap[nameVersion]
 		if !ok {
-			if len(locations) == 0 {
-				return nil, nil, errors.Errorf("failed to find action: %s", nameVersion)
-			}
+			return nil, nil, errors.Errorf("failed to find action: %s", nameVersion)
 		}
 
 		diceYmlStr, ok := action.Dice.(string)
@@ -128,6 +109,33 @@ func (s *provider) SearchActions(items []string, locations []string, ops ...OpOp
 	}
 
 	return actionDiceYmlJobMap, actionSpecMap, nil
+}
+
+func (s *provider) searchFromDiceHub(notFindNameVersion []string) map[string]apistructs.ExtensionVersion {
+	notFindActionMap := make(map[string]apistructs.ExtensionVersion)
+
+	if s.EdgeRegister.IsEdge() {
+		return notFindActionMap
+	}
+
+	worker := limit_sync_group.NewWorker(5)
+	for _, nameVersion := range notFindNameVersion {
+		worker.AddFunc(func(locker *limit_sync_group.Locker, i ...interface{}) error {
+			nameVersion := i[0].(string)
+			action, ok := s.getOrUpdateExtensionFromCache(nameVersion)
+
+			locker.Lock()
+			defer locker.Unlock()
+
+			if ok {
+				notFindActionMap[nameVersion] = action
+			}
+			return nil
+		}, nameVersion)
+	}
+	worker.Do()
+
+	return notFindActionMap
 }
 
 // MakeActionTypeVersion return ext item.

--- a/modules/pipeline/providers/actionmgr/impl_test.go
+++ b/modules/pipeline/providers/actionmgr/impl_test.go
@@ -15,14 +15,65 @@
 package actionmgr
 
 import (
+	"context"
+	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml"
 	"github.com/erda-project/erda/pkg/strutil"
 )
+
+type TestEdgePipelineRegister struct {
+}
+
+func (t TestEdgePipelineRegister) GetAccessToken(req apistructs.OAuth2TokenGetRequest) (*apistructs.OAuth2Token, error) {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) GetOAuth2Token(req apistructs.OAuth2TokenGetRequest) (*apistructs.OAuth2Token, error) {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) GetEdgePipelineEnvs() apistructs.ClusterDialerClientDetail {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) CheckAccessToken(token string) error {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) CheckAccessTokenFromHttpRequest(req *http.Request) error {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) IsEdge() bool {
+	return true
+}
+
+func (t TestEdgePipelineRegister) CanProxyToEdge(source apistructs.PipelineSource, clusterName string) bool {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error) {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) ClusterIsEdge(clusterName string) (bool, error) {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) OnEdge(f func(context.Context)) {
+	panic("implement me")
+}
+
+func (t TestEdgePipelineRegister) OnCenter(f func(context.Context)) {
+	panic("implement me")
+}
 
 func TestMakeActionTypeVersion(t *testing.T) {
 	p := &provider{}
@@ -118,5 +169,33 @@ func Test_provider_MakeActionLocationsBySource(t *testing.T) {
 				t.Fatalf("missing expected output location %s", el)
 			}
 		}
+	}
+}
+
+func Test_provider_searchFromDiceHub(t *testing.T) {
+	type args struct {
+		notFindNameVersion []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]apistructs.ExtensionVersion
+	}{
+		{
+			name: "test is edge return",
+			args: args{
+				notFindNameVersion: []string{"custom"},
+			},
+			want: map[string]apistructs.ExtensionVersion{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &provider{}
+			s.EdgeRegister = TestEdgePipelineRegister{}
+			if got := s.searchFromDiceHub(tt.args.notFindNameVersion); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("searchFromDiceHub() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
The edge pipeline does not query the extension on dicehub

#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       The edge pipeline does not query the extension on dicehub       |
| 🇨🇳 中文    |      边缘流水线不查询 dicehub 上的 extension        |

