### PR TITLE
refactor(pipeline): query any match labels only once instead of multiple queries

### DIFF
--- a/internal/tools/pipeline/dbclient/op_pipeline_test.go
+++ b/internal/tools/pipeline/dbclient/op_pipeline_test.go
@@ -17,9 +17,15 @@ package dbclient
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"github.com/xormplus/xorm"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
 func TestNotFoundBaseErrorIs(t *testing.T) {
@@ -28,4 +34,94 @@ func TestNotFoundBaseErrorIs(t *testing.T) {
 
 	ne := fmt.Errorf("other error")
 	assert.False(t, errors.Is(NotFoundBaseError, ne))
+}
+
+func TestPageListPipelines(t *testing.T) {
+	tests := []struct {
+		name            string
+		labels          map[string][]string
+		wantPipelineIDS []uint64
+	}{
+		{
+			name:            "no labels",
+			labels:          map[string][]string{},
+			wantPipelineIDS: []uint64{1, 2, 3},
+		},
+		{
+			name: "with labels",
+			labels: map[string][]string{
+				"source": {"s1", "s2"},
+			},
+			wantPipelineIDS: []uint64{1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbSession := &xorm.Session{}
+			session := &Session{Session: dbSession}
+			client := &Client{}
+			pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(client), "NewSession", func(_ *Client, ops ...SessionOption) *Session {
+				return session
+			})
+			defer pm1.Unpatch()
+			pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "Where", func(_ *xorm.Session, query interface{}, args ...interface{}) *xorm.Session {
+				return dbSession
+			})
+			defer pm2.Unpatch()
+			pm3 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "Cols", func(_ *xorm.Session, columns ...string) *xorm.Session {
+				return dbSession
+			})
+			defer pm3.Unpatch()
+			pm4 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "Table", func(_ *xorm.Session, tableNameOrBean interface{}) *xorm.Session {
+				return dbSession
+			})
+			defer pm4.Unpatch()
+			pm5 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "Desc", func(_ *xorm.Session, colNames ...string) *xorm.Session {
+				return dbSession
+			})
+			defer pm5.Unpatch()
+			pm6 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "FindAndCount", func(_ *xorm.Session, rowsSlicePtr interface{}, condiBean ...interface{}) (int64, error) {
+				basePipelines, ok := rowsSlicePtr.(*[]spec.PipelineBase)
+				if ok {
+					for _, pipelineID := range tt.wantPipelineIDS {
+						*basePipelines = append(*basePipelines, spec.PipelineBase{ID: pipelineID})
+					}
+				}
+				total := int64(len(tt.wantPipelineIDS))
+				return total, nil
+			})
+			defer pm6.Unpatch()
+			pm7 := monkey.PatchInstanceMethod(reflect.TypeOf(client), "ListPipelinesByIDs", func(_ *Client, pipelineIDs []uint64, needQueryDefinition bool, ops ...SessionOption) ([]spec.Pipeline, error) {
+				return []spec.Pipeline{
+					{PipelineBase: spec.PipelineBase{ID: 1}},
+					{PipelineBase: spec.PipelineBase{ID: 2}},
+					{PipelineBase: spec.PipelineBase{ID: 3}},
+				}, nil
+			})
+			defer pm7.Unpatch()
+			pm8 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "SQL", func(_ *xorm.Session, query interface{}, args ...interface{}) *xorm.Session {
+				return dbSession
+			})
+			defer pm8.Unpatch()
+			pm9 := monkey.PatchInstanceMethod(reflect.TypeOf(dbSession), "Find", func(_ *xorm.Session, rowsSlicePtr interface{}, condiBean ...interface{}) error {
+				innerPipelineIDs, ok := rowsSlicePtr.(*[]uint64)
+				if ok {
+					for _, pipelineID := range tt.wantPipelineIDS {
+						*innerPipelineIDs = append(*innerPipelineIDs, pipelineID)
+					}
+				}
+				return nil
+			})
+			defer pm9.Unpatch()
+			pagingRes, err := client.PageListPipelines(apistructs.PipelinePageListRequest{
+				AnyMatchLabels: tt.labels,
+				PageNo:         1,
+				PageSize:       3,
+				AllSources:     true,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPipelineIDS, pagingRes.PagingPipelineIDs)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
query any match labels only once instead of multiple queries

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=311070&iterationID=1224&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: query any match labels only once instead of multiple queries （减少标签的查询次数）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | query any match labels only once instead of multiple queries             |
| 🇨🇳 中文    |     减少标签的查询次数         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
