### PR TITLE
fix: tips of finished time parse error

### DIFF
--- a/internal/apps/dop/providers/issue/core/file.go
+++ b/internal/apps/dop/providers/issue/core/file.go
@@ -720,7 +720,7 @@ func (i *IssueService) decodeFromExcelFile(req *pb.ImportExcelIssueRequest, r io
 			finishedTime, err := time.Parse("2006-01-02 15:04:05", row[14])
 			if err != nil {
 				falseExcel = append(falseExcel, i+1)
-				falseReason = append(falseReason, "无法解析任务结束时间")
+				falseReason = append(falseReason, "无法解析任务截止时间, 正确格式: 2006-01-02 15:04:05")
 				continue
 			}
 			issue.PlanFinishedAt = timestamppb.New(finishedTime)

--- a/internal/apps/dop/providers/issue/core/file_test.go
+++ b/internal/apps/dop/providers/issue/core/file_test.go
@@ -36,9 +36,10 @@ func TestIssueService_decodeFromExcelFile(t *testing.T) {
 			{
 				[]string{"ID", "标题", "内容", "状态", "创建人", "处理人", "负责人", "任务类型或缺陷引入源", "优先级", "所属迭代", "复杂度", "严重程度", "标签", "类型", "截止时间", "创建时间", "被以下事项关联", "预估时间", "关闭时间", "开始时间", "custom"},
 				[]string{"1", "erda", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "", "2021-09-26 15:19:00", "", "", "", "", "a"},
-				[]string{"a", "erda", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "", "2021-09-26 15:19:00", "", "", "", "", "b"},
+				[]string{"a", "invalid-id", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "", "2021-09-26 15:19:00", "", "", "", "", "b"},
 				[]string{"2", "erda", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "", "2021-09-26 15:19:00", "", "3h", "", "", "c"},
 				[]string{"2", "erda", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "", "2021-09-26 15:19:00", "", "3d", "", "2021-09-26 15:19:00", "d"},
+				[]string{"2", "invalid-time", "erda", "待处理", "erda", "erda", "erda", "缺陷", "低", "1.1", "中", "一般", "", "缺陷", "2021/09/26 15:19:00", "2021-09-26 15:19:00", "", "3d", "", "2021-09-26 15:19:00", "d"},
 			},
 		}, nil
 	})
@@ -72,8 +73,9 @@ func TestIssueService_decodeFromExcelFile(t *testing.T) {
 	defer p2.Unpatch()
 
 	svc := &IssueService{db: db}
-	_, _, _, _, _, _, err := svc.decodeFromExcelFile(&pb.ImportExcelIssueRequest{ProjectID: 1, OrgID: 1}, strings.NewReader(""), []*pb.IssuePropertyIndex{{PropertyName: "custom", Index: 1}})
+	_, _, _, _, failReason, _, err := svc.decodeFromExcelFile(&pb.ImportExcelIssueRequest{ProjectID: 1, OrgID: 1}, strings.NewReader(""), []*pb.IssuePropertyIndex{{PropertyName: "custom", Index: 1}})
 	assert.Equal(t, nil, err)
+	assert.Equal(t, 3, len(failReason))
 }
 
 func Test_importIssueBuilder(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
tips of finished time parse error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=320064&iterationID=1280&pId=0&type=BUG)


#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that tips of finished time parse error（事项导入错误提示信息优化）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that tips of finished time parse error          |
| 🇨🇳 中文    |     事项导入错误提示信息优化         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
