### PR TITLE
fix: change action-runner-scheduler auth check

### DIFF
--- a/api/proto/core/pipeline/action_runner_scheduler/runner_task.proto
+++ b/api/proto/core/pipeline/action_runner_scheduler/runner_task.proto
@@ -11,10 +11,6 @@ option go_package = "github.com/erda-project/erda-proto-go/core/pipeline/action_
 service RunnerTaskService {
   option (erda.common.openapi_service) = {
     service: "pipeline",
-    auth: {
-      check_login: false,
-      check_token: false,
-    }
   };
 
   rpc CreateRunnerTask (RunnerTaskCreateRequest) returns (RunnerTaskCreateResponse) {
@@ -32,10 +28,13 @@ service RunnerTaskService {
 
   rpc UpdateRunnerTask (RunnerTaskUpdateRequest) returns (RunnerTaskUpdateResponse) {
     option (google.api.http) = {
-      post: "/api/runner/tasks/{id}",
+      put: "/api/runner/tasks/{id}",
     };
     option (erda.common.openapi) = {
       path: "/api/runner/tasks/{id}",
+      auth: {
+        no_check: true,
+      }
     };
   }
 
@@ -58,6 +57,9 @@ service RunnerTaskService {
     };
     option (erda.common.openapi) = {
       path: "/api/runner/fetch-task",
+      auth: {
+        no_check: true,
+      }
     };
   }
 
@@ -68,6 +70,9 @@ service RunnerTaskService {
     };
     option (erda.common.openapi) = {
       path: "/api/runner/collect/logs/{source}",
+      auth: {
+        no_check: true,
+      }
     };
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
change action-runner-scheduler auth check

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=317801&iterationID=1250&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： change action-runner-scheduler auth check（修复了action-runner-scheduler接口的权限校验）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   change action-runner-scheduler auth check           |
| 🇨🇳 中文    |    修复了action-runner-scheduler接口的权限校验          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
