### PR TITLE
feat(protobuf): openapi proto  add doc field for old spec migration

### DIFF
--- a/api/proto/common/openapi.proto
+++ b/api/proto/common/openapi.proto
@@ -1,4 +1,3 @@
-
 syntax = "proto3";
 
 package erda.common;
@@ -20,6 +19,7 @@ message OpenAPIOption {
     string service = 4;
     bool private = 5;
     APIAuth auth = 6;
+    string doc = 7;
 }
 
 message APIAuth {


### PR DESCRIPTION
#### What this PR does / why we need it:

openapi proto add doc field for old spec migration


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  openapi proto add doc field for old spec migration            |
| 🇨🇳 中文    |   openapi proto option 增加 doc 字段，支持迁移老的 openapi 定义 doc 字段           |