### PR TITLE
feat(http-server): http-endpoints support singleton mode

### DIFF
--- a/pkg/http/httpserver/router.go
+++ b/pkg/http/httpserver/router.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"github.com/erda-project/erda-infra/providers/httpserver"
+)
+
+func (s *Server) RegisterToNewHttpServerRouter(newRouter httpserver.Router) {
+	newRouter.Any("/**", s.router)
+}

--- a/pkg/http/httpserver/singleton.go
+++ b/pkg/http/httpserver/singleton.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"sync"
+)
+
+var singleton *Server
+var once sync.Once
+
+func NewSingleton(addr string) *Server {
+	once.Do(func() {
+		singleton = New(addr)
+	})
+	return singleton
+}

--- a/pkg/http/httpserver/singleton_test.go
+++ b/pkg/http/httpserver/singleton_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSingleton(t *testing.T) {
+	// NewSingleton not invoked
+	assert.Nil(t, singleton)
+
+	// NewSingleton invoked
+	s1 := NewSingleton("")
+	assert.NotNil(t, singleton)
+	assert.NotNil(t, s1)
+	assert.Equal(t, s1, singleton)
+
+	// NewSingleton invoked again
+	s2 := NewSingleton("")
+	assert.NotNil(t, singleton)
+	assert.NotNil(t, s2)
+	assert.Equal(t, s1, singleton)
+	assert.Equal(t, s2, s1)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

- http-endpoints support singleton mode
- add servicehub.Listener to register routes of http-endpoints to new http-server router


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  http-endpoints support singleton mode            |
| 🇨🇳 中文    |   http-endpoints 支持单例模式           |
