### PR TITLE
fix(monitor): Unreliable kubernetes log, Skip empty interval

### DIFF
--- a/internal/tools/monitor/core/log/storage/kubernetes-logs/provider.go
+++ b/internal/tools/monitor/core/log/storage/kubernetes-logs/provider.go
@@ -61,7 +61,7 @@ func (p *provider) Provide(ctx servicehub.DependencyContext, args ...interface{}
 			}
 			return func(it *logsIterator, opts *v1.PodLogOptions) (io.ReadCloser, error) {
 				if it.debug {
-					fmt.Printf("namespace: %v,podname: %v, opts: %s \n", it.podNamespace, it.podName, jsonx.MarshalAndIndent(opts))
+					fmt.Printf("[%v] namespace: %v,podname: %v, opts: %s \n", opts.SinceTime.UnixNano(), it.podNamespace, it.podName, jsonx.MarshalAndIndent(opts))
 				}
 				return client.CoreV1().Pods(it.podNamespace).GetLogs(it.podName, opts).Stream(it.ctx)
 			}, nil

--- a/internal/tools/monitor/core/log/storage/kubernetes-logs/storage.go
+++ b/internal/tools/monitor/core/log/storage/kubernetes-logs/storage.go
@@ -271,10 +271,21 @@ func (it *logsIterator) Next() bool {
 	}
 	if it.lastEndTime != 0 {
 		if it.lastEndTime <= it.sel.End {
+			originLastEndTime := it.lastEndTime
 			it.fetch(it.lastEndTime, it.pageSize, false)
+			if it.lastEndTime == originLastEndTime {
+				it.log.Infof("timespan :%v is no data, skip [%v]", it.lastEndTime, it.timeSpan)
+				// May return ineligible data, maybe data is too long, or time format is failed, skip timespan
+				it.lastEndTime = it.lastEndTime + it.timeSpan
+			}
 		}
 	} else {
 		it.fetch(it.sel.Start, it.pageSize, false)
+		if it.lastEndTime == 0 {
+			it.log.Infof("timespan :%v is no data, skip [%v]", it.sel.Start, it.timeSpan)
+			// May return ineligible data, maybe data is too long, or time format is failed, skip timespan
+			it.lastEndTime = it.sel.Start + it.timeSpan
+		}
 	}
 	if it.offset >= 0 && it.offset < len(it.buffer) {
 		it.value = it.buffer[it.offset]


### PR DESCRIPTION
#### What this PR does / why we need it:

Unreliable kubernetes log

The bottom line is through the timestamp, if it is empty, it will be skipped

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Unreliable kubernetes log, Skip empty interval           |
| 🇨🇳 中文    |    不可信的 kubernetes log, 跳过空区间          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
