### PR TITLE
fix: add build-routers to common openapi

### DIFF
--- a/api/proto/core/pipeline/build/build.proto
+++ b/api/proto/core/pipeline/build/build.proto
@@ -24,15 +24,24 @@ service BuildService {
     option (google.api.http) = {
       get: "/api/build-artifacts/{sha}",
     };
+    option(erda.common.openapi) = {
+      path : "/api/build-artifacts/{sha}",
+    };
   }
   rpc RegisterBuildArtifact (BuildArtifactRegisterRequest) returns (BuildArtifactRegisterResponse) {
     option (google.api.http) = {
       post: "/api/build-artifacts",
     };
+    option(erda.common.openapi) = {
+      path : "/api/build-artifacts",
+    };
   }
   rpc ReportBuildCache (BuildCacheReportRequest) returns (BuildCacheReportResponse) {
     option (google.api.http) = {
       post: "/api/build-caches",
+    };
+    option(erda.common.openapi) = {
+      path : "/api/build-caches",
     };
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
add build-routers to common openapi


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add build-routers to common openapi（修复了构建产物相关路由添加到openapi）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that add build-routers to common openapi           |
| 🇨🇳 中文    |  修复了构建产物相关路由添加到openapi            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
