### PR TITLE
fix: add quotation marks for time type format

### DIFF
--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -50,6 +50,10 @@ func TestGetTime(t *testing.T) {
 	t.Log("ns-after-hour:", getTime(TimeStampNsAfterHour))
 	t.Log("ns-day:", getTime(TimeStampNsDay))
 	t.Log("ns-after-day:", getTime(TimeStampNsAfterDay))
+	t.Log("date-before-hour", getTime(DateTimeHour))
+	t.Log("date-now", getTime(Date))
+	t.Log("date-day", getTime(DateDay))
+	t.Log("date-time", getTime(DateTime))
 
 	for k := range dateTimeCustoms {
 		t.Log(DateTimeCustom+k+":", getTime(DateTimeCustom+k))

--- a/pkg/mock/time.go
+++ b/pkg/mock/time.go
@@ -15,6 +15,7 @@
 package mock
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -103,13 +104,13 @@ func getTime(timeType string) string {
 	case TimeStampNsAfterDay:
 		return strconv.FormatInt(currentTime.UnixNano()+HourStampNs*24, 10)
 	case Date:
-		return currentTime.Format("2006-01-02")
+		return fmt.Sprintf(`"%s"`, currentTime.Format("2006-01-02"))
 	case DateDay:
-		return currentTime.Add(day).Format("2006-01-02")
+		return fmt.Sprintf(`"%s"`, currentTime.Add(day).Format("2006-01-02"))
 	case DateTime:
-		return currentTime.Format("2006-01-02 15:04:05")
+		return fmt.Sprintf(`"%s"`, currentTime.Format("2006-01-02 15:04:05"))
 	case DateTimeHour:
-		return currentTime.Add(hour).Format("2006-01-02 15:04:05")
+		return fmt.Sprintf(`"%s"`, currentTime.Add(hour).Format("2006-01-02 15:04:05"))
 	}
 
 	if !strings.HasPrefix(timeType, DateTimeCustom) {
@@ -118,7 +119,7 @@ func getTime(timeType string) string {
 
 	key := strings.TrimPrefix(timeType, DateTimeCustom)
 	if format, ok := dateTimeCustoms[key]; ok {
-		return currentTime.Format(format)
+		return fmt.Sprintf(`"%s"`, currentTime.Format(format))
 	}
 	return currentTime.Format(key)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
add comma for time type format

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=313329&iterationID=-1&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add comma for time type format （修复了自动化测试执行时时间类型格式错误）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that add comma for time type format            |
| 🇨🇳 中文    |   修复了自动化测试执行时时间类型格式错误           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
