### PR TITLE
feat: find invalid kong route and service by redirect inner address

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run Go Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.29
+          version: v1.46
           args: --timeout=10m
           skip-go-installation: true
           skip-pkg-cache: false

--- a/api/proto/core/hepa/endpoint_api/endpoint_api.proto
+++ b/api/proto/core/hepa/endpoint_api/endpoint_api.proto
@@ -92,7 +92,7 @@ service EndpointApiService {
     };
   }
 
-  rpc ListInvalidEndpointApi(common.VoidRequest) returns(ListInvalidEndpointApiResp) {
+  rpc ListInvalidEndpointApi(ListInvalidEndpointApiReq) returns(ListInvalidEndpointApiResp) {
     option(google.api.http) = {
       get: "/api/gateway/openapi/invalid-endpoints",
     };
@@ -102,7 +102,7 @@ service EndpointApiService {
     };
   }
 
-  rpc ClearInvalidEndpointApi(common.VoidRequest) returns (common.VoidResponse) {
+  rpc ClearInvalidEndpointApi(ListInvalidEndpointApiReq) returns (common.VoidResponse) {
     option(google.api.http) = {
       delete: "/api/gateway/openapi/invalid-endpoints",
     };
@@ -257,8 +257,16 @@ message GetEndpointResponse {
   Endpoint data = 1;
 }
 
+message ListInvalidEndpointApiReq {
+  string clusterName = 1;
+}
+
 message ListInvalidEndpointApiResp {
-  repeated ListInvalidEndpointApiItem list = 1;
+  uint64 total = 1;
+  uint64 totalProjectIsInvalid = 2;
+  uint64 totalRuntimeIsInvalid = 3;
+  uint64 totalInnerAddrIsInvalid = 4;
+  repeated ListInvalidEndpointApiItem list = 5;
 }
 
 message ListInvalidEndpointApiItem {
@@ -267,8 +275,11 @@ message ListInvalidEndpointApiItem {
   string projectID = 3;
   string packageID = 4;
   string packageApiID = 5;
-  string upstreamApiID = 6;
-  string upstreamID = 7;
-  string upstreamName = 8;
   string runtimeID = 9;
+  string innerHostname = 10;
+  string kongRouteID = 11;
+  string kongServiceID = 12;
+  string clusterName = 13;
+  string routeDeleting = 15;
+  string serviceDeleting = 16;
 }

--- a/internal/tools/orchestrator/hepa/k8s/k8s_adapter.go
+++ b/internal/tools/orchestrator/hepa/k8s/k8s_adapter.go
@@ -86,6 +86,7 @@ type K8SAdapter interface {
 	CheckIngressExist(namespace, name string) (bool, error)
 	UpdateIngressAnnotaion(namespace, name string, annotaion map[string]*string, snippet *string) error
 	UpdateIngressConroller(options map[string]*string, mainSnippet, httpSnippet, serverSnippet *string) error
+	ListAllServices(namespace string) ([]v1.Service, error)
 }
 
 type K8SAdapterImpl struct {
@@ -580,6 +581,14 @@ func (impl *K8SAdapterImpl) UpdateIngressConroller(options map[string]*string, m
 		err = impl.updateIngressConroller(SYSTEM_NS, INGRESS_CONFIG_NAME, options, mainSnippet, httpSnippet, serverSnippet)
 	}
 	return
+}
+
+func (impl *K8SAdapterImpl) ListAllServices(namespace string) ([]v1.Service, error) {
+	services, err := impl.client.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return services.Items, nil
 }
 
 func (impl *K8SAdapterImpl) updateIngressConroller(namespace, cmName string, options map[string]*string, mainSnippet, httpSnippet, serverSnippet *string) error {

--- a/internal/tools/orchestrator/hepa/k8s/k8s_adapter_test.go
+++ b/internal/tools/orchestrator/hepa/k8s/k8s_adapter_test.go
@@ -16,14 +16,17 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	apiCorev1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/common/util"
 	"github.com/erda-project/erda/pkg/k8s/union_interface"
@@ -90,6 +93,35 @@ func (ingressInterface) Apply(ctx context.Context, ingress interface{}, opts v1.
 }
 func (ingressInterface) ApplyStatus(ctx context.Context, ingress interface{}, opts v1.ApplyOptions) (interface{}, error) {
 	return nil, nil
+}
+
+type mockK8sClient struct {
+	kubernetes.Interface
+}
+
+func (m mockK8sClient) CoreV1() corev1.CoreV1Interface {
+	return mockCoreV1Interface{}
+}
+
+type mockCoreV1Interface struct {
+	corev1.CoreV1Interface
+}
+
+func (m mockCoreV1Interface) Services(namespace string) corev1.ServiceInterface {
+	return mockServiceInterface{namespace: namespace}
+}
+
+type mockServiceInterface struct {
+	corev1.ServiceInterface
+
+	namespace string
+}
+
+func (m mockServiceInterface) List(ctx context.Context, opts v1.ListOptions) (*apiCorev1.ServiceList, error) {
+	if m.namespace == "" {
+		return nil, fmt.Errorf("invalid namespace")
+	}
+	return &apiCorev1.ServiceList{Items: []apiCorev1.Service{}}, nil
 }
 
 func TestK8SAdapterImpl_DeleteIngress(t *testing.T) {
@@ -187,4 +219,10 @@ func TestK8SAdapterImpl_CreateOrUpdateIngress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestK8SAdapterImpl_ListAllServices(t *testing.T) {
+	impl := &K8SAdapterImpl{client: mockK8sClient{}}
+	_, _ = impl.ListAllServices("")
+	_, _ = impl.ListAllServices("xxx")
 }

--- a/internal/tools/orchestrator/hepa/providers/endpoint_api/endpoint.api.service.go
+++ b/internal/tools/orchestrator/hepa/providers/endpoint_api/endpoint.api.service.go
@@ -16,8 +16,10 @@ package endpoint_api
 
 import (
 	"context"
-	"path/filepath"
+	"net/url"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -28,25 +30,39 @@ import (
 	runtimePb "github.com/erda-project/erda-proto-go/orchestrator/runtime/pb"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/common/vars"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway/dto"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/k8s"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/kong"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/orm"
 	repositoryService "github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/service"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/endpoint_api"
+	endpointApiImpl "github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/endpoint_api/impl"
 	"github.com/erda-project/erda/pkg/common/apis"
 	erdaErr "github.com/erda-project/erda/pkg/common/errors"
 )
 
+const (
+	invalidReasonProjectIsInvalid           = "package's project is invalid"
+	invalidReasonPackageRuntimeIsInvalid    = "package's runtime is invalid"
+	invalidReasonPackageAPIRuntimeIsInvalid = "package_api's runtime is invalid"
+	invalidReasonInnerAddrIsInvalid         = "package_api's redirect inner address is invalid"
+
+	invalidTypePackage    = "package"
+	invalidTypePackageAPI = "package_api"
+)
+
 var (
-	invalidProject = "project not found"
-	invalidRuntime = "runtime not found"
+	innerAddrRegexp, _ = regexp.Compile(`^.+\..+\.svc\.cluster\.local$`)
+	innerAddrSuffix    = ".svc.cluster.local"
 )
 
 // endpointApiService implements pb.EndpointApiServiceServer
 type endpointApiService struct {
-	projCli            projPb.ProjectServer
-	runtimeCli         runtimePb.RuntimeServiceServer
-	gatewayApiService  repositoryService.GatewayApiService
-	upstreamApiService repositoryService.GatewayUpstreamApiService
-	upstreamService    repositoryService.GatewayUpstreamService
+	projCli               projPb.ProjectServer
+	runtimeCli            runtimePb.RuntimeServiceServer
+	runtimeService        repositoryService.GatewayRuntimeServiceService
+	gatewayRouteService   repositoryService.GatewayRouteService
+	gatewayServiceService repositoryService.GatewayServiceService
+	kongInfoService       repositoryService.GatewayKongInfoService
 }
 
 func (s *endpointApiService) GetEndpointsName(ctx context.Context, req *pb.GetEndpointsNameRequest) (resp *pb.GetEndpointsNameResponse, err error) {
@@ -269,9 +285,30 @@ func (s *endpointApiService) ChangeEndpointRoot(ctx context.Context, req *pb.Cha
 	return
 }
 
-func (s *endpointApiService) ListInvalidEndpointApi(ctx context.Context, _ *commonPb.VoidRequest) (*pb.ListInvalidEndpointApiResp, error) {
+func (s *endpointApiService) ListInvalidEndpointApi(ctx context.Context, req *pb.ListInvalidEndpointApiReq) (*pb.ListInvalidEndpointApiResp, error) {
 	var result pb.ListInvalidEndpointApiResp
-	err := s.rangeInvalidEndpointApi(ctx, func(item *pb.ListInvalidEndpointApiItem) {
+	kongInfo, err := s.kongInfoService.GetKongInfo(&orm.GatewayKongInfo{Az: req.ClusterName})
+	if err != nil {
+		return nil, err
+	}
+	err = s.rangeInvalidEndpointApi(ctx, req.GetClusterName(), func(item *pb.ListInvalidEndpointApiItem) {
+		if item.GetType() == invalidTypePackageAPI && kongInfo != nil && kongInfo.KongAddr != "" {
+			if item.GetKongRouteID() != "" {
+				item.RouteDeleting = "curl -sIL -w '%{http_code}\n' -X DELETE " + kongInfo.KongAddr + "/routes/" + item.GetKongRouteID()
+			}
+			if item.GetKongServiceID() != "" {
+				item.ServiceDeleting = "curl -sIL -w '%{http_code}\n' -X DELETE " + kongInfo.KongAddr + "/routes/" + item.GetKongServiceID()
+			}
+		}
+		result.Total += 1
+		switch item.GetInvalidReason() {
+		case invalidReasonProjectIsInvalid:
+			result.TotalProjectIsInvalid += 1
+		case invalidReasonPackageRuntimeIsInvalid, invalidReasonPackageAPIRuntimeIsInvalid:
+			result.TotalRuntimeIsInvalid += 1
+		case invalidReasonInnerAddrIsInvalid:
+			result.TotalInnerAddrIsInvalid += 1
+		}
 		result.List = append(result.List, item)
 	})
 	if err != nil {
@@ -281,12 +318,67 @@ func (s *endpointApiService) ListInvalidEndpointApi(ctx context.Context, _ *comm
 	return &result, nil
 }
 
-func (s *endpointApiService) ClearInvalidEndpointApi(ctx context.Context, req *commonPb.VoidRequest) (*commonPb.VoidResponse, error) {
-	return s.clearInvalidEndpointApi(ctx, req)
+func (s *endpointApiService) ClearInvalidEndpointApi(ctx context.Context, req *pb.ListInvalidEndpointApiReq) (*commonPb.VoidResponse, error) {
+	l := logrus.WithField("func", "clearInvalidEndpointApi")
+	service := endpoint_api.Service.Clone(ctx)
+	kongInfo, err := s.kongInfoService.GetKongInfo(&orm.GatewayKongInfo{Az: req.ClusterName})
+	if err != nil {
+		return nil, err
+	}
+	kongAdapter := kong.NewKongAdapter(kongInfo.KongAddr)
+	err = s.rangeInvalidEndpointApi(ctx, req.GetClusterName(), func(item *pb.ListInvalidEndpointApiItem) {
+		if item.GetType() == invalidTypePackage {
+			l.Infof("delete package: %+v", item)
+			if _, err := s.DeleteEndpoint(ctx, &pb.DeleteEndpointRequest{
+				PackageId: item.GetPackageID(),
+			}); err != nil {
+				l.WithError(err).WithField("package id", item.GetPackageID()).Warnln("failed to DeleteEndpoint")
+			}
+		}
+		if item.GetType() == invalidTypePackageAPI {
+			l.Infof("delete package api: %+v", item)
+			if _, err := s.DeleteEndpointApi(ctx, &pb.DeleteEndpointApiRequest{
+				PackageId: item.GetPackageID(),
+				ApiId:     item.GetPackageApiID(),
+			}); err != nil {
+				l.WithError(err).
+					WithField("package id", item.GetPackageID()).
+					WithField("package api id", item.GetPackageApiID()).
+					Warnln("failed to DeleteEndpointApi")
+			}
+			if item.GetKongRouteID() != "" || item.GetKongServiceID() != "" {
+				if err := service.(*endpointApiImpl.GatewayOpenapiServiceImpl).DeleteKongApi(kongAdapter, item.GetPackageApiID()); err != nil {
+					l.WithError(err).WithField("packageAPIID", item.GetPackageApiID()).Warnln("failed to DeleteKongApi")
+				}
+			}
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return new(commonPb.VoidResponse), nil
 }
 
-func (s *endpointApiService) rangeInvalidEndpointApi(ctx context.Context, f func(item *pb.ListInvalidEndpointApiItem)) error {
+func (s *endpointApiService) rangeInvalidEndpointApi(ctx context.Context, clusterName string, f func(item *pb.ListInvalidEndpointApiItem)) error {
 	l := logrus.WithField("func", "rangeInvalidEndpointApi")
+	if clusterName == "" {
+		return errors.New("invalid clusterName")
+	}
+
+	k8SAdapter, err := k8s.NewAdapter(clusterName)
+	if err != nil {
+		return errors.Wrap(err, "failed to k8s.NewAdapter")
+	}
+	k8SServices, err := k8SAdapter.ListAllServices("")
+	if err != nil {
+		return errors.Wrap(err, "failed to k8SAdapter.ListAllServices")
+	}
+	var k8SServicesAddresses = make(map[string]struct{})
+	for _, service := range k8SServices {
+		k8SServicesAddresses[service.Name+"."+service.Namespace] = struct{}{}
+	}
+
 	// list all packages
 	eas := endpoint_api.Service.Clone(ctx)
 	packages, err := eas.ListAllPackages()
@@ -300,16 +392,16 @@ func (s *endpointApiService) rangeInvalidEndpointApi(ctx context.Context, f func
 	}
 
 	var projectPackages = make(map[string][]orm.GatewayPackage)
-	for _, package_ := range packages {
-		if package_.DiceProjectId != "" {
-			projectPackages[package_.DiceProjectId] = append(projectPackages[package_.DiceProjectId], package_)
+	for _, pkg := range packages {
+		if pkg.DiceClusterName == clusterName && pkg.DiceProjectId != "" {
+			projectPackages[pkg.DiceProjectId] = append(projectPackages[pkg.DiceProjectId], pkg)
 		}
 	}
 	for projectID := range projectPackages {
 		l = l.WithField("projectID", projectID)
 		id, err := strconv.ParseUint(projectID, 10, 32)
 		if err != nil {
-			l.WithError(err).Warnln("projectI can not be parsed to uint")
+			l.WithError(err).Warnln("projectID can not be parsed to uint")
 			continue
 		}
 
@@ -317,95 +409,80 @@ func (s *endpointApiService) rangeInvalidEndpointApi(ctx context.Context, f func
 		// collect the package if it's project is invalid
 		resp, err := s.projCli.CheckProjectExist(ctx, &projPb.CheckProjectExistReq{Id: id})
 		if err == nil && !resp.GetOk() {
-			for _, package_ := range packages {
+			for _, pkg := range packages {
+				packageApis, _ := eas.ListPackageAllApis(pkg.Id)
+				for _, packageApi := range packageApis {
+					item := s.adjustInvalidPackageAPIItem(pkg, packageApi, invalidReasonProjectIsInvalid)
+					f(item)
+				}
+
 				item := &pb.ListInvalidEndpointApiItem{
-					InvalidReason: invalidProject,
-					Type:          "package",
+					InvalidReason: invalidReasonProjectIsInvalid,
+					Type:          invalidTypePackage,
 					ProjectID:     projectID,
-					PackageID:     package_.Id,
+					PackageID:     pkg.Id,
 				}
 				f(item)
 			}
 			continue
 		}
 
-		// collect the package_api if it's relation runtime is invalid
-		//
-		// join on tb_gateway_package_api.dice_api_id = tb_gateway_api.id
-		//         tb_gateway_api.upstream_api_id = tb_gateway_upstream_api.id
-		//         tb_gateway_upstream_api.upstream_id = tb_gateway_upstream.id
-		//         runtimeID = filepath.base(tb_gateway_api.upstream_name)
-		for _, package_ := range packages {
-			l := l.WithField("tb_gateway_package_api.id", package_.Id)
-			packageApis, err := eas.ListPackageAllApis(package_.Id)
+		for _, pkg := range packages {
+			l := l.WithField("tb_gateway_package_api.id", pkg.Id)
+			if pkg.RuntimeServiceId != "" {
+				l := l.WithField("runtimeServiceID", pkg.RuntimeServiceId)
+				runtimeService, err := s.runtimeService.Get(pkg.RuntimeServiceId)
+				if err != nil {
+					l.WithError(err).Errorln("failed to runtimeService.Get")
+					return err
+				}
+				if runtimeService != nil {
+					if runtimeID, err := strconv.ParseUint(runtimeService.RuntimeId, 10, 32); err == nil && runtimeID != 0 {
+						if resp, err := s.runtimeCli.CheckRuntimeExist(ctx, &runtimePb.CheckRuntimeExistReq{Id: runtimeID}); err != nil && resp != nil && !resp.GetOk() {
+							item := &pb.ListInvalidEndpointApiItem{
+								InvalidReason: invalidReasonPackageRuntimeIsInvalid,
+								Type:          invalidTypePackage,
+								ProjectID:     pkg.DiceProjectId,
+								PackageID:     pkg.Id,
+								PackageApiID:  "",
+								RuntimeID:     runtimeService.RuntimeId,
+							}
+							f(item)
+						}
+					}
+				}
+			}
+
+			packageApis, err := eas.ListPackageAllApis(pkg.Id)
 			if err != nil {
 				l.WithError(err).Warnln("failed to ListPackageAllApis")
 				continue
 			}
 			for _, packageApi := range packageApis {
-				l := l.WithField("tb_gateway_package_api.dice_api_id", packageApi.DiceApiId)
-				if packageApi.DiceApiId == "" {
-					l.Warnln("packageApi.DiceApiId is empty")
-					continue
-				}
-				l = l.WithField("tb_gateway_api.id", packageApi.DiceApiId)
-				gatewayApi, err := s.gatewayApiService.GetById(packageApi.DiceApiId)
-				if err != nil {
-					l.WithError(err).Warnf("failed to gatewayApiService.GetById(%s)", packageApi.DiceApiId)
-					continue
-				}
-				if gatewayApi == nil {
-					continue
-				}
-				// todo: if gatewayApi.redirect_addr is invalid inner address, collect the package_api
-				if gatewayApi.UpstreamApiId == "" {
-					l.Warnln("gatewayApi.UpstreamApiID is empty")
-					continue
-				}
-				l = l.WithField("tb_gateway_upstream_api.id", gatewayApi.UpstreamApiId)
-				upstreamApi, err := s.upstreamApiService.GetById(gatewayApi.UpstreamApiId)
-				if err != nil {
-					l.WithError(err).Warnln("failed to upstreamApiService.GetById")
-					continue
-				}
-				l = l.WithField("tb_gateway_upstream.id", upstreamApi.UpstreamId)
-				var cond orm.GatewayUpstream
-				cond.Id = upstreamApi.UpstreamId
-				upstreams, err := s.upstreamService.SelectByAny(&cond)
-				if err != nil {
-					l.WithError(err).Warnf("failed to upstreamService.SelectByAny(%+v)", cond)
-					continue
-				}
-				if len(upstreams) == 0 {
-					l.Warnln("not found any upstreams")
-					continue
-				}
-				for _, upstream := range upstreams {
-					l := l.WithField("upstreamName", upstream.UpstreamName)
-					runtimeID, err := strconv.ParseUint(filepath.Base(upstream.UpstreamName), 10, 32)
+				if packageApi.RuntimeServiceId != "" {
+					l := l.WithField("packageApi.RuntimeServiceId", packageApi.RuntimeServiceId)
+					runtimeService, err := s.runtimeService.Get(packageApi.RuntimeServiceId)
 					if err != nil {
-						l.WithError(err).Warnln("failed to parse runtime id from upstream name")
-						continue
+						l.WithError(err).Errorln("failed to runtimeService.Get")
+						return err
 					}
-					if runtimeID == 0 {
-						l.Warnln("runtime id is 0 parsed from upstream name")
-						continue
-					}
-					l = l.WithField("runtimeID", runtimeID)
-					resp, err := s.runtimeCli.CheckRuntimeExist(ctx, &runtimePb.CheckRuntimeExistReq{Id: runtimeID})
-					if err == nil && !resp.GetOk() {
-						item := &pb.ListInvalidEndpointApiItem{
-							InvalidReason: invalidRuntime,
-							Type:          "package_api",
-							ProjectID:     projectID,
-							PackageID:     package_.Id,
-							PackageApiID:  packageApi.Id,
-							UpstreamApiID: upstreamApi.Id,
-							UpstreamID:    upstream.Id,
-							UpstreamName:  upstream.UpstreamName,
-							RuntimeID:     filepath.Base(upstream.UpstreamName),
+					if runtimeService != nil {
+						if runtimeID, err := strconv.ParseUint(runtimeService.RuntimeId, 10, 32); err == nil && runtimeID != 0 {
+							if resp, err := s.runtimeCli.CheckRuntimeExist(ctx, &runtimePb.CheckRuntimeExistReq{Id: runtimeID}); err != nil && resp != nil && !resp.GetOk() {
+								item := s.adjustInvalidPackageAPIItem(pkg, packageApi, invalidReasonPackageAPIRuntimeIsInvalid)
+								f(item)
+							}
 						}
-						f(item)
+					}
+				}
+
+				// if redirect address is inner host, check if it is invalid
+				if redirectAddr, err := url.Parse(packageApi.RedirectAddr); err == nil {
+					if ok := innerAddrRegexp.MatchString(redirectAddr.Hostname()); ok {
+						if _, ok := k8SServicesAddresses[strings.TrimSuffix(redirectAddr.Hostname(), innerAddrSuffix)]; !ok {
+							item := s.adjustInvalidPackageAPIItem(pkg, packageApi, invalidReasonInnerAddrIsInvalid)
+							f(item)
+						}
 					}
 				}
 			}
@@ -415,33 +492,34 @@ func (s *endpointApiService) rangeInvalidEndpointApi(ctx context.Context, f func
 	return nil
 }
 
-func (s *endpointApiService) clearInvalidEndpointApi(ctx context.Context, _ *commonPb.VoidRequest) (*commonPb.VoidResponse, error) {
-	l := logrus.WithField("func", "clearInvalidEndpointApi")
-	err := s.rangeInvalidEndpointApi(ctx, func(item *pb.ListInvalidEndpointApiItem) {
-		if item.GetType() == "package" {
-			l.Infof("delete package: %+v", item)
-			if _, err := s.DeleteEndpoint(ctx, &pb.DeleteEndpointRequest{
-				PackageId: item.GetPackageID(),
-			}); err != nil {
-				l.WithError(err).WithField("package id", item.GetPackageID()).Warnln("failed to DeleteEndpoint")
-			}
-		}
-		if item.GetType() == "package_api" {
-			l.Infof("delete package api: %+v", item)
-			if _, err := s.DeleteEndpointApi(ctx, &pb.DeleteEndpointApiRequest{
-				PackageId: item.GetPackageID(),
-				ApiId:     item.GetPackageApiID(),
-			}); err != nil {
-				l.WithError(err).
-					WithField("package id", item.GetPackageID()).
-					WithField("package api id", item.GetPackageApiID()).
-					Warnln("failed to DeleteEndpointApi")
-			}
-		}
-	})
-	if err != nil {
-		return nil, err
+func (s *endpointApiService) adjustInvalidPackageAPIItem(pkg orm.GatewayPackage, packageApi orm.GatewayPackageApi, reason string) *pb.ListInvalidEndpointApiItem {
+	item := &pb.ListInvalidEndpointApiItem{
+		InvalidReason: reason,
+		Type:          invalidTypePackageAPI,
+		ProjectID:     pkg.DiceProjectId,
+		PackageID:     pkg.Id,
+		PackageApiID:  packageApi.Id,
+		InnerHostname: "",
+		KongRouteID:   "",
+		KongServiceID: "",
+		ClusterName:   pkg.DiceClusterName,
 	}
-
-	return new(commonPb.VoidResponse), nil
+	if redirectAddr, _ := url.Parse(packageApi.RedirectAddr); redirectAddr != nil {
+		item.InnerHostname = redirectAddr.Hostname()
+	}
+	kongRoute, _ := s.gatewayRouteService.GetByApiId(packageApi.Id)
+	if kongRoute == nil {
+		kongRoute, _ = s.gatewayRouteService.GetByApiId(packageApi.DiceApiId)
+	}
+	kongService, _ := s.gatewayServiceService.GetByApiId(packageApi.Id)
+	if kongService == nil {
+		kongService, _ = s.gatewayServiceService.GetByApiId(packageApi.DiceApiId)
+	}
+	if kongRoute != nil {
+		item.KongRouteID = kongRoute.RouteId
+	}
+	if kongService != nil {
+		item.KongServiceID = kongService.ServiceId
+	}
+	return item
 }

--- a/internal/tools/orchestrator/hepa/providers/endpoint_api/provider.go
+++ b/internal/tools/orchestrator/hepa/providers/endpoint_api/provider.go
@@ -48,17 +48,21 @@ type provider struct {
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
-	gatewayApiService, err := repositoryService.NewGatewayApiServiceImpl()
+	runtimeService, err := repositoryService.NewGatewayRuntimeServiceServiceImpl()
 	if err != nil {
-		return errors.Wrap(err, "failed to NewGatewayApiServiceImpl")
+		return errors.Wrap(err, "failed to NewGatewayRuntimeServiceServiceImpl")
 	}
-	upstreamApiService, err := repositoryService.NewGatewayUpstreamApiServiceImpl()
+	gatewayRouteService, err := repositoryService.NewGatewayRouteServiceImpl()
 	if err != nil {
-		return errors.Wrap(err, "failed to NewGatewayUpstreamApiServiceImpl")
+		return errors.Wrap(err, "failed to NewGatewayRouteServiceImpl")
 	}
-	upstreamService, err := repositoryService.NewGatewayUpstreamServiceImpl()
+	gatewayServiceService, err := repositoryService.NewGatewayServiceServiceImpl()
 	if err != nil {
-		return errors.Wrap(err, "failed to NewGatewayUpstreamServiceImpl")
+		return errors.Wrap(err, "failed to NewGatewayServiceServiceImpl")
+	}
+	kongInfoService, err := repositoryService.NewGatewayKongInfoServiceImpl()
+	if err != nil {
+		return errors.Wrap(err, "failed to NewGatewayKongInfoServiceImpl")
 	}
 	if p.ProjCli == nil {
 		p.Log.Fatal("projCli is nil")
@@ -67,11 +71,12 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		p.Log.Fatal("runtimeCli is nil")
 	}
 	p.endpointApiService = &endpointApiService{
-		projCli:            p.ProjCli,
-		runtimeCli:         p.RuntimeCli,
-		gatewayApiService:  gatewayApiService,
-		upstreamApiService: upstreamApiService,
-		upstreamService:    upstreamService,
+		projCli:               p.ProjCli,
+		runtimeCli:            p.RuntimeCli,
+		runtimeService:        runtimeService,
+		gatewayRouteService:   gatewayRouteService,
+		gatewayServiceService: gatewayServiceService,
+		kongInfoService:       kongInfoService,
 	}
 	err = zoneI.NewGatewayZoneServiceImpl()
 	if err != nil {

--- a/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
@@ -1155,7 +1155,7 @@ func (impl GatewayOpenapiServiceImpl) deleteKongRoute(adapter kong.KongAdapter, 
 	return nil
 }
 
-func (impl GatewayOpenapiServiceImpl) deleteKongApi(adapter kong.KongAdapter, apiId string) error {
+func (impl GatewayOpenapiServiceImpl) DeleteKongApi(adapter kong.KongAdapter, apiId string) error {
 	err := impl.deleteKongRoute(adapter, apiId)
 	if err != nil {
 		return err
@@ -1863,7 +1863,7 @@ func (impl GatewayOpenapiServiceImpl) UpdatePackageApi(packageId, apiId string, 
 		} else if updateDao.RedirectType == gw.RT_SERVICE {
 			var runtimeService *orm.GatewayRuntimeService
 			if dao.RedirectType == gw.RT_URL {
-				err = impl.deleteKongApi(kongAdapter, apiId)
+				err = impl.DeleteKongApi(kongAdapter, apiId)
 				if err != nil {
 					return
 				}
@@ -2028,7 +2028,7 @@ func (impl *GatewayOpenapiServiceImpl) DeletePackageApi(packageId, apiId string)
 		}
 
 	} else if dao.Origin == string(gw.FROM_CUSTOM) || dao.Origin == string(gw.FROM_DICEYML) {
-		err = impl.deleteKongApi(kongAdapter, apiId)
+		err = impl.DeleteKongApi(kongAdapter, apiId)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
find invalid kong route and service by redirect inner address

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | find invalid kong route and service by redirect inner address |
| 🇨🇳 中文    | 查找转发的内部地址已无效的路由(package_api) 对应的 kong Route 和 Service |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
