### PR TITLE
fix(openapi): solve path mismatch caused by case

### DIFF
--- a/internal/tools/openapi/legacy/auth/token.go
+++ b/internal/tools/openapi/legacy/auth/token.go
@@ -92,7 +92,7 @@ type OpenapiSpec struct {
 }
 
 func (s *OpenapiSpec) MatchPath(path string) bool {
-	return s.Spec.Path.String() == path
+	return strings.EqualFold(s.Spec.Path.String(), path)
 }
 
 func (s *OpenapiSpec) Method() string {

--- a/internal/tools/openapi/legacy/auth/token_test.go
+++ b/internal/tools/openapi/legacy/auth/token_test.go
@@ -22,6 +22,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 
 	tokenpb "github.com/erda-project/erda-proto-go/core/token/pb"
+	"github.com/erda-project/erda/internal/tools/openapi/legacy/api/spec"
 	"github.com/erda-project/erda/pkg/http/httputil"
 )
 
@@ -69,5 +70,37 @@ func TestVerifyAccessKey(t *testing.T) {
 				t.Errorf("internal client header = %v, want %v", got, "2")
 			}
 		})
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		specPath string
+		path     string
+		want     bool
+	}{
+		{
+			name:     "same path",
+			specPath: "/api/publish-items/<publishItemId>/versions",
+			path:     "/api/publish-items/<publishItemId>/versions",
+			want:     true,
+		},
+		{
+			name:     "one lower case",
+			specPath: "/api/publish-items/<publishItemId>/versions",
+			path:     "/api/publish-items/<publishItemID>/versions",
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		s := &OpenapiSpec{
+			Spec: &spec.Spec{
+				Path: spec.NewPath(tt.specPath),
+			},
+		}
+		if got := s.MatchPath(tt.path); got != tt.want {
+			t.Errorf("%s: MatchPath() = %v, want %v", tt.name, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
solve path mismatch caused by case

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=322439&iterationID=1297&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： solve path mismatch caused by case（修复了由大小写造成的路径不匹配）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    solve path mismatch caused by case           |
| 🇨🇳 中文    |     修复了由大小写造成的路径不匹配         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
