### PR TITLE
fix(pipeline): task op always begin queue due to `fetchLatestTask` when user click cancel

### DIFF
--- a/internal/tools/pipeline/providers/reconciler/taskrun/framework.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/framework.go
@@ -40,9 +40,6 @@ func (tr *TaskRun) Do(itr TaskOp) error {
 
 	// define op handle func
 	handleProcessingResult := func(data interface{}, err error) {
-		// fetchLatestTask for task update after processing
-		_ = loop.New(loop.WithDeclineRatio(2), loop.WithDeclineLimit(time.Minute)).
-			Do(func() (bool, error) { return tr.fetchLatestTask() == nil, nil })
 
 		if tr.Task.Status.IsEndStatus() {
 			o.ExitCh <- struct{}{}


### PR DESCRIPTION
#### What this PR does / why we need it:
task op always begin queue due to `fetchLatestTask`

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=317259&issueFilter__urlQuery=e30%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=-1&type=TICKET)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that task op always begin queue due to `fetchLatestTask` when user click cancel（修复用户点击取消后后状态一直变成取消）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that task op always begin queue due to `fetchLatestTask` when user click cancel             |
| 🇨🇳 中文    |   修复用户点击取消后后状态一直变成取消           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
