### PR TITLE
fix: msp default to cassandra

### DIFF
--- a/cmd/msp/bootstrap.yaml
+++ b/cmd/msp/bootstrap.yaml
@@ -59,7 +59,7 @@ redis:
   sentinels_addr: "${REDIS_SENTINELS_ADDR}"
 
 cassandra:
-  _enable: ${CASSANDRA_ENABLE:false}
+  _enable: ${CASSANDRA_ENABLE:true}
   host: "${CASSANDRA_ADDR:localhost:9042}"
   security: ${CASSANDRA_SECURITY_ENABLE:false}
   username: ${CASSANDRA_SECURITY_USERNAME}
@@ -74,8 +74,12 @@ elasticsearch@span:
   username: "${SPAN_ELASTICSEARCH_SECURITY_USERNAME}"
   password: "${SPAN_ELASTICSEARCH_SECURITY_PASSWORD}"
 
+span-storage-elasticsearch:
+  _enable: ${QUERY_SPAN_FROM_ES_ENABLE|QUERY_SPAN_FROM_CASSANDRA_ENABLE:true}
+  query_timeout: "1m"
+  read_page_size: 200
 elasticsearch.index.loader@span:
-  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:true}
+  _enable: ${QUERY_SPAN_FROM_ES_ENABLE|QUERY_SPAN_FROM_CASSANDRA_ENABLE:true}
   load_mode: "LoadWithCache"
   index_reload_interval: "1m"
   query_index_time_range: true
@@ -87,17 +91,18 @@ elasticsearch.index.loader@span:
       patterns:
         - "<org>-{number}"
         - "<org>.<key>-{number}"
+
 storage-retention-strategy@span:
-  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:true}
+  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:false}
   default_ttl: "${SPAN_TTL:168h}"
   load_from_database: false
   ttl_reload_interval: "3m"
 elasticsearch.index.retention-strategy@span:
-  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:true}
+  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:false}
   key_patterns:
     - "erda-spans-<org>.<key>-{number}"
 elasticsearch.index.cleaner@span:
-  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:true}
+  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:false}
   check_interval: "30m"
   disk_clean:
     enable: ${SPAN_DISK_CLEAN_ENABLE:true}
@@ -117,10 +122,6 @@ elasticsearch.index.cleaner@span:
         alias: "erda-spans-<org>-rollover"
       - index: "erda-spans-<org>.<key>-{number}"
         alias: "erda-spans-<org>.<key>-rollover"
-span-storage-elasticsearch:
-  _enable: ${QUERY_SPAN_FROM_ES_ENABLE:true}
-  query_timeout: "1m"
-  read_page_size: 200
 
 grpc-client@erda.core.monitor.diagnotor:
   addr: "${MONITOR_GRPC_ADDR:monitor:7080}"


### PR DESCRIPTION
#### What this PR does / why we need it:
should default to cassandra instead of elasticsearch

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       msp default to cassandra       |
| 🇨🇳 中文    |      msp默认以cassandra存储        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
