### PR TITLE
revert: add quotation marks for time type format (#4895)

### DIFF
--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -50,10 +50,6 @@ func TestGetTime(t *testing.T) {
 	t.Log("ns-after-hour:", getTime(TimeStampNsAfterHour))
 	t.Log("ns-day:", getTime(TimeStampNsDay))
 	t.Log("ns-after-day:", getTime(TimeStampNsAfterDay))
-	t.Log("date-before-hour", getTime(DateTimeHour))
-	t.Log("date-now", getTime(Date))
-	t.Log("date-day", getTime(DateDay))
-	t.Log("date-time", getTime(DateTime))
 
 	for k := range dateTimeCustoms {
 		t.Log(DateTimeCustom+k+":", getTime(DateTimeCustom+k))

--- a/pkg/mock/time.go
+++ b/pkg/mock/time.go
@@ -15,7 +15,6 @@
 package mock
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -104,13 +103,13 @@ func getTime(timeType string) string {
 	case TimeStampNsAfterDay:
 		return strconv.FormatInt(currentTime.UnixNano()+HourStampNs*24, 10)
 	case Date:
-		return fmt.Sprintf(`"%s"`, currentTime.Format("2006-01-02"))
+		return currentTime.Format("2006-01-02")
 	case DateDay:
-		return fmt.Sprintf(`"%s"`, currentTime.Add(day).Format("2006-01-02"))
+		return currentTime.Add(day).Format("2006-01-02")
 	case DateTime:
-		return fmt.Sprintf(`"%s"`, currentTime.Format("2006-01-02 15:04:05"))
+		return currentTime.Format("2006-01-02 15:04:05")
 	case DateTimeHour:
-		return fmt.Sprintf(`"%s"`, currentTime.Add(hour).Format("2006-01-02 15:04:05"))
+		return currentTime.Add(hour).Format("2006-01-02 15:04:05")
 	}
 
 	if !strings.HasPrefix(timeType, DateTimeCustom) {
@@ -119,7 +118,7 @@ func getTime(timeType string) string {
 
 	key := strings.TrimPrefix(timeType, DateTimeCustom)
 	if format, ok := dateTimeCustoms[key]; ok {
-		return fmt.Sprintf(`"%s"`, currentTime.Format(format))
+		return currentTime.Format(format)
 	}
 	return currentTime.Format(key)
 }


### PR DESCRIPTION
This reverts commit a8079a2acb790c15d67307b02a5e69d676f40212.

#### What this PR does / why we need it:
add quotation marks for time type format (#4895)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/all?id=313329&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDEyLDQ1MzgsNDQxMyw0NDE0LDQ0MTUsNDQxNl0sImFzc2lnbmVlSURzIjpbIjEwMDA0MzIiXX0%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that revert quotation marks for time type format （回退给时间类型的mock添加引号）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that revert quotation marks for time type format            |
| 🇨🇳 中文    |     回退给时间类型的mock添加引号         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
