### PR TITLE
fix: aop `autotest_cookie_keep_before` plugin merge all cookies from report

### DIFF
--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
@@ -15,13 +15,8 @@
 package autotest_cookie_keep_before
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
-
-	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 // appendOrReplaceSetCookiesToCookie
@@ -80,20 +75,4 @@ func appendOrReplaceSetCookiesToCookie(setCookies []string, originCookie string)
 	newCookieStr := strings.Join(newCookieItems, "; ")
 
 	return newCookieStr
-}
-
-func (p *provider) getCookiesFromMeta(meta *structpb.Struct) ([]string, error) {
-	var cookies []string
-	for field, value := range meta.Fields {
-		if field == apitestsv2.HeaderSetCookie {
-			cookieJsonStr := value.GetStringValue()
-			if len(cookieJsonStr) == 0 {
-				return cookies, nil
-			}
-			if err := json.Unmarshal([]byte(cookieJsonStr), &cookies); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return cookies, nil
 }

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
@@ -15,8 +15,13 @@
 package autotest_cookie_keep_before
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 // appendOrReplaceSetCookiesToCookie
@@ -75,4 +80,20 @@ func appendOrReplaceSetCookiesToCookie(setCookies []string, originCookie string)
 	newCookieStr := strings.Join(newCookieItems, "; ")
 
 	return newCookieStr
+}
+
+func (p *provider) getCookiesFromMeta(meta *structpb.Struct) ([]string, error) {
+	var cookies []string
+	for field, value := range meta.Fields {
+		if field == apitestsv2.HeaderSetCookie {
+			cookieJsonStr := value.GetStringValue()
+			if len(cookieJsonStr) == 0 {
+				return cookies, nil
+			}
+			if err := json.Unmarshal([]byte(cookieJsonStr), &cookies); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return cookies, nil
 }

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
@@ -15,8 +15,13 @@
 package autotest_cookie_keep_before
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 // appendOrReplaceSetCookiesToCookie
@@ -75,4 +80,21 @@ func appendOrReplaceSetCookiesToCookie(setCookies []string, originCookie string)
 	newCookieStr := strings.Join(newCookieItems, "; ")
 
 	return newCookieStr
+}
+
+func (p *provider) getCookiesFromMeta(meta *structpb.Struct) ([]string, error) {
+	var cookies []string
+	for field, value := range meta.Fields {
+		if field == apitestsv2.HeaderSetCookie {
+			cookieJsonStr := value.GetStringValue()
+			if len(cookieJsonStr) == 0 {
+				return cookies, nil
+			}
+			if err := json.Unmarshal([]byte(cookieJsonStr), &cookies); err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
+	return cookies, nil
 }

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
@@ -15,24 +15,7 @@
 package autotest_cookie_keep_before
 
 import (
-	"context"
-	"encoding/json"
-	"reflect"
-	"strings"
 	"testing"
-
-	"bou.ke/monkey"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/erda-project/erda-proto-go/core/pipeline/report/pb"
-	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/internal/tools/pipeline/aop/aoptypes"
-	"github.com/erda-project/erda/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_after"
-	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
-	"github.com/erda-project/erda/internal/tools/pipeline/providers/report"
-	"github.com/erda-project/erda/internal/tools/pipeline/spec"
-	"github.com/erda-project/erda/pkg/apitestsv2"
 )
 
 func Test_appendOrReplaceSetCookiesToCookie(t *testing.T) {
@@ -77,75 +60,4 @@ func Test_appendOrReplaceSetCookiesToCookie(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestHandle(t *testing.T) {
-	db := &dbclient.Client{}
-	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(db), "UpdatePipelineTaskExtra", func(_ *dbclient.Client, id uint64, extra spec.PipelineTaskExtra, ops ...dbclient.SessionOption) error {
-		return nil
-	})
-	defer pm1.Unpatch()
-	mockReport := &report.MockReport{}
-	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(mockReport), "QueryPipelineReportSet", func(_ *report.MockReport, _ context.Context, _ *pb.PipelineReportSetQueryRequest) (*pb.PipelineReportSetQueryResponse, error) {
-		cookieMeta1 := map[string]interface{}{
-			"Set-Cookie": `[
-    "BAIDUID=EA64A26D7004088DC84439A66DB1EC6E:FG=1; expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=2147483647; path=/; domain=.baidu.com",
-    "BIDUPSID=EA64A26D7004088DC84439A66DB1EC6E; expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=2147483647; path=/; domain=.baidu.com",
-    "PSTM=1657609331; expires=Thu, 31-Dec-37 23:55:55 GMT; max-age=2147483647; path=/; domain=.baidu.com",
-    "BAIDUID=EA64A26D7004088D02646E5A79CBAF9D:FG=1; max-age=31536000; expires=Wed, 12-Jul-23 07:02:11 GMT; domain=.baidu.com; path=/; version=1; comment=bd",
-    "BDSVRTM=0; path=/",
-    "BD_HOME=1; path=/",
-    "H_PS_PSSID=36548_36463_36726_36454_36452_36691_36166_36695_36698_36816_36569_36530_36772_36730_36746_36761_36768_36764_26350_36649; path=/; domain=.baidu.com"
-]`,
-		}
-		cookieMeta2 := map[string]interface{}{
-			"Set-Cookie": `[
-    "BDSVRTM=0; path=/",
-    "BD_HOME=1; path=/",
-    "H_PS_PSSID=36559_36750_36726_36454_36453_36692_36167_36695_36696_36816_36570_36530_36772_36746_36762_36768_36766_26350; path=/; domain=.baidu.com"
-]`,
-		}
-		pbMeta1, _ := structpb.NewStruct(cookieMeta1)
-		pbMeta2, _ := structpb.NewStruct(cookieMeta2)
-		return &pb.PipelineReportSetQueryResponse{
-			Data: &pb.PipelineReportSet{
-				Reports: []*pb.PipelineReport{
-					{
-						Meta: pbMeta1,
-					},
-					{
-						Meta: pbMeta2,
-					},
-				},
-			},
-		}, nil
-	})
-	defer pm2.Unpatch()
-	ctx := &aoptypes.TuneContext{
-		SDK: aoptypes.SDK{
-			Task: spec.PipelineTask{
-				Extra: spec.PipelineTaskExtra{
-					PrivateEnvs: map[string]string{
-						autotest_cookie_keep_after.AutotestApiGlobalConfig: "{}",
-					},
-				},
-				Type: taskType,
-			},
-			Pipeline: spec.Pipeline{},
-			DBClient: db,
-			Report:   mockReport,
-		},
-	}
-	p := provider{}
-	err := p.Handle(ctx)
-	assert.NoError(t, err)
-	var config apistructs.AutoTestAPIConfig
-	err = json.Unmarshal([]byte(ctx.SDK.Task.Extra.PrivateEnvs[autotest_cookie_keep_after.AutotestApiGlobalConfig]), &config)
-	assert.NoError(t, err)
-	cookie := config.Header[apitestsv2.HeaderCookie]
-	assert.Equal(t, "BAIDUID=EA64A26D7004088D02646E5A79CBAF9D:FG=1; BIDUPSID=EA64A26D7004088DC84439A66DB1EC6E; PSTM=1657609331; BDSVRTM=0; BD_HOME=1; H_PS_PSSID=36559_36750_36726_36454_36453_36692_36167_36695_36696_36816_36570_36530_36772_36746_36762_36768_36766_26350", cookie)
-	cookieLst := strings.Split(cookie, "; ")
-	assert.Equal(t, 6, len(cookieLst))
-	assert.Equal(t, "H_PS_PSSID=36559_36750_36726_36454_36453_36692_36167_36695_36696_36816_36570_36530_36772_36746_36762_36768_36766_26350", cookieLst[5])
-	assert.Equal(t, "BIDUPSID=EA64A26D7004088DC84439A66DB1EC6E", cookieLst[1])
 }

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
@@ -16,7 +16,6 @@ package autotest_cookie_keep_before
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -57,28 +56,20 @@ func (p *provider) Handle(ctx *aoptypes.TuneContext) error {
 		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get pipeline reports, err: %", err)
 		return err
 	}
-	var setCookieJSON string
+	var setCookies []string
 	for _, v := range reportSets.Data.Reports {
 		if v.Meta == nil {
 			continue
 		}
-		meta := v.Meta.AsMap()
-		if meta[apitestsv2.HeaderSetCookie] == nil {
+		cookies, err := p.getCookiesFromMeta(v.Meta)
+		if err != nil {
+			rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get cookies from meta(continue next report), err: %, meta: %v", err, v.Meta)
 			continue
 		}
-		setCookieJSON = meta[apitestsv2.HeaderSetCookie].(string)
-		break
-	}
-	rlog.TDebugf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "setCookieJSON: %s", setCookieJSON)
-	if setCookieJSON == "" {
-		return nil
+		setCookies = append(setCookies, cookies...)
 	}
 	// parse Set-Cookie-JSON to Cookie
 	// header key `set-cookie` can have many values
-	var setCookies []string
-	if err := json.Unmarshal([]byte(setCookieJSON), &setCookies); err != nil {
-		return fmt.Errorf("failed to parse Set-Cookie: %s, err: %v", setCookieJSON, err)
-	}
 	if len(setCookies) == 0 {
 		return nil
 	}

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
@@ -16,7 +16,6 @@ package autotest_cookie_keep_before
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -57,28 +56,20 @@ func (p *provider) Handle(ctx *aoptypes.TuneContext) error {
 		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get pipeline reports, err: %", err)
 		return err
 	}
-	var setCookieJSON string
+	var setCookies []string
 	for _, v := range reportSets.Data.Reports {
 		if v.Meta == nil {
 			continue
 		}
-		meta := v.Meta.AsMap()
-		if meta[apitestsv2.HeaderSetCookie] == nil {
-			continue
+		cookies, err := p.getCookiesFromMeta(v.Meta)
+		if err != nil {
+			rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get cookies from meta, err: %, meta: %v", err, v.Meta)
+			return err
 		}
-		setCookieJSON = meta[apitestsv2.HeaderSetCookie].(string)
-		break
-	}
-	rlog.TDebugf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "setCookieJSON: %s", setCookieJSON)
-	if setCookieJSON == "" {
-		return nil
+		setCookies = append(setCookies, cookies...)
 	}
 	// parse Set-Cookie-JSON to Cookie
 	// header key `set-cookie` can have many values
-	var setCookies []string
-	if err := json.Unmarshal([]byte(setCookieJSON), &setCookies); err != nil {
-		return fmt.Errorf("failed to parse Set-Cookie: %s, err: %v", setCookieJSON, err)
-	}
 	if len(setCookies) == 0 {
 		return nil
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
aop `autotest_cookie_keep_before` plugin merge all cookies from report

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=325656&iterationID=1321&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： aop `autotest_cookie_keep_before` plugin merge all cookies from report（修复了自动化测试缺失cookie的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   aop `autotest_cookie_keep_before` plugin merge all cookies from report           |
| 🇨🇳 中文    |     修复了自动化测试缺失cookie的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
