### PR TITLE
fix(pipeline): fulfill parent snippet task status stored in processed tasks

### DIFF
--- a/modules/pipeline/providers/reconciler/snippet.go
+++ b/modules/pipeline/providers/reconciler/snippet.go
@@ -79,7 +79,7 @@ func (tr *defaultTaskReconciler) CreateSnippetPipeline(ctx context.Context, p *s
 }
 
 // fulfillParentSnippetTask 填充 parent snippet task 信息
-func (tr *defaultTaskReconciler) fulfillParentSnippetTask(p *spec.Pipeline) error {
+func (tr *defaultTaskReconciler) fulfillParentSnippetTask(p *spec.Pipeline, task *spec.PipelineTask) error {
 	if !p.IsSnippet || p.ParentTaskID == nil {
 		return nil
 	}
@@ -107,6 +107,7 @@ func (tr *defaultTaskReconciler) fulfillParentSnippetTask(p *spec.Pipeline) erro
 	if err := tr.dbClient.UpdatePipelineTaskStatus(*p.ParentTaskID, p.Status); err != nil {
 		return err
 	}
+	task.Status = p.Status
 	// update the costTime,timeBegin,timeEnd of pipeline task
 	if err := tr.dbClient.UpdatePipelineTaskTime(p); err != nil {
 		return err

--- a/modules/pipeline/providers/reconciler/snippet_test.go
+++ b/modules/pipeline/providers/reconciler/snippet_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/dbclient"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_fulfillParentSnippetTask(t *testing.T) {
+	var (
+		dbClient *dbclient.Client
+	)
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskStatus", func(_ *dbclient.Client, id uint64, status apistructs.PipelineStatus, ops ...dbclient.SessionOption) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskTime", func(_ *dbclient.Client, p *spec.Pipeline, ops ...dbclient.SessionOption) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineExtraSnapshot", func(_ *dbclient.Client, pipelineID uint64, snapshot spec.Snapshot, ops ...dbclient.SessionOption) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "GetPipelineTask", func(_ *dbclient.Client, id interface{}) (spec.PipelineTask, error) {
+		return spec.PipelineTask{ID: 1}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskSnippetDetail", func(_ *dbclient.Client, id uint64, snippetDetail apistructs.PipelineTaskSnippetDetail, ops ...dbclient.SessionOption) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskMetadata", func(_ *dbclient.Client, id uint64, result *apistructs.PipelineTaskResult) error {
+		return nil
+	})
+	defer monkey.UnpatchAll()
+	tests := []struct {
+		name           string
+		p              *spec.Pipeline
+		task           *spec.PipelineTask
+		wantTaskStatus apistructs.PipelineStatus
+	}{
+		{
+			name: "success snippet pipeline",
+			p: &spec.Pipeline{
+				PipelineBase: spec.PipelineBase{
+					IsSnippet:    true,
+					ParentTaskID: &[]uint64{1}[0],
+					Status:       apistructs.PipelineStatusSuccess,
+				},
+			},
+			task:           &spec.PipelineTask{},
+			wantTaskStatus: apistructs.PipelineStatusSuccess,
+		},
+		{
+			name: "success snippet pipeline",
+			p: &spec.Pipeline{
+				PipelineBase: spec.PipelineBase{
+					IsSnippet:    true,
+					ParentTaskID: &[]uint64{2}[0],
+					Status:       apistructs.PipelineStatusFailed,
+				},
+			},
+			task:           &spec.PipelineTask{},
+			wantTaskStatus: apistructs.PipelineStatusFailed,
+		},
+	}
+	tr := &defaultTaskReconciler{dbClient: dbClient}
+	//monkey.PatchInstanceMethod(reflect.TypeOf(tr), "calculateAndUpdatePipelineOutputValues", func(_ *defaultTaskReconciler, p *spec.Pipeline, tasks []*spec.PipelineTask) ([]apistructs.PipelineOutputWithValue, error) {
+	//	return []apistructs.PipelineOutputWithValue{}, nil
+	//})
+	//monkey.PatchInstanceMethod(reflect.TypeOf(tr), "handleParentSnippetTaskOutputs", func(_ *defaultTaskReconciler, snippetPipeline *spec.Pipeline, outputValues []apistructs.PipelineOutputWithValue) error {
+	//	return nil
+	//})
+	for _, tt := range tests {
+		monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "GetPipelineWithTasks",
+			func(_ *dbclient.Client, id uint64) (*spec.PipelineWithTasks, error) {
+				return &spec.PipelineWithTasks{
+					Pipeline: &spec.Pipeline{
+						PipelineBase: spec.PipelineBase{
+							ID:           1,
+							Status:       tt.p.Status,
+							ParentTaskID: &[]uint64{1}[0],
+						},
+					},
+					Tasks: []*spec.PipelineTask{
+						{
+							ID: 1,
+						},
+					},
+				}, nil
+			})
+		t.Run(tt.name, func(t *testing.T) {
+			err := tr.fulfillParentSnippetTask(tt.p, tt.task)
+			if err != nil {
+				t.Errorf("fulfillParentSnippetTask() error = %v", err)
+			}
+			if tt.task.Status != tt.wantTaskStatus {
+				t.Errorf("fulfillParentSnippetTask() task.Status = %v, want %v", tt.task.Status, tt.wantTaskStatus)
+			}
+		})
+	}
+}

--- a/modules/pipeline/providers/reconciler/task_reconciler.go
+++ b/modules/pipeline/providers/reconciler/task_reconciler.go
@@ -185,7 +185,7 @@ func (tr *defaultTaskReconciler) ReconcileSnippetTask(ctx context.Context, p *sp
 	tr.pr.r.ReconcileOnePipeline(ctx, snippetPipeline.ID)
 
 	// setup snippet task info according to snippet pipeline result
-	if err := tr.fulfillParentSnippetTask(snippetPipeline); err != nil {
+	if err := tr.fulfillParentSnippetTask(snippetPipeline, task); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
fulfill parent snippet task status stored in processed tasks


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that fulfill parent snippet task status stored in processed tasks（修复了内存中嵌套流水线任务的状态错误）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that fulfill parent snippet task status stored in processed tasks             |
| 🇨🇳 中文    |  修复了内存中嵌套流水线任务的状态错误            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
