### PR TITLE
chore(protobuf): do not register openapiv1 protos

### DIFF
--- a/api/proto/openapiv1/admin/admin.proto
+++ b/api/proto/openapiv1/admin/admin.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.admin;
+package erda.openapiv1.admin; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/admin/pb";
 

--- a/api/proto/openapiv1/api_gateway/api.proto
+++ b/api/proto/openapiv1/api_gateway/api.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.api;
+package erda.openapiv1.api; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/api/gateway/pb";
 

--- a/api/proto/openapiv1/cluster_manager/cluster.proto
+++ b/api/proto/openapiv1/cluster_manager/cluster.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.cluster;
+package erda.openapiv1.cluster; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/cluster/manager/pb";
 

--- a/api/proto/openapiv1/cmp/cmp.proto
+++ b/api/proto/openapiv1/cmp/cmp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.cmp;
+package erda.openapiv1.cmp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/cmp/pb";
 

--- a/api/proto/openapiv1/core_services/core.proto
+++ b/api/proto/openapiv1/core_services/core.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.core;
+package erda.openapiv1.core; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/core/services/pb";
 

--- a/api/proto/openapiv1/dicehub/dicehub.proto
+++ b/api/proto/openapiv1/dicehub/dicehub.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.dicehub;
+package erda.openapiv1.dicehub; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/dicehub/pb";
 

--- a/api/proto/openapiv1/dop/dop.proto
+++ b/api/proto/openapiv1/dop/dop.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.dop;
+package erda.openapiv1.dop; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/dop/pb";
 

--- a/api/proto/openapiv1/dop_config_manage/dop.proto
+++ b/api/proto/openapiv1/dop_config_manage/dop.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.dop;
+package erda.openapiv1.dop; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/dop/config/manage/pb";
 

--- a/api/proto/openapiv1/dop_filetree/dop.proto
+++ b/api/proto/openapiv1/dop_filetree/dop.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.dop;
+package erda.openapiv1.dop; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/dop/filetree/pb";
 

--- a/api/proto/openapiv1/elf/elf.proto
+++ b/api/proto/openapiv1/elf/elf.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.elf;
+package erda.openapiv1.elf; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/elf/pb";
 

--- a/api/proto/openapiv1/fdp/fdp.proto
+++ b/api/proto/openapiv1/fdp/fdp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.fdp;
+package erda.openapiv1.fdp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/fdp/pb";
 

--- a/api/proto/openapiv1/gittar/gittar.proto
+++ b/api/proto/openapiv1/gittar/gittar.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.gittar;
+package erda.openapiv1.gittar; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/gittar/pb";
 

--- a/api/proto/openapiv1/hepa/hepa.proto
+++ b/api/proto/openapiv1/hepa/hepa.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.hepa;
+package erda.openapiv1.hepa; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/hepa/pb";
 

--- a/api/proto/openapiv1/monitor/monitor.proto
+++ b/api/proto/openapiv1/monitor/monitor.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.monitor;
+package erda.openapiv1.monitor; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/monitor/pb";
 

--- a/api/proto/openapiv1/msp/msp.proto
+++ b/api/proto/openapiv1/msp/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/pb";
 

--- a/api/proto/openapiv1/msp_apm_alert/msp.proto
+++ b/api/proto/openapiv1/msp_apm_alert/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/alert/pb";
 

--- a/api/proto/openapiv1/msp_apm_block/msp.proto
+++ b/api/proto/openapiv1/msp_apm_block/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/block/pb";
 

--- a/api/proto/openapiv1/msp_apm_exception/msp.proto
+++ b/api/proto/openapiv1/msp_apm_exception/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/exception/pb";
 

--- a/api/proto/openapiv1/msp_apm_log_service/msp.proto
+++ b/api/proto/openapiv1/msp_apm_log_service/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/log/service/pb";
 

--- a/api/proto/openapiv1/msp_apm_metric/msp.proto
+++ b/api/proto/openapiv1/msp_apm_metric/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/metric/pb";
 

--- a/api/proto/openapiv1/msp_apm_trace/msp.proto
+++ b/api/proto/openapiv1/msp_apm_trace/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/apm/trace/pb";
 

--- a/api/proto/openapiv1/msp_tenant/msp.proto
+++ b/api/proto/openapiv1/msp_tenant/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/tenant/pb";
 

--- a/api/proto/openapiv1/msp_tenant_project/msp.proto
+++ b/api/proto/openapiv1/msp_tenant_project/msp.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.msp;
+package erda.openapiv1.msp; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/msp/tenant/project/pb";
 

--- a/api/proto/openapiv1/officer/officer.proto
+++ b/api/proto/openapiv1/officer/officer.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.officer;
+package erda.openapiv1.officer; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/officer/pb";
 

--- a/api/proto/openapiv1/onedata/onedata.proto
+++ b/api/proto/openapiv1/onedata/onedata.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.onedata;
+package erda.openapiv1.onedata; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/onedata/pb";
 

--- a/api/proto/openapiv1/openapi/openapi.proto
+++ b/api/proto/openapiv1/openapi/openapi.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.openapi;
+package erda.openapiv1.openapi; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/openapi/pb";
 

--- a/api/proto/openapiv1/openapi_component_protocol/openapi.proto
+++ b/api/proto/openapiv1/openapi_component_protocol/openapi.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.openapi;
+package erda.openapiv1.openapi; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/openapi/component/protocol/pb";
 

--- a/api/proto/openapiv1/orchestrator/orchestrator.proto
+++ b/api/proto/openapiv1/orchestrator/orchestrator.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.orchestrator;
+package erda.openapiv1.orchestrator; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/orchestrator/pb";
 

--- a/api/proto/openapiv1/pipeline/pipeline.proto
+++ b/api/proto/openapiv1/pipeline/pipeline.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.pipeline;
+package erda.openapiv1.pipeline; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/pipeline/pb";
 

--- a/api/proto/openapiv1/testplatform_autotest/testplatform.proto
+++ b/api/proto/openapiv1/testplatform_autotest/testplatform.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.testplatform;
+package erda.openapiv1.testplatform; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/testplatform/autotest/pb";
 

--- a/api/proto/openapiv1/testplatform_testcase/testplatform.proto
+++ b/api/proto/openapiv1/testplatform_testcase/testplatform.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.testplatform;
+package erda.openapiv1.testplatform; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/testplatform/testcase/pb";
 

--- a/api/proto/openapiv1/testplatform_testplan/testplatform.proto
+++ b/api/proto/openapiv1/testplatform_testplan/testplatform.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.testplatform;
+package erda.openapiv1.testplatform; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/testplatform/testplan/pb";
 

--- a/api/proto/openapiv1/testplatform_testplan_rel/testplatform.proto
+++ b/api/proto/openapiv1/testplatform_testplan_rel/testplatform.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.testplatform;
+package erda.openapiv1.testplatform; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/testplatform/testplan/rel/pb";
 

--- a/api/proto/openapiv1/testplatform_testset/testplatform.proto
+++ b/api/proto/openapiv1/testplatform_testset/testplatform.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.testplatform;
+package erda.openapiv1.testplatform; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/testplatform/testset/pb";
 

--- a/api/proto/openapiv1/uc/uc.proto
+++ b/api/proto/openapiv1/uc/uc.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package erda.uc;
+package erda.openapiv1.uc; // remove 'openapiv1.' when you make this proto file effective
 
 option go_package = "github.com/erda-project/erda-proto-go/openapiv1/uc/pb";
 

--- a/internal/tools/openapi/legacy/api/generate/generate_proto.go
+++ b/internal/tools/openapi/legacy/api/generate/generate_proto.go
@@ -333,7 +333,7 @@ func (pf *protoFile) writeProtoHeader(apiName string) {
 	pf.writeline(`syntax = "proto3";`)
 	pf.newline(1)
 
-	pf.writeline("package " + getProtoPackageByAPIName(apiName) + ";")
+	pf.writeline("package " + getProtoPackageByAPIName(apiName) + ";" + ` // remove 'openapiv1.' when you make this proto file effective`)
 	pf.newline(1)
 
 	pf.writeline(`option go_package = "` + getProtoGoPackageByAPIName(apiName) + `";`)
@@ -369,7 +369,7 @@ func getCompAndSubDirsByAPIName(apiName string) (compName string, subDirs []stri
 
 func getProtoPackageByAPIName(apiName string) string {
 	compName := getCompNameByAPIName(apiName)
-	return "erda." + compName
+	return "erda.openapiv1." + compName
 }
 
 func getProtoGoPackageByAPIName(apiName string) string {

--- a/internal/tools/openapi/openapi-ng/routes/proto/proto.go
+++ b/internal/tools/openapi/openapi-ng/routes/proto/proto.go
@@ -78,6 +78,10 @@ func RangeOpenAPIs(pkgPrefix string, handler OneOpenAPIHandler) (err error) {
 		if !strings.HasPrefix(pkgName, pkgPrefix) {
 			return true
 		}
+		// do not register openapiv1 apis to router
+		if strings.HasPrefix(pkgName, "erda.openapiv1.") {
+			return true
+		}
 		services := fd.Services()
 		for i, n := 0, services.Len(); i < n; i++ {
 			service := services.Get(i)


### PR DESCRIPTION
#### What this PR does / why we need it:

do not register openapiv1 protos to router


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  do not register openapiv1 protos to router            |
| 🇨🇳 中文    |   router 不注册 openapiv1 protos           |
