### PR TITLE
fix: return error if cluster-manager ip not found for clusterkey

### DIFF
--- a/modules/cluster/cluster-manager/dialer/server/tunnel-server.go
+++ b/modules/cluster/cluster-manager/dialer/server/tunnel-server.go
@@ -241,14 +241,15 @@ func queryIP(rw http.ResponseWriter, req *http.Request, etcd *clientv3.Client) {
 
 	r, err := etcd.Get(req.Context(), ClusterManagerETCDKeyPrefix+clusterKey)
 	if err != nil {
-		resp.Error = errors.Errorf("failed to get clusterKey from etcd, %v", err).Error()
+		resp.Error = errors.Errorf("failed to get ip for clusterKey %s from etcd, %v", clusterKey, err).Error()
 		resp.Succeeded = false
 		writeResp(rw, resp, http.StatusInternalServerError)
 		return
 	}
 	if len(r.Kvs) == 0 {
-		resp.Succeeded = true
-		writeResp(rw, resp, http.StatusOK)
+		resp.Error = errors.Errorf("can not find ip for clusterKey %s", clusterKey).Error()
+		resp.Succeeded = false
+		writeResp(rw, resp, http.StatusNotFound)
 		return
 	}
 

--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -107,12 +107,12 @@ func (r *ComponentReleaseTable) InitComponent(ctx context.Context) {
 	r.svc = svc
 }
 
-func (r *ComponentReleaseTable) GenComponentState(component *cptype.Component) error {
-	if component == nil || component.State == nil {
+func (r *ComponentReleaseTable) GenComponentState(c *cptype.Component) error {
+	if c == nil || c.State == nil {
 		return nil
 	}
 	var state State
-	data, err := json.Marshal(component.State)
+	data, err := json.Marshal(c.State)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: return error if cluster-manager ip not found for clusterkey

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: return error if cluster-manager ip not found for clusterkey |
| 🇨🇳 中文    | 若找不到目标clusterKey对应的cluster-manager ip地址则返回错误 |

