### PR TITLE
fix: overwrite current task with latest when status is ending

### DIFF
--- a/modules/pipeline/providers/reconciler/task_reconciler_test.go
+++ b/modules/pipeline/providers/reconciler/task_reconciler_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/modules/pipeline/dbclient"
+	"github.com/erda-project/erda/modules/pipeline/spec"
+)
+
+func Test_overwriteTaskWithLatest(t *testing.T) {
+	client := &dbclient.Client{}
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(client), "GetPipelineTask", func(_ *dbclient.Client, id interface{}) (spec.PipelineTask, error) {
+		return spec.PipelineTask{
+			ID: 1,
+			Result: &apistructs.PipelineTaskResult{
+				Metadata: apistructs.Metadata{
+					{
+						Name:  "result",
+						Value: "success",
+					},
+				},
+			},
+		}, nil
+	})
+	defer pm1.Unpatch()
+	tr := &defaultTaskReconciler{
+		dbClient: client,
+	}
+	task := &spec.PipelineTask{
+		ID: 1,
+	}
+	err := tr.overwriteTaskWithLatest(task)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", task.Result.Metadata[0].Value)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
hotfix overwrite current task with latest when status is ending
related pr: (https://github.com/erda-project/erda/pull/5044/files)


#### Specified Reviewers:

/assign @sfwn 



`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  overwrite current task with latest when status is ending            |
| 🇨🇳 中文    |     修复了自动化测试 setcookie 没有继承下去         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
