### PR TITLE
fix: reutrn null if opus is null

### DIFF
--- a/api/proto/core/dicehub/release/release.proto
+++ b/api/proto/core/dicehub/release/release.proto
@@ -517,6 +517,7 @@ message ReleaseData {
   int64 applicationID = 20 [json_name = "applicationId"];
 
   string projectName = 21;
+  string projectDisplayName = 30;
 
   string applicationName = 22;
 

--- a/modules/dicehub/release/release.service.go
+++ b/modules/dicehub/release/release.service.go
@@ -625,13 +625,14 @@ func (s *ReleaseService) ListRelease(ctx context.Context, req *pb.ReleaseListReq
 			logrus.WithError(err).Errorln("failed to ListArtifacts")
 			return nil, errors.Wrap(err, "failed to ListArtifacts")
 		}
-		if len(artifacts.Data) > 0 {
-			var releaseIDs []string
-			for k := range artifacts.Data {
-				releaseIDs = append(releaseIDs, k)
-			}
-			req.ReleaseID = strings.Join(releaseIDs, ",")
+		if len(artifacts.Data) == 0 {
+			return &pb.ReleaseListResponse{}, nil
 		}
+		var releaseIDs []string
+		for k := range artifacts.Data {
+			releaseIDs = append(releaseIDs, k)
+		}
+		req.ReleaseID = strings.Join(releaseIDs, ",")
 		req.ProjectID = 0
 	}
 	resp, err := s.List(ctx, orgID, params)

--- a/modules/dicehub/release/release_test.go
+++ b/modules/dicehub/release/release_test.go
@@ -75,7 +75,7 @@ func TestConvertToListReleaseResponse(t *testing.T) {
 		UpdatedAt:        time.Unix(0, 0),
 	}
 
-	respData, err := convertToListReleaseResponse(release, nil, nil, nil)
+	respData, err := convertToListReleaseResponse(release, nil, nil, nil, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
+++ b/modules/dop/component-protocol/components/release-manage/releaseTable/render.go
@@ -550,12 +550,12 @@ func (r *ComponentReleaseTable) SetComponentValue() {
 	}
 }
 
-func (r *ComponentReleaseTable) Transfer(c *cptype.Component) {
-	c.Props = cputil.MustConvertProps(r.Props)
-	c.Data = map[string]interface{}{
+func (r *ComponentReleaseTable) Transfer(component *cptype.Component) {
+	component.Props = cputil.MustConvertProps(r.Props)
+	component.Data = map[string]interface{}{
 		"list": r.Data.List,
 	}
-	c.State = map[string]interface{}{
+	component.State = map[string]interface{}{
 		"releaseTable__urlQuery": r.State.ReleaseTableURLQuery,
 		"pageNo":                 r.State.PageNo,
 		"pageSize":               r.State.PageSize,
@@ -568,7 +568,7 @@ func (r *ComponentReleaseTable) Transfer(c *cptype.Component) {
 		"applicationID":          r.State.ApplicationID,
 		"filterValues":           r.State.FilterValues,
 	}
-	c.Operations = r.Operations
+	component.Operations = r.Operations
 }
 
 func (r *ComponentReleaseTable) formalReleases(ctx context.Context, releaseID []string) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

1. reutrn null if opus is null
2. add project displayName in list release

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | reutrn null if opus is null; add project displayName in list release  |
| 🇨🇳 中文    | 修复获取来源为gallery的制品时返回所有制品的问题；获取制品接口返回值添加projectDisplayName字段  |

