### PR TITLE
revert: end listening log lines use context done instead of end tailflag (#4984)

### DIFF
--- a/internal/tools/pipeline/actionagent/execute.go
+++ b/internal/tools/pipeline/actionagent/execute.go
@@ -65,7 +65,7 @@ func (agent *Agent) Execute(r io.Reader) {
 		return
 	}
 	defer func() {
-		// it's not necessary to write flag end line for tail, because tail watcher listen context to end
+		// defer write flag end line for tail
 		agent.writeEndFlagLine()
 	}()
 

--- a/internal/tools/pipeline/actionagent/file_watch.go
+++ b/internal/tools/pipeline/actionagent/file_watch.go
@@ -43,6 +43,7 @@ func (agent *Agent) watchFiles() {
 		return
 	}
 	agent.FileWatcher = watcher
+	agent.FileWatcher.EndLineForTail = agent.EasyUse.FlagEndLineForTail
 
 	// ${METAFILE}
 	watcher.RegisterFullHandler(agent.EasyUse.ContainerMetaFile, metaFileFullHandler(agent))

--- a/internal/tools/pipeline/actionagent/file_watch_collector.go
+++ b/internal/tools/pipeline/actionagent/file_watch_collector.go
@@ -49,6 +49,8 @@ const (
 
 // asyncPushCollectorLog async push log to collector
 func (agent *Agent) asyncPushCollectorLog() {
+	agent.FileWatcher.Wait.Add(1)
+
 	// pushLogic do push logic
 	pushLogic := func(logs *[]apistructs.LogPushLine, lock *sync.Mutex, _type string) {
 		lock.Lock()
@@ -68,6 +70,10 @@ func (agent *Agent) asyncPushCollectorLog() {
 		*logs = nil
 	}
 
+	// gracefulDoneC is a channel to represent all push done
+	chanCapacity := 2 // stdout + stderr
+	gracefulDoneC := make(chan struct{}, chanCapacity)
+
 	// rangePush range push log to collector
 	rangePush := func(logs *[]apistructs.LogPushLine, lock *sync.Mutex, _type string) {
 		ticker := time.NewTicker(asyncPushInterval)
@@ -83,6 +89,7 @@ func (agent *Agent) asyncPushCollectorLog() {
 				logrus.Debugf("collector: recevied agent exit channel, wait %s and push %s directly", waitTail.String(), _type)
 				time.Sleep(waitTail)
 				pushLogic(logs, lock, _type)
+				gracefulDoneC <- struct{}{}
 				return
 			}
 		}
@@ -92,6 +99,15 @@ func (agent *Agent) asyncPushCollectorLog() {
 	go rangePush(stdoutLogs, &stdoutLock, "stdout")
 	go rangePush(stderrLogs, &stderrLock, "stderr")
 
+	// send to graceful doneC when all rangePush done
+	receivedNum := 0
+	for range gracefulDoneC {
+		receivedNum++
+		if receivedNum == 2 {
+			agent.FileWatcher.Wait.Done()
+			break
+		}
+	}
 }
 
 func (agent *Agent) pushCollectorLog(logLines *[]apistructs.LogPushLine) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
This reverts commit 831627f7ac64946f2f8a46dea39ee9e689c305f7.
revert end listening log lines use context done instead of end tailflag (#4984)

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： revert end listening log lines use context done instead of end tailflag (#4984) （回退解决actionagent日志卡住的提交）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  revert end listening log lines use context done instead of end tailflag (#4984)            |
| 🇨🇳 中文    |   回退解决actionagent日志卡住的提交           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
