### PR TITLE
refactor: split task result/inspect/error from apistructs

### DIFF
--- a/apistructs/pipeline_actions.go
+++ b/apistructs/pipeline_actions.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/erda-project/erda-proto-go/core/pipeline/action/pb"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
 	"github.com/erda-project/erda/pkg/metadata"
 )
 
@@ -33,7 +34,7 @@ type ActionCallback struct {
 	Errors []ErrorResponse `json:"errors"`
 
 	// machine stat
-	MachineStat *PipelineTaskMachineStat `json:"machineStat,omitempty"`
+	MachineStat *taskinspect.PipelineTaskMachineStat `json:"machineStat,omitempty"`
 
 	// behind
 	PipelineID     uint64 `json:"pipelineID"`

--- a/apistructs/pipeline_report_basic.go
+++ b/apistructs/pipeline_report_basic.go
@@ -14,7 +14,11 @@
 
 package apistructs
 
-import "time"
+import (
+	"time"
+
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
+)
 
 type PipelineBasicReport struct {
 	ID               uint64         `json:"id"`
@@ -31,19 +35,19 @@ type PipelineBasicReport struct {
 }
 
 type TaskReportInfo struct {
-	ID               uint64                   `json:"id"`
-	Status           PipelineStatus           `json:"status"`
-	Name             string                   `json:"name"`
-	ActionType       string                   `json:"actionType"`
-	ActionVersion    string                   `json:"actionVersion"`
-	ExecutorType     string                   `json:"executorType"`
-	ClusterName      string                   `json:"clusterName"`
-	TimeBegin        *time.Time               `json:"timeBegin,omitempty"`
-	TimeEnd          *time.Time               `json:"timeEnd,omitempty"`
-	TimeBeginQueue   *time.Time               `json:"timeBeginQueue,omitempty"`
-	TimeEndQueue     *time.Time               `json:"timeEndQueue,omitempty"`
-	QueueCostTimeSec int64                    `json:"queueCostTimeSec"`
-	RunCostTimeSec   int64                    `json:"runCostTimeSec"`
-	MachineStat      *PipelineTaskMachineStat `json:"machineStat,omitempty"`
-	Meta             map[string]string        `json:"meta"`
+	ID               uint64                               `json:"id"`
+	Status           PipelineStatus                       `json:"status"`
+	Name             string                               `json:"name"`
+	ActionType       string                               `json:"actionType"`
+	ActionVersion    string                               `json:"actionVersion"`
+	ExecutorType     string                               `json:"executorType"`
+	ClusterName      string                               `json:"clusterName"`
+	TimeBegin        *time.Time                           `json:"timeBegin,omitempty"`
+	TimeEnd          *time.Time                           `json:"timeEnd,omitempty"`
+	TimeBeginQueue   *time.Time                           `json:"timeBeginQueue,omitempty"`
+	TimeEndQueue     *time.Time                           `json:"timeEndQueue,omitempty"`
+	QueueCostTimeSec int64                                `json:"queueCostTimeSec"`
+	RunCostTimeSec   int64                                `json:"runCostTimeSec"`
+	MachineStat      *taskinspect.PipelineTaskMachineStat `json:"machineStat,omitempty"`
+	Meta             map[string]string                    `json:"meta"`
 }

--- a/apistructs/pipeline_task.go
+++ b/apistructs/pipeline_task.go
@@ -15,12 +15,9 @@
 package apistructs
 
 import (
-	"fmt"
-	"sort"
-	"strings"
 	"time"
 
-	"github.com/erda-project/erda/pkg/metadata"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 )
 
 const (
@@ -32,7 +29,6 @@ const (
 	MSPTerminusOrgNameTag        = "msp.erda.cloud/org_name"
 	PipelineTaskMaxRetryLimit    = 144
 	PipelineTaskMaxRetryDuration = 24 * time.Hour
-	PipelineTaskMaxErrorPerHour  = 180
 )
 
 type PipelineTaskDTO struct {
@@ -40,13 +36,13 @@ type PipelineTaskDTO struct {
 	PipelineID uint64 `json:"pipelineID"`
 	StageID    uint64 `json:"stageID"`
 
-	Name   string             `json:"name"`
-	OpType string             `json:"opType"`         // get, put, task
-	Type   string             `json:"type,omitempty"` // git, buildpack, release, dice ... 当 OpType 为自定义任务时为空
-	Status PipelineStatus     `json:"status"`
-	Extra  PipelineTaskExtra  `json:"extra"`
-	Labels map[string]string  `json:"labels"`
-	Result PipelineTaskResult `json:"result"`
+	Name   string                        `json:"name"`
+	OpType string                        `json:"opType"`         // get, put, task
+	Type   string                        `json:"type,omitempty"` // git, buildpack, release, dice ... 当 OpType 为自定义任务时为空
+	Status PipelineStatus                `json:"status"`
+	Extra  PipelineTaskExtra             `json:"extra"`
+	Labels map[string]string             `json:"labels"`
+	Result taskresult.PipelineTaskResult `json:"result"`
 
 	IsSnippet             bool                       `json:"isSnippet"`
 	SnippetPipelineID     *uint64                    `json:"snippetPipelineID,omitempty"`
@@ -69,22 +65,6 @@ type PipelineTaskExtra struct {
 type TaskContainer struct {
 	TaskName    string `json:"taskName"`
 	ContainerID string `json:"containerID"`
-}
-
-// PipelineTaskResult spec.pipeline task only use metadata, task dto has all fields
-type PipelineTaskResult struct {
-	Metadata    metadata.Metadata          `json:"metadata,omitempty"`
-	Errors      []*PipelineTaskErrResponse `json:"errors,omitempty"`
-	MachineStat *PipelineTaskMachineStat   `json:"machineStat,omitempty"`
-	Inspect     string                     `json:"inspect,omitempty"`
-	Events      string                     `json:"events,omitempty"`
-}
-
-type PipelineTaskInspect struct {
-	Errors      []*PipelineTaskErrResponse `json:"errors,omitempty"`
-	MachineStat *PipelineTaskMachineStat   `json:"machineStat,omitempty"`
-	Inspect     string                     `json:"inspect,omitempty"`
-	Events      string                     `json:"events,omitempty"`
 }
 
 type PipelineTaskSnippetDetail struct {
@@ -110,48 +90,6 @@ type PipelineTaskGetBootstrapInfoResponse struct {
 
 type PipelineTaskGetBootstrapInfoResponseData struct {
 	Data []byte `json:"data"`
-}
-
-type PipelineTaskMachineStat struct {
-	Host PipelineTaskMachineHostStat `json:"host,omitempty"`
-	Pod  PipelineTaskMachinePodStat  `json:"pod,omitempty"`
-	Load PipelineTaskMachineLoadStat `json:"load,omitempty"`
-	Mem  PipelineTaskMachineMemStat  `json:"mem,omitempty"`
-	Swap PipelineTaskMachineSwapStat `json:"swap,omitempty"`
-}
-type PipelineTaskMachineHostStat struct {
-	HostIP          string `json:"hostIP,omitempty"`
-	Hostname        string `json:"hostname,omitempty"`
-	UptimeSec       uint64 `json:"uptimeSec,omitempty"`
-	BootTimeSec     uint64 `json:"bootTimeSec,omitempty"`
-	OS              string `json:"os,omitempty"`
-	Platform        string `json:"platform,omitempty"`
-	PlatformVersion string `json:"platformVersion,omitempty"`
-	KernelVersion   string `json:"kernelVersion,omitempty"`
-	KernelArch      string `json:"kernelArch,omitempty"`
-}
-type PipelineTaskMachinePodStat struct {
-	PodIP string `json:"podIP,omitempty"`
-}
-type PipelineTaskMachineLoadStat struct {
-	Load1  float64 `json:"load1,omitempty"`
-	Load5  float64 `json:"load5,omitempty"`
-	Load15 float64 `json:"load15,omitempty"`
-}
-type PipelineTaskMachineMemStat struct { // all byte
-	Total       uint64  `json:"total,omitempty"`
-	Available   uint64  `json:"available,omitempty"`
-	Used        uint64  `json:"used,omitempty"`
-	Free        uint64  `json:"free,omitempty"`
-	UsedPercent float64 `json:"usedPercent,omitempty"`
-	Buffers     uint64  `json:"buffers,omitempty"`
-	Cached      uint64  `json:"cached,omitempty"`
-}
-type PipelineTaskMachineSwapStat struct { // all byte
-	Total       uint64  `json:"total,omitempty"`
-	Used        uint64  `json:"used,omitempty"`
-	Free        uint64  `json:"free,omitempty"`
-	UsedPercent float64 `json:"usedPercent,omitempty"`
 }
 
 const TaskLoopTimeBegin = 1
@@ -192,104 +130,6 @@ func (l *PipelineTaskLoop) IsEmpty() bool {
 	}
 
 	return true
-}
-
-type PipelineTaskErrResponse struct {
-	Code string             `json:"code"`
-	Msg  string             `json:"msg"`
-	Ctx  PipelineTaskErrCtx `json:"ctx"`
-}
-
-type PipelineTaskErrCtx struct {
-	StartTime time.Time `json:"startTime"`
-	EndTime   time.Time `json:"endTime"`
-	Count     uint64    `json:"count"`
-}
-
-func (c *PipelineTaskErrCtx) CalculateFrequencyPerHour() uint64 {
-	if c.StartTime.IsZero() || c.EndTime.IsZero() || c.EndTime.Sub(c.StartTime) <= time.Hour {
-		return c.Count
-	}
-	return uint64(float64(c.Count) / c.EndTime.Sub(c.StartTime).Hours())
-}
-
-type orderedResponses []*PipelineTaskErrResponse
-
-func (o orderedResponses) Len() int           { return len(o) }
-func (o orderedResponses) Less(i, j int) bool { return o[i].Ctx.EndTime.Before(o[j].Ctx.EndTime) }
-func (o orderedResponses) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }
-
-func (t *PipelineTaskInspect) AppendError(newResponses ...*PipelineTaskErrResponse) []*PipelineTaskErrResponse {
-	if len(newResponses) == 0 {
-		return t.Errors
-	}
-	var orderd orderedResponses
-	for _, g := range t.Errors {
-		orderd = append(orderd, g)
-	}
-
-	var newResponseOrder orderedResponses
-	now := time.Now()
-	for index, g := range newResponses {
-		if g.Ctx.StartTime.IsZero() {
-			g.Ctx.StartTime = now.Add(time.Duration(index) * time.Millisecond)
-		}
-		if g.Ctx.EndTime.IsZero() {
-			g.Ctx.EndTime = now.Add(time.Duration(index) * time.Millisecond)
-		}
-		if g.Ctx.Count == 0 {
-			g.Ctx.Count = 1
-		}
-		newResponseOrder = append(newResponseOrder, g)
-	}
-	sort.Sort(newResponseOrder)
-
-	var lastResponse *PipelineTaskErrResponse
-	if len(orderd) != 0 {
-		lastResponse = orderd[len(orderd)-1]
-	}
-
-	for _, g := range newResponseOrder {
-		if lastResponse == nil {
-			orderd = append(orderd, g)
-			lastResponse = g
-			continue
-		}
-
-		if strings.EqualFold(lastResponse.Msg, g.Msg) {
-			if !g.Ctx.StartTime.IsZero() && g.Ctx.StartTime.Before(lastResponse.Ctx.StartTime) {
-				lastResponse.Ctx.StartTime = g.Ctx.StartTime
-			}
-			if g.Ctx.EndTime.After(lastResponse.Ctx.EndTime) {
-				lastResponse.Ctx.EndTime = g.Ctx.EndTime
-			}
-			lastResponse.Ctx.Count++
-			continue
-		} else {
-			orderd = append(orderd, g)
-			lastResponse = g
-		}
-	}
-	return orderd
-}
-
-func (t *PipelineTaskInspect) ConvertErrors() {
-	for _, response := range t.Errors {
-		if response.Ctx.Count > 1 {
-			response.Msg = fmt.Sprintf("%s\nstartTime: %s\nendTime: %s\ncount: %d",
-				response.Msg, response.Ctx.StartTime.Format("2006-01-02 15:04:05"),
-				response.Ctx.EndTime.Format("2006-01-02 15:04:05"), response.Ctx.Count)
-		}
-	}
-}
-
-func (t *PipelineTaskInspect) IsErrorsExceed() (bool, *PipelineTaskErrResponse) {
-	for _, g := range t.Errors {
-		if g.Ctx.CalculateFrequencyPerHour() > PipelineTaskMaxErrorPerHour {
-			return true, g
-		}
-	}
-	return false, nil
 }
 
 func (l *PipelineTaskLoop) Duplicate() *PipelineTaskLoop {

--- a/apistructs/pipeline_task_test.go
+++ b/apistructs/pipeline_task_test.go
@@ -17,7 +17,6 @@ package apistructs
 import (
 	"fmt"
 	"testing"
-	"time"
 )
 
 func TestPipelineTaskLoop_Duplicate(t *testing.T) {
@@ -94,48 +93,5 @@ func TestPipelineTaskLoop_IsEmpty(t *testing.T) {
 				t.Errorf("IsEmpty() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestIsErrorsExceed(t *testing.T) {
-	tests := []struct {
-		name    string
-		inspect *PipelineTaskInspect
-		want    bool
-	}{
-		{
-			name: "less than one hour and count less than 180",
-			inspect: &PipelineTaskInspect{
-				Errors: []*PipelineTaskErrResponse{&PipelineTaskErrResponse{Msg: "xxx", Ctx: PipelineTaskErrCtx{StartTime: time.Now().Add(-59 * time.Minute), Count: 179, EndTime: time.Now()}}},
-			},
-			want: false,
-		},
-		{
-			name: "less than one hour but count more than 180",
-			inspect: &PipelineTaskInspect{
-				Errors: []*PipelineTaskErrResponse{&PipelineTaskErrResponse{Msg: "xxx", Ctx: PipelineTaskErrCtx{StartTime: time.Now().Add(-59 * time.Minute), Count: 181, EndTime: time.Now()}}},
-			},
-			want: true,
-		},
-		{
-			name: "more than one hour ans count less than 180 per hour",
-			inspect: &PipelineTaskInspect{
-				Errors: []*PipelineTaskErrResponse{&PipelineTaskErrResponse{Msg: "xxx", Ctx: PipelineTaskErrCtx{StartTime: time.Now().Add(-61 * time.Minute), Count: 180, EndTime: time.Now()}}},
-			},
-			want: false,
-		},
-		{
-			name: "more than one hour ans count more than 180 per hour",
-			inspect: &PipelineTaskInspect{
-				Errors: []*PipelineTaskErrResponse{&PipelineTaskErrResponse{Msg: "xxx", Ctx: PipelineTaskErrCtx{StartTime: time.Now().Add(-61 * time.Minute), Count: 185, EndTime: time.Now()}}},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		got, _ := tt.inspect.IsErrorsExceed()
-		if got != tt.want {
-			t.Errorf("%s want: %v, but got: %v", tt.name, tt.want, got)
-		}
 	}
 }

--- a/internal/apps/cmp/impl/clusters/add_edge_cluster.go
+++ b/internal/apps/cmp/impl/clusters/add_edge_cluster.go
@@ -30,6 +30,7 @@ import (
 	clusterpb "github.com/erda-project/erda-proto-go/core/clustermanager/cluster/pb"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/apps/cmp/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/pkg/envconf"
 	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/pkg/strutil"
@@ -301,7 +302,7 @@ func (c *Clusters) processFailedPipeline(ctx context.Context, record dbclient.Re
 	return nil
 }
 
-func (c *Clusters) processSuccessPipeline(pTaskResult apistructs.PipelineTaskResult, record dbclient.Record) error {
+func (c *Clusters) processSuccessPipeline(pTaskResult taskresult.PipelineTaskResult, record dbclient.Record) error {
 	req := &clusterpb.CreateClusterRequest{}
 	// get cluster info from pipeline result
 	for _, m := range pTaskResult.Metadata {

--- a/internal/tools/pipeline/actionagent/define.go
+++ b/internal/tools/pipeline/actionagent/define.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/actionagent/filewatch"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
@@ -107,7 +108,7 @@ type EasyUse struct {
 	TaskLogID               string // 日志 ID，推送和查询时需要一致
 
 	// Machine stat
-	MachineStat apistructs.PipelineTaskMachineStat
+	MachineStat taskinspect.PipelineTaskMachineStat
 
 	FileStreamTimeoutSec time.Duration // download or upload file stream timeout
 }

--- a/internal/tools/pipeline/actionagent/step_validate.go
+++ b/internal/tools/pipeline/actionagent/step_validate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/sirupsen/logrus"
 
-	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
 )
 
 // validate
@@ -142,7 +142,7 @@ func (agent *Agent) reportMachineStat() {
 		}
 	}()
 
-	var stat apistructs.PipelineTaskMachineStat
+	var stat taskinspect.PipelineTaskMachineStat
 
 	// host
 	hostIP := os.Getenv("HOST_IP")
@@ -150,7 +150,7 @@ func (agent *Agent) reportMachineStat() {
 	if err != nil {
 		logrus.Warnf("[Ignore] failed to collect host stat, err: %v", err)
 	} else {
-		stat.Host = apistructs.PipelineTaskMachineHostStat{
+		stat.Host = taskinspect.PipelineTaskMachineHostStat{
 			HostIP:          hostIP,
 			Hostname:        hostStat.Hostname,
 			UptimeSec:       hostStat.Uptime,
@@ -164,7 +164,7 @@ func (agent *Agent) reportMachineStat() {
 	}
 
 	// pod
-	stat.Pod = apistructs.PipelineTaskMachinePodStat{
+	stat.Pod = taskinspect.PipelineTaskMachinePodStat{
 		PodIP: os.Getenv("POD_IP"),
 	}
 
@@ -173,7 +173,7 @@ func (agent *Agent) reportMachineStat() {
 	if err != nil {
 		logrus.Warnf("[Ignore] failed to collect load avg, err: %v", err)
 	} else {
-		stat.Load = apistructs.PipelineTaskMachineLoadStat{
+		stat.Load = taskinspect.PipelineTaskMachineLoadStat{
 			Load1:  loadAvg.Load1,
 			Load5:  loadAvg.Load5,
 			Load15: loadAvg.Load15,
@@ -185,7 +185,7 @@ func (agent *Agent) reportMachineStat() {
 	if err != nil {
 		logrus.Warnf("[Ignore] failed to collect mem stat, err: %v", err)
 	} else {
-		stat.Mem = apistructs.PipelineTaskMachineMemStat{
+		stat.Mem = taskinspect.PipelineTaskMachineMemStat{
 			Total:       vm.Total,
 			Available:   vm.Available,
 			Used:        vm.Used,
@@ -201,7 +201,7 @@ func (agent *Agent) reportMachineStat() {
 	if err != nil {
 		logrus.Warnf("[Ignore] failed to collect swap stat, err: %v", err)
 	} else {
-		stat.Swap = apistructs.PipelineTaskMachineSwapStat{
+		stat.Swap = taskinspect.PipelineTaskMachineSwapStat{
 			Total:       swap.Total,
 			Used:        swap.Used,
 			Free:        swap.Free,

--- a/internal/tools/pipeline/dbclient/op_pipeline_task.go
+++ b/internal/tools/pipeline/dbclient/op_pipeline_task.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/commonutil/statusutil"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 	"github.com/erda-project/erda/pkg/crypto/uuid"
 	"github.com/erda-project/erda/pkg/retry"
@@ -144,7 +146,7 @@ func (client *Client) ListPipelineTasksByPipelineID(pipelineID uint64, ops ...Se
 	return tasks, nil
 }
 
-func (client *Client) UpdatePipelineTaskMetadata(id uint64, result *apistructs.PipelineTaskResult) error {
+func (client *Client) UpdatePipelineTaskMetadata(id uint64, result *taskresult.PipelineTaskResult) error {
 	_, err := client.ID(id).Cols("result").Update(&spec.PipelineTask{Result: result})
 	if err != nil {
 		b, _ := json.Marshal(&result)
@@ -153,7 +155,7 @@ func (client *Client) UpdatePipelineTaskMetadata(id uint64, result *apistructs.P
 	return nil
 }
 
-func (client *Client) UpdatePipelineTaskInspect(id uint64, inspect apistructs.PipelineTaskInspect) error {
+func (client *Client) UpdatePipelineTaskInspect(id uint64, inspect taskinspect.PipelineTaskInspect) error {
 	_, err := client.ID(id).Cols("inspect").Update(&spec.PipelineTask{Inspect: inspect})
 	if err != nil {
 		b, _ := json.Marshal(&inspect)

--- a/internal/tools/pipeline/events/event_task.go
+++ b/internal/tools/pipeline/events/event_task.go
@@ -21,6 +21,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/pkg/websocket"
 	"github.com/erda-project/erda/internal/tools/pipeline/commonutil/costtimeutil"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
@@ -86,7 +87,7 @@ type WSPipelineTaskStatusUpdatePayload struct {
 	wsHeader
 	PipelineTaskID uint64                        `json:"pipelineTaskID"`
 	Status         apistructs.PipelineStatus     `json:"status"`
-	Result         apistructs.PipelineTaskResult `json:"result"`
+	Result         taskresult.PipelineTaskResult `json:"result"`
 
 	CostTimeSec int64 `json:"costTimeSec"`
 }

--- a/internal/tools/pipeline/pkg/taskerror/err.go
+++ b/internal/tools/pipeline/pkg/taskerror/err.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskerror
+
+import (
+	"time"
+)
+
+type PipelineTaskErrResponse struct {
+	Code string             `json:"code"`
+	Msg  string             `json:"msg"`
+	Ctx  PipelineTaskErrCtx `json:"ctx"`
+}
+
+type PipelineTaskErrCtx struct {
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+	Count     uint64    `json:"count"`
+}
+
+func (c *PipelineTaskErrCtx) CalculateFrequencyPerHour() uint64 {
+	if c.StartTime.IsZero() || c.EndTime.IsZero() || c.EndTime.Sub(c.StartTime) <= time.Hour {
+		return c.Count
+	}
+	return uint64(float64(c.Count) / c.EndTime.Sub(c.StartTime).Hours())
+}

--- a/internal/tools/pipeline/pkg/taskerror/err_test.go
+++ b/internal/tools/pipeline/pkg/taskerror/err_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskerror
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipelineTaskErrCtx_CalculateFrequencyPerHour(t *testing.T) {
+	type fields struct {
+		StartTime time.Time
+		EndTime   time.Time
+		Count     uint64
+	}
+	now := time.Now().Round(0)
+	tests := []struct {
+		name   string
+		fields fields
+		want   uint64
+	}{
+		{
+			name: "no start time",
+			fields: fields{
+				StartTime: time.Time{},
+				EndTime:   time.Time{},
+				Count:     1,
+			},
+			want: 1,
+		},
+		{
+			name: "no end time",
+			fields: fields{
+				StartTime: now,
+				EndTime:   time.Time{},
+				Count:     2,
+			},
+			want: 2,
+		},
+		{
+			name: "less than one hour",
+			fields: fields{
+				StartTime: now,
+				EndTime:   now.Add(time.Minute),
+				Count:     3,
+			},
+			want: 3,
+		},
+		{
+			name: "normal",
+			fields: fields{
+				StartTime: now,
+				EndTime:   now.Add(2 * time.Hour),
+				Count:     100,
+			},
+			want: uint64(float64(100 / 2)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &PipelineTaskErrCtx{
+				StartTime: tt.fields.StartTime,
+				EndTime:   tt.fields.EndTime,
+				Count:     tt.fields.Count,
+			}
+			assert.Equalf(t, tt.want, c.CalculateFrequencyPerHour(), "CalculateFrequencyPerHour()")
+		})
+	}
+}

--- a/internal/tools/pipeline/pkg/taskerror/ordered.go
+++ b/internal/tools/pipeline/pkg/taskerror/ordered.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskerror
+
+type OrderedResponses []*PipelineTaskErrResponse
+
+func (o OrderedResponses) Len() int           { return len(o) }
+func (o OrderedResponses) Less(i, j int) bool { return o[i].Ctx.EndTime.Before(o[j].Ctx.EndTime) }
+func (o OrderedResponses) Swap(i, j int)      { o[i], o[j] = o[j], o[i] }

--- a/internal/tools/pipeline/pkg/taskerror/ordered_test.go
+++ b/internal/tools/pipeline/pkg/taskerror/ordered_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskerror
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedResponses(t *testing.T) {
+	now := time.Now()
+	respA := &PipelineTaskErrResponse{
+		Code: "codeA",
+		Msg:  "msg of codeA",
+		Ctx: PipelineTaskErrCtx{
+			StartTime: time.Time{},
+			EndTime:   now,
+			Count:     0,
+		},
+	}
+	respB := &PipelineTaskErrResponse{
+		Code: "codeB",
+		Msg:  "msg of codeB",
+		Ctx: PipelineTaskErrCtx{
+			StartTime: time.Time{},
+			EndTime:   now.Add(-time.Second), // before codeA
+			Count:     0,
+		},
+	}
+	resps := OrderedResponses{respA, respB}
+	sort.Sort(resps)
+
+	assert.Equal(t, 2, len(resps))
+	assert.Equal(t, "codeB", resps[0].Code)
+	assert.Equal(t, "codeA", resps[1].Code)
+}

--- a/internal/tools/pipeline/pkg/taskinspect/inspect.go
+++ b/internal/tools/pipeline/pkg/taskinspect/inspect.go
@@ -28,10 +28,10 @@ const (
 )
 
 type PipelineTaskInspect struct {
-	Errors      []*taskerror.PipelineTaskErrResponse `json:"errors,omitempty"`
-	MachineStat *PipelineTaskMachineStat             `json:"machineStat,omitempty"`
 	Inspect     string                               `json:"inspect,omitempty"`
 	Events      string                               `json:"events,omitempty"`
+	MachineStat *PipelineTaskMachineStat             `json:"machineStat,omitempty"`
+	Errors      []*taskerror.PipelineTaskErrResponse `json:"errors,omitempty"`
 }
 
 func (t *PipelineTaskInspect) ConvertErrors() {

--- a/internal/tools/pipeline/pkg/taskinspect/inspect.go
+++ b/internal/tools/pipeline/pkg/taskinspect/inspect.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskinspect
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+)
+
+const (
+	PipelineTaskMaxErrorPerHour = 180
+)
+
+type PipelineTaskInspect struct {
+	Errors      []*taskerror.PipelineTaskErrResponse `json:"errors,omitempty"`
+	MachineStat *PipelineTaskMachineStat             `json:"machineStat,omitempty"`
+	Inspect     string                               `json:"inspect,omitempty"`
+	Events      string                               `json:"events,omitempty"`
+}
+
+func (t *PipelineTaskInspect) ConvertErrors() {
+	for _, response := range t.Errors {
+		if response.Ctx.Count > 1 {
+			response.Msg = fmt.Sprintf("%s\nstartTime: %s\nendTime: %s\ncount: %d",
+				response.Msg, response.Ctx.StartTime.Format("2006-01-02 15:04:05"),
+				response.Ctx.EndTime.Format("2006-01-02 15:04:05"), response.Ctx.Count)
+		}
+	}
+}
+
+func (t *PipelineTaskInspect) IsErrorsExceed() (bool, *taskerror.PipelineTaskErrResponse) {
+	for _, g := range t.Errors {
+		if g.Ctx.CalculateFrequencyPerHour() > PipelineTaskMaxErrorPerHour {
+			return true, g
+		}
+	}
+	return false, nil
+}
+
+func (t *PipelineTaskInspect) AppendError(newResponses ...*taskerror.PipelineTaskErrResponse) []*taskerror.PipelineTaskErrResponse {
+	if len(newResponses) == 0 {
+		return t.Errors
+	}
+	var ordered taskerror.OrderedResponses
+	for _, g := range t.Errors {
+		ordered = append(ordered, g)
+	}
+
+	var newResponseOrder taskerror.OrderedResponses
+	now := time.Now()
+	for index, g := range newResponses {
+		if g.Ctx.StartTime.IsZero() {
+			g.Ctx.StartTime = now.Add(time.Duration(index) * time.Millisecond)
+		}
+		if g.Ctx.EndTime.IsZero() {
+			g.Ctx.EndTime = now.Add(time.Duration(index) * time.Millisecond)
+		}
+		if g.Ctx.Count == 0 {
+			g.Ctx.Count = 1
+		}
+		newResponseOrder = append(newResponseOrder, g)
+	}
+	sort.Sort(newResponseOrder)
+
+	var lastResponse *taskerror.PipelineTaskErrResponse
+	if len(ordered) != 0 {
+		lastResponse = ordered[len(ordered)-1]
+	}
+
+	for _, g := range newResponseOrder {
+		if lastResponse == nil {
+			ordered = append(ordered, g)
+			lastResponse = g
+			continue
+		}
+
+		if strings.EqualFold(lastResponse.Msg, g.Msg) {
+			if !g.Ctx.StartTime.IsZero() && g.Ctx.StartTime.Before(lastResponse.Ctx.StartTime) {
+				lastResponse.Ctx.StartTime = g.Ctx.StartTime
+			}
+			if g.Ctx.EndTime.After(lastResponse.Ctx.EndTime) {
+				lastResponse.Ctx.EndTime = g.Ctx.EndTime
+			}
+			lastResponse.Ctx.Count++
+			continue
+		} else {
+			ordered = append(ordered, g)
+			lastResponse = g
+		}
+	}
+	return ordered
+}

--- a/internal/tools/pipeline/pkg/taskinspect/inspect_test.go
+++ b/internal/tools/pipeline/pkg/taskinspect/inspect_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskinspect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+)
+
+func TestIsErrorsExceed(t *testing.T) {
+	tests := []struct {
+		name    string
+		inspect *PipelineTaskInspect
+		want    bool
+	}{
+		{
+			name: "less than one hour and count less than 180",
+			inspect: &PipelineTaskInspect{
+				Errors: []*taskerror.PipelineTaskErrResponse{&taskerror.PipelineTaskErrResponse{Msg: "xxx", Ctx: taskerror.PipelineTaskErrCtx{StartTime: time.Now().Add(-59 * time.Minute), Count: 179, EndTime: time.Now()}}},
+			},
+			want: false,
+		},
+		{
+			name: "less than one hour but count more than 180",
+			inspect: &PipelineTaskInspect{
+				Errors: []*taskerror.PipelineTaskErrResponse{&taskerror.PipelineTaskErrResponse{Msg: "xxx", Ctx: taskerror.PipelineTaskErrCtx{StartTime: time.Now().Add(-59 * time.Minute), Count: 181, EndTime: time.Now()}}},
+			},
+			want: true,
+		},
+		{
+			name: "more than one hour ans count less than 180 per hour",
+			inspect: &PipelineTaskInspect{
+				Errors: []*taskerror.PipelineTaskErrResponse{&taskerror.PipelineTaskErrResponse{Msg: "xxx", Ctx: taskerror.PipelineTaskErrCtx{StartTime: time.Now().Add(-61 * time.Minute), Count: 180, EndTime: time.Now()}}},
+			},
+			want: false,
+		},
+		{
+			name: "more than one hour ans count more than 180 per hour",
+			inspect: &PipelineTaskInspect{
+				Errors: []*taskerror.PipelineTaskErrResponse{&taskerror.PipelineTaskErrResponse{Msg: "xxx", Ctx: taskerror.PipelineTaskErrCtx{StartTime: time.Now().Add(-61 * time.Minute), Count: 185, EndTime: time.Now()}}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		got, _ := tt.inspect.IsErrorsExceed()
+		if got != tt.want {
+			t.Errorf("%s want: %v, but got: %v", tt.name, tt.want, got)
+		}
+	}
+}

--- a/internal/tools/pipeline/pkg/taskinspect/inspect_test.go
+++ b/internal/tools/pipeline/pkg/taskinspect/inspect_test.go
@@ -15,8 +15,11 @@
 package taskinspect
 
 import (
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
 )
@@ -61,5 +64,61 @@ func TestIsErrorsExceed(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("%s want: %v, but got: %v", tt.name, tt.want, got)
 		}
+	}
+}
+
+func TestPipelineTaskInspect_ConvertErrors(t1 *testing.T) {
+	type fields struct {
+		Inspect     string
+		Events      string
+		MachineStat *PipelineTaskMachineStat
+		Errors      []*taskerror.PipelineTaskErrResponse
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		converted bool
+	}{
+		{
+			name: "count = 1",
+			fields: fields{
+				Errors: []*taskerror.PipelineTaskErrResponse{
+					{
+						Msg: "count = 1",
+						Ctx: taskerror.PipelineTaskErrCtx{
+							Count: 1,
+						},
+					},
+				},
+			},
+			converted: false,
+		},
+		{
+			name: "count = 2",
+			fields: fields{
+				Errors: []*taskerror.PipelineTaskErrResponse{
+					{
+						Msg: "count = 2",
+						Ctx: taskerror.PipelineTaskErrCtx{
+							Count: 2,
+						},
+					},
+				},
+			},
+			converted: true,
+		},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t := &PipelineTaskInspect{
+				Inspect:     tt.fields.Inspect,
+				Events:      tt.fields.Events,
+				MachineStat: tt.fields.MachineStat,
+				Errors:      tt.fields.Errors,
+			}
+			t.ConvertErrors()
+			resp := t.Errors[0]
+			assert.Equal(t1, tt.converted, strings.Contains(resp.Msg, "startTime: "))
+		})
 	}
 }

--- a/internal/tools/pipeline/pkg/taskinspect/machine.go
+++ b/internal/tools/pipeline/pkg/taskinspect/machine.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskinspect
+
+type PipelineTaskMachineStat struct {
+	Host PipelineTaskMachineHostStat `json:"host,omitempty"`
+	Pod  PipelineTaskMachinePodStat  `json:"pod,omitempty"`
+	Load PipelineTaskMachineLoadStat `json:"load,omitempty"`
+	Mem  PipelineTaskMachineMemStat  `json:"mem,omitempty"`
+	Swap PipelineTaskMachineSwapStat `json:"swap,omitempty"`
+}
+type PipelineTaskMachineHostStat struct {
+	HostIP          string `json:"hostIP,omitempty"`
+	Hostname        string `json:"hostname,omitempty"`
+	UptimeSec       uint64 `json:"uptimeSec,omitempty"`
+	BootTimeSec     uint64 `json:"bootTimeSec,omitempty"`
+	OS              string `json:"os,omitempty"`
+	Platform        string `json:"platform,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty"`
+	KernelVersion   string `json:"kernelVersion,omitempty"`
+	KernelArch      string `json:"kernelArch,omitempty"`
+}
+type PipelineTaskMachinePodStat struct {
+	PodIP string `json:"podIP,omitempty"`
+}
+type PipelineTaskMachineLoadStat struct {
+	Load1  float64 `json:"load1,omitempty"`
+	Load5  float64 `json:"load5,omitempty"`
+	Load15 float64 `json:"load15,omitempty"`
+}
+type PipelineTaskMachineMemStat struct { // all byte
+	Total       uint64  `json:"total,omitempty"`
+	Available   uint64  `json:"available,omitempty"`
+	Used        uint64  `json:"used,omitempty"`
+	Free        uint64  `json:"free,omitempty"`
+	UsedPercent float64 `json:"usedPercent,omitempty"`
+	Buffers     uint64  `json:"buffers,omitempty"`
+	Cached      uint64  `json:"cached,omitempty"`
+}
+type PipelineTaskMachineSwapStat struct { // all byte
+	Total       uint64  `json:"total,omitempty"`
+	Used        uint64  `json:"used,omitempty"`
+	Free        uint64  `json:"free,omitempty"`
+	UsedPercent float64 `json:"usedPercent,omitempty"`
+}

--- a/internal/tools/pipeline/pkg/taskresult/result.go
+++ b/internal/tools/pipeline/pkg/taskresult/result.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskresult
+
+import (
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
+	"github.com/erda-project/erda/pkg/metadata"
+)
+
+// PipelineTaskResult spec.pipeline task only use metadata, task dto has all fields
+type PipelineTaskResult struct {
+	Metadata    metadata.Metadata                    `json:"metadata,omitempty"`
+	Errors      []*taskerror.PipelineTaskErrResponse `json:"errors,omitempty"`
+	MachineStat *taskinspect.PipelineTaskMachineStat `json:"machineStat,omitempty"`
+	Inspect     string                               `json:"inspect,omitempty"`
+	Events      string                               `json:"events,omitempty"`
+}

--- a/internal/tools/pipeline/providers/reconciler/snippet.go
+++ b/internal/tools/pipeline/providers/reconciler/snippet.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 	"github.com/erda-project/erda/pkg/metadata"
 	"github.com/erda-project/erda/pkg/strutil"
@@ -34,7 +36,7 @@ func (tr *defaultTaskReconciler) CreateSnippetPipeline(ctx context.Context, p *s
 	defer func() {
 		if failedError != nil {
 			err = failedError
-			task.Inspect.Errors = append(task.Inspect.Errors, &apistructs.PipelineTaskErrResponse{
+			task.Inspect.Errors = append(task.Inspect.Errors, &taskerror.PipelineTaskErrResponse{
 				Msg: err.Error(),
 			})
 			task.Status = apistructs.PipelineStatusFailed
@@ -143,7 +145,7 @@ func (tr *defaultTaskReconciler) handleParentSnippetTaskOutputs(snippetPipeline 
 	// update result.metadata for value-context reference
 	for _, outputValue := range snippetPipeline.Snapshot.OutputValues {
 		if parentTask.Result == nil {
-			parentTask.Result = &apistructs.PipelineTaskResult{Metadata: metadata.Metadata{}}
+			parentTask.Result = &taskresult.PipelineTaskResult{Metadata: metadata.Metadata{}}
 		}
 		parentTask.Result.Metadata = append(parentTask.Result.Metadata, metadata.MetadataField{
 			Name:  outputValue.Name,

--- a/internal/tools/pipeline/providers/reconciler/snippet_test.go
+++ b/internal/tools/pipeline/providers/reconciler/snippet_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
@@ -44,7 +45,7 @@ func Test_fulfillParentSnippetTask(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskSnippetDetail", func(_ *dbclient.Client, id uint64, snippetDetail apistructs.PipelineTaskSnippetDetail, ops ...dbclient.SessionOption) error {
 		return nil
 	})
-	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskMetadata", func(_ *dbclient.Client, id uint64, result *apistructs.PipelineTaskResult) error {
+	monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "UpdatePipelineTaskMetadata", func(_ *dbclient.Client, id uint64, result *taskresult.PipelineTaskResult) error {
 		return nil
 	})
 	defer monkey.UnpatchAll()

--- a/internal/tools/pipeline/providers/reconciler/task_reconciler.go
+++ b/internal/tools/pipeline/providers/reconciler/task_reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erda-project/erda/internal/tools/pipeline/pipengine/actionexecutor"
 	"github.com/erda-project/erda/internal/tools/pipeline/pipengine/actionexecutor/types"
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/errorsx"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/actionmgr"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/cache"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/clusterinfo"
@@ -203,7 +204,7 @@ func (tr *defaultTaskReconciler) ReconcileNormalTask(ctx context.Context, p *spe
 		if err != nil {
 			msg := fmt.Sprintf("failed to get task executor(auto retry), pipelineID: %d, taskID: %d, taskName: %s, err: %v", p.ID, task.ID, task.Name, err)
 			tr.log.Error(msg)
-			task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: msg})
+			task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: msg})
 			if err := tr.dbClient.UpdatePipelineTaskInspect(task.ID, task.Inspect); err != nil {
 				tr.log.Errorf("failed to append last message while get executor failed(auto retry), pipelineID: %d, taskID: %d, taskName: %s, err: %v", p.ID, task.ID, task.Name, err)
 			}

--- a/internal/tools/pipeline/providers/reconciler/task_reconciler_test.go
+++ b/internal/tools/pipeline/providers/reconciler/task_reconciler_test.go
@@ -21,8 +21,8 @@ import (
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 	"github.com/erda-project/erda/pkg/metadata"
 )
@@ -32,7 +32,7 @@ func Test_overwriteTaskWithLatest(t *testing.T) {
 	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(client), "GetPipelineTask", func(_ *dbclient.Client, id interface{}) (spec.PipelineTask, error) {
 		return spec.PipelineTask{
 			ID: 1,
-			Result: &apistructs.PipelineTaskResult{
+			Result: &taskresult.PipelineTaskResult{
 				Metadata: metadata.Metadata{
 					{
 						Name:  "result",

--- a/internal/tools/pipeline/providers/reconciler/taskrun/framework.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/framework.go
@@ -22,10 +22,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/aop"
 	"github.com/erda-project/erda/internal/tools/pipeline/conf"
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/errorsx"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/leaderworker/lwctx"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rlog"
 	"github.com/erda-project/erda/pkg/loop"
@@ -95,9 +95,9 @@ func (tr *TaskRun) waitOp(itr TaskOp, o *Elem) (result error) {
 		}
 		resultErrMsg = append(resultErrMsg, errs...)
 		if len(resultErrMsg) > 0 {
-			tr.Task.Inspect.Errors = tr.Task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{
+			tr.Task.Inspect.Errors = tr.Task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{
 				Msg: strutil.Join(resultErrMsg, "\n", true),
-				Ctx: apistructs.PipelineTaskErrCtx{
+				Ctx: taskerror.PipelineTaskErrCtx{
 					StartTime: startTime,
 					EndTime:   time.Now(),
 					Count:     1,

--- a/internal/tools/pipeline/providers/reconciler/taskrun/framework_test.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/framework_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/aop/aoptypes"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
@@ -82,7 +83,7 @@ func Test_waitOpForLoopNetWorkError(t *testing.T) {
 		op         string
 		taskStatus apistructs.PipelineStatus
 		loop       *apistructs.PipelineTaskLoopOptions
-		inspect    apistructs.PipelineTaskInspect
+		inspect    taskinspect.PipelineTaskInspect
 	}
 	tests := []struct {
 		name           string
@@ -97,7 +98,7 @@ func Test_waitOpForLoopNetWorkError(t *testing.T) {
 				op:         "wait",
 				taskStatus: apistructs.PipelineStatusRunning,
 				loop:       nil,
-				inspect:    apistructs.PipelineTaskInspect{},
+				inspect:    taskinspect.PipelineTaskInspect{},
 			},
 			executeErr:     nil,
 			expectedStatus: apistructs.PipelineStatusSuccess,
@@ -109,7 +110,7 @@ func Test_waitOpForLoopNetWorkError(t *testing.T) {
 				op:         "wait",
 				taskStatus: apistructs.PipelineStatusRunning,
 				loop:       nil,
-				inspect:    apistructs.PipelineTaskInspect{},
+				inspect:    taskinspect.PipelineTaskInspect{},
 			},
 			executeErr:     fmt.Errorf("failed to find session"),
 			expectedStatus: apistructs.PipelineStatusRunning,

--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare.go
@@ -37,6 +37,7 @@ import (
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/container_provider"
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/containers"
 	"github.com/erda-project/erda/internal/tools/pipeline/pkg/errorsx"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/actionmgr"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/taskrun"
 	"github.com/erda-project/erda/internal/tools/pipeline/services/apierrors"
@@ -78,7 +79,7 @@ func (pre *prepare) WhenDone(data interface{}) error {
 	// no need retry
 	if err != nil {
 		pre.Task.Status = apistructs.PipelineStatusAnalyzeFailed
-		pre.Task.Inspect.Errors = pre.Task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: err.Error()})
+		pre.Task.Inspect.Errors = pre.Task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: err.Error()})
 		return nil
 	}
 
@@ -739,13 +740,13 @@ func condition(task *spec.PipelineTask) bool {
 	if sign.Err != nil {
 		task.Status = apistructs.PipelineStatusFailed
 		if sign.Err != nil {
-			task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{
+			task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{
 				Msg: sign.Err.Error(),
 			})
 		}
 
 		if sign.Msg != "" {
-			task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{
+			task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{
 				Msg: sign.Msg,
 			})
 		}
@@ -755,13 +756,13 @@ func condition(task *spec.PipelineTask) bool {
 	if sign.Sign == expression.TaskJumpOver {
 		task.Status = apistructs.PipelineStatusNoNeedBySystem
 		if sign.Err != nil {
-			task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{
+			task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{
 				Msg: sign.Err.Error(),
 			})
 		}
 
 		if sign.Msg != "" {
-			task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{
+			task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{
 				Msg: sign.Msg,
 			})
 		}

--- a/internal/tools/pipeline/providers/reconciler/taskrun/update.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/update.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/events"
 	"github.com/erda-project/erda/internal/tools/pipeline/metrics"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rlog"
 	"github.com/erda-project/erda/pkg/loop"
 )
@@ -70,7 +70,7 @@ func (tr *TaskRun) AppendLastMsg(msg string) error {
 	if err := tr.fetchLatestTask(); err != nil {
 		return err
 	}
-	tr.Task.Inspect.Errors = tr.Task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: msg})
+	tr.Task.Inspect.Errors = tr.Task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: msg})
 	if err := tr.DBClient.UpdatePipelineTaskInspect(tr.Task.ID, tr.Task.Inspect); err != nil {
 		logrus.Errorf("[alert] reconciler: pipelineID: %d, task %q append last message failed, err: %v",
 			tr.P.ID, tr.Task.Name, err)

--- a/internal/tools/pipeline/services/pipelinesvc/callback.go
+++ b/internal/tools/pipeline/services/pipelinesvc/callback.go
@@ -24,6 +24,8 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
 	"github.com/erda-project/erda/internal/tools/pipeline/events"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/cron/db"
 	"github.com/erda-project/erda/internal/tools/pipeline/services/apierrors"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
@@ -88,9 +90,9 @@ func (s *PipelineSvc) appendPipelineTaskInspect(p *spec.Pipeline, task *spec.Pip
 		return nil
 	}
 	// TODO action agent should add err start time and end time
-	newTaskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
+	newTaskErrors := make([]*taskerror.PipelineTaskErrResponse, 0)
 	for _, e := range cb.Errors {
-		newTaskErrors = append(newTaskErrors, &apistructs.PipelineTaskErrResponse{
+		newTaskErrors = append(newTaskErrors, &taskerror.PipelineTaskErrResponse{
 			Msg: e.Msg,
 		})
 	}
@@ -111,7 +113,7 @@ func (s *PipelineSvc) appendPipelineTaskMetadata(p *spec.Pipeline, task *spec.Pi
 		return nil
 	}
 	if task.Result == nil {
-		task.Result = &apistructs.PipelineTaskResult{Metadata: metadata.Metadata{}}
+		task.Result = &taskresult.PipelineTaskResult{Metadata: metadata.Metadata{}}
 	}
 
 	task.Result.Metadata = append(task.Result.Metadata, cb.Metadata...)

--- a/internal/tools/pipeline/services/pipelinesvc/callback_test.go
+++ b/internal/tools/pipeline/services/pipelinesvc/callback_test.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
 	"github.com/erda-project/erda/internal/tools/pipeline/events"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 
 	"github.com/erda-project/erda/apistructs"
@@ -39,16 +42,16 @@ func TestAppendPipelineTaskResult(t *testing.T) {
 	}
 
 	task := &spec.PipelineTask{
-		Inspect: apistructs.PipelineTaskInspect{
-			Errors: []*apistructs.PipelineTaskErrResponse{
-				&apistructs.PipelineTaskErrResponse{Msg: "a"},
+		Inspect: taskinspect.PipelineTaskInspect{
+			Errors: []*taskerror.PipelineTaskErrResponse{
+				&taskerror.PipelineTaskErrResponse{Msg: "a"},
 			},
 		},
 	}
 
-	newTaskErrors := make([]*apistructs.PipelineTaskErrResponse, 0)
+	newTaskErrors := make([]*taskerror.PipelineTaskErrResponse, 0)
 	for _, e := range cb.Errors {
-		newTaskErrors = append(newTaskErrors, &apistructs.PipelineTaskErrResponse{
+		newTaskErrors = append(newTaskErrors, &taskerror.PipelineTaskErrResponse{
 			Msg: e.Msg,
 		})
 	}
@@ -70,12 +73,12 @@ func TestDealPipelineCallbackOfAction(t *testing.T) {
 	})
 	defer m2.Unpatch()
 
-	m3 := monkey.PatchInstanceMethod(reflect.TypeOf(db), "UpdatePipelineTaskMetadata", func(_ *dbclient.Client, id uint64, result *apistructs.PipelineTaskResult) error {
+	m3 := monkey.PatchInstanceMethod(reflect.TypeOf(db), "UpdatePipelineTaskMetadata", func(_ *dbclient.Client, id uint64, result *taskresult.PipelineTaskResult) error {
 		return nil
 	})
 	defer m3.Unpatch()
 
-	m4 := monkey.PatchInstanceMethod(reflect.TypeOf(db), "UpdatePipelineTaskInspect", func(_ *dbclient.Client, id uint64, inspect apistructs.PipelineTaskInspect) error {
+	m4 := monkey.PatchInstanceMethod(reflect.TypeOf(db), "UpdatePipelineTaskInspect", func(_ *dbclient.Client, id uint64, inspect taskinspect.PipelineTaskInspect) error {
 		return nil
 	})
 	defer m4.Unpatch()

--- a/internal/tools/pipeline/services/pipelinesvc/detail.go
+++ b/internal/tools/pipeline/services/pipelinesvc/detail.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/commonutil/costtimeutil"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/cron/crontypes"
 	"github.com/erda-project/erda/internal/tools/pipeline/services/apierrors"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
@@ -115,7 +116,7 @@ func (s *PipelineSvc) Detail(pipelineID uint64) (*apistructs.PipelineDetailDTO, 
 			}
 			task.CostTimeSec = costtimeutil.CalculateTaskCostTimeSec(&task)
 			if task.Result == nil {
-				task.Result = &apistructs.PipelineTaskResult{}
+				task.Result = &taskresult.PipelineTaskResult{}
 				task.Result.Metadata = make([]metadata.MetadataField, 0)
 			}
 			// add task events to result metadata if task status isn`t success and events it`s failed

--- a/internal/tools/pipeline/spec/pipeline_task.go
+++ b/internal/tools/pipeline/spec/pipeline_task.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/conf"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskinspect"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/pkg/encoding/jsonparse"
 	"github.com/erda-project/erda/pkg/metadata"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml"
@@ -36,15 +38,15 @@ type PipelineTask struct {
 	PipelineID uint64 `json:"pipelineID"`
 	StageID    uint64 `json:"stageID"`
 
-	Name         string                         `json:"name"`
-	OpType       PipelineTaskOpType             `json:"opType"`         // Deprecated: get, put, task
-	Type         string                         `json:"type,omitempty"` // git, buildpack, release, dice ... 当 OpType 为自定义任务时为空
-	ExecutorKind PipelineTaskExecutorKind       `json:"executorKind"`   // scheduler, memory
-	Status       apistructs.PipelineStatus      `json:"status"`
-	Extra        PipelineTaskExtra              `json:"extra" xorm:"json"`
-	Context      PipelineTaskContext            `json:"context" xorm:"json"`
-	Result       *apistructs.PipelineTaskResult `json:"result" xorm:"json"`
-	Inspect      apistructs.PipelineTaskInspect `json:"inspect" xorm:"json"`
+	Name         string                          `json:"name"`
+	OpType       PipelineTaskOpType              `json:"opType"`         // Deprecated: get, put, task
+	Type         string                          `json:"type,omitempty"` // git, buildpack, release, dice ... 当 OpType 为自定义任务时为空
+	ExecutorKind PipelineTaskExecutorKind        `json:"executorKind"`   // scheduler, memory
+	Status       apistructs.PipelineStatus       `json:"status"`
+	Extra        PipelineTaskExtra               `json:"extra" xorm:"json"`
+	Context      PipelineTaskContext             `json:"context" xorm:"json"`
+	Result       *taskresult.PipelineTaskResult  `json:"result" xorm:"json"`
+	Inspect      taskinspect.PipelineTaskInspect `json:"inspect" xorm:"json"`
 
 	IsSnippet             bool                                  `json:"isSnippet"`                         // 该节点是否是嵌套流水线节点
 	SnippetPipelineID     *uint64                               `json:"snippetPipelineID"`                 // 嵌套的流水线 id

--- a/internal/tools/pipeline/spec/pipeline_task_test.go
+++ b/internal/tools/pipeline/spec/pipeline_task_test.go
@@ -24,13 +24,15 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskerror"
+	"github.com/erda-project/erda/internal/tools/pipeline/pkg/taskresult"
 	"github.com/erda-project/erda/pkg/metadata"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml"
 )
 
 func TestRuntimeID(t *testing.T) {
 	s := `{"metadata":[{"name":"runtimeID","value":"9","type":"link"},{"name":"operatorID","value":"2"}]}`
-	r := apistructs.PipelineTaskResult{}
+	r := taskresult.PipelineTaskResult{}
 	if err := json.Unmarshal([]byte(s), &r); err != nil {
 		logrus.Fatal(err)
 	}
@@ -139,18 +141,18 @@ func TestMakeTaskExecutorCtxKey(t *testing.T) {
 
 func TestPipelineTaskAppendError(t *testing.T) {
 	task := PipelineTask{}
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "a"})
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "a"})
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "a"})
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "a"})
 	assert.Equal(t, 1, len(task.Inspect.Errors))
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "b"})
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "b"})
 	assert.Equal(t, 2, len(task.Inspect.Errors))
 	startA := time.Date(2021, 8, 19, 10, 10, 0, 0, time.Local)
 	endA := time.Date(2021, 8, 19, 10, 30, 0, 0, time.Local)
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "a", Ctx: apistructs.PipelineTaskErrCtx{StartTime: startA, EndTime: endA}})
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "a", Ctx: taskerror.PipelineTaskErrCtx{StartTime: startA, EndTime: endA}})
 	assert.Equal(t, 3, len(task.Inspect.Errors))
 	start := time.Date(2021, 8, 19, 10, 9, 0, 0, time.Local)
 	end := time.Date(2021, 8, 19, 10, 29, 0, 0, time.Local)
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "a", Ctx: apistructs.PipelineTaskErrCtx{StartTime: start, EndTime: end}})
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "a", Ctx: taskerror.PipelineTaskErrCtx{StartTime: start, EndTime: end}})
 	taskDto := task.Convert2DTO()
 	assert.Equal(t, uint64(2), taskDto.Result.Errors[2].Ctx.Count)
 	assert.Equal(t, 3, len(taskDto.Result.Errors))
@@ -162,7 +164,7 @@ func TestConvertErrors(t *testing.T) {
 	task := PipelineTask{}
 	start := time.Date(2021, 8, 24, 9, 45, 1, 1, time.Local)
 	end := time.Date(2021, 8, 24, 9, 46, 1, 1, time.Local)
-	task.Inspect.Errors = task.Inspect.AppendError(&apistructs.PipelineTaskErrResponse{Msg: "err", Ctx: apistructs.PipelineTaskErrCtx{
+	task.Inspect.Errors = task.Inspect.AppendError(&taskerror.PipelineTaskErrResponse{Msg: "err", Ctx: taskerror.PipelineTaskErrCtx{
 		StartTime: start,
 		EndTime:   end,
 		Count:     2,


### PR DESCRIPTION
#### What this PR does / why we need it:

split task result/inspect/error from apistructs


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   split task result/inspect/error from apistructs           |
| 🇨🇳 中文    |   将 task result/inspect/error 从 apistructs 中分离           |
