### PR TITLE
fix(cluster-manager): retrywatcher resource version reference error

### DIFF
--- a/internal/tools/cluster-agent/pkg/client/credential_test.go
+++ b/internal/tools/cluster-agent/pkg/client/credential_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func Test_getRetryWatcher(t *testing.T) {
+	c := New()
+	fc := &fakeclientset.Clientset{}
+	fc.AddReactor("list", "secrets", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &corev1.SecretList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: "1",
+			},
+			Items: []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      apistructs.ErdaClusterCredential,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Data: map[string][]byte{
+						apistructs.ClusterAccessKey: []byte("test"),
+					},
+				},
+			},
+		}, nil
+	})
+	_, err := c.getRetryWatcher(fc, metav1.NamespaceDefault)
+	assert.NoError(t, err)
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -297,7 +297,7 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 	)
 	cluster, err := bdl.GetCluster(clusterName)
 	if err != nil {
-		logrus.Errorf("get cluster error: %v", cluster)
+		logrus.Errorf("get cluster %s error: %v", clusterName, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
retrywatcher resource version reference error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix retrywatcher resource version reference error          |
| 🇨🇳 中文    |    修复 retrywatcher resourceVersion 引用错误的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
