### PR TITLE
fix(pipeline): query cron is-existed by transaction session to avoid competing links

### DIFF
--- a/modules/pipeline/endpoints/v2_test.go
+++ b/modules/pipeline/endpoints/v2_test.go
@@ -56,7 +56,7 @@ func createV2(url string) (result benchmarkPipelineCreateRes) {
     "labels": {
         "branch": "develop",
         "diceWorkspace": "TEST",
-        "has-report-basic": "true",
+        "has-report-basic": "true"
     },
     "normalLabels": {
         "appName": "go-demo",

--- a/modules/pipeline/providers/cron/cron.service.go
+++ b/modules/pipeline/providers/cron/cron.service.go
@@ -392,7 +392,7 @@ func (s *provider) InsertOrUpdatePipelineCron(new *db.PipelineCron, ops ...mysql
 		Branch:          new.Branch,
 		PipelineYmlName: new.PipelineYmlName,
 	}
-	v1Exist, err := s.dbClient.GetDBClient().Get(queryV1)
+	v1Exist, err := s.dbClient.IsCronExist(queryV1, ops...)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (s *provider) InsertOrUpdatePipelineCron(new *db.PipelineCron, ops ...mysql
 		PipelineSource:  new.PipelineSource,
 		PipelineYmlName: new.PipelineYmlName,
 	}
-	v2Exist, err := s.dbClient.GetDBClient().Get(queryV2)
+	v2Exist, err := s.dbClient.IsCronExist(queryV2, ops...)
 	if err != nil {
 		return err
 	}
@@ -448,7 +448,7 @@ func (s *provider) disable(cron *db.PipelineCron, option mysqlxorm.SessionOption
 		Branch:          cron.Branch,
 		PipelineYmlName: cron.PipelineYmlName,
 	}
-	v1Exist, err := s.dbClient.GetDBClient().Get(queryV1)
+	v1Exist, err := s.dbClient.IsCronExist(queryV1, option)
 	if err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func (s *provider) disable(cron *db.PipelineCron, option mysqlxorm.SessionOption
 		PipelineSource:  cron.PipelineSource,
 		PipelineYmlName: cron.PipelineYmlName,
 	}
-	v2Exist, err := s.dbClient.GetDBClient().Get(queryV2)
+	v2Exist, err := s.dbClient.IsCronExist(queryV2, option)
 	if err != nil {
 		return err
 	}

--- a/modules/pipeline/providers/cron/db/define_extra.go
+++ b/modules/pipeline/providers/cron/db/define_extra.go
@@ -211,3 +211,14 @@ func (client *Client) ListAllPipelineCrons(ops ...mysqlxorm.SessionOption) (cron
 	}
 	return crons, nil
 }
+
+func (client *Client) IsCronExist(cron *PipelineCron, ops ...mysqlxorm.SessionOption) (bool bool, err error) {
+	session := client.NewSession(ops...)
+	defer session.Close()
+
+	existed, err := session.Get(cron)
+	if err != nil {
+		return false, err
+	}
+	return existed, nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
query cron is-existed by transaction session to avoid competing links

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=311911&iterationID=1224&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that query cron is-existed by transaction session to avoid competing links（修复并发数大于mysql链接数的情况下事物卡住）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that query cron is-existed by transaction session to avoid competing links            |
| 🇨🇳 中文    |     修复并发数大于mysql链接数的情况下事物卡住         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
