### PR TITLE
refactor: handle dup api for admin and core-services

### DIFF
--- a/bundle/approve.go
+++ b/bundle/approve.go
@@ -55,7 +55,7 @@ func (b *Bundle) ListApprove(orgID uint64, userID string, params url.Values) (*a
 
 	hc := b.hc
 	var approveList apistructs.ApproveListResponse
-	resp, err := hc.Get(host).Path("/api/approves/actions/list-approves").
+	resp, err := hc.Get(host).Path("/core/api/approves/actions/list-approves").
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).
@@ -83,7 +83,7 @@ func (b *Bundle) GetApprove(orgID, userID string, approveID int64) (*apistructs.
 	hc := b.hc
 
 	var approve apistructs.ApproveDetailResponse
-	resp, err := hc.Get(host).Path(fmt.Sprintf("/api/approves/%d", approveID)).
+	resp, err := hc.Get(host).Path(fmt.Sprintf("/core/api/approves/%d", approveID)).
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, orgID).
 		Header(httputil.UserHeader, userID).
@@ -112,7 +112,7 @@ func (b *Bundle) UpdateApprove(orgID uint64, userID string, approveID int64, bod
 	hc := b.hc
 
 	var updateApprove apistructs.ApproveUpdateResponse
-	resp, err := hc.Put(host).Path(fmt.Sprintf("/api/approves/%d", approveID)).
+	resp, err := hc.Put(host).Path(fmt.Sprintf("/core/api/approves/%d", approveID)).
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, strconv.Itoa(int(orgID))).
 		Header(httputil.UserHeader, userID).

--- a/bundle/audit.go
+++ b/bundle/audit.go
@@ -86,7 +86,7 @@ func (b *Bundle) ListAuditEvent(orgID string, userID string, params url.Values) 
 	var listAudit apistructs.AuditsListResponse
 	resp, err := hc.
 		Get(host).
-		Path("/api/audits/actions/list").
+		Path("/core/api/audits/actions/list").
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, orgID).
 		Header(httputil.UserHeader, userID).
@@ -119,7 +119,7 @@ func (b *Bundle) ExportAuditExcel(orgID, userID, lang string, params url.Values)
 	}
 	respBody, resp, err := hc.
 		Get(host).
-		Path("/api/audits/actions/export-excel").
+		Path("/core/api/audits/actions/export-excel").
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, orgID).
 		Header(httputil.UserHeader, userID).

--- a/bundle/notice.go
+++ b/bundle/notice.go
@@ -33,7 +33,7 @@ func (b *Bundle) CreateNoticeRequest(userID string, orgID uint64, body io.Reader
 
 	var ncresp apistructs.NoticeCreateResponse
 	httpClient := b.hc
-	resp, err := httpClient.Post(csURL).Path("/api/notices").
+	resp, err := httpClient.Post(csURL).Path("/core/api/notices").
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).
@@ -62,7 +62,7 @@ func (b *Bundle) UpdateNotice(noticeID, orgID uint64, userID string, body io.Rea
 	httpClient := b.hc
 
 	var ncresp apistructs.NoticeUpdateResponse
-	resp, err := httpClient.Put(csURL).Path(fmt.Sprintf("/api/notices/%d", noticeID)).
+	resp, err := httpClient.Put(csURL).Path(fmt.Sprintf("/core/api/notices/%d", noticeID)).
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).
@@ -92,7 +92,7 @@ func (b *Bundle) DeleteNotice(noticeID, orgID uint64, userID string) (*apistruct
 	httpClient := b.hc
 
 	var ncresp apistructs.NoticeDeleteResponse
-	resp, err := httpClient.Delete(csURL).Path(fmt.Sprintf("/api/notices/%d", noticeID)).
+	resp, err := httpClient.Delete(csURL).Path(fmt.Sprintf("/core/api/notices/%d", noticeID)).
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).
@@ -120,7 +120,7 @@ func (b *Bundle) PublishORUnPublishNotice(orgID uint64, noticeID uint64, userID,
 	}
 
 	var buf bytes.Buffer
-	resp, err := b.hc.Put(csURL).Path(fmt.Sprintf("/api/notices/%d/actions/%s", noticeID, publishType)).
+	resp, err := b.hc.Put(csURL).Path(fmt.Sprintf("/core/api/notices/%d/actions/%s", noticeID, publishType)).
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).
@@ -148,7 +148,7 @@ func (b *Bundle) ListNoticeByOrgID(orgID uint64, userID string, params url.Value
 	}
 
 	var noteList apistructs.NoticeListResponse
-	resp, err := b.hc.Get(csURL).Path("/api/notices").
+	resp, err := b.hc.Get(csURL).Path("/core/api/notices").
 		Header(httputil.InternalHeader, "bundle").
 		Header(httputil.OrgHeader, fmt.Sprintf("%d", orgID)).
 		Header(httputil.UserHeader, userID).

--- a/bundle/user.go
+++ b/bundle/user.go
@@ -52,7 +52,7 @@ func (b *Bundle) ListUsers(req apistructs.UserListRequest) (*apistructs.UserList
 	hc := b.hc
 
 	var userResp apistructs.UserListResponse
-	resp, err := hc.Get(host).Path("/api/users").
+	resp, err := hc.Get(host).Path("/core/api/users").
 		Header(httputil.InternalHeader, "bundle").
 		Param("q", req.Query).
 		Param("plaintext", strconv.FormatBool(req.Plaintext)).
@@ -97,7 +97,7 @@ func (b *Bundle) SearchUser(params url.Values) (*apistructs.UserListResponseData
 
 	var userResp apistructs.UserListResponse
 	resp, err := hc.Get(host).
-		Path("/api/users/actions/search").
+		Path("/core/api/users/actions/search").
 		Header(httputil.InternalHeader, "bundle").
 		Params(params).
 		Do().JSON(&userResp)

--- a/internal/apps/admin/provider.go
+++ b/internal/apps/admin/provider.go
@@ -77,8 +77,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	server := httpserver.NewSingleton("")
 	server.Router().UseEncodedPath()
 	server.RegisterEndpoint(admin.Routers())
-	server.RegisterToNewHttpServerRouter(p.Router)
-	return nil
+	return server.RegisterToNewHttpServerRouter(p.Router)
 }
 
 func init() {

--- a/internal/apps/dop/dicehub/initialize.go
+++ b/internal/apps/dop/dicehub/initialize.go
@@ -68,9 +68,7 @@ func Initialize(p *provider) error {
 	server.Router().Path("/api/releases/{releaseId}/actions/pull").Methods(http.MethodGet).HandlerFunc(ep.GetDiceYAML)
 	server.Router().Path("/api/releases/{releaseId}/actions/get-dice").Methods(http.MethodGet).HandlerFunc(ep.GetDiceYAML)
 
-	server.RegisterToNewHttpServerRouter(p.Router)
-	// return server.ListenAndServe()
-	return nil
+	return server.RegisterToNewHttpServerRouter(p.Router)
 }
 
 // ReleaseGC 启动release gc定时任务

--- a/internal/core/legacy/endpoints/endpoints.go
+++ b/internal/core/legacy/endpoints/endpoints.go
@@ -333,12 +333,12 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 		{Path: "/api/applications/actions/get-id-by-names", Method: http.MethodGet, Handler: e.GetAppIDByNames},
 
 		// the interface of notice
-		{Path: "/api/notices", Method: http.MethodPost, Handler: e.CreateNotice},
-		{Path: "/api/notices/{id}", Method: http.MethodPut, Handler: e.UpdateNotice},
-		{Path: "/api/notices/{id}/actions/publish", Method: http.MethodPut, Handler: e.PublishNotice},
-		{Path: "/api/notices/{id}/actions/unpublish", Method: http.MethodPut, Handler: e.UnpublishNotice},
-		{Path: "/api/notices/{id}", Method: http.MethodDelete, Handler: e.DeleteNotice},
-		{Path: "/api/notices", Method: http.MethodGet, Handler: e.ListNotice},
+		{Path: "/core/api/notices", Method: http.MethodPost, Handler: e.CreateNotice},
+		{Path: "/core/api/notices/{id}", Method: http.MethodPut, Handler: e.UpdateNotice},
+		{Path: "/core/api/notices/{id}/actions/publish", Method: http.MethodPut, Handler: e.PublishNotice},
+		{Path: "/core/api/notices/{id}/actions/unpublish", Method: http.MethodPut, Handler: e.UnpublishNotice},
+		{Path: "/core/api/notices/{id}", Method: http.MethodDelete, Handler: e.DeleteNotice},
+		{Path: "/core/api/notices", Method: http.MethodGet, Handler: e.ListNotice},
 
 		// the interface of member
 		{Path: "/api/members", Method: http.MethodPost, Handler: e.CreateOrUpdateMember},
@@ -416,16 +416,16 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 		// the interface of audit
 		{Path: "/api/audits/actions/create", Method: http.MethodPost, Handler: e.CreateAudits},
 		{Path: "/api/audits/actions/batch-create", Method: http.MethodPost, Handler: e.BatchCreateAudits},
-		{Path: "/api/audits/actions/list", Method: http.MethodGet, Handler: e.ListAudits},
+		{Path: "/core/api/audits/actions/list", Method: http.MethodGet, Handler: e.ListAudits},
 		{Path: "/api/audits/actions/setting", Method: http.MethodPut, Handler: e.PutAuditsSettings},
 		{Path: "/api/audits/actions/setting", Method: http.MethodGet, Handler: e.GetAuditsSettings},
-		{Path: "/api/audits/actions/export-excel", Method: http.MethodGet, WriterHandler: e.ExportExcelAudit},
+		{Path: "/core/api/audits/actions/export-excel", Method: http.MethodGet, WriterHandler: e.ExportExcelAudit},
 
 		// the interface of approval
 		{Path: "/api/approves", Method: http.MethodPost, Handler: e.CreateApprove},
-		{Path: "/api/approves/{approveId}", Method: http.MethodPut, Handler: e.UpdateApprove},
-		{Path: "/api/approves/{approveId}", Method: http.MethodGet, Handler: e.GetApprove},
-		{Path: "/api/approves/actions/list-approves", Method: http.MethodGet, Handler: e.ListApproves},
+		{Path: "/core/api/approves/{approveId}", Method: http.MethodPut, Handler: e.UpdateApprove},
+		{Path: "/core/api/approves/{approveId}", Method: http.MethodGet, Handler: e.GetApprove},
+		{Path: "/core/api/approves/actions/list-approves", Method: http.MethodGet, Handler: e.ListApproves},
 
 		// the interface of file
 		{Path: "/api/files", Method: http.MethodPost, Handler: e.UploadFile},
@@ -436,9 +436,9 @@ func (e *Endpoints) Routes() []httpserver.Endpoint {
 		{Path: "/api/images/actions/upload", Method: http.MethodPost, Handler: e.UploadImage},
 
 		// the interface of user
-		{Path: "/api/users", Method: http.MethodGet, Handler: e.ListUser},
+		{Path: "/core/api/users", Method: http.MethodGet, Handler: e.ListUser},
 		{Path: "/api/users/current", Method: http.MethodGet, Handler: e.GetCurrentUser},
-		{Path: "/api/users/actions/search", Method: http.MethodGet, Handler: e.SearchUser},
+		{Path: "/core/api/users/actions/search", Method: http.MethodGet, Handler: e.SearchUser},
 		{Path: "/api/users/actions/get-uc-user-id", Method: http.MethodGet, Handler: e.GetUcUserID},
 
 		// the interface of subscribe

--- a/internal/core/legacy/initialize.go
+++ b/internal/core/legacy/initialize.go
@@ -90,8 +90,7 @@ func (p *provider) Initialize() error {
 	}()
 	server.Router().PathPrefix("/api/dice/eventbox").Path("/ws/{any:.*}").
 		Handler(sockjs.NewHandler("/api/dice/eventbox/ws", sockjs.DefaultOptions, wsi.HTTPHandle))
-	server.RegisterToNewHttpServerRouter(p.Router)
-	return nil
+	return server.RegisterToNewHttpServerRouter(p.Router)
 }
 
 // 初始化 Endpoints

--- a/pkg/http/httpserver/router.go
+++ b/pkg/http/httpserver/router.go
@@ -15,13 +15,56 @@
 package httpserver
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 
+	"github.com/gorilla/mux"
+
 	"github.com/erda-project/erda-infra/providers/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 var registerOnce sync.Once
 
-func (s *Server) RegisterToNewHttpServerRouter(newRouter httpserver.Router) {
+func (s *Server) RegisterToNewHttpServerRouter(newRouter httpserver.Router) error {
+	duplicateRoutes, ok := s.CheckDuplicateRoutes()
+	if !ok {
+		for _, route := range duplicateRoutes {
+			fmt.Printf("duplicate route: %s\n", route)
+		}
+		return fmt.Errorf("duplicate routes found")
+	}
 	registerOnce.Do(func() { newRouter.Any("/*", s.router) })
+	return nil
+}
+
+func (s *Server) CheckDuplicateRoutes() ([]string, bool) {
+	pathParamRegex := regexp.MustCompile(`{([^{}]*)}`)
+	genKey := func(method, path string) string {
+		path = strutil.ReplaceAllStringSubmatchFunc(pathParamRegex, path, func(i []string) string {
+			return "{}"
+		})
+		return strings.ToLower(method) + ":" + path
+	}
+	// get all routes
+	routeMap := make(map[string]int) // key: method + path
+	_ = s.router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		path, _ := route.GetPathTemplate()
+		methods, _ := route.GetMethods()
+		for _, method := range methods {
+			key := genKey(method, path)
+			routeMap[key]++
+		}
+		return nil
+	})
+	// check duplicate routes
+	var duplicateRoutes []string
+	for k, v := range routeMap {
+		if v > 1 {
+			duplicateRoutes = append(duplicateRoutes, k)
+		}
+	}
+	return duplicateRoutes, len(duplicateRoutes) == 0
 }

--- a/pkg/http/httpserver/router_test.go
+++ b/pkg/http/httpserver/router_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_normalizePath(t *testing.T) {
+	assert.Equal(t, "/api/projects/{}", normalizePath("/api/projects/{projectID}"))
+	assert.Equal(t, "/api/projects/{}", normalizePath("/api/projects/{projectId}"))
+}
+
+func Test_genMapKeyForCompare(t *testing.T) {
+	assert.Equal(t, "get:/api/projects/{}", genMapKeyForCompare(http.MethodGet, "/api/projects/{projectID}"))
+	assert.Equal(t, "head:/api/projects/{}", genMapKeyForCompare(http.MethodHead, "/api/projects/{projectId}"))
+}
+
+func TestServer_CheckDuplicateRoutes(t *testing.T) {
+	s := &Server{router: mux.NewRouter()}
+	s.router.Path("/api/projects/{projectID}").Methods(http.MethodGet)
+	s.router.Path("/api/projects/{projectId}").Methods(http.MethodGet, http.MethodPut)
+	duplicates, ok := s.CheckDuplicateRoutes()
+	assert.False(t, ok)
+	assert.Equal(t, 1, len(duplicates))
+	assert.Equal(t, "get:/api/projects/{}", duplicates[0])
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

handle dup api for admin and core-services


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=324601&issueFilter__urlQuery=eyJzdGF0ZXMiOls0NDAyLDcxMDQsNzEwNSw0NDAzLDQ0MDQsNzEwNiw0NDA2LDQ0MDcsNDQxMiw0NTM4LDQ0MTMsNDQxNCw0NDE1LDQ0MTZdfQ%3D%3D&issueTable__urlQuery=eyJwYWdlTm8iOjEsICJwYWdlU2l6ZSI6MTB9&iterationID=1297&type=TASK)


#### Specified Reviewers:

/assign @shuofan 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   handle dup api for admin and core-services           |
| 🇨🇳 中文    |    处理 erda-server 中路径相同的 API          |
