### PR TITLE
fix: autowired clusterSvc in monitor

### DIFF
--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -107,12 +107,12 @@ func (r *ComponentReleaseTable) InitComponent(ctx context.Context) {
 	r.svc = svc
 }
 
-func (r *ComponentReleaseTable) GenComponentState(c *cptype.Component) error {
-	if c == nil || c.State == nil {
+func (r *ComponentReleaseTable) GenComponentState(component *cptype.Component) error {
+	if component == nil || component.State == nil {
 		return nil
 	}
 	var state State
-	data, err := json.Marshal(c.State)
+	data, err := json.Marshal(component.State)
 	if err != nil {
 		return err
 	}

--- a/modules/monitor/dashboard/org-apis/permission.go
+++ b/modules/monitor/dashboard/org-apis/permission.go
@@ -176,7 +176,7 @@ func (p *provider) checkOrgIDByClusters(orgID uint64, clusterNames []string) err
 
 func (p *provider) listClustersByOrg(orgID uint64) ([]string, error) {
 	ctx := transport.WithHeader(context.Background(), metadata.New(map[string]string{httputil.InternalHeader: "cmp"}))
-	resp, err := p.clusterSvc.ListCluster(ctx, &clusterpb.ListClusterRequest{OrgID: orgID})
+	resp, err := p.ClusterSvc.ListCluster(ctx, &clusterpb.ListClusterRequest{OrgID: orgID})
 	if err != nil {
 		return nil, err
 	}

--- a/modules/monitor/dashboard/org-apis/provider.go
+++ b/modules/monitor/dashboard/org-apis/provider.go
@@ -42,7 +42,7 @@ type provider struct {
 	metricq    metricq.Queryer
 	service    queryServiceImpl
 	t          i18n.Translator
-	clusterSvc clusterpb.ClusterServiceServer `autowired:"erda.core.clustermanager.cluster.ClusterService"`
+	ClusterSvc clusterpb.ClusterServiceServer `autowired:"erda.core.clustermanager.cluster.ClusterService"`
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: autowired clusterSvc in monitor

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: autowired clusterSvc in monitor |
| 🇨🇳 中文    | 修复monitor组件中注入clusterSvc失败导致panic的问题 |

