### PR TITLE
fix: use changed-files action to handle push event

### DIFF
--- a/.github/workflows/ci-it-noneed.yml
+++ b/.github/workflows/ci-it-noneed.yml
@@ -33,17 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: check
+        with:
+          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v21
+      - name: List all changed files
         run: |
-          PR_NUMBER=${{ github.event.number }}
-          files=$(gh pr view ${PR_NUMBER} --json files -q '.files[].path')
-          for file in $files; do
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             ext="${file##*.}"
             echo "file: $file, ext: $ext"
             echo "::set-output name=have-${ext}::true"
           done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       have-go: ${{ steps.check.outputs.have-go }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

We use pr number from workflow context before, so it fails when squash merged (it's a push event, no pr id).

<img width="818" alt="image" src="https://user-images.githubusercontent.com/13919034/170928220-a3b3faa9-310a-401e-a414-c99643b8632a.png">


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   use changed-files action to handle push event           |
| 🇨🇳 中文    |     使用 changed-files Action 来处理 Push 事件         |