### PR TITLE
feat: erda-cli gw commands

### DIFF
--- a/internal/tools/orchestrator/cache/org/org.go
+++ b/internal/tools/orchestrator/cache/org/org.go
@@ -31,7 +31,11 @@ var (
 func init() {
 	bdl := bundle.New(bundle.WithErdaServer())
 	orgID2Org = cache.New("orchestrator-org-id-for-org", time.Minute, func(i interface{}) (interface{}, bool) {
-		orgDTO, err := bdl.GetOrg(i.(string))
+		id := i.(string)
+		if id == "" {
+			return nil, false
+		}
+		orgDTO, err := bdl.GetOrg(id)
 		if err != nil {
 			return nil, false
 		}

--- a/pkg/http/httpclient/request.go
+++ b/pkg/http/httpclient/request.go
@@ -235,7 +235,7 @@ func (r AfterDo) JSON(o interface{}) (*Response, error) {
 
 // 适用于a) 如果成功，不关心body内容及其结构体；
 //   并且b) 如果失败，需要把body内容封装进error里返回给上层定位错误
-func (r AfterDo) Body(b *bytes.Buffer) (*Response, error) {
+func (r AfterDo) Body(b io.Writer) (*Response, error) {
 	resp, err := doRequest(r)
 	if err != nil {
 		return nil, err

--- a/pkg/http/httpclient/request.go
+++ b/pkg/http/httpclient/request.go
@@ -241,12 +241,17 @@ func (r AfterDo) Body(b io.Writer) (*Response, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if _, err = io.Copy(b, resp.Body); err != nil {
+	if err = writeBody(b, resp); err != nil {
 		return nil, err
 	}
 	return &Response{
 		internal: resp,
 	}, nil
+}
+
+func writeBody(writer io.Writer, resp *http.Response) error {
+	_, err := io.Copy(writer, resp.Body)
+	return err
 }
 
 // StreamBody 返回 response body, 用于流式读取。

--- a/pkg/http/httpclient/request_test.go
+++ b/pkg/http/httpclient/request_test.go
@@ -14,6 +14,13 @@
 
 package httpclient
 
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
 //import (
 //	"net/http"
 //	"net/url"
@@ -153,3 +160,27 @@ package httpclient
 ////	fmt.Println(body.String())
 ////	_ = resp
 ////}
+
+type buffer struct {
+	*bytes.Buffer
+}
+
+func (b buffer) Close() error {
+	return nil
+}
+
+func TestWriteBody(t *testing.T) {
+	buff := []byte("buffer")
+	resp := http.Response{Body: buffer{bytes.NewBuffer(buff)}}
+	w := bytes.NewBuffer(nil)
+	if err := writeBody(w, &resp); err != nil {
+		t.Fatal(err)
+	}
+	data, err := ioutil.ReadAll(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(buff, data) {
+		t.Fatal("buff != data")
+	}
+}

--- a/tools/cli/cmd/gw.go
+++ b/tools/cli/cmd/gw.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+var Gw = command.Command{
+	ParentName:                 "",
+	Name:                       "gw",
+	ShortHelp:                  "Erda Gateway Tools",
+	LongHelp:                   "erda-cli gw --help",
+	Example:                    "erda-cli gw ls --cluster erda-cloud -o xxxx",
+	Hidden:                     false,
+	DontHideCursor:             false,
+	Args:                       nil,
+	MarkFlagRequired:           nil,
+	RegisterFlagCompletionFunc: nil,
+	ValidArgsFunction:          nil,
+	Flags:                      nil,
+	Run:                        nil,
+}

--- a/tools/cli/cmd/gw_del.go
+++ b/tools/cli/cmd/gw_del.go
@@ -31,17 +31,11 @@ import (
 )
 
 var GwDel = command.Command{
-	ParentName:                 "Gw",
-	Name:                       "del",
-	ShortHelp:                  "Erda Gateway delete invalid endpoints",
-	LongHelp:                   "Erda Gateway delete invalid endpoints",
-	Example:                    "erda-cli gw del -i erda.cloud.invalid-endpoints.json --kong-admin inet://terminus-captain/api-gateway.api-gateway-xxx.svc.cluster.local=>https://kong-admin.erda.cloud -y",
-	Hidden:                     false,
-	DontHideCursor:             false,
-	Args:                       nil,
-	MarkFlagRequired:           nil,
-	RegisterFlagCompletionFunc: nil,
-	ValidArgsFunction:          nil,
+	ParentName: "Gw",
+	Name:       "del",
+	ShortHelp:  "Erda Gateway delete invalid endpoints",
+	LongHelp:   "Erda Gateway delete invalid endpoints",
+	Example:    "erda-cli gw del -i erda.cloud.invalid-endpoints.json --kong-admin https://your-admin-host --cluster your-cluster",
 	Flags: []command.Flag{
 		command.StringFlag{
 			Short:        "i",

--- a/tools/cli/cmd/gw_del.go
+++ b/tools/cli/cmd/gw_del.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+var GwDel = command.Command{
+	ParentName:                 "Gw",
+	Name:                       "del",
+	ShortHelp:                  "Erda Gateway delete invalid endpoints",
+	LongHelp:                   "Erda Gateway delete invalid endpoints",
+	Example:                    "erda-cli gw del -i erda.cloud.invalid-endpoints.json --kong-admin inet://terminus-captain/api-gateway.api-gateway-xxx.svc.cluster.local=>https://kong-admin.erda.cloud -y",
+	Hidden:                     false,
+	DontHideCursor:             false,
+	Args:                       nil,
+	MarkFlagRequired:           nil,
+	RegisterFlagCompletionFunc: nil,
+	ValidArgsFunction:          nil,
+	Flags: []command.Flag{
+		command.StringFlag{
+			Short:        "i",
+			Name:         "input",
+			Doc:          "[Required] the input file which is generated from 'erda-cli gw ls'",
+			DefaultValue: "",
+		},
+		command.StringFlag{
+			Short:        "o",
+			Name:         "output",
+			Doc:          "[Optional] the output file for the result",
+			DefaultValue: "",
+		},
+		command.StringFlag{
+			Short:        "C",
+			Name:         "cluster",
+			Doc:          "[Required] cluster specified",
+			DefaultValue: "",
+		},
+		command.StringFlag{
+			Short:        "",
+			Name:         "kong-admin",
+			Doc:          "[Required] replace the kong-admin host from the input file",
+			DefaultValue: "",
+		},
+		command.BoolFlag{
+			Short:        "y",
+			Name:         "yes",
+			Doc:          "[Optional] to be sure to delete",
+			DefaultValue: false,
+		},
+		command.BoolFlag{
+			Short:        "",
+			Name:         "delete-from-erda",
+			Doc:          "[Optional] delete endpoints from erda if specified this, or else only delete from Kong",
+			DefaultValue: false,
+		},
+	},
+	Run: RunGwDel,
+}
+
+type InvalidEndpoints struct {
+	Success bool                 `json:"success"`
+	Data    InvalidEndpointsData `json:"data"`
+}
+
+type InvalidEndpointsData struct {
+	Total                   int                    `json:"total"`
+	TotalProjectIsInvalid   int                    `json:"totalProjectIsInvalid"`
+	TotalRuntimeIsInvalid   int                    `json:"totalRuntimeIsInvalid"`
+	TotalInnerAddrIsInvalid int                    `json:"totalInnerAddrIsInvalid"`
+	List                    []InvalidEndpointsItem `json:"list"`
+}
+
+type InvalidEndpointsItem struct {
+	InvalidReason   string `json:"invalidReason"`
+	Type            string `json:"type"`
+	ProjectID       string `json:"projectID"`
+	PackageID       string `json:"packageID"`
+	PackageApiID    string `json:"packageApiID"`
+	RuntimeID       string `json:"runtimeID"`
+	InnerHostname   string `json:"innerHostname"`
+	KongRouteID     string `json:"kongRouteID"`
+	KongServiceID   string `json:"kongServiceID"`
+	ClusterName     string `json:"clusterName"`
+	RouteDeleting   string `json:"routeDeleting"`
+	ServiceDeleting string `json:"serviceDeleting"`
+}
+
+func RunGwDel(context *command.Context, input, output, cluster, kongAdmin string, yes, deleteFromErda bool) error {
+	var ctx = *context
+
+	// check --input
+	if input == "" {
+		return errors.New("the endpoints input file must be specified")
+	}
+
+	// check --output
+	if output == "" {
+		output = "result." + input
+	}
+	out, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// check --kong-admin
+	kongAdmin = strings.TrimSuffix(kongAdmin, "/")
+	if _, err := url.Parse(kongAdmin); err != nil {
+		return err
+	}
+
+	// check --delete-from
+	if deleteFromErda {
+		return errors.New("the flag --delete-from-erda is not supported yet")
+	}
+
+	// read from file
+	in, err := ioutil.ReadFile(input)
+	if err != nil {
+		return err
+	}
+	var endpoints InvalidEndpoints
+	if err = json.Unmarshal(in, &endpoints); err != nil {
+		return err
+	}
+	if !endpoints.Success {
+		return errors.Errorf("invalid endpoints file: %s", "not success")
+	}
+	if endpoints.Data.Total == 0 || len(endpoints.Data.List) == 0 {
+		ctx.Warn("exit: %s", "endpoints total is 0")
+		return nil
+	}
+
+	// check the cluster
+	if cluster == "" {
+		return errors.New("--cluster must be specified")
+	}
+	for _, item := range endpoints.Data.List {
+		if item.ClusterName != cluster {
+			return errors.Errorf("the item's cluster %s dose not equals with %s that you specified. api: %s/%s", item.ClusterName, cluster, item.PackageID, item.PackageApiID)
+		}
+	}
+
+	// do deleting
+	for _, item := range endpoints.Data.List {
+		if err := deleteItem(ctx, out, item, kongAdmin, !yes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteItem(ctx command.Context, w io.Writer, item InvalidEndpointsItem, kongAdmin string, needSure bool) error {
+	ctx.Info("%s/%s ", item.PackageID, item.PackageApiID)
+	_, _ = fmt.Fprintf(w, "%s/%s: ", item.PackageID, item.PackageApiID)
+	defer fmt.Fprintf(w, "\n")
+
+	client := http.DefaultClient
+	client.Timeout = time.Second * 100
+
+	const (
+		Route   = "Route"
+		Service = "Service"
+	)
+	var deleting = func(typ, id string) error {
+		if err := sure(ctx, needSure, typ, id); err != nil {
+			return err
+		}
+		var uri string
+		switch typ {
+		case Route:
+			uri = kongAdmin + "/routes/" + id
+		case Service:
+			uri = kongAdmin + "/services/" + id
+		default:
+			return errors.New("invalid Kong Object")
+		}
+		request, err := http.NewRequest(http.MethodDelete, uri, nil)
+		if err != nil {
+			return err
+		}
+		response, err := client.Do(request)
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(w, "Delete Kong %s %v ", typ, response.StatusCode)
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			return nil
+		}
+		ctx.Warn("failed to delete")
+		if data, err := ioutil.ReadAll(response.Body); err == nil {
+			defer response.Body.Close()
+			_, _ = fmt.Fprint(w, string(data))
+		}
+		return nil
+	}
+
+	if item.KongRouteID == "" {
+		ctx.Warn("No KongRouteID in the Item. %s/%s", item.PackageID, item.PackageApiID)
+		_, _ = fmt.Fprintf(w, "No Kong Route. ")
+	} else if err := deleting(Route, item.KongRouteID); err != nil {
+		return err
+	}
+	if item.KongServiceID == "" {
+		ctx.Warn("No KongServiceID in the Item. %s/%s", item.PackageID, item.PackageApiID)
+		_, _ = fmt.Fprintf(w, "No Kong Service. ")
+	} else if err := deleting(Service, item.KongServiceID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func sure(ctx command.Context, needSure bool, tye, id string) error {
+	if !needSure {
+		return nil
+	}
+	ctx.Info("please press 'y' to be sure you are going to delete the %s %s", tye, id)
+	var sure string
+	if _, err := fmt.Scanln(&sure); err != nil {
+		return err
+	}
+	if strings.EqualFold(sure, "y") ||
+		strings.EqualFold(sure, "yes") ||
+		strings.EqualFold(sure, "y\n") ||
+		strings.EqualFold(sure, "yes\n") {
+		return nil
+	}
+	return errors.New("not sure")
+}

--- a/tools/cli/cmd/gw_del_test.go
+++ b/tools/cli/cmd/gw_del_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/tools/cli/cmd"
+)
+
+func TestGwDelPreCheck(t *testing.T) {
+	var (
+		input     = "erda-cloud.invalid-endpoints.json"
+		output    string
+		cluster   = "erda-cloud"
+		kongAdmin = "https://kong-gateway.erda.cloud/"
+	)
+	if err := cmd.GwDelPreCheck("", &output, cluster, kongAdmin, true); err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if err := cmd.GwDelPreCheck(input, &output, "", kongAdmin, true); err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if err := cmd.GwDelPreCheck(input, &output, cluster, "", true); err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if err := cmd.GwDelPreCheck(input, &output, cluster, kongAdmin, true); err == nil {
+		t.Fatal("err should not be nil")
+	}
+	if err := cmd.GwDelPreCheck(input, &output, cluster, kongAdmin, false); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tools/cli/cmd/gw_ls.go
+++ b/tools/cli/cmd/gw_ls.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+var GwLs = command.Command{
+	ParentName:                 "Gw",
+	Name:                       "ls",
+	ShortHelp:                  "Erda Gateway list all invalid endpoints",
+	LongHelp:                   "Erda Gateway list all invalid endpoints",
+	Example:                    "erda-cli gw ls --invalid-only --cluster erda-cloud -o erda-cloud.invalid-endpoints.json",
+	Hidden:                     false,
+	DontHideCursor:             false,
+	Args:                       nil,
+	MarkFlagRequired:           nil,
+	RegisterFlagCompletionFunc: nil,
+	ValidArgsFunction:          nil,
+	Flags: []command.Flag{
+		command.BoolFlag{
+			Short:        "",
+			Name:         "invalid-only",
+			Doc:          "[Required] --invalid-only must be specified",
+			DefaultValue: false,
+		},
+		command.StringFlag{
+			Short:        "C",
+			Name:         "cluster",
+			Doc:          "[Required] the cluster name must be specified",
+			DefaultValue: "",
+		},
+		command.StringFlag{
+			Short:        "o",
+			Name:         "output",
+			Doc:          "[Optional] the output file should be specified",
+			DefaultValue: "",
+		},
+		command.StringFlag{
+			Short:        "",
+			Name:         "hepa",
+			Doc:          "[Optional] hepa address like https://hepa.erda.cloud",
+			DefaultValue: "",
+		},
+	},
+	Run: RunGwLs,
+}
+
+type BaseResponse struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data"`
+	Err     BaseResponseErr `json:"err"`
+}
+
+type BaseResponseData struct {
+	List  []command.OrgInfo `json:"list"`
+	Total int               `json:"total"`
+}
+
+type BaseResponseErr struct {
+	Code string      `json:"code"`
+	Msg  string      `json:"msg"`
+	Ctx  interface{} `json:"ctx"`
+}
+
+func RunGwLs(context *command.Context, invalidOnly bool, cluster, output, hepa string) error {
+	if !invalidOnly {
+		return errors.New("--invalid-only must be specified")
+	}
+	if cluster == "" {
+		return errors.New("cluster name must be specified")
+	}
+	if output == "" {
+		output = cluster + "." + time.Now().Format("2006-01-02_150405") + ".invalid-endpoints.json"
+	}
+
+	file, err := os.OpenFile(output, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var ctx = *context
+	// to find an org
+	if ctx.CurrentOrg.Name == "" {
+		var orgResp BaseResponse
+		response, err := ctx.Get().
+			Path("/api/orgs").
+			Do().
+			JSON(&orgResp)
+		if err != nil {
+			return err
+		}
+		if !response.IsOK() {
+			return errors.New(string(response.Body()))
+		}
+
+		var orgData BaseResponseData
+		if err = json.Unmarshal(orgResp.Data, &orgData); err != nil {
+			return err
+		}
+		if len(orgData.List) == 0 {
+			return errors.Errorf("no org found for the user: %s", ctx.GetUserID())
+		}
+
+		ctx.CurrentOrg = orgData.List[0]
+	}
+	ctx.Info("Org-ID: %v, Org-Name: %v, User-ID: %v", ctx.CurrentOrg.ID, ctx.CurrentOrg.Name, ctx.GetUserID())
+
+	// generate hepa host
+	if hepa == "" {
+		host, err := url.Parse(ctx.CurrentOpenApiHost)
+		if err != nil {
+			return err
+		}
+		host.Host = "hepa." + strings.TrimPrefix(host.Host, "openapi.")
+		hepa = host.String()
+	}
+	ctx.CurrentOpenApiHost = hepa
+	ctx.Info("HEPA host: %s", ctx.CurrentOpenApiHost)
+
+	// get invalid endpoints
+	response, err := ctx.Get().
+		Path("/api/gateway/openapi/invalid-endpoints").
+		Param("clusterName", cluster).
+		Header("Org-ID", strconv.FormatUint(ctx.CurrentOrg.ID, 10)).
+		Header("User-ID", ctx.GetUserID()).
+		Header("Internal-Client", "erda-cli").
+		Do().
+		Body(file)
+	if err != nil {
+		return err
+	}
+	if !response.IsOK() {
+		return errors.Errorf("success: %v, status: %v, message: %v", response.IsOK(), response.StatusCode(), string(response.Body()))
+	}
+	ctx.Info("result is writen into %s", output)
+	return nil
+}

--- a/tools/cli/cmd/gw_ls.go
+++ b/tools/cli/cmd/gw_ls.go
@@ -28,17 +28,11 @@ import (
 )
 
 var GwLs = command.Command{
-	ParentName:                 "Gw",
-	Name:                       "ls",
-	ShortHelp:                  "Erda Gateway list all invalid endpoints",
-	LongHelp:                   "Erda Gateway list all invalid endpoints",
-	Example:                    "erda-cli gw ls --invalid-only --cluster erda-cloud -o erda-cloud.invalid-endpoints.json",
-	Hidden:                     false,
-	DontHideCursor:             false,
-	Args:                       nil,
-	MarkFlagRequired:           nil,
-	RegisterFlagCompletionFunc: nil,
-	ValidArgsFunction:          nil,
+	ParentName: "Gw",
+	Name:       "ls",
+	ShortHelp:  "Erda Gateway list all invalid endpoints",
+	LongHelp:   "Erda Gateway list all invalid endpoints",
+	Example:    "erda-cli gw ls --invalid-only --cluster erda-cloud -o erda-cloud.invalid-endpoints.json",
 	Flags: []command.Flag{
 		command.BoolFlag{
 			Short:        "",

--- a/tools/cli/cmd/gw_ls_test.go
+++ b/tools/cli/cmd/gw_ls_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/tools/cli/cmd"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestHepaHostFromOpenapi(t *testing.T) {
+	var ctx = command.Context{
+		CurrentOpenApiHost: "https://openapi.erda.cloud",
+	}
+	var hepa = "https://hepa.erda.cloud"
+	if err := cmd.HepaHostFromOpenapi(&ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.CurrentOpenApiHost != hepa {
+		t.Fatal("ctx.CurrentOpenApiHost != hepa")
+	}
+
+	ctx.CurrentOpenApiHost = "https://openapi.erda.cloud"
+	if err := cmd.HepaHostFromOpenapi(&ctx, hepa); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.CurrentOpenApiHost != hepa {
+		t.Fatal("ctx.CurrentOpenApiHost != hepa")
+	}
+}

--- a/tools/cli/command/generate/collect/collect.go
+++ b/tools/cli/command/generate/collect/collect.go
@@ -41,6 +41,9 @@ func main() {
 	cmds := []string{}
 	for _, pkg := range pkgs {
 		for fname, f := range pkg.Files {
+			if strings.HasSuffix(fname, "_test.go") {
+				continue
+			}
 			cmd := parseFile(fname, f)
 			cmds = append(cmds, cmd)
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:

a erda-cli command for retrieving invalid Route and Service.

you can use `erda-cli gw ls` to list all invalid endpoints with the specified cluster.
```shell
erda-cli gw ls \
    --host 'https://your-host' \
    --cluster your-cluster
```
it will output a result file. you can use it as input file to delete the endpints from kong gateway.

```shell
erda-cli gw del \
    --host 'https://your-host' \
    --cluster your-cluster \
    --input 'your-cluster.invalid-endpoints.json' \
    --output 'result.07091916.terminus-captain.invalid-endpoints.txt' \
    --kong-admin 'https://your-kong-admin-host' \
    --yes
```
#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | A erda-cli command for list and delete invalid endpoints from Kong |
| 🇨🇳 中文    | 一个用以从 Kong 查询和删除无效的路由和服务的的 erda-cli 命令 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
