### PR TITLE
chore: codecov ignore legacy openapi specs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,12 +3,12 @@ codecov:
   notify:
     wait_for_ci: false
 
-comment:                  # this is a top-level key
+comment: # this is a top-level key
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
+  require_changes: false   # if true: only post the comment if coverage changes
+  require_base: false      # [yes :: must have a base report to post]
+  require_head: false      # [yes :: must have a head report to post]
 #  branches:               # branch names that can post comment
 
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -44,3 +44,4 @@ ignore:
   - "internal/**/dao"
   - "bundle"
   - "api/proto-go"
+  - "internal/tools/openapi/legacy/api/apis/**/*.go"


### PR DESCRIPTION
#### What this PR does / why we need it:

codecov ignore legacy openapi specs


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   codecov ignore legacy openapi specs           |
| 🇨🇳 中文    |   codecov 忽略老的 openapi 定义           |
