### PR TITLE
chore: specify gohub image tag to 1.0.5

### DIFF
--- a/.erda/pipelines/ci-build-ce.yml
+++ b/.erda/pipelines/ci-build-ce.yml
@@ -26,7 +26,7 @@ stages:
   - stage:
       - custom-script:
           alias: erda
-          image: registry.erda.cloud/erda/gohub:latest
+          image: registry.erda.cloud/erda/gohub:1.0.5
           commands:
             - cp -a ${{ dirs.raw-erda }}/. .
             - make proto-go-in-local

--- a/.erda/pipelines/ci-deploy.yml
+++ b/.erda/pipelines/ci-deploy.yml
@@ -46,7 +46,7 @@ stages:
   - stage:
       - custom-script:
           alias: erda
-          image: registry.erda.cloud/erda/gohub:latest
+          image: registry.erda.cloud/erda/gohub:1.0.5
           commands:
             - cp -a ${{ dirs.raw-erda }}/. .
             - make proto-go-in-local

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -36,7 +36,7 @@ jobs:
   PREPARE:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/gohub:latest
+      image: registry.erda.cloud/erda/gohub:1.0.5
     steps:
       - name: Clone repo
         uses: actions/checkout@v3

--- a/api/proto-go/Makefile
+++ b/api/proto-go/Makefile
@@ -36,5 +36,5 @@ build-use-docker-image:
 		-v $${proj_root}:/go/src/github.com/erda-project/erda \
 		-v $$(go env GOMODCACHE):/go/pkg/mod \
 		-e target_proj_root=$${target_proj_root} \
-		registry.erda.cloud/erda/gohub:latest \
+		registry.erda.cloud/erda/gohub:1.0.5 \
 		sh -c 'cd /go/src/github.com/erda-project/erda && make proto-go-in-local'

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -47,7 +47,7 @@ stages:
   - stage:
       - custom-script:
           alias: erda
-          image: registry.erda.cloud/erda/gohub:latest
+          image: registry.erda.cloud/erda/gohub:1.0.5
           commands:
             - cp -a ${{ dirs.raw-erda }}/. .
             - make proto-go-in-local


### PR DESCRIPTION
#### What this PR does / why we need it:

specify gohub image tag to 1.0.5


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   specify gohub image tag to 1.0.5           |
| 🇨🇳 中文    |    指定 gohub 镜像 tag 为 1.0.5          |