### PR TITLE
fix: dlock failed cause orchestrator panic

### DIFF
--- a/modules/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
@@ -250,6 +250,10 @@ func TestNew(t *testing.T) {
 		return &rest.Config{}, nil
 	})
 
+	monkey.Patch(k8sclient.NewForRestConfig, func(*rest.Config, ...k8sclient.Option) (*k8sclient.K8sClient, error) {
+		return &k8sclient.K8sClient{}, nil
+	})
+
 	monkey.Patch(util.GetClient, func(_ string, _ *apistructs.ManageConfig) (string, *httpclient.HTTPClient, error) {
 		return "localhost", httpclient.New(), nil
 	})
@@ -265,8 +269,7 @@ func TestNew(t *testing.T) {
 	defer monkey.UnpatchAll()
 
 	_, err := New("MARATHONFORMOCKCLUSTER", mockCluster, map[string]string{})
-	//assert.NilError(t, err)
-	fmt.Println(err)
+	assert.NilError(t, err)
 }
 
 func TestSetFineGrainedCPU(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
dlock failed cause orchestrator panic

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix dlock failed cause orchestrator panic             |
| 🇨🇳 中文    |    修复分布式锁获取失败导致 orchestrator panic         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
