### PR TITLE
fix(pipeline): end listening log lines use context done instead of end tail flag

### DIFF
--- a/modules/tools/pipeline/actionagent/execute.go
+++ b/modules/tools/pipeline/actionagent/execute.go
@@ -65,7 +65,7 @@ func (agent *Agent) Execute(r io.Reader) {
 		return
 	}
 	defer func() {
-		// defer write flag end line for tail
+		// it's not necessary to write flag end line for tail, because tail watcher listen context to end
 		agent.writeEndFlagLine()
 	}()
 

--- a/modules/tools/pipeline/actionagent/file_watch.go
+++ b/modules/tools/pipeline/actionagent/file_watch.go
@@ -43,7 +43,6 @@ func (agent *Agent) watchFiles() {
 		return
 	}
 	agent.FileWatcher = watcher
-	agent.FileWatcher.EndLineForTail = agent.EasyUse.FlagEndLineForTail
 
 	// ${METAFILE}
 	watcher.RegisterFullHandler(agent.EasyUse.ContainerMetaFile, metaFileFullHandler(agent))


### PR DESCRIPTION
#### What this PR does / why we need it:
end listening log lines use context done instead of end tail flag

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=314618&iterationID=-1&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： end listening log lines use context done instead of end tail flag （修复agent监听日志长时间卡住）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   end listening log lines use context done instead of end tail flag           |
| 🇨🇳 中文    |     修复agent监听日志长时间卡住         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
