### PR TITLE
fix(pipeline): solve status of task is reset to running due to cancel timeout

### DIFF
--- a/internal/tools/pipeline/providers/reconciler/taskrun/framework_test.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/framework_test.go
@@ -134,6 +134,15 @@ func Test_waitOpForLoopNetWorkError(t *testing.T) {
 			expectedStatus: apistructs.PipelineStatusRunning,
 			wantErr:        true,
 		},
+		{
+			name: "stopByUser task with network error ,no loop",
+			args: args{
+				op:         "wait",
+				taskStatus: apistructs.PipelineStatusStopByUser,
+			},
+			expectedStatus: apistructs.PipelineStatusStopByUser,
+			wantErr:        false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
solve status of task is reset to running due to cancel timeout

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=322849&iterationID=1321&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： solve status of task is reset to running due to cancel timeout （修复了流水线取消成功后任务状态有的还在运行中）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   solve status of task is reset to running due to cancel timeout           |
| 🇨🇳 中文    |    修复了流水线取消成功后任务状态有的还在运行中          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
