### PR TITLE
fix(pipeline): switch buildkitd certs namespace from default to erda namespace

### DIFF
--- a/internal/apps/cmp/component-protocol/components/cmp-cluster-list/common/model.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-cluster-list/common/model.go
@@ -108,7 +108,7 @@ func GetClusterStatus(kc *k8sclient.K8sClient, meta *clusterpb.ClusterInfo) (str
 	)
 
 	for _, selfLink := range checkCRDs {
-		res, err = kc.ClientSet.RESTClient().Get().
+		res, err = kc.ClientSet.Discovery().RESTClient().Get().
 			AbsPath(fmt.Sprintf(selfLink, conf.ErdaNamespace())).
 			DoRaw(context.Background())
 		if err != nil {

--- a/internal/apps/cmp/component-protocol/components/cmp-cluster-list/list/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-cluster-list/list/render.go
@@ -402,7 +402,7 @@ func (l *List) GetVersion(clusterName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	info, err := client.ClientSet.ServerVersion()
+	info, err := client.ClientSet.Discovery().ServerVersion()
 	if err != nil {
 		return "", err
 	}

--- a/internal/apps/cmp/impl/clusters/clusterinfo.go
+++ b/internal/apps/cmp/impl/clusters/clusterinfo.go
@@ -185,7 +185,7 @@ func (c *Clusters) getClusterStatus(kc *k8sclient.K8sClient, meta *clusterpb.Clu
 	)
 
 	for _, selfLink := range checkCRDs {
-		res, err = kc.ClientSet.RESTClient().Get().
+		res, err = kc.ClientSet.Discovery().RESTClient().Get().
 			AbsPath(fmt.Sprintf(selfLink, conf.ErdaNamespace())).
 			DoRaw(context.Background())
 		if err != nil {

--- a/internal/apps/cmp/impl/clusters/credential.go
+++ b/internal/apps/cmp/impl/clusters/credential.go
@@ -181,7 +181,7 @@ func (c *Clusters) ResetAccessKey(ctx context.Context, clusterName string) (*tok
 }
 
 // ResetAccessKeyWithClientSet reset access key with specified clientSet
-func (c *Clusters) ResetAccessKeyWithClientSet(ctx context.Context, clusterName string, cs *kubernetes.Clientset) (*tokenpb.Token, error) {
+func (c *Clusters) ResetAccessKeyWithClientSet(ctx context.Context, clusterName string, cs kubernetes.Interface) (*tokenpb.Token, error) {
 	// Get worker namespace
 	workerNs := getWorkerNamespace()
 

--- a/internal/tools/orchestrator/hepa/k8s/k8s_adapter.go
+++ b/internal/tools/orchestrator/hepa/k8s/k8s_adapter.go
@@ -89,7 +89,7 @@ type K8SAdapter interface {
 }
 
 type K8SAdapterImpl struct {
-	client          *kubernetes.Clientset
+	client          kubernetes.Interface
 	ingressesHelper union_interface.IngressesHelper
 	pool            *util.GPool
 }

--- a/internal/tools/pipeline/conf/conf.go
+++ b/internal/tools/pipeline/conf/conf.go
@@ -28,6 +28,7 @@ type Conf struct {
 	Debug           bool   `env:"DEBUG" default:"false"`
 	DiceClusterName string `env:"DICE_CLUSTER_NAME" default:"local"` // 服务所在集群
 	DiceIsEdge      bool   `env:"DICE_IS_EDGE" default:"false"`      // is edge cluster
+	ErdaNamespace   string `env:"DICE_NAMESPACE" default:"default"`  // erda installed namespace
 
 	// task level
 	TaskDefaultCPU             float64       `env:"TASK_DEFAULT_CPU" default:"0.5"`
@@ -140,6 +141,11 @@ func Debug() bool {
 // DiceClusterName return the cluster where pipeline belong to
 func DiceClusterName() string {
 	return cfg.DiceClusterName
+}
+
+// ErdaNamespace return the namespace which erda instaleld
+func ErdaNamespace() string {
+	return cfg.ErdaNamespace
 }
 
 // DiceIsEdge return if the cluster is edge

--- a/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
+++ b/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob.go
@@ -904,7 +904,7 @@ func (k *K8sJob) createInnerSecretIfNotExist(namespace, secretName string) error
 	}
 
 	// When the cluster is initialized, a secret to pull the mirror will be created in the default namespace
-	s, err := k.client.ClientSet.CoreV1().Secrets(metav1.NamespaceDefault).Get(context.Background(), secretName, metav1.GetOptions{})
+	s, err := k.client.ClientSet.CoreV1().Secrets(conf.ErdaNamespace()).Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return nil

--- a/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob_test.go
+++ b/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sjob/k8sjob_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/conf"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/clusterinfo"
 	"github.com/erda-project/erda/pkg/k8sclient"
 )
@@ -71,7 +72,7 @@ func Test_generateKubeJob(t *testing.T) {
 			ClientSet: fake.NewSimpleClientset(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      apistructs.BuildkitClientSecret,
-					Namespace: metav1.NamespaceDefault,
+					Namespace: conf.ErdaNamespace(),
 				},
 			}),
 		}, nil

--- a/pkg/k8s-client-manager/provider.go
+++ b/pkg/k8s-client-manager/provider.go
@@ -48,7 +48,7 @@ type (
 	}
 	cacheItem struct {
 		Config    *rest.Config
-		Clientset *kubernetes.Clientset
+		Clientset kubernetes.Interface
 		CRClient  *client.Client
 	}
 )
@@ -72,7 +72,7 @@ func (p *provider) Init(ctx servicehub.Context) (err error) {
 	return nil
 }
 
-func (p *provider) GetClient(clusterName string) (*kubernetes.Clientset, *rest.Config, error) {
+func (p *provider) GetClient(clusterName string) (kubernetes.Interface, *rest.Config, error) {
 	val, err := p.cache.Get(clusterName)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/k8s/interface_factory/discover.go
+++ b/pkg/k8s/interface_factory/discover.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func IsResourceExist(client *kubernetes.Clientset, resourceKind, groupVersion string) (bool, error) {
+func IsResourceExist(client kubernetes.Interface, resourceKind, groupVersion string) (bool, error) {
 	groups, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
 		return false, err

--- a/pkg/k8s/interface_factory/ingress.go
+++ b/pkg/k8s/interface_factory/ingress.go
@@ -28,7 +28,7 @@ import (
 
 const IngressKind = "Ingress"
 
-func CreateIngressesHelper(client *kubernetes.Clientset) (union_interface.IngressesHelper, error) {
+func CreateIngressesHelper(client kubernetes.Interface) (union_interface.IngressesHelper, error) {
 	// k8s version >=1.19
 	exist, err := IsResourceExist(client, IngressKind, v1.SchemeGroupVersion.String())
 	if err != nil {

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -36,7 +36,7 @@ type K8sClient struct {
 	schemes              []func(scheme *runtime.Scheme) error
 
 	// client for kubernetes
-	ClientSet *kubernetes.Clientset
+	ClientSet kubernetes.Interface
 	CRClient  client.Client
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
1. switch buildkitd certs namespace from default to erda namespace
2. fix clientset from *kubernetes.Clientset to kubernetes.Interface, now can use "k8s.io/client-go/kubernetes/fake" to programing unit test about client-go.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc @sfwn @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | switch buildkitd certs namespace from default to erda namespace             |
| 🇨🇳 中文    |     切换 buildkitd 证书命名空间，从 default 到 erda 所在 namespace         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
