### PR TITLE
feat: add unit test for taskop-prepare

### DIFF
--- a/modules/pipeline/endpoints/v2_test.go
+++ b/modules/pipeline/endpoints/v2_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	successCode         = 200
+	limitCostTime int64 = 500 // ms
+)
+
+type benchmarkPipelineCreateRes struct {
+	Name       string `json:"name"`
+	CostTime   int64  `json:"costTime"` // ms
+	StatusCode int    `json:"statusCode"`
+	Body       string `json:"body"`
+	err        error  `json:"err"`
+}
+
+func createV2(url string) (result benchmarkPipelineCreateRes) {
+	if len(url) == 0 {
+		return
+	}
+	method := "POST"
+
+	payload := strings.NewReader(`{
+    "appID": 10,
+    "pipelineYml": "version: \"1.1\"\nstages:\n  - stage:\n      - git-checkout:\n          alias: git-checkout\n          description: 代码仓库克隆\n          version: \"1.0\"\n          params:\n            branch: ((gittar.branch))\n            depth: 1\n            password: ((gittar.password))\n            uri: ((gittar.repo))\n            username: ((gittar.username))\n          timeout: 3600\n  - stage:\n      - golang:\n          alias: go-demo\n          description: golang action\n          params:\n            command: go build -o web-server main.go\n            context: ${git-checkout}\n            service: web-server\n            target: web-server\n  - stage:\n      - release:\n          alias: release\n          description: 用于打包完成时，向dicehub 提交完整可部署的dice.yml。用户若没在pipeline.yml里定义该action，CI会自动在pipeline.yml里插入该action\n          params:\n            dice_yml: ${git-checkout}/dice.yml\n            image:\n              go-demo: ${go-demo:OUTPUT:image}\n  - stage:\n      - dice:\n          alias: dice\n          description: 用于 Erda 平台部署应用服务\n          params:\n            release_id: ${release:OUTPUT:releaseID}\n",
+    "pipelineSource": "dice",
+    "pipelineYmlName": "pipeline.yml",
+    "clusterName": "dev",
+    "autoRunAtOnce": false,
+    "autoStartCron": false,
+    "labels": {
+        "branch": "develop",
+        "diceWorkspace": "TEST",
+        "has-report-basic": "true",
+    },
+    "normalLabels": {
+        "appName": "go-demo",
+        "projectName": "go-demo",
+        "orgName": "erda"
+    },
+    "configManageNamespaces": []
+}`)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, err := http.NewRequest(method, url, payload)
+
+	if err != nil {
+		result.err = err
+		return
+	}
+	req.Header.Add("Internal-Client", "bundle")
+	req.Header.Add("Content-Type", "application/json")
+
+	timeStart := time.Now()
+	res, err := client.Do(req)
+	if err != nil {
+		result.err = err
+		return
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		result.err = err
+		return
+	}
+	timeEnd := time.Now()
+	result.CostTime = timeEnd.Sub(timeStart).Milliseconds()
+	result.StatusCode = res.StatusCode
+	result.Body = string(body)
+	result.Name = "createV2"
+	return
+}
+
+func newCreateV2Work(workerID int) (count int) {
+	resChan := make(chan benchmarkPipelineCreateRes, 0)
+	execChan := make(chan struct{}, 0)
+	defer close(resChan)
+	defer close(execChan)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-execChan:
+				data := createV2("")
+				resChan <- data
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	execChan <- struct{}{}
+	for {
+		select {
+		case data := <-resChan:
+			count++
+			logrus.Infof("worker: %d execute pipeline, statusCode: %d, costTime: %dms", workerID, data.StatusCode, data.CostTime)
+			if data.err != nil {
+				logrus.Errorf("%s: %s", data.Name, data.err.Error())
+				return
+			}
+			if data.StatusCode != successCode {
+				logrus.Errorf("status code is not %d, but %d", successCode, data.StatusCode)
+				return
+			}
+			if count >= 1 {
+				return
+			}
+			execChan <- struct{}{}
+		}
+	}
+	return
+}
+
+func Test_benchmarkCreateV2(t *testing.T) {
+	wait := &sync.WaitGroup{}
+	// concurrency of create pipeline
+	for i := 0; i < 1; i++ {
+		wait.Add(1)
+		go func(idx int) {
+			defer wait.Done()
+			count := newCreateV2Work(idx)
+			logrus.Infof("worker %d created %d pipelines", idx, count)
+		}(i)
+	}
+	wait.Wait()
+}

--- a/modules/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
+++ b/modules/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
@@ -90,33 +90,33 @@ func Test_existContinuePrivateEnv(t *testing.T) {
 	}{
 		{
 			name: "application name",
-			key:  "DICE_APPLICATION_NAME",
+			key:  apistructs.DiceApplicationName,
 			envs: map[string]string{
-				"DICE_APPLICATION_NAME": "test",
+				apistructs.DiceApplicationName: "test",
 			},
 			wantExist: true,
 		},
 		{
 			name: "application id",
-			key:  "DICE_APPLICATION_ID",
+			key:  apistructs.DiceApplicationId,
 			envs: map[string]string{
-				"DICE_APPLICATION_ID": "1",
+				apistructs.DiceApplicationId: "1",
 			},
 			wantExist: true,
 		},
 		{
 			name: "gittar branch",
-			key:  "GITTAR_BRANCH",
+			key:  apistructs.GittarBranchEnv,
 			envs: map[string]string{
-				"GITTAR_BRANCH": "develop",
+				apistructs.GittarBranchEnv: "develop",
 			},
 			wantExist: true,
 		},
 		{
 			name: "no exist",
-			key:  "DICE_SOURCE_NAME",
+			key:  apistructs.SourceDeployPipeline,
 			envs: map[string]string{
-				"DICE_SOURCE_NAME": "cdp",
+				apistructs.SourceDeployPipeline: "cdp",
 			},
 			wantExist: false,
 		},

--- a/modules/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
+++ b/modules/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
@@ -16,6 +16,7 @@ package taskop
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -78,4 +79,126 @@ func Test_condition(t *testing.T) {
 	task := &spec.PipelineTask{Extra: spec.PipelineTaskExtra{Action: pipelineyml.Action{If: "${{   1 == 1   }}"}}}
 	b := condition(task)
 	assert.Equal(t, false, b)
+}
+
+func Test_existContinuePrivateEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		envs      map[string]string
+		wantExist bool
+	}{
+		{
+			name: "application name",
+			key:  "DICE_APPLICATION_NAME",
+			envs: map[string]string{
+				"DICE_APPLICATION_NAME": "test",
+			},
+			wantExist: true,
+		},
+		{
+			name: "application id",
+			key:  "DICE_APPLICATION_ID",
+			envs: map[string]string{
+				"DICE_APPLICATION_ID": "1",
+			},
+			wantExist: true,
+		},
+		{
+			name: "gittar branch",
+			key:  "GITTAR_BRANCH",
+			envs: map[string]string{
+				"GITTAR_BRANCH": "develop",
+			},
+			wantExist: true,
+		},
+		{
+			name: "no exist",
+			key:  "DICE_SOURCE_NAME",
+			envs: map[string]string{
+				"DICE_SOURCE_NAME": "cdp",
+			},
+			wantExist: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotExist := existContinuePrivateEnv(tt.envs, tt.key); gotExist != tt.wantExist {
+				t.Fatalf("existContinuePrivateEnv() = %v, want %v", gotExist, tt.wantExist)
+			}
+		})
+	}
+}
+
+func Test_handleAccessTokenExpiredIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		expect  string
+	}{
+		{
+			name:    "no timeout",
+			timeout: -1,
+			expect:  "0",
+		},
+		{
+			name:    "defualt timeout",
+			timeout: 0,
+			expect:  "30s",
+		},
+		{
+			name:    "half hour",
+			timeout: time.Minute * 30,
+			expect:  "1830s",
+		},
+	}
+	task := &spec.PipelineTask{
+		Extra: spec.PipelineTaskExtra{},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task.Extra.Timeout = tt.timeout
+			got := handleAccessTokenExpiredIn(task)
+			if got != tt.expect {
+				t.Fatalf("expect timeout: %s, but got: %s", tt.expect, got)
+			}
+		})
+	}
+}
+
+func Test_handleInternalClient(t *testing.T) {
+	p := &spec.Pipeline{
+		PipelineExtra: spec.PipelineExtra{
+			Extra: spec.PipelineExtraInfo{
+				InternalClient: "bundle",
+			},
+		},
+	}
+	client := handleInternalClient(p)
+	assert.Equal(t, "bundle", client)
+	p.Extra.InternalClient = ""
+	client = handleInternalClient(p)
+	assert.Equal(t, "pipeline-signed-openapi-token", client)
+}
+
+func Test_generateTaskCMDs(t *testing.T) {
+	cmd, args, err := generateTaskCMDs(&pipelineyml.Action{}, spec.PipelineTaskContext{}, 1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "agent", cmd)
+	assert.Equal(t, "eyJwdWxsQm9vdHN0cmFwSW5mbyI6dHJ1ZSwiY29udGV4dCI6e30sInBpcGVsaW5lSUQiOjEsInBpcGVsaW5lVGFza0lEIjoxLCJlbmNyeXB0U2VjcmV0S2V5cyI6bnVsbH0=", args[0])
+}
+
+func Test_getActionAgentTypeVersion(t *testing.T) {
+	version := getActionAgentTypeVersion()
+	assert.Equal(t, "agent@1.0", version)
+}
+
+func Test_contextVolumes(t *testing.T) {
+	taskContext := spec.PipelineTaskContext{
+		InStorages:  apistructs.Metadata{{Name: "in1"}},
+		OutStorages: apistructs.Metadata{{Name: "out1"}},
+	}
+	fields := contextVolumes(taskContext)
+	assert.Equal(t, 2, len(fields))
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
add unit test for taskop-prepare

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=305706&iterationID=1190&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix：add unit test for taskop-prepare（增加prepare的单元测试）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add unit test for taskop-prepare            |
| 🇨🇳 中文    |     增加prepare的单元测试         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
