### PR TITLE
fix(pipeline): pipeline status is always running when all tasks are disabled

### DIFF
--- a/modules/pipeline/providers/reconciler/pipeline_reconciler_impl_test.go
+++ b/modules/pipeline/providers/reconciler/pipeline_reconciler_impl_test.go
@@ -17,12 +17,12 @@ package reconciler
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 
 	"bou.ke/monkey"
 
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/modules/pipeline/dbclient"
 	"github.com/erda-project/erda/modules/pipeline/spec"
 )
 
@@ -131,13 +131,7 @@ func Test_defaultPipelineReconciler_updateCalculatedPipelineStatusForTaskUseFiel
 
 	// running
 	pr = &defaultPipelineReconciler{r: r}
-	dbClient := &dbclient.Client{}
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{
-				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
-			}, nil
-		})
+	pr.processedTasks.Store("s1c1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess})
 	p.Status = apistructs.PipelineStatusRunning
 	err = pr.UpdateCalculatedPipelineStatusForTaskUseField(ctx, p)
 	if err != nil {
@@ -157,84 +151,58 @@ func Test_defaultPipelineReconciler_calculateNewStatusByReconciledTasks(t *testi
 	ctx := context.TODO()
 	r := &provider{}
 	pr := &defaultPipelineReconciler{r: r}
-	dbClient := &dbclient.Client{}
 
 	// no tasks
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{}, nil
-		})
 	pr.totalTaskNumber = &[]int{0}[0]
-	newStatus, err := pr.calculatePipelineStatusForTaskUseField(ctx, p)
-	if err != nil {
-		t.Fatalf("should no err, err: %v", err)
-	}
+	newStatus := pr.calculatePipelineStatusForTaskUseField(ctx, p)
 	if newStatus != apistructs.PipelineStatusSuccess {
 		t.Fatalf("should be success if no task")
 	}
 
 	// one task but nothing scheduled (first loop)
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{}, nil
-		})
 	pr.totalTaskNumber = &[]int{1}[0]
-	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
-	if err != nil {
-		t.Fatalf("should no err, err: %v", err)
-	}
+	newStatus = pr.calculatePipelineStatusForTaskUseField(ctx, p)
 	if newStatus != apistructs.PipelineStatusRunning {
 		t.Fatalf("should be running")
 	}
 
 	// three task and two scheduled (one success, one running) => running
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{
-				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
-				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusRunning},
-			}, nil
-		})
+	pr.processedTasks.Store("s1c1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess})
+	pr.processedTasks.Store("s2c1", &spec.PipelineTask{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusRunning})
 	pr.totalTaskNumber = &[]int{3}[0]
-	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
-	if err != nil {
-		t.Fatalf("should no err, err: %v", err)
-	}
+	newStatus = pr.calculatePipelineStatusForTaskUseField(ctx, p)
 	if newStatus != apistructs.PipelineStatusRunning {
 		t.Fatalf("should be running")
 	}
 
 	// three task and two scheduled (one success, one failed) => failed
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{
-				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess},
-				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusFailed},
-			}, nil
-		})
+	pr.processedTasks = sync.Map{}
+	pr.processedTasks.Store("s1c1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusSuccess})
+	pr.processedTasks.Store("s2c1", &spec.PipelineTask{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusFailed})
 	pr.totalTaskNumber = &[]int{3}[0]
-	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
-	if err != nil {
-		t.Fatalf("should no err, err: %v", err)
-	}
+	newStatus = pr.calculatePipelineStatusForTaskUseField(ctx, p)
 	if newStatus != apistructs.PipelineStatusFailed {
 		t.Fatalf("should be failed")
 	}
 
 	// three task and two scheduled (one running, one failed) => running
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "ListPipelineTasksByPipelineID",
-		func(_ *dbclient.Client, pipelineID uint64, ops ...dbclient.SessionOption) ([]spec.PipelineTask, error) {
-			return []spec.PipelineTask{
-				{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusRunning},
-				{ID: 2, Name: "s2c1", Status: apistructs.PipelineStatusFailed},
-			}, nil
-		})
+	pr.processedTasks = sync.Map{}
+	pr.processedTasks.Store("s1c1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusRunning})
+	pr.processingTasks.Store("s2c1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusFailed})
 	pr.totalTaskNumber = &[]int{3}[0]
-	newStatus, err = pr.calculatePipelineStatusForTaskUseField(ctx, p)
-	if err != nil {
-		t.Fatalf("should no err, err: %v", err)
-	}
+	newStatus = pr.calculatePipelineStatusForTaskUseField(ctx, p)
 	if newStatus != apistructs.PipelineStatusRunning {
 		t.Fatalf("should be running")
+	}
+
+	// three tasks are all disabled => success
+	pr.totalTaskNumber = &[]int{3}[0]
+	pr.processedTasks = sync.Map{}
+	pr.processedTasks.Store("task-1", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusDisabled})
+	pr.processedTasks.Store("task-2", &spec.PipelineTask{ID: 2, Name: "s1c1", Status: apistructs.PipelineStatusDisabled})
+	pr.processedTasks.Store("task-3", &spec.PipelineTask{ID: 1, Name: "s1c1", Status: apistructs.PipelineStatusDisabled})
+	newStatus = pr.calculatePipelineStatusForTaskUseField(ctx, p)
+	if newStatus != apistructs.PipelineStatusSuccess {
+		t.Fatalf("should be success")
 	}
 }

--- a/modules/pipeline/providers/reconciler/reconcile.go
+++ b/modules/pipeline/providers/reconciler/reconcile.go
@@ -90,7 +90,7 @@ func (pr *defaultPipelineReconciler) releaseTaskAfterReconciled(ctx context.Cont
 	pr.lock.Lock()
 	defer pr.lock.Unlock()
 	pr.processingTasks.Delete(task.NodeName())
-	pr.processedTasks.Store(task.NodeName(), struct{}{})
+	pr.processedTasks.Store(task.NodeName(), task)
 }
 
 func (pr *defaultPipelineReconciler) waitPipelineDoneAndDoTeardown(ctx context.Context, p *spec.Pipeline) {


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline status is always running when all tasks are disabled

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=311116&iterationID=1190&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that pipeline status is always running when all tasks are disabled （修复了流水线的状态一直running中当所有任务都被禁用）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that pipeline status is always running when all tasks are disabled          |
| 🇨🇳 中文    | 修复了流水线的状态一直running中当所有任务都被禁用             |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
