### PR TITLE
feat: project pipeline display existed running link when runs repeatedly

### DIFF
--- a/bundle/pipeline.go
+++ b/bundle/pipeline.go
@@ -61,7 +61,7 @@ func (b *Bundle) CreatePipeline(req interface{}) (*apistructs.PipelineDTO, error
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 	if !resp.IsOK() || !createResp.Success {
-		return nil, toAPIError(resp.StatusCode(), createResp.Error)
+		return nil, toAPIError(resp.StatusCode(), createResp.Error).SetCtx(createResp.Error.Ctx)
 	}
 
 	return createResp.Data, nil

--- a/bundle/pipeline.go
+++ b/bundle/pipeline.go
@@ -61,7 +61,7 @@ func (b *Bundle) CreatePipeline(req interface{}) (*apistructs.PipelineDTO, error
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 	if !resp.IsOK() || !createResp.Success {
-		return nil, toAPIError(resp.StatusCode(), createResp.Error).SetCtx(createResp.Error.Ctx)
+		return nil, toAPIError(resp.StatusCode(), createResp.Error)
 	}
 
 	return createResp.Data, nil

--- a/bundle/utils.go
+++ b/bundle/utils.go
@@ -20,5 +20,5 @@ import (
 )
 
 func toAPIError(statusCode int, err apistructs.ErrorResponse) *errorresp.APIError {
-	return errorresp.New(errorresp.WithCode(statusCode, err.Code), errorresp.WithMessage(err.Msg))
+	return errorresp.New(errorresp.WithCode(statusCode, err.Code), errorresp.WithMessage(err.Msg), errorresp.WithCtx(err.Ctx))
 }

--- a/internal/apps/dop/endpoints/endpoints.go
+++ b/internal/apps/dop/endpoints/endpoints.go
@@ -34,6 +34,7 @@ import (
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/apps/dop/dao"
 	"github.com/erda-project/erda/internal/apps/dop/event"
+	"github.com/erda-project/erda/internal/apps/dop/providers/projectpipeline"
 	"github.com/erda-project/erda/internal/apps/dop/services/apidocsvc"
 	"github.com/erda-project/erda/internal/apps/dop/services/appcertificate"
 	"github.com/erda-project/erda/internal/apps/dop/services/application"
@@ -684,6 +685,7 @@ type Endpoints struct {
 	PipelineSource     sourcepb.SourceServiceServer
 	PipelineDefinition dpb.DefinitionServiceServer
 	DevFlowRule        dwfpb.DevFlowRuleServiceServer
+	ProjectPipelineSvc *projectpipeline.ProjectPipelineService
 
 	ImportChannel chan uint64
 	ExportChannel chan uint64
@@ -1055,6 +1057,12 @@ func WithPipelineDefinition(svc dpb.DefinitionServiceServer) Option {
 func WithDevFlowRule(svc dwfpb.DevFlowRuleServiceServer) Option {
 	return func(e *Endpoints) {
 		e.DevFlowRule = svc
+	}
+}
+
+func WithProjectPipelineSvc(svc *projectpipeline.ProjectPipelineService) Option {
+	return func(e *Endpoints) {
+		e.ProjectPipelineSvc = svc
 	}
 }
 

--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -395,9 +395,9 @@ func (e *Endpoints) pipelineRun(ctx context.Context, r *http.Request, vars map[s
 		ConfigManageNamespaces: []string{utils.MakeUserOrgPipelineCmsNs(identityInfo.UserID, p.OrgID)},
 		Secrets:                utils.GetGittarSecrets(p.ClusterName, p.Branch, p.CommitDetail),
 	}); err != nil {
-		runningPipelineLink, ok := e.ProjectPipelineSvc.TryGenRunningPipelineLinkFromErr(p.PipelineDTO.OrgName, p.PipelineDTO.ProjectID, p.PipelineDTO.ApplicationID, err)
+		runningPipelineErr, ok := e.ProjectPipelineSvc.TryAddRunningPipelineLinkToErr(p.PipelineDTO.OrgName, p.PipelineDTO.ProjectID, p.PipelineDTO.ApplicationID, err)
 		if ok {
-			return errorresp.ErrResp(apierrors.ErrParallelRunPipeline.InvalidState(fmt.Sprintf("failed to run pipeline, there is already running: %s", runningPipelineLink)))
+			return errorresp.ErrResp(runningPipelineErr)
 		}
 		return errorresp.ErrResp(err)
 	}

--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -395,26 +395,11 @@ func (e *Endpoints) pipelineRun(ctx context.Context, r *http.Request, vars map[s
 		ConfigManageNamespaces: []string{utils.MakeUserOrgPipelineCmsNs(identityInfo.UserID, p.OrgID)},
 		Secrets:                utils.GetGittarSecrets(p.ClusterName, p.Branch, p.CommitDetail),
 	}); err != nil {
-		var apiError, ok = err.(*errorresp.APIError)
-		if !ok {
-			// Failed to convert to apiError type, return the error passed by the pipeline component
-			return errorresp.ErrResp(err)
+		runningPipelineLink, ok := e.ProjectPipelineSvc.TryGenRunningPipelineLinkFromErr(p.PipelineDTO.OrgName, p.PipelineDTO.ProjectID, p.PipelineDTO.ApplicationID, err)
+		if ok {
+			return errorresp.ErrResp(apierrors.ErrParallelRunPipeline.InvalidState(fmt.Sprintf("failed to run pipeline, there is already running: %s", runningPipelineLink)))
 		}
-
-		ctxMap, ok := apiError.Ctx().(map[string]interface{})
-		if !ok {
-			// Interface converted to map[string]interface{} fails and returns the error passed by the pipeline component
-			return errorresp.ErrResp(err)
-		}
-
-		// Get the link to the running pipeline
-		link, ok := GetPipelineLink(p.PipelineDTO, ctxMap)
-		if !ok {
-			// Failed to get the pipeline information and return an error
-			return errorresp.ErrResp(fmt.Errorf("failed to get the running pipeline"))
-		}
-
-		return errorresp.ErrResp(apierrors.ErrParallelRunPipeline.InvalidState(fmt.Sprintf("failed to run pipeline, there is already running: %s", link)))
+		return errorresp.ErrResp(err)
 	}
 
 	return httpserver.OkResp(nil)

--- a/internal/apps/dop/initialize.go
+++ b/internal/apps/dop/initialize.go
@@ -654,6 +654,7 @@ func (p *provider) initEndpoints(db *dao.DBClient) (*endpoints.Endpoints, error)
 		endpoints.WithDevFlowRule(p.DevFlowRule),
 		endpoints.WithTokenSvc(p.TokenService),
 		endpoints.WithOrgClient(p.Org),
+		endpoints.WithProjectPipelineSvc(p.ProjectPipelineSvc),
 	)
 
 	ep.ImportChannel = make(chan uint64)

--- a/internal/apps/dop/providers/projectpipeline/provider.go
+++ b/internal/apps/dop/providers/projectpipeline/provider.go
@@ -38,6 +38,7 @@ import (
 )
 
 type config struct {
+	UIPublicURL string `env:"UI_PUBLIC_URL" required:"true"`
 }
 
 type provider struct {
@@ -68,6 +69,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 			},
 		},
 		bundle:             p.bundle,
+		cfg:                p.Cfg,
 		PipelineSource:     p.PipelineSource,
 		PipelineDefinition: p.PipelineDefinition,
 		PipelineCms:        p.PipelineCms,

--- a/internal/apps/dop/providers/projectpipeline/service.go
+++ b/internal/apps/dop/providers/projectpipeline/service.go
@@ -39,6 +39,7 @@ type ProjectPipelineService struct {
 	logger logs.Logger
 	db     *dao.DBClient
 	bundle *bundle.Bundle
+	cfg    *config
 
 	pipelineSvc        *pipeline.Pipeline
 	PipelineSource     sourcepb.SourceServiceServer

--- a/internal/apps/dop/providers/projectpipeline/service_impl.go
+++ b/internal/apps/dop/providers/projectpipeline/service_impl.go
@@ -1356,6 +1356,12 @@ func (p *ProjectPipelineService) autoRunPipeline(identityInfo apistructs.Identit
 	if err != nil {
 		return nil, err
 	}
+	projectIDStr := createV2.Labels[apistructs.LabelProjectID]
+	projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	orgName := createV2.NormalLabels[apistructs.LabelOrgName]
 
 	// If source type is erda，should sync pipelineYml file
 	pipelineYml := params.source.PipelineYml
@@ -1441,6 +1447,10 @@ func (p *ProjectPipelineService) autoRunPipeline(identityInfo apistructs.Identit
 
 	value, err := p.bundle.CreatePipeline(createV2)
 	if err != nil {
+		runningPipelineLink, ok := p.TryGenRunningPipelineLinkFromErr(orgName, projectID, appID, err)
+		if ok {
+			return nil, apierrors.ErrParallelRunPipeline.InvalidState(fmt.Sprintf("failed to run pipeline, there is already running: %s", runningPipelineLink))
+		}
 		return nil, apierrors.ErrRunProjectPipeline.InternalError(err)
 	}
 	return value, nil
@@ -1935,4 +1945,26 @@ func pipelineYmlsFilterIn(ymls []string, fn func(yml string) bool) (newYmls []st
 		}
 	}
 	return
+}
+
+func (p *ProjectPipelineService) TryGenRunningPipelineLinkFromErr(orgName string, projectID uint64, appID uint64, err error) (string, bool) {
+	apiError, ok := err.(*errorresp.APIError)
+	if !ok {
+		return "", false
+	}
+
+	ctxMap, ok := apiError.Ctx().(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	var runningPipelineID string
+	for key, value := range ctxMap {
+		if key == apierrors.ErrParallelRunPipeline.Error() {
+			runningPipelineID, _ = value.(string)
+		}
+	}
+	if runningPipelineID == "" {
+		return "", false
+	}
+	return fmt.Sprintf("%s/%s/dop/projects/%d/apps/%d/pipeline?pipelineID=%s", p.cfg.UIPublicURL, orgName, projectID, appID, runningPipelineID), true
 }

--- a/pkg/common/apis/response_test.go
+++ b/pkg/common/apis/response_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apis
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/erda-project/erda/pkg/http/httpserver/errorresp"
+)
+
+type mockResponseWriter struct {
+	data []byte
+}
+
+func (m *mockResponseWriter) Header() http.Header {
+	return map[string][]string{}
+}
+
+func (m *mockResponseWriter) Write(bytes []byte) (int, error) {
+	m.data = bytes
+	return 0, nil
+}
+
+func (m *mockResponseWriter) WriteHeader(statusCode int) {
+
+}
+
+type transhttpError struct{}
+
+func (t *transhttpError) Error() string {
+	return "transport error"
+}
+
+func (t *transhttpError) HTTPStatus() int {
+	return http.StatusBadRequest
+}
+
+func Test_encodeError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "api error",
+			args: args{
+				err: errorresp.New(
+					errorresp.WithMessage("api error msg"),
+					errorresp.WithTemplateMessage("err1", "val1"),
+					errorresp.WithCode(400, "400"),
+				),
+			},
+			want: []byte(`{"success":false,"err":{"code":"400","msg":"api error msg: val1","ctx":null}}
+`),
+		},
+		{
+			name: "transhttp error",
+			args: args{
+				err: &transhttpError{},
+			},
+			want: []byte(`{"success":false,"err":{"code":"400","msg":"transport error","ctx":"/api"}}
+`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, r := &mockResponseWriter{}, &http.Request{URL: &url.URL{Path: "/api"}}
+			encodeError(w, r, tt.args.err)
+			if string(w.data) != string(tt.want) {
+				t.Errorf("encodeError() = %v, want %v", w.data, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
project pipeline display existed running link when runs repeatedly

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=322630&iterationID=1297&pId=0&type=REQUIREMENT)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: project pipeline display existed running link when runs repeatedly （项目级流水线展示正在运行的流水线链接）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  project pipeline display existed running link when runs repeatedly            |
| 🇨🇳 中文    |   项目级流水线展示正在运行的流水线链接           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
