### PR TITLE
fix: action agent support set file stream timeout by env

### DIFF
--- a/modules/actionagent/callback_reporter.go
+++ b/modules/actionagent/callback_reporter.go
@@ -47,10 +47,11 @@ type CallbackReporter interface {
 }
 
 type CenterCallbackReporter struct {
-	OpenAPIAddr       string
-	OpenAPIToken      string
-	TokenForBootstrap string
-	CollectorAddr     string
+	OpenAPIAddr          string
+	OpenAPIToken         string
+	TokenForBootstrap    string
+	CollectorAddr        string
+	FileStreamTimeoutSec time.Duration
 }
 
 func (cr *CenterCallbackReporter) CallbackToPipelinePlatform(cbReq apistructs.PipelineCallbackRequest) error {
@@ -74,7 +75,7 @@ func (cr *CenterCallbackReporter) CallbackToPipelinePlatform(cbReq apistructs.Pi
 
 func (cr *CenterCallbackReporter) UploadFile(pipelineID, taskID uint64, file *os.File) (apistructs.FileUploadResponse, error) {
 	var uploadResp apistructs.FileUploadResponse
-	resp, err := httpclient.New(httpclient.WithCompleteRedirect(), httpclient.WithTimeout(defaultFileUploadTimeout, defaultFileUploadTimeout)).
+	resp, err := httpclient.New(httpclient.WithCompleteRedirect(), httpclient.WithTimeout(cr.FileStreamTimeoutSec, cr.FileStreamTimeoutSec)).
 		Post(cr.OpenAPIAddr).
 		Path("/api/files").
 		Param("fileFrom", fmt.Sprintf("action-upload-%d-%d", pipelineID, taskID)).
@@ -144,7 +145,7 @@ func (cr *CenterCallbackReporter) PushCollectorLog(logLines *[]apistructs.LogPus
 }
 
 func (cr *CenterCallbackReporter) GetCmsFile(uuid string, absPath string) error {
-	respBody, resp, err := httpclient.New(httpclient.WithCompleteRedirect(), httpclient.WithTimeout(defaultClientTimeout, defaultClientTimeout)).
+	respBody, resp, err := httpclient.New(httpclient.WithCompleteRedirect(), httpclient.WithTimeout(cr.FileStreamTimeoutSec, cr.FileStreamTimeoutSec)).
 		Get(cr.OpenAPIAddr).
 		Path("/api/files").
 		Param("file", uuid).
@@ -166,10 +167,11 @@ func (cr *CenterCallbackReporter) GetCmsFile(uuid string, absPath string) error 
 }
 
 type EdgeCallbackReporter struct {
-	PipelineAddr      string
-	OpenAPIToken      string
-	TokenForBootstrap string
-	CollectorAddr     string
+	PipelineAddr         string
+	OpenAPIToken         string
+	TokenForBootstrap    string
+	CollectorAddr        string
+	FileStreamTimeoutSec time.Duration
 }
 
 func (er *EdgeCallbackReporter) CallbackToPipelinePlatform(cbReq apistructs.PipelineCallbackRequest) error {

--- a/modules/actionagent/callback_test.go
+++ b/modules/actionagent/callback_test.go
@@ -15,7 +15,9 @@
 package actionagent
 
 import (
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -149,4 +151,15 @@ func Test_canDoEdgeCallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_SetCallbackReporter(t *testing.T) {
+	agent := &Agent{
+		EasyUse: EasyUse{},
+	}
+	os.Setenv(apistructs.EnvOpenapiTokenForActionBootstrap, "xxx")
+	os.Setenv(EnvFileStreamTimeoutSec, "30")
+	agent.SetCallbackReporter()
+	reporter := agent.CallbackReporter.(*CenterCallbackReporter)
+	assert.Equal(t, time.Second*time.Duration(30), reporter.FileStreamTimeoutSec)
 }

--- a/modules/actionagent/define.go
+++ b/modules/actionagent/define.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 
@@ -107,6 +108,8 @@ type EasyUse struct {
 
 	// Machine stat
 	MachineStat apistructs.PipelineTaskMachineStat
+
+	FileStreamTimeoutSec time.Duration // download or upload file stream timeout
 }
 
 type RunningEnvironment struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
action agent support set file stream timeout by env

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=310784)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that action agent support set file stream timeout by env（action agent支持配置文件流的超时时间）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that action agent support set file stream timeout by env             |
| 🇨🇳 中文    |   action agent支持配置文件流的超时时间           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
