### PR TITLE
fix: openapi transport

### DIFF
--- a/api/proto/core/hepa/endpoint_api/endpoint_api.proto
+++ b/api/proto/core/hepa/endpoint_api/endpoint_api.proto
@@ -97,6 +97,7 @@ service EndpointApiService {
       get: "/api/gateway/openapi/invalid-endpoints",
     };
     option(erda.common.openapi) = {
+      service: "hepa",
       path: "/api/gateway/openapi/invalid-endpoints",
     };
   }
@@ -106,6 +107,7 @@ service EndpointApiService {
       delete: "/api/gateway/openapi/invalid-endpoints",
     };
     option(erda.common.openapi) = {
+      service: "hepa",
       path: "/api/gateway/openapi/invalid-endpoints",
     };
   }

--- a/internal/tools/orchestrator/hepa/providers/endpoint_api/provider.go
+++ b/internal/tools/orchestrator/hepa/providers/endpoint_api/provider.go
@@ -96,6 +96,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 			perm.Method(apiService.UpdateEndpoint, perm.ScopeOrg, "org", perm.ActionGet, perm.OrgIDValue()),
 			perm.Method(apiService.UpdateEndpointApi, perm.ScopeOrg, "org", perm.ActionGet, perm.OrgIDValue()),
 			perm.Method(apiService.ListInvalidEndpointApi, perm.ScopeOrg, "org", perm.ActionGet, perm.OrgIDValue()),
+			perm.Method(apiService.ClearInvalidEndpointApi, perm.ScopeOrg, "org", perm.ActionGet, perm.OrgIDValue()),
 		), common.AccessLogWrap(common.AccessLog))
 	}
 	return nil

--- a/internal/tools/orchestrator/hepa/services/micro_api/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/micro_api/impl/impl.go
@@ -1490,6 +1490,9 @@ func (impl GatewayApiServiceImpl) deleteApi(apiId string) (StandardErrorCode, er
 		err = errors.Errorf("invalid api: %+v", gatewayApi)
 		goto errorHappened
 	}
+	if kongAdapter == nil {
+		return ret, errors.New("kongAdapter is nil")
+	}
 	if gatewayRoute, err = impl.routeDb.GetByApiId(apiId); err == nil && gatewayRoute != nil {
 		err = kongAdapter.DeleteRoute(gatewayRoute.RouteId)
 		err = impl.routeDb.DeleteById(gatewayRoute.Id)

--- a/pkg/common/errors/data.go
+++ b/pkg/common/errors/data.go
@@ -17,7 +17,6 @@ package errors
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/erda-project/erda-infra/providers/i18n"
 )
@@ -32,10 +31,6 @@ var _ Error = (*NotFoundError)(nil)
 // NewNotFoundError .
 func NewNotFoundError(resource string) *NotFoundError {
 	return &NotFoundError{Resource: resource}
-}
-
-func IsNotFoundError(err error) bool {
-	return err != nil && strings.HasSuffix(err.Error(), "not found")
 }
 
 func (e *NotFoundError) Error() string {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix the problem that fail to init service hub: fail to Init provider openapi-protobuf-routes: fail to discover url (GET /api/gateway/openapi/invalid-endpoints) of service "erda.core.hepa.endpoint_api.EndpointApiService": resolve service endpoint failed, service:erda.core.hepa.endpoint_api.EndpointApiService: lookup erda.core.hepa.endpoint_api.EndpointApiService ..: no such host

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix the problem that failed to init service hub in openapi module|
| 🇨🇳 中文    | 修复 Openapi 中寻找 hepa 某接口的地址失败的问题 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
