### PR TITLE
fix(pipeline): Solve the problem that the pipeline records of timed execution cannot be queried according to the executor

### DIFF
--- a/apistructs/pipeline_page.go
+++ b/apistructs/pipeline_page.go
@@ -70,3 +70,10 @@ func (p *PagePipeline) GetUserID() string {
 	}
 	return ""
 }
+
+func (p *PagePipeline) GetRunUserID() string {
+	if p.Extra.RunUser != nil && p.Extra.RunUser.ID != nil {
+		return fmt.Sprintf("%v", p.Extra.RunUser.ID)
+	}
+	return ""
+}

--- a/apistructs/pipeline_page_test.go
+++ b/apistructs/pipeline_page_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apistructs
+
+import (
+	"testing"
+)
+
+func TestPagePipeline_GetRunUserID(t *testing.T) {
+	type fields struct {
+		ID    uint64
+		Extra PipelineExtra
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test with empty",
+			fields: fields{
+				ID: 10001,
+				Extra: PipelineExtra{RunUser: &PipelineUser{
+					ID:   nil,
+					Name: "erda",
+				}},
+			},
+			want: "",
+		},
+		{
+			name: "test with empty2",
+			fields: fields{
+				ID:    10001,
+				Extra: PipelineExtra{RunUser: nil},
+			},
+			want: "",
+		},
+		{
+			name: "test with correct",
+			fields: fields{
+				ID:    10001,
+				Extra: PipelineExtra{RunUser: &PipelineUser{
+					ID:   1,
+					Name: "erda",
+				}},
+			},
+			want: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PagePipeline{
+				ID:    tt.fields.ID,
+				Extra: tt.fields.Extra,
+			}
+			if got := p.GetRunUserID(); got != tt.want {
+				t.Errorf("GetRunUserID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/apps/dop/providers/projectpipeline/service_impl.go
+++ b/internal/apps/dop/providers/projectpipeline/service_impl.go
@@ -1407,10 +1407,6 @@ func (p *ProjectPipelineService) autoRunPipeline(identityInfo apistructs.Identit
 	createV2.DefinitionID = definition.ID
 	createV2.UserID = identityInfo.UserID
 
-	// add run,create userID label for history list search
-	createV2.Labels[apistructs.LabelRunUserID] = identityInfo.UserID
-	createV2.Labels[apistructs.LabelCreateUserID] = identityInfo.UserID
-
 	// run params
 	var pipelineRunParams apistructs.PipelineRunParams
 	for _, runParams := range params.runParams {

--- a/internal/apps/dop/providers/projectpipeline/service_impl.go
+++ b/internal/apps/dop/providers/projectpipeline/service_impl.go
@@ -875,7 +875,7 @@ func makeListPipelineExecHistoryResponse(data *apistructs.PipelinePageListData) 
 			}(),
 			AppName:    getApplicationNameFromDefinitionRemote(pipeline.DefinitionPageInfo.SourceRemote),
 			Branch:     pipeline.DefinitionPageInfo.SourceRef,
-			Executor:   pipeline.GetUserID(),
+			Executor:   pipeline.GetRunUserID(),
 			TimeBegin:  timeBegin,
 			PipelineID: pipeline.ID,
 		})

--- a/internal/tools/pipeline/providers/run/run_test.go
+++ b/internal/tools/pipeline/providers/run/run_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/spec"
+)
+
+func Test_provider_createPipelineRunLabels(t *testing.T) {
+	type fields struct {
+		dbClient *dbclient.Client
+	}
+	type args struct {
+		p   spec.Pipeline
+		req *apistructs.PipelineRunRequest
+	}
+
+	dbClient := &dbclient.Client{}
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "BatchInsertLabels", func(dbClient *dbclient.Client, labels []spec.PipelineLabel, ops ...dbclient.SessionOption) (err error) {
+		return nil
+	})
+	defer monkey.UnpatchAll()
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test with create labels",
+			fields: fields{
+				dbClient: dbClient,
+			},
+			args: args{
+				p: spec.Pipeline{
+					PipelineBase: spec.PipelineBase{
+						ID:              1,
+						PipelineSource:  "dice",
+						PipelineYmlName: "pipeline.yml",
+					},
+				},
+				req: &apistructs.PipelineRunRequest{
+					IdentityInfo: apistructs.IdentityInfo{
+						UserID: "1",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &provider{
+				dbClient: tt.fields.dbClient,
+			}
+			if err := s.createPipelineRunLabels(tt.args.p, tt.args.req); (err != nil) != tt.wantErr {
+				t.Errorf("createPipelineRunLabels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tools/pipeline/services/pipelinesvc/create_v2.go
+++ b/internal/tools/pipeline/services/pipelinesvc/create_v2.go
@@ -175,6 +175,9 @@ func (s *PipelineSvc) makePipelineFromRequestV2(req *apistructs.PipelineCreateRe
 	if p.Labels == nil {
 		p.Labels = make(map[string]string)
 	}
+	// add run,create userID label for history list search
+	p.Labels[apistructs.LabelRunUserID] = req.UserID
+	p.Labels[apistructs.LabelCreateUserID] = req.UserID
 
 	// envs
 	p.Snapshot.Envs = req.Envs

--- a/internal/tools/pipeline/services/pipelinesvc/create_v2.go
+++ b/internal/tools/pipeline/services/pipelinesvc/create_v2.go
@@ -175,8 +175,6 @@ func (s *PipelineSvc) makePipelineFromRequestV2(req *apistructs.PipelineCreateRe
 	if p.Labels == nil {
 		p.Labels = make(map[string]string)
 	}
-	// add run,create userID label for history list search
-	p.Labels[apistructs.LabelRunUserID] = req.UserID
 	p.Labels[apistructs.LabelCreateUserID] = req.UserID
 
 	// envs


### PR DESCRIPTION


#### What this PR does / why we need it:
Solve the problem that the pipeline records of timed execution cannot be queried according to the executor

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJpdGVyYXRpb25JRHMiOlsxMjgwLDEyNTBdLCJhc3NpZ25lZSI6WyIxMDAxMjYxIl19&id=317719&iterationID=1280&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Solve the problem that the pipeline records of timed execution cannot be queried according to the executor        |
| 🇨🇳 中文    |      解决定时执行的流水线记录根据执行者查询不到问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
