### PR TITLE
feat(pipeline): edge-side pipeline support register webhook and dispatch events

### DIFF
--- a/apistructs/event_request.go
+++ b/apistructs/event_request.go
@@ -16,6 +16,8 @@ package apistructs
 
 import (
 	"encoding/json"
+
+	"github.com/erda-project/erda-proto-go/core/messenger/eventbox/pb"
 )
 
 // EventCreateRequest  用于发送 event 的 json request (非 OPENAPI)
@@ -44,4 +46,16 @@ func (r EventCreateRequest) MarshalJSON() ([]byte, error) {
 		}{Webhook: r.EventHeader},
 	}
 	return json.Marshal(result)
+}
+
+func (r *EventCreateRequest) ConvertToPB() (*pb.CreateMessageRequest, error) {
+	reqByte, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	reqPb := pb.CreateMessageRequest{}
+	if err := json.Unmarshal(reqByte, &reqPb); err != nil {
+		return nil, err
+	}
+	return &reqPb, nil
 }

--- a/apistructs/event_request_test.go
+++ b/apistructs/event_request_test.go
@@ -43,3 +43,21 @@ func TestEventCreateRequestMarshal(t *testing.T) {
 	assert.False(t, ok)
 
 }
+
+func TestConvertEventToPB(t *testing.T) {
+	event := &EventCreateRequest{
+		Sender: "pipeline",
+		Content: PipelineInstanceEventData{
+			PipelineID: 1,
+			Status:     PipelineStatusSuccess.String(),
+			Branch:     "develop",
+		},
+		EventHeader: EventHeader{
+			Event: "pipeline",
+		},
+	}
+
+	eventPB, err := event.ConvertToPB()
+	assert.NoError(t, err)
+	assert.Equal(t, "pipeline", eventPB.Sender)
+}

--- a/internal/tools/pipeline/events/event.go
+++ b/internal/tools/pipeline/events/event.go
@@ -50,6 +50,13 @@ func (*DefaultEvent) HandleDingDing() error  { return nil }
 func (*DefaultEvent) HandleHTTP() error      { return nil }
 func (*DefaultEvent) HandleDB() error        { return nil }
 
+func (ev *DefaultEvent) CreateEvent(req *apistructs.EventCreateRequest) error {
+	if !ev.edgeRegister.IsEdge() {
+		return ev.bdl.CreateEvent(req)
+	}
+	return ev.edgeRegister.CreateMessageEvent(req)
+}
+
 const (
 	SenderPipeline = "pipeline"
 )

--- a/internal/tools/pipeline/events/event_pipeline.go
+++ b/internal/tools/pipeline/events/event_pipeline.go
@@ -77,8 +77,7 @@ func (e *PipelineEvent) HandleWebhook() error {
 	req.Sender = SenderPipeline
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
-
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	return e.DefaultEvent.CreateEvent(req)
 }
 
 const (

--- a/internal/tools/pipeline/events/event_task.go
+++ b/internal/tools/pipeline/events/event_task.go
@@ -75,8 +75,7 @@ func (e *PipelineTaskEvent) HandleWebhook() error {
 	req.Sender = SenderPipeline
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
-
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	return e.DefaultEvent.CreateEvent(req)
 }
 
 const (

--- a/internal/tools/pipeline/events/event_task_runtime.go
+++ b/internal/tools/pipeline/events/event_task_runtime.go
@@ -65,7 +65,7 @@ func (e *PipelineTaskRuntimeEvent) HandleWebhook() error {
 	req.EventHeader = e.Header()
 	req.Content = e.Content()
 
-	return e.DefaultEvent.bdl.CreateEvent(req)
+	return e.DefaultEvent.CreateEvent(req)
 }
 
 type WSPipelineTaskRuntimeIDUpdatePayload struct {

--- a/internal/tools/pipeline/providers/edgepipeline_register/interface.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/interface.go
@@ -44,6 +44,9 @@ type Interface interface {
 	GetEdgeBundleByClusterName(clusterName string) (*bundle.Bundle, error)
 	ClusterIsEdge(clusterName string) (bool, error)
 
+	// CreateMessageEvent edge-side pipeline send events by event-dispatcher
+	CreateMessageEvent(event *apistructs.EventCreateRequest) error
+
 	// OnEdge register hook that will be invoked if you are running on edge.
 	// Could register multi hooks as you need.
 	// All hooks executed asynchronously.

--- a/internal/tools/pipeline/providers/edgepipeline_register/mock.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/mock.go
@@ -50,8 +50,9 @@ func (m *MockEdgeRegister) GetEdgeBundleByClusterName(clusterName string) (*bund
 func (m *MockEdgeRegister) ClusterIsEdge(clusterName string) (bool, error) {
 	return true, nil
 }
-func (m *MockEdgeRegister) OnEdge(f func(context.Context))   {}
-func (m *MockEdgeRegister) OnCenter(f func(context.Context)) {}
+func (m *MockEdgeRegister) OnEdge(f func(context.Context))                                {}
+func (m *MockEdgeRegister) OnCenter(f func(context.Context))                              {}
+func (m *MockEdgeRegister) CreateMessageEvent(event *apistructs.EventCreateRequest) error { return nil }
 
 type MockKV struct{}
 

--- a/internal/tools/pipeline/providers/edgepipeline_register/provider.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/provider.go
@@ -21,10 +21,15 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/schema"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda-infra/pkg/transport"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/internal/core/messenger/eventbox/dispatcher"
+	httpinput "github.com/erda-project/erda/internal/core/messenger/eventbox/input/http"
+	"github.com/erda-project/erda/internal/core/messenger/eventbox/webhook"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/leaderworker"
 )
 
@@ -44,15 +49,21 @@ type Config struct {
 type provider struct {
 	sync.Mutex
 
-	Log logs.Logger
-	Cfg *Config
-	LW  leaderworker.Interface
+	Log      logs.Logger
+	Cfg      *Config
+	LW       leaderworker.Interface
+	Register transport.Register
 
-	bdl          *bundle.Bundle
-	EtcdClient   *clientv3.Client
-	started      bool
-	forCenterUse forCenterUse
-	forEdgeUse   forEdgeUse
+	bdl                *bundle.Bundle
+	EtcdClient         *clientv3.Client
+	started            bool
+	forCenterUse       forCenterUse
+	forEdgeUse         forEdgeUse
+	queryStringDecoder *schema.Decoder
+
+	webHookHTTP     *webhook.WebHookHTTP
+	httpI           *httpinput.HttpInput
+	eventDispatcher dispatcher.Dispatcher
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
@@ -63,10 +74,28 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		return err
 	}
 	p.bdl = bundle.New(bundle.WithClusterManager())
+	p.queryStringDecoder = schema.NewDecoder()
+	webHookHTTP, err := webhook.NewWebHookHTTP()
+	if err != nil {
+		return err
+	}
+	p.webHookHTTP = webHookHTTP
+	httpI, err := httpinput.New()
+	if err != nil {
+		return err
+	}
+	p.httpI = httpI
+	eventDispatcher, err := p.newEventDispatcher()
+	if err != nil {
+		return err
+	}
+	p.eventDispatcher = eventDispatcher
 	p.forEdgeUse.handlersOnEdge = make(chan func(context.Context), 0)
 	p.forCenterUse.handlersOnCenter = make(chan func(context.Context), 0)
 	p.startEdgeCenterUse(ctx)
 	p.OnEdge(p.watchClusterCredential)
+	p.OnEdge(p.initWebHookEndpoints)
+	p.OnEdge(p.startEventDispatcher)
 	p.waitingEdgeReady(ctx)
 	return nil
 }

--- a/internal/tools/pipeline/providers/edgepipeline_register/webhook.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/webhook.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/erda-project/erda-proto-go/core/messenger/eventbox/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/core/messenger/eventbox/dispatcher"
+	httpsubscriber "github.com/erda-project/erda/internal/core/messenger/eventbox/subscriber/http"
+	"github.com/erda-project/erda/pkg/http/httpserver"
+)
+
+func (p *provider) listWebHook(rw http.ResponseWriter, r *http.Request) {
+	var req pb.ListHooksRequest
+	if err := p.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	vars := mux.Vars(r)
+	hooks, err := p.webHookHTTP.ListHooks(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, hooks)
+}
+
+func (p *provider) getWebHook(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	hookID := vars["id"]
+	var req pb.InspectHookRequest
+	if err := p.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	req.Id = hookID
+	res, err := p.webHookHTTP.InspectHook(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, res)
+}
+
+func (p *provider) createWebHook(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var req pb.CreateHookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	res, err := p.webHookHTTP.CreateHook(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, res)
+}
+
+func (p *provider) editWebHook(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var req pb.EditHookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	req.Id = vars["id"]
+	res, err := p.webHookHTTP.EditHook(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, res)
+}
+
+func (p *provider) pingWebHook(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var req pb.PingHookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	req.Id = vars["id"]
+	res, err := p.webHookHTTP.PingHook(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, res)
+}
+
+func (p *provider) deleteWebHook(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var req pb.DeleteHookRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	req.Id = vars["id"]
+	res, err := p.webHookHTTP.DeleteHook(context.Background(), &req, vars)
+	if err != nil {
+		p.wrapBadRequest(rw, err)
+		return
+	}
+	httpserver.WriteJSON(rw, res)
+}
+
+func (p *provider) initWebHookEndpoints(ctx context.Context) {
+	p.Register.Add(http.MethodGet, "/api/dice/eventbox/webhooks", p.listWebHook)
+
+	p.Register.Add(http.MethodGet, "/api/dice/eventbox/webhooks/{id}", p.getWebHook)
+
+	p.Register.Add(http.MethodPost, "/api/dice/eventbox/webhooks", p.createWebHook)
+
+	p.Register.Add(http.MethodPut, "/api/dice/eventbox/webhooks/{id}", p.editWebHook)
+
+	p.Register.Add(http.MethodPost, "/api/dice/eventbox/webhooks/{id}/actions/ping", p.pingWebHook)
+
+	p.Register.Add(http.MethodDelete, "/api/dice/eventbox/webhooks/{id}", p.deleteWebHook)
+}
+
+func (p *provider) wrapBadRequest(rw http.ResponseWriter, err error) {
+	httpserver.WriteErr(rw, strconv.FormatInt(int64(http.StatusBadRequest), 10), err.Error())
+}
+
+func (p *provider) newEventDispatcher() (dispatcher.Dispatcher, error) {
+	eventDispatcher, err := dispatcher.NewImpl()
+	if err != nil {
+		return nil, err
+	}
+
+	eventDispatcher.RegisterInput(p.httpI)
+
+	httpS := httpsubscriber.New()
+	eventDispatcher.RegisterSubscriber(httpS)
+
+	router, err := dispatcher.NewRouter(eventDispatcher)
+	if err != nil {
+		return nil, err
+	}
+	eventDispatcher.SetRouter(router)
+
+	return eventDispatcher, nil
+}
+
+func (p *provider) startEventDispatcher(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				p.eventDispatcher.Stop()
+			}
+		}
+	}()
+	p.eventDispatcher.Start()
+}
+
+func (p *provider) CreateMessageEvent(event *apistructs.EventCreateRequest) error {
+	eventPB, err := event.ConvertToPB()
+	if err != nil {
+		return err
+	}
+	err = p.httpI.CreateMessage(context.Background(), eventPB, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/tools/pipeline/providers/edgepipeline_register/webhook_test.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/webhook_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgepipeline_register
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"github.com/erda-project/erda-infra/pkg/transport/http"
+	"github.com/erda-project/erda-proto-go/core/messenger/eventbox/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/core/messenger/eventbox/dispatcher"
+	httpinput "github.com/erda-project/erda/internal/core/messenger/eventbox/input/http"
+	"github.com/erda-project/erda/internal/core/messenger/eventbox/subscriber"
+)
+
+type MockRegister struct{}
+
+func (m *MockRegister) Add(method string, path string, handler http.HandlerFunc) {}
+
+func (m *MockRegister) RegisterService(desc *grpc.ServiceDesc, impl interface{}) {}
+
+func Test_initWebHookEndpoints(t *testing.T) {
+	p := &provider{}
+
+	p.Register = &MockRegister{}
+
+	t.Run("initWebHookEndpoints", func(t *testing.T) {
+		p.initWebHookEndpoints(context.Background())
+	})
+}
+
+//func Test_startEventDispatcher(t *testing.T) {
+//	p := &provider{}
+//	dispatcherImpl := &dispatcher.DispatcherImpl{}
+//	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(dispatcherImpl), "Start", func(_ *dispatcher.DispatcherImpl) {})
+//	defer pm1.Unpatch()
+//	pm3 := monkey.PatchInstanceMethod(reflect.TypeOf(dispatcherImpl), "Stop", func(_ *dispatcher.DispatcherImpl) {})
+//	defer pm3.Unpatch()
+//	pm2 := monkey.Patch(dispatcher.NewImpl, func() (*dispatcher.DispatcherImpl, error) {
+//		return dispatcherImpl, nil
+//	})
+//	defer pm2.Unpatch()
+//	p.eventDispatcher, _ = dispatcher.NewImpl()
+//	t.Run("startEventDispatcher", func(t *testing.T) {
+//		ctx, cancel := context.WithCancel(context.Background())
+//		p.startEventDispatcher(ctx)
+//		time.Sleep(time.Second)
+//		cancel()
+//	})
+//}
+
+func Test_newEventDispatcher(t *testing.T) {
+	p := &provider{}
+	p.httpI = &httpinput.HttpInput{}
+	dispatcherImpl := &dispatcher.DispatcherImpl{}
+	pm1 := monkey.Patch(dispatcher.NewImpl, func() (*dispatcher.DispatcherImpl, error) {
+		return dispatcherImpl, nil
+	})
+	defer pm1.Unpatch()
+
+	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(dispatcherImpl), "RegisterSubscriber", func(_ *dispatcher.DispatcherImpl, s subscriber.Subscriber) {
+		return
+	})
+	defer pm2.Unpatch()
+
+	pm3 := monkey.Patch(dispatcher.NewRouter, func(*dispatcher.DispatcherImpl) (*dispatcher.Router, error) {
+		return &dispatcher.Router{}, nil
+	})
+	defer pm3.Unpatch()
+
+	t.Run("newEventDispatcher", func(t *testing.T) {
+		_, err := p.newEventDispatcher()
+		if err != nil {
+			t.Logf("newEventDispatcher error: %v", err)
+		}
+	})
+}
+
+func TestCreateMessageEvent(t *testing.T) {
+	httpI := &httpinput.HttpInput{}
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(httpI), "CreateMessage", func(b *httpinput.HttpInput, ctx context.Context, request *pb.CreateMessageRequest, vars map[string]string) error {
+		return nil
+	})
+	defer pm1.Unpatch()
+	p := &provider{
+		httpI: httpI,
+	}
+	err := p.CreateMessageEvent(&apistructs.EventCreateRequest{})
+	assert.NoError(t, err)
+}
+
+type mockResponseWriter struct {
+}
+
+func (m mockResponseWriter) Header() nethttp.Header {
+	return map[string][]string{}
+}
+
+func (m mockResponseWriter) Write(bytes []byte) (int, error) {
+	return 0, nil
+}
+
+func (m mockResponseWriter) WriteHeader(statusCode int) {
+
+}
+
+func Test_wrapBadRequest(t *testing.T) {
+	p := &provider{}
+	t.Run("wrapBadRequest", func(t *testing.T) {
+		p.wrapBadRequest(&mockResponseWriter{}, fmt.Errorf("test error"))
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
edge-side pipeline support register webhook client and dispatch events

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=313658&iterationID=1218&pId=0&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: edge-side pipeline support register webhook client and dispatch events （边缘pipeline支持注册webhook并发送事件）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  edge-side pipeline support register webhook client and dispatch events             |
| 🇨🇳 中文    |   边缘pipeline支持注册webhook并发送事件           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
