### PR TITLE
feat(pipeline): support dispatch cron to edge when edge side pipeline registered

### DIFF
--- a/api/proto/core/pipeline/cron/cron.proto
+++ b/api/proto/core/pipeline/cron/cron.proto
@@ -59,6 +59,7 @@ message CronPagingRequest {
   google.protobuf.BoolValue enable = 6;
   repeated string pipelineDefinitionID = 7;
   string clusterName = 8;
+  bool getAll = 9;
 }
 
 message CronPagingResponse {

--- a/apistructs/cluster_dialer.go
+++ b/apistructs/cluster_dialer.go
@@ -45,6 +45,16 @@ func (c ClusterManagerClientType) String() string {
 	return string(c)
 }
 
+type ClusterManagerClientEventType string
+
+var (
+	ClusterManagerClientEventRegister ClusterManagerClientEventType = "register"
+)
+
+func (c ClusterManagerClientType) GenEventName(eventType ClusterManagerClientEventType) string {
+	return fmt.Sprintf("client-%s-event-%s", c, eventType)
+}
+
 func (c ClusterManagerClientType) MakeClientKey(clusterKey string) string {
 	if c == "" {
 		return clusterKey
@@ -55,6 +65,8 @@ func (c ClusterManagerClientType) MakeClientKey(clusterKey string) string {
 type ClusterManagerClientDetailKey string
 
 var (
+	ClusterManagerDataKeyClusterKey ClusterManagerClientDetailKey = "clusterKey"
+
 	ClusterManagerDataKeyPipelineHost ClusterManagerClientDetailKey = "pipelineHost"
 	ClusterManagerDataKeyPipelineAddr ClusterManagerClientDetailKey = "pipelineAddr"
 )

--- a/apistructs/event.go
+++ b/apistructs/event.go
@@ -249,3 +249,8 @@ type GittarPushPayloadEvent struct {
 		} `json:"pusher"`
 	} `json:"content"`
 }
+
+type ClusterManagerClientEvent struct {
+	EventHeader
+	Content ClusterManagerClientDetail `json:"content"`
+}

--- a/bundle/cluster_manager.go
+++ b/bundle/cluster_manager.go
@@ -65,3 +65,24 @@ func (b *Bundle) GetClusterManagerClientData(clientType apistructs.ClusterManage
 	}
 	return getResp, nil
 }
+
+func (b *Bundle) ListClusterManagerClientByType(clientType apistructs.ClusterManagerClientType) ([]apistructs.ClusterManagerClientDetail, error) {
+	host, err := b.urls.ClusterManager()
+	if err != nil {
+		return []apistructs.ClusterManagerClientDetail{}, err
+	}
+	hc := b.hc
+
+	var getResp []apistructs.ClusterManagerClientDetail
+	resp, err := hc.Get(host).
+		Path(fmt.Sprintf("/clusteragent/client-detail/%s", clientType)).
+		Do().
+		JSON(&getResp)
+	if err != nil {
+		return []apistructs.ClusterManagerClientDetail{}, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !resp.IsOK() {
+		return []apistructs.ClusterManagerClientDetail{}, apierrors.ErrInvoke.InternalError(fmt.Errorf("%s", resp.Body()))
+	}
+	return getResp, nil
+}

--- a/internal/core/cluster-manager/dialer/provider.go
+++ b/internal/core/cluster-manager/dialer/provider.go
@@ -50,7 +50,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 }
 
 func (p *provider) Run(ctx context.Context) error {
-	p.Router.Any("/**", server.NewDialerRouter(ctx, p.Cluster, p.Credential, p.Cfg, p.Etcd).ServeHTTP)
+	p.Router.Any("/**", server.NewDialerRouter(ctx, p.Cluster, p.Credential, p.Cfg, p.Etcd, p.Bdl).ServeHTTP)
 	return nil
 }
 

--- a/internal/core/cluster-manager/dialer/server/dialer_test.go
+++ b/internal/core/cluster-manager/dialer/server/dialer_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	clusterpb "github.com/erda-project/erda-proto-go/core/clustermanager/cluster/pb"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/core/cluster-manager/dialer/auth"
 	"github.com/erda-project/erda/internal/core/cluster-manager/dialer/config"
 	clusteragent "github.com/erda-project/erda/internal/tools/cluster-agent/client"
@@ -50,7 +51,7 @@ func startServer(etcd *clientv3.Client) (context.Context, context.CancelFunc) {
 	go Start(ctx, &fakeClusterSvc{}, nil, &config.Config{
 		Listen:          fmt.Sprintf("%s:%s", dialerListenAddr, dialerListenPort),
 		NeedClusterInfo: false,
-	}, etcd)
+	}, etcd, &bundle.Bundle{})
 	return ctx, cancel
 }
 

--- a/internal/core/cluster-manager/dialer/server/tunnel-server_test.go
+++ b/internal/core/cluster-manager/dialer/server/tunnel-server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/core/cluster-manager/dialer/auth"
 	"github.com/erda-project/erda/internal/core/cluster-manager/dialer/config"
 	clusteragent "github.com/erda-project/erda/internal/tools/cluster-agent/client"
@@ -59,7 +60,7 @@ func Test_netportal(t *testing.T) {
 	go Start(context.Background(), &fakeClusterSvc{}, nil, &config.Config{
 		Listen:          dialerListenAddr2,
 		NeedClusterInfo: false,
-	}, &clientv3.Client{KV: &fakeKV{}})
+	}, &clientv3.Client{KV: &fakeKV{}}, bundle.New())
 
 	helloHandler := func(w http.ResponseWriter, req *http.Request) {
 		io.WriteString(w, "Hello, world!")

--- a/internal/tools/pipeline/providers/edgepipeline_register/cluster_access_key.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/cluster_access_key.go
@@ -112,7 +112,7 @@ func (p *provider) watchClusterCredential(ctx context.Context) {
 }
 
 func (p *provider) getInClusterRetryWatcher(ns string) (*watch.RetryWatcher, error) {
-	cs, err := k8sclient.New(p.Cfg.ClusterName)
+	cs, err := k8sclient.New(p.Cfg.ClusterName, k8sclient.WithPreferredToUseInClusterConfig())
 	if err != nil {
 		return nil, fmt.Errorf("create clientset error: %v", err)
 	}

--- a/internal/tools/pipeline/providers/edgepipeline_register/edge_client.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/edge_client.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/mohae/deepcopy"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/pkg/discover"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+var (
+	// center pipeline could receive edge event after edge side pipeline registered
+	EdgeHookApiPath = "/api/pipeline-edge/actions/hook"
+)
+
+type EventHandler func(ctx context.Context, eventDetail apistructs.ClusterManagerClientDetail)
+
+func (p *provider) registerClientHook(ctx context.Context) error {
+	ev := apistructs.CreateHookRequest{
+		Name:   "pipeline_watch_edge_client_changed",
+		Events: []string{apistructs.ClusterManagerClientTypePipeline.GenEventName(apistructs.ClusterManagerClientEventRegister)},
+		URL:    strutil.Concat("http://", discover.Pipeline(), EdgeHookApiPath),
+		Active: true,
+		HookLocation: apistructs.HookLocation{
+			Org:         "-1",
+			Project:     "-1",
+			Application: "-1",
+		},
+	}
+	if err := p.bdl.CreateWebhook(ev); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *provider) registerClientHookUntilSuccess(ctx context.Context) {
+	p.initClientHook(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			err := p.registerClientHook(ctx)
+			if err == nil {
+				return
+			}
+			p.Log.Errorf("failed to register edge clients hook(auto retry), err: %v", err)
+			time.Sleep(3 * time.Second)
+		}
+	}
+}
+
+func (p *provider) initClientHook(ctx context.Context) {
+	p.Register.Add(http.MethodPost, EdgeHookApiPath, func(rw http.ResponseWriter, r *http.Request) {
+		req := apistructs.ClusterManagerClientEvent{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			p.Log.Errorf("failed to decode request body, err: %v", err)
+			httpserver.WriteErr(rw, strconv.FormatInt(int64(http.StatusBadRequest), 10), err.Error())
+			return
+		}
+		p.Log.Infof("received edge client event: %v", req)
+		p.updateClientByEvent(&req)
+		p.emitClientEvent(ctx, req.Content)
+	})
+}
+
+func (p *provider) RegisterEventHandler(handler EventHandler) {
+	p.Lock()
+	defer p.Unlock()
+	p.eventHandlers = append(p.eventHandlers, handler)
+}
+
+func (p *provider) updateClientByEvent(ev *apistructs.ClusterManagerClientEvent) {
+	detail := ev.Content
+	if detail == nil {
+		return
+	}
+	clusterKey := detail.Get(apistructs.ClusterManagerDataKeyClusterKey)
+	if clusterKey == "" {
+		return
+	}
+	p.Lock()
+	p.edgeClients[clusterKey] = detail
+	p.Unlock()
+}
+
+func (p *provider) continuousUpdateClient(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ticker.Reset(p.Cfg.UpdateClientInterval)
+			edgeClients, err := p.bdl.ListClusterManagerClientByType(apistructs.ClusterManagerClientTypePipeline)
+			if err != nil {
+				p.Log.Errorf("failed to list edge clients, err: %v", err)
+				continue
+			}
+			for _, edgeClient := range edgeClients {
+				p.updateClientByEvent(&apistructs.ClusterManagerClientEvent{Content: edgeClient})
+			}
+		}
+	}
+}
+
+func (p *provider) emitClientEvent(ctx context.Context, eventDetail apistructs.ClusterManagerClientDetail) {
+	p.Lock()
+	for _, handler := range p.eventHandlers {
+		go handler(ctx, eventDetail)
+	}
+	p.Unlock()
+}
+
+func (p *provider) ListAllClients() []apistructs.ClusterManagerClientDetail {
+	p.Lock()
+	defer p.Unlock()
+	var result []apistructs.ClusterManagerClientDetail
+	for _, detail := range p.edgeClients {
+		clientDetailDup, ok := deepcopy.Copy(detail).(apistructs.ClusterManagerClientDetail)
+		if !ok {
+			continue
+		}
+		result = append(result, clientDetailDup)
+	}
+	return result
+}

--- a/internal/tools/pipeline/providers/edgepipeline_register/edge_client_test.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/edge_client_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestRegisterEventHandler(t *testing.T) {
+	p := &provider{}
+	p.eventHandlers = make([]EventHandler, 0)
+	p.edgeClients = make(map[string]apistructs.ClusterManagerClientDetail)
+
+	p.RegisterEventHandler(func(ctx context.Context, eventDetail apistructs.ClusterManagerClientDetail) {
+		t.Log("event handler called")
+	})
+	p.RegisterEventHandler(func(ctx context.Context, eventDetail apistructs.ClusterManagerClientDetail) {
+		t.Log("event handler called")
+	})
+	p.emitClientEvent(context.Background(), apistructs.ClusterManagerClientDetail{})
+}
+
+func Test_updateClientByEvent(t *testing.T) {
+	p := &provider{}
+	p.eventHandlers = make([]EventHandler, 0)
+	p.edgeClients = make(map[string]apistructs.ClusterManagerClientDetail)
+
+	p.updateClientByEvent(&apistructs.ClusterManagerClientEvent{
+		Content: apistructs.ClusterManagerClientDetail{
+			apistructs.ClusterManagerDataKeyClusterKey: "erda",
+		},
+	})
+
+	assert.Equal(t, apistructs.ClusterManagerClientDetail{
+		apistructs.ClusterManagerDataKeyClusterKey: "erda",
+	}, p.edgeClients["erda"])
+}

--- a/internal/tools/pipeline/providers/edgepipeline_register/interface.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/interface.go
@@ -56,6 +56,14 @@ type Interface interface {
 	// Could register multi hooks as you need.
 	// All hooks executed asynchronously.
 	OnCenter(func(context.Context))
+
+	// RegisterEventHandler register edge event handler.
+	// Now only support update-operation event.
+	// All handlers executed asynchronously.
+	RegisterEventHandler(handler EventHandler)
+
+	// ListAllClients list all edge pipelines that are registered in center.
+	ListAllClients() []apistructs.ClusterManagerClientDetail
 }
 
 func (p *provider) ClusterIsEdge(clusterName string) (bool, error) {

--- a/internal/tools/pipeline/providers/edgepipeline_register/mock.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/mock.go
@@ -53,6 +53,8 @@ func (m *MockEdgeRegister) ClusterIsEdge(clusterName string) (bool, error) {
 func (m *MockEdgeRegister) OnEdge(f func(context.Context))                                {}
 func (m *MockEdgeRegister) OnCenter(f func(context.Context))                              {}
 func (m *MockEdgeRegister) CreateMessageEvent(event *apistructs.EventCreateRequest) error { return nil }
+func (m *MockEdgeRegister) RegisterEventHandler(handler EventHandler)                     {}
+func (m *MockEdgeRegister) ListAllClients() []apistructs.ClusterManagerClientDetail       { return nil }
 
 type MockKV struct{}
 

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -52,6 +52,10 @@ func New(clusterName string, ops ...Option) (*K8sClient, error) {
 	inClusterName := os.Getenv(string(apistructs.DICE_CLUSTER_NAME))
 	if inClusterName == clusterName && kc.priorityUseInCluster {
 		rc, err = config.GetInClusterRestConfig()
+		// if get config from /var/sericeaccount failed, try cluster-manager again
+		if err != nil {
+			rc, err = GetRestConfig(clusterName)
+		}
 	} else {
 		rc, err = GetRestConfig(clusterName)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
support dispatch cron to edge when edge side pipeline registered

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=313905&iterationID=-1&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature:  support dispatch cron to edge when edge side pipeline registered（dge pipeline 注册上来之后，center pipeline 主动下发相关 cron ）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   support dispatch cron to edge when edge side pipeline registered           |
| 🇨🇳 中文    |    dge pipeline 注册上来之后，center pipeline 主动下发相关 cron          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
