### PR TITLE
fix: groutinepool pkg `WaitGroup is reused before previous Wait has returned`

### DIFF
--- a/pkg/goroutinepool/goroutinepool.go
+++ b/pkg/goroutinepool/goroutinepool.go
@@ -45,7 +45,6 @@ type worker struct {
 }
 
 func (w *worker) run() {
-	w.pool.Add(1)
 	for {
 		w.pool.addIdleWorker(w)
 		select {
@@ -98,11 +97,13 @@ func (p *GoroutinePool) Start() {
 		for i := 0; i < p.cap; i++ {
 			w := &worker{pool: p, job: make(chan func()), stop: make(chan struct{}, 1)}
 			p.allWorkers = append(p.allWorkers, w)
+			w.pool.Add(1)
 			go w.run()
 		}
 	} else {
 		p.workers = make(chan *worker, p.cap)
 		for _, w := range p.allWorkers {
+			w.pool.Add(1)
 			go w.run()
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
groutinepool pkg `WaitGroup is reused before previous Wait has returned` panic

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that groutinepool pkg `WaitGroup is reused before previous Wait has returned` panic（修复了goroutinepool公共包panic的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that groutinepool pkg `WaitGroup is reused before previous Wait has returned` panic            |
| 🇨🇳 中文    |  修复了goroutinepool公共包panic的问题          |

