### PR TITLE
fix: hpa support min replicas to 0

### DIFF
--- a/internal/tools/orchestrator/components/horizontalpodscaler/hp.scaler.service.go
+++ b/internal/tools/orchestrator/components/horizontalpodscaler/hp.scaler.service.go
@@ -567,12 +567,12 @@ func (s *hpscalerService) updateHPARules(userInfo *apistructs.UserInfo, appInfo 
 		newRule := newRulesBase[rule.RuleID]
 		needUpdate := false
 
-		if rule.ScaledConfig.MinReplicaCount != 0 && newRule.MinReplicaCount != rule.ScaledConfig.MinReplicaCount {
+		if rule.ScaledConfig.MinReplicaCount >= 0 && newRule.MinReplicaCount != rule.ScaledConfig.MinReplicaCount {
 			needUpdate = true
 			newRule.MinReplicaCount = rule.ScaledConfig.MinReplicaCount
 		}
 
-		if rule.ScaledConfig.MaxReplicaCount != 0 && newRule.MaxReplicaCount != rule.ScaledConfig.MaxReplicaCount {
+		if rule.ScaledConfig.MaxReplicaCount > 0 && newRule.MaxReplicaCount != rule.ScaledConfig.MaxReplicaCount {
 			needUpdate = true
 			newRule.MaxReplicaCount = rule.ScaledConfig.MaxReplicaCount
 		}
@@ -989,7 +989,7 @@ func validateHPARuleConfigCustom(serviceName string, maxReplicas int32, scaledCo
 		return errors.Errorf("service %s not set scaledConfig", serviceName)
 	}
 
-	if scaledConf.MinReplicaCount <= 0 {
+	if scaledConf.MinReplicaCount < 0 {
 		return errors.Errorf("service %s not set scaledConfig.minReplicaCount", serviceName)
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix hpa rules which use cron trigger not scale down to 0


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
Bugfix： Fix hpa rules which use cron trigger not scale down to 0（修复了支持 cron hpa 将副本数缩为 0）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix hpa rules which use cron trigger not scale down to 0       |
| 🇨🇳 中文    |      修复了支持 cron hpa 将副本数缩为 0      |



