### PR TITLE
fix: log_metrics support use tag keys without dice prefix

### DIFF
--- a/modules/msp/apm/log-service/rules/log_metric_config.go
+++ b/modules/msp/apm/log-service/rules/log_metric_config.go
@@ -131,7 +131,11 @@ func (p *provider) convertToMetricMeta(cfg *db.LogMetricConfig) (*pb.MetricMeta,
 		"dice_project_id", "dice_project_name",
 		"dice_application_id", "dice_application_name",
 		"dice_runtime_id", "dice_runtime_name",
-		"dice_service_name", "_level"} {
+		"dice_service_name", "_level",
+		"org_id", "org_name",
+		"project_id", "project_name",
+		"application_id", "application_name",
+		"runtime_id", "runtime_name", "service_name"} {
 		m.Tags[key] = &pb.TagDefine{Key: key, Name: key}
 	}
 

--- a/modules/msp/apm/log-service/rules/log_metric_config_test.go
+++ b/modules/msp/apm/log-service/rules/log_metric_config_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/erda-project/erda/modules/msp/apm/log-service/rules/db"
+)
+
+func Test_convertToMetricMeta(t *testing.T) {
+	p := &provider{}
+	_, err := p.convertToMetricMeta(&db.LogMetricConfig{
+		Metric: "log_test",
+		Name:   "log_test",
+	})
+
+	assert.NilError(t, err)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @innerpeacez 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      log_metrics support use tag keys without dice prefix        |
| 🇨🇳 中文    |       分析规则指标支持使用不带dice前缀的标签key       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
