### PR TITLE
fix: pipeline reduce refresh clusterinfo interval

### DIFF
--- a/conf/pipeline/pipeline.yaml
+++ b/conf/pipeline/pipeline.yaml
@@ -36,7 +36,7 @@ leader-worker:
     etcd_key_prefix_with_slash: "${LW_WORKER_ETCD_KEY_PREFIX_WITH_SLASH:/devops/pipeline/v2/leader-worker/worker/}"
 reconciler: {}
 clusterinfo:
-  refresh_clusters_interval: "${REFRESH_CLUSTERS_INTERVAL:20m}"
+  refresh_clusters_interval: "${REFRESH_CLUSTERS_INTERVAL:5m}"
 edgepipeline_register:
   cluster_dialer_endpoint: "${CLUSTER_DIALER_PUBLIC_URL}/clusteragent/connect"
   cluster_access_key: "${CLUSTER_ACCESS_KEY}"

--- a/modules/pipeline/providers/clusterinfo/provider.go
+++ b/modules/pipeline/providers/clusterinfo/provider.go
@@ -32,7 +32,7 @@ type config struct {
 	ErdaNamespace            string        `env:"DICE_NAMESPACE"`
 	IsEdge                   bool          `env:"DICE_IS_EDGE" default:"false"`
 	RetryClusterHookInterval time.Duration `file:"retry_cluster_hook_interval" default:"5s"`
-	RefreshClustersInterval  time.Duration `file:"refresh_clusters_interval" default:"20m"`
+	RefreshClustersInterval  time.Duration `file:"refresh_clusters_interval" env:"REFRESH_CLUSTERS_INTERVAL"`
 }
 
 type provider struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline reduce refresh clusterinfo interval

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=310755&iterationID=1190&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that  pipeline reduce refresh clusterinfo interval（pipeline加快集群信息缓存的刷新速度）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that  pipeline reduce refresh clusterinfo interval            |
| 🇨🇳 中文    |    pipeline加快集群信息缓存的刷新速度          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
