### PR TITLE
fix(dop): export autotest failure due to `file_name` length

### DIFF
--- a/.erda/migrations/qa/20220520-file-record-name-length.sql
+++ b/.erda/migrations/qa/20220520-file-record-name-length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `erda_file_record` MODIFY `file_name` VARCHAR(255) NOT NULL COMMENT 'file name';


### PR DESCRIPTION
#### What this PR does / why we need it:
fix export autotest failure due to `file_name` length

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=302217&iterationID=-1&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix export autotest failure due to `file_name` length（修复由于记录表名称限制导致的自动化测试导出失败）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix export autotest failure due to `file_name` length           |
| 🇨🇳 中文    | 修复由于记录表名称限制导致的自动化测试导出失败             |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
