### PR TITLE
fix(pipeline): overwrite current task with latest when status is ending

### DIFF
--- a/internal/tools/pipeline/providers/reconciler/task_reconciler.go
+++ b/internal/tools/pipeline/providers/reconciler/task_reconciler.go
@@ -316,9 +316,13 @@ func (tr *defaultTaskReconciler) TeardownAfterReconcileDone(ctx context.Context,
 	tr.log.Infof("begin teardown task, pipelineID: %d, taskID: %d, taskName: %s", p.ID, task.ID, task.Name)
 	defer tr.log.Infof("end teardown task, pipelineID: %d, taskID: %d, taskName: %s", p.ID, task.ID, task.Name)
 
+	// overwrite current task with latest, otherwise aop will lose result information and so on
+	if err := tr.overwriteTaskWithLatest(task); err != nil {
+		tr.log.Errorf("failed to overwrite task with latest(continue teardown), pipelineID: %d, taskID: %d, err: %v", p.ID, task.ID, err)
+	}
+
 	// handle aop synchronously, then do subsequent tasks
 	_ = aop2.Handle(aop2.NewContextForTask(*task, *p, aoptypes.TuneTriggerTaskAfterExec))
-
 	// report task in edge cluster
 	if tr.edgeRegister.IsEdge() {
 		tr.edgeReporter.TriggerOnceTaskReport(task.ID)
@@ -440,5 +444,16 @@ func (tr *defaultTaskReconciler) judgeIfExpression(ctx context.Context, p *spec2
 		tr.log.Infof("set task status to %s (calculatedStatusForTaskUse: %s, action if expression is empty), pipelineID: %d, taskID: %d, taskName: %s",
 			apistructs.PipelineStatusNoNeedBySystem, tr.pr.calculatedStatusForTaskUse, p.ID, task.ID, task.Name)
 	}
+	return nil
+}
+
+// overwriteTaskWithLatest overwrite current task with latest
+// the same as taskrun.fetchlatesttask, use one later when refactored
+func (tr *defaultTaskReconciler) overwriteTaskWithLatest(task *spec2.PipelineTask) error {
+	latest, err := tr.dbClient.GetPipelineTask(task.ID)
+	if err != nil {
+		return err
+	}
+	*(task) = *(&latest)
 	return nil
 }

--- a/internal/tools/pipeline/providers/reconciler/task_reconciler_test.go
+++ b/internal/tools/pipeline/providers/reconciler/task_reconciler_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/spec"
+)
+
+func Test_overwriteTaskWithLatest(t *testing.T) {
+	client := &dbclient.Client{}
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(client), "GetPipelineTask", func(_ *dbclient.Client, id interface{}) (spec.PipelineTask, error) {
+		return spec.PipelineTask{
+			ID: 1,
+			Result: &apistructs.PipelineTaskResult{
+				Metadata: apistructs.Metadata{
+					{
+						Name:  "result",
+						Value: "success",
+					},
+				},
+			},
+		}, nil
+	})
+	defer pm1.Unpatch()
+	tr := &defaultTaskReconciler{
+		dbClient: client,
+	}
+	task := &spec.PipelineTask{
+		ID: 1,
+	}
+	err := tr.overwriteTaskWithLatest(task)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", task.Result.Metadata[0].Value)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
overwrite current task with latest when status is ending

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=317954&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： overwrite current task with latest when status is ending （修复了自动化测试 setcookie 没有继承下去）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  overwrite current task with latest when status is ending            |
| 🇨🇳 中文    |       修复了自动化测试 setcookie 没有继承下去       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
