### PR TITLE
fix: add expose for 9094 port of cluster-manager

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -178,6 +178,7 @@ services:
     cmd: "/app/cluster-manager"
     ports:
       - port: 9094
+        expose: true
         protocol: "TCP"
         l4_protocol: "TCP"
       - port: 9095


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: add expose for 9094 port of cluster-manager

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: add expose for 9094 port of cluster-manager |
| 🇨🇳 中文    | 在 erda.yml 中添加对cluster-manager 9094 端口的暴露 |

