### PR TITLE
feat(pipeline): edge-side pipeline support register webhook client and dispatch events

### DIFF
--- a/apistructs/event_request.go
+++ b/apistructs/event_request.go
@@ -16,6 +16,8 @@ package apistructs
 
 import (
 	"encoding/json"
+
+	"github.com/erda-project/erda-proto-go/core/messenger/eventbox/pb"
 )
 
 // EventCreateRequest  用于发送 event 的 json request (非 OPENAPI)
@@ -44,4 +46,16 @@ func (r EventCreateRequest) MarshalJSON() ([]byte, error) {
 		}{Webhook: r.EventHeader},
 	}
 	return json.Marshal(result)
+}
+
+func (r *EventCreateRequest) ConvertToPB() (*pb.CreateMessageRequest, error) {
+	reqByte, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	reqPb := pb.CreateMessageRequest{}
+	if err := json.Unmarshal(reqByte, &reqPb); err != nil {
+		return nil, err
+	}
+	return &reqPb, nil
 }

--- a/apistructs/event_request_test.go
+++ b/apistructs/event_request_test.go
@@ -43,3 +43,20 @@ func TestEventCreateRequestMarshal(t *testing.T) {
 	assert.False(t, ok)
 
 }
+
+func TestConvertEventToPB(t *testing.T) {
+	event := &EventCreateRequest{
+		Sender: "pipeline",
+		Content: PipelineInstanceEventData{
+			PipelineID: 1,
+			Status:     PipelineStatusSuccess.String(),
+			Branch:     "develop",
+		},
+		EventHeader: EventHeader{
+			Event: "pipeline",
+		},
+	}
+	eventPB, err := event.ConvertToPB()
+	assert.NoError(t, err)
+	assert.Equal(t, "pipeline", eventPB.Sender)
+}

--- a/modules/pipeline/events/event_pipeline.go
+++ b/modules/pipeline/events/event_pipeline.go
@@ -77,8 +77,10 @@ func (e *PipelineEvent) HandleWebhook() error {
 	req.Sender = SenderPipeline
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
-
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	if !e.edgeRegister.IsEdge() {
+		return e.DefaultEvent.bdl.CreateEvent(req)
+	}
+	return e.edgeRegister.CreateMessageEvent(req)
 }
 
 const (

--- a/modules/pipeline/events/event_task.go
+++ b/modules/pipeline/events/event_task.go
@@ -75,8 +75,10 @@ func (e *PipelineTaskEvent) HandleWebhook() error {
 	req.Sender = SenderPipeline
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
-
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	if !e.edgeRegister.IsEdge() {
+		return e.DefaultEvent.bdl.CreateEvent(req)
+	}
+	return e.edgeRegister.CreateMessageEvent(req)
 }
 
 const (

--- a/modules/pipeline/events/event_task_runtime.go
+++ b/modules/pipeline/events/event_task_runtime.go
@@ -65,7 +65,10 @@ func (e *PipelineTaskRuntimeEvent) HandleWebhook() error {
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
 
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	if !e.edgeRegister.IsEdge() {
+		return e.DefaultEvent.bdl.CreateEvent(req)
+	}
+	return e.edgeRegister.CreateMessageEvent(req)
 }
 
 type WSPipelineTaskRuntimeIDUpdatePayload struct {

--- a/modules/pipeline/events/manager.go
+++ b/modules/pipeline/events/manager.go
@@ -52,9 +52,9 @@ func Initialize(bdl *bundle.Bundle, wsClient *websocket.Publisher, dbClient *dbc
 				//	e.Kind(), e, e.Kind(), e.Header(), e.Sender(), e.Content())
 
 				go handle(ev, HookTypeDB, ev.HandleDB)
+				go handle(ev, HookTypeWebHook, ev.HandleWebhook)
 
 				if !edgeRegister.IsEdge() {
-					go handle(ev, HookTypeWebHook, ev.HandleWebhook)
 					go handle(ev, HookTypeWebSocket, ev.HandleWebSocket)
 					go handle(ev, HookTypeDINGDING, ev.HandleDingDing)
 					go handle(ev, HookTypeHTTP, ev.HandleHTTP)

--- a/modules/pipeline/providers/edgepipeline_register/interface.go
+++ b/modules/pipeline/providers/edgepipeline_register/interface.go
@@ -44,6 +44,9 @@ type Interface interface {
 	GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error)
 	ClusterIsEdge(clusterName string) (bool, error)
 
+	// CreateMessageEvent edge-side pipeline send events by event-dispatcher
+	CreateMessageEvent(event *apistructs.EventCreateRequest) error
+
 	// OnEdge register hook that will be invoked if you are running on edge.
 	// Could register multi hooks as you need.
 	// All hooks executed asynchronously.

--- a/modules/pipeline/providers/edgepipeline_register/mock.go
+++ b/modules/pipeline/providers/edgepipeline_register/mock.go
@@ -47,5 +47,6 @@ func (m *MockEdgeRegister) GetEdgeBundleByClusterName(clusterName string) (*bund
 func (m *MockEdgeRegister) ClusterIsEdge(clusterName string) (bool, error) {
 	return true, nil
 }
-func (m *MockEdgeRegister) OnEdge(f func(context.Context))   {}
-func (m *MockEdgeRegister) OnCenter(f func(context.Context)) {}
+func (m *MockEdgeRegister) OnEdge(f func(context.Context))                                {}
+func (m *MockEdgeRegister) OnCenter(f func(context.Context))                              {}
+func (m *MockEdgeRegister) CreateMessageEvent(event *apistructs.EventCreateRequest) error { return nil }

--- a/modules/pipeline/providers/edgepipeline_register/webhook.go
+++ b/modules/pipeline/providers/edgepipeline_register/webhook.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/erda-project/erda-proto-go/core/messenger/eventbox/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/messenger/eventbox/dispatcher"
+	httpsubscriber "github.com/erda-project/erda/modules/messenger/eventbox/subscriber/http"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+)
+
+func (p *provider) initWebHookEndpoints(ctx context.Context) {
+	p.Register.Add(http.MethodGet, "/api/dice/eventbox/webhooks", func(rw http.ResponseWriter, r *http.Request) {
+		var req pb.ListHooksRequest
+		if err := p.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		vars := mux.Vars(r)
+		hooks, err := p.webHookHTTP.ListHooks(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, hooks)
+	})
+
+	p.Register.Add(http.MethodGet, "/api/dice/eventbox/webhooks/{id}", func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		hookID := vars["id"]
+		var req pb.InspectHookRequest
+		if err := p.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		req.Id = hookID
+		res, err := p.webHookHTTP.InspectHook(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, res)
+	})
+
+	p.Register.Add(http.MethodPost, "/api/dice/eventbox/webhooks", func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		var req pb.CreateHookRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		res, err := p.webHookHTTP.CreateHook(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, res)
+	})
+
+	p.Register.Add(http.MethodPut, "/api/dice/eventbox/webhooks/{id}", func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		var req pb.EditHookRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		req.Id = vars["id"]
+		res, err := p.webHookHTTP.EditHook(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, res)
+	})
+
+	p.Register.Add(http.MethodPost, "/api/dice/eventbox/webhooks/{id}/actions/ping", func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		var req pb.PingHookRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		req.Id = vars["id"]
+		res, err := p.webHookHTTP.PingHook(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, res)
+	})
+
+	p.Register.Add(http.MethodDelete, "/api/dice/eventbox/webhooks/{id}", func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		var req pb.DeleteHookRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		req.Id = vars["id"]
+		res, err := p.webHookHTTP.DeleteHook(ctx, &req, vars)
+		if err != nil {
+			p.wrapBadRequest(rw, err)
+			return
+		}
+		httpserver.WriteJSON(rw, res)
+	})
+}
+
+func (p *provider) wrapBadRequest(rw http.ResponseWriter, err error) {
+	httpserver.WriteErr(rw, strconv.FormatInt(int64(http.StatusBadRequest), 10), err.Error())
+}
+
+func (p *provider) newEventDispatcher() (dispatcher.Dispatcher, error) {
+	eventDispatcher, err := dispatcher.NewImpl()
+	if err != nil {
+		return nil, err
+	}
+
+	eventDispatcher.RegisterInput(p.httpI)
+
+	httpS := httpsubscriber.New()
+	eventDispatcher.RegisterSubscriber(httpS)
+
+	router, err := dispatcher.NewRouter(eventDispatcher)
+	if err != nil {
+		return nil, err
+	}
+	eventDispatcher.SetRouter(router)
+
+	return eventDispatcher, nil
+}
+
+func (p *provider) startEventDispatcher(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				p.eventDispatcher.Stop()
+			}
+		}
+	}()
+	p.eventDispatcher.Start()
+}
+
+func (p *provider) CreateMessageEvent(event *apistructs.EventCreateRequest) error {
+	eventPB, err := event.ConvertToPB()
+	if err != nil {
+		return err
+	}
+	err = p.httpI.CreateMessage(context.Background(), eventPB, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
edge-side pipeline support register webhook client and dispatch events

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=313658&iterationID=1218&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: edge-side pipeline support register webhook client and dispatch events （边缘pipeline支持注册webhook并发送事件）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  edge-side pipeline support register webhook client and dispatch events             |
| 🇨🇳 中文    |   边缘pipeline支持注册webhook并发送事件           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
