### PR TITLE
fix: panic when history job list less than 2

### DIFF
--- a/modules/orchestrator/scheduler/executor/plugins/k8s/job.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/job.go
@@ -216,6 +216,9 @@ func (k *Kubernetes) deleteHistoryJob(namespace, name string) error {
 	sort.Slice(list.Items, func(i, j int) bool {
 		return list.Items[i].CreationTimestamp.After(list.Items[j].CreationTimestamp.Time)
 	})
+	if len(list.Items) < 2 {
+		return nil
+	}
 	for _, job := range list.Items[2:] {
 		logrus.Errorf("job name for deleted: %+v\n", job.Name)
 		if err = k.job.Delete(namespace, job.Name); err != nil {

--- a/modules/orchestrator/scheduler/executor/plugins/k8s/job_test.go
+++ b/modules/orchestrator/scheduler/executor/plugins/k8s/job_test.go
@@ -92,6 +92,30 @@ func TestNewJob(t *testing.T) {
 
 }
 
+func TestDeleteHistoryJob(t *testing.T) {
+	k := &Kubernetes{
+		job: &job.Job{},
+	}
+	monkey.PatchInstanceMethod(reflect.TypeOf(k.job), "List", func(job *job.Job, namespace string, labelSelector map[string]string) (batchv1.JobList, error) {
+		return batchv1.JobList{
+			TypeMeta: metav1.TypeMeta{},
+			ListMeta: metav1.ListMeta{},
+			Items: []batchv1.Job{batchv1.Job{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-job",
+					Namespace: "test-ns",
+				},
+				Status: batchv1.JobStatus{
+					Succeeded: 1,
+				},
+			}},
+		}, nil
+	})
+	err := k.deleteHistoryJob("test-ns", "test-job")
+	assert.Equal(t, err, nil)
+}
+
 func TestGetJobStatusFromMap(t *testing.T) {
 	k := &Kubernetes{
 		job: &job.Job{},


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: panic when history job list less than 2
#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix: panic when history job list less than 2         |
| 🇨🇳 中文    |       修复历史job小于2的panic问题       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
