### PR TITLE
fix: Set time location in issue update request for time comparison.

### DIFF
--- a/internal/apps/dop/providers/issue/core/query/update.go
+++ b/internal/apps/dop/providers/issue/core/query/update.go
@@ -260,6 +260,7 @@ func validPlanTime(req *pb.UpdateIssueRequest, issue *dao.Issue) error {
 	return nil
 }
 
+// Convert to local time for comparing date without location, timestamppb uses UTC different with db global time zone.
 func asTime(s *string) *time.Time {
 	if s == nil || *s == "" {
 		return nil
@@ -268,7 +269,8 @@ func asTime(s *string) *time.Time {
 	if err != nil {
 		return nil
 	}
-	return &t
+	localTime := t.Local()
+	return &localTime
 }
 
 // GetChangedFields 从 IssueUpdateRequest 中找出需要更新(不为空)的字段

--- a/internal/apps/dop/providers/issue/core/query/update_test.go
+++ b/internal/apps/dop/providers/issue/core/query/update_test.go
@@ -81,6 +81,8 @@ func Test_asTime(t *testing.T) {
 		s *string
 	}
 	s1, s2 := "", "1234"
+	s3, s4 := "2022-06-24T00:00:00+08:00", "2022-06-23T16:00:00Z"
+	t1 := time.Date(2022, 6, 24, 0, 0, 0, 0, time.Now().Location())
 	tests := []struct {
 		name string
 		args args
@@ -97,6 +99,14 @@ func Test_asTime(t *testing.T) {
 		{
 			args: args{&s2},
 			want: nil,
+		},
+		{
+			args: args{&s3},
+			want: &t1,
+		},
+		{
+			args: args{&s4},
+			want: &t1,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:
Set time location in issue update request for time comparison.

#### Which issue(s) this PR fixes:
Convert to local time for comparing date without location in issue update and stream.

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Set time location in issue update request for time comparison.            |
| 🇨🇳 中文    |    设置时区          |


#### Need cherry-pick to release versions?
release/2.2
Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
