### PR TITLE
feat(dop): return parent code coverage data when list qa unittest

### DIFF
--- a/modules/dop/dbclient/dao.go
+++ b/modules/dop/dbclient/dao.go
@@ -65,7 +65,7 @@ func FindTPRecordByCommitId(commitID string) (*TPRecordDO, error) {
 
 func FindTPRecordPagingByAppID(req *pb.TestRecordPagingRequest) (*Paging, error) {
 	var list []*TPRecordDO
-	total, err := cimysql.Engine.Select("id,name,branch,operator_name,totals,type,created_at").Where("app_id = ?", req.ApplicationId).
+	total, err := cimysql.Engine.Select("id,name,branch,operator_name,totals,type,created_at,coverage_report").Where("app_id = ?", req.ApplicationId).
 		Limit(int(req.PageSize), (int(req.PageNo)-1)*int(req.PageSize)).Desc("id").FindAndCount(&list)
 	if err != nil {
 		return nil, err

--- a/modules/dop/providers/qa/unittest/unittest-service.go
+++ b/modules/dop/providers/qa/unittest/unittest-service.go
@@ -90,6 +90,10 @@ func (s *UnitTestService) ListRecords(ctx context.Context, req *pb.TestRecordPag
 	for _, r := range pagingResult.List.([]*dbclient.TPRecordDO) {
 		// erase sensitive information
 		r.EraseSensitiveInfo()
+		// only return the parent code coverage data when list unittest records
+		for _, coverageReport := range r.CoverageReport {
+			coverageReport.Children = nil
+		}
 		records = append(records, convertRecordToPB(r))
 	}
 	return &pb.TestRecordPagingResponse{


### PR DESCRIPTION
#### What this PR does / why we need it:
return parent code coverage data when list qa unittest


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: return parent code coverage data when list qa unittest（查询测试覆盖率列表时返回父节点的值）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   return parent code coverage data when list qa unittest           |
| 🇨🇳 中文    |  查询测试覆盖率列表时返回父节点的值            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
