### PR TITLE
fix(orchestrator): manual pod scaler failed when other services in th…

### DIFF
--- a/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale.go
+++ b/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale.go
@@ -49,9 +49,10 @@ func (s *hpscalerService) processRuntimeScaleRecord(rsc pb.RuntimeScaleRecord, a
 		}
 	}
 
-	if len(appliedScaledObjects) > 0 {
-		logrus.Errorf("[processRuntimeScaleRecord] hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
-		return nil, errors.Errorf("[processRuntimeScaleRecord] hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
+	for svcName := range rsc.Payload.Services {
+		if _, ok := appliedScaledObjects[svcName]; ok {
+			return nil, errors.Errorf("[processRuntimeScaleRecord] hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
+		}
 	}
 
 	pre, err := s.db.GetPreDeployment(uniqueId)

--- a/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale_test.go
+++ b/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale_test.go
@@ -121,6 +121,31 @@ func Test_hpscalerService_processRuntimeScaleRecord(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Test_02",
+			fields: fields{
+				bundle:           &bundle.Bundle{},
+				db:               &dbServiceImpl{},
+				serviceGroupImpl: &servicegroup.ServiceGroupImpl{},
+			},
+			args: args{
+				rsc: pb.RuntimeScaleRecord{
+					ApplicationId: 1,
+					Workspace:     "prod",
+					Name:          "master",
+					RuntimeId:     1,
+					Payload: &pb.PreDiceDTO{
+						Name:     "master",
+						Envs:     nil,
+						Services: services,
+					},
+					ErrorMsg: "",
+				},
+				action: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -135,6 +160,9 @@ func Test_hpscalerService_processRuntimeScaleRecord(t *testing.T) {
 					rules := make([]dbclient.RuntimeHPA, 0)
 					rule := generateRuntimeHPA(tTime)
 					rule.IsApplied = "N"
+					if tt.name == "Test_02" {
+						rule.IsApplied = "Y"
+					}
 					rule.ServiceName = "test"
 					rule.Rules = "{\"ruleName\":\"test\",\"ruleNameSpace\":\"project-3-prod\",\"scaleTargetRef\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"test-cdd1a9f7c4\",\"envSourceContainerName\":\"\"},\"pollingInterval\":0,\"cooldownPeriod\":0,\"minReplicaCount\":1,\"maxReplicaCount\":3,\"advanced\":{\"restoreToOriginalReplicaCount\":true,\"horizontalPodAutoscalerConfig\":null},\"triggers\":[{\"type\":\"memory\",\"name\":\"\",\"metadata\":{\"type\":\"Utilization\",\"value\":\"20\"},\"authenticationRef\":null,\"metricType\":\"\"}],\"fallback\":{\"failureThreshold\":0,\"replicas\":1}}"
 					rules = append(rules, rule)

--- a/internal/tools/orchestrator/endpoints/server_handler.go
+++ b/internal/tools/orchestrator/endpoints/server_handler.go
@@ -114,10 +114,12 @@ func (s *Endpoints) processRuntimeScaleRecord(rsc apistructs.RuntimeScaleRecord,
 	if err != nil {
 		logrus.Warnf("get applied hpa rules for RuntimeUniqueId %#v failed: %v", uniqueId, err)
 	}
-	if len(appliedScaledObjects) > 0 {
-		logrus.Errorf("hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
-		errMsg := fmt.Sprintf("hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
-		return apistructs.PreDiceDTO{}, errors.Errorf("hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId), errMsg
+
+	for svcName := range rsc.PayLoad.Services {
+		if _, ok := appliedScaledObjects[svcName]; ok {
+			errMsg := fmt.Sprintf("hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId)
+			return apistructs.PreDiceDTO{}, errors.Errorf("hpa rules has applied for RuntimeUniqueId %#v, can not do this scale action, please delete or canel the applied rules first", uniqueId), errMsg
+		}
 	}
 
 	pre, err := s.db.FindPreDeployment(uniqueId)


### PR DESCRIPTION

#### What this PR does / why we need it:
manual pod scaler failed when other services in the same runtime with hpa enabled


#### Specified Reviewers:

/assign @sixther-dc @luobily 


#### ChangeLog
Bugfix： Fix the bug that manual pod scaler failed when other services in the same runtime with hpa enabled （修复了 runtime 下多个 services 当中有 services 开启 HPA 导致其他 services 不能进行手动扩缩容的问题）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Fix the bug that manual pod scaler failed when other services in the same runtime with hpa enabled         |
| 🇨🇳 中文    |       修复了 runtime 下多个 services 当中有 services 开启 HPA 导致其他 services 不能进行手动扩缩容的问题       |

