### PR TITLE
fix: add cluster-manager connect path to openapi

### DIFF
--- a/conf/cluster-agent/cluster-agent.yaml
+++ b/conf/cluster-agent/cluster-agent.yaml
@@ -1,6 +1,6 @@
 cluster-agent:
   debug: ${DEBUG:false}
-  clusterManagerEndpoint: "${CLUSTER_MANAGER_PUBLIC_URL}/clusteragent/connect"
+  clusterManagerEndpoint: "${OPENAPI_PUBLIC_URL}/clusteragent/connect"
   clusterKey: "${DICE_CLUSTER_NAME}"
   erdaNamespace: "${DICE_NAMESPACE}"
   clusterAccessKey: "${CLUSTER_ACCESS_KEY}"

--- a/modules/openapi/api/apis/cluster_manager/connect.go
+++ b/modules/openapi/api/apis/cluster_manager/connect.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster_manager
+
+import (
+	"github.com/erda-project/erda/modules/openapi/api/apis"
+)
+
+var CLUSTER_MANAGER_CONNECT = apis.ApiSpec{
+	Path:        "/clusteragent/connect",
+	BackendPath: "/clusteragent/connect",
+	Host:        "cluster-manager.marathon.l4lb.thisdcos.directory:9094",
+	Scheme:      "ws",
+	Method:      "GET",
+	Doc:         "cluster-agent向cluster-manager注册",
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: add cluster-manager connect path to openapi

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: add cluster-manager connect path to openapi |
| 🇨🇳 中文    | 把cluster-manager接收cluster-agent注册的路由暴露到openapi |

