### PR TITLE
feat: transfer pipeline status to analyzed failed when precheck fails

### DIFF
--- a/apistructs/pipeline_status.go
+++ b/apistructs/pipeline_status.go
@@ -159,7 +159,7 @@ func (status PipelineStatus) IsReconcilerRunningStatus() bool {
 
 func (status PipelineStatus) IsBeforePressRunButton() bool {
 	switch status {
-	case PipelineStatusInitializing, PipelineStatusAnalyzed, PipelineStatusAnalyzeFailed:
+	case PipelineStatusInitializing, PipelineStatusAnalyzed:
 		return true
 	default:
 		return false

--- a/internal/tools/pipeline/providers/run/can_manual_run.go
+++ b/internal/tools/pipeline/providers/run/can_manual_run.go
@@ -25,12 +25,12 @@ import (
 func (s *provider) CanManualRun(ctx context.Context, p *spec.Pipeline) (reason string, can bool) {
 	can = false
 
-	if p.Status != apistructs.PipelineStatusAnalyzed {
-		reason = fmt.Sprintf("pipeline already begin run")
-		return
-	}
 	if p.Extra.ShowMessage != nil && p.Extra.ShowMessage.AbortRun {
 		reason = "abort run, please check PreCheck result"
+		return
+	}
+	if p.Status != apistructs.PipelineStatusAnalyzed {
+		reason = fmt.Sprintf("pipeline already begin run")
 		return
 	}
 	if p.Type == apistructs.PipelineTypeRerunFailed && p.Extra.RerunFailedDetail != nil {

--- a/internal/tools/pipeline/services/pipelinesvc/convert_test.go
+++ b/internal/tools/pipeline/services/pipelinesvc/convert_test.go
@@ -57,3 +57,54 @@ func Test_ConvertPipeline(t *testing.T) {
 		}
 	}
 }
+
+func Test_transferStatusToAnalyzedFailedIfNeed(t *testing.T) {
+	tests := []struct {
+		name string
+		p    spec.Pipeline
+		want apistructs.PipelineStatus
+	}{
+		{
+			name: "analyzed and not abort pipeline",
+			p: spec.Pipeline{
+				PipelineBase: spec.PipelineBase{
+					Status: apistructs.PipelineStatusAnalyzed,
+				},
+			},
+			want: apistructs.PipelineStatusAnalyzed,
+		},
+		{
+			name: "analyzed and abort pipeline",
+			p: spec.Pipeline{
+				PipelineBase: spec.PipelineBase{
+					Status: apistructs.PipelineStatusAnalyzed,
+				},
+				PipelineExtra: spec.PipelineExtra{
+					Extra: spec.PipelineExtraInfo{
+						ShowMessage: &apistructs.ShowMessage{
+							AbortRun: true,
+						},
+					},
+				},
+			},
+			want: apistructs.PipelineStatusAnalyzeFailed,
+		},
+		{
+			name: "normal pipeline",
+			p: spec.Pipeline{
+				PipelineBase: spec.PipelineBase{
+					Status: apistructs.PipelineStatusRunning,
+				},
+			},
+			want: apistructs.PipelineStatusRunning,
+		},
+	}
+	s := PipelineSvc{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.transferStatusToAnalyzedFailedIfNeed(&tt.p); got != tt.want {
+				t.Errorf("transferStatusToAnalyzedFailedIfNeed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/pipeline/services/pipelinesvc/precheck.go
+++ b/internal/tools/pipeline/services/pipelinesvc/precheck.go
@@ -114,6 +114,9 @@ func (s *PipelineSvc) PreCheck(p *spec.Pipeline, stages []spec.PipelineStage, us
 		}
 	}
 	if abort {
+		if err := s.dbClient.UpdatePipelineBaseStatus(p.PipelineID, apistructs.PipelineStatusAnalyzeFailed); err != nil {
+			return apierrors.ErrPreCheckPipeline.InternalError(err)
+		}
 		return apierrors.ErrPreCheckPipeline.InvalidParameter("precheck failed")
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
transfer pipeline status to analyzed failed when precheck fails

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=318195&iterationID=1297&pId=0&type=REQUIREMENT)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: transfer pipeline status to analyzed failed when precheck fails （将禁止执行的流水线置为初始化失败状态）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | transfer pipeline status to analyzed failed when precheck fails             |
| 🇨🇳 中文    |     将禁止执行的流水线置为初始化失败状态         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
