### PR TITLE
fix: cms batch query configs remain the same order as namespaces

### DIFF
--- a/internal/tools/pipeline/providers/cms/cms.service.go
+++ b/internal/tools/pipeline/providers/cms/cms.service.go
@@ -154,8 +154,6 @@ func (s *cmsService) BatchGetCmsNsConfigs(ctx context.Context, req *pb.CmsNsConf
 		return nil, err
 	}
 
-	sortResult(result)
-
 	return &pb.CmsNsConfigsBatchGetResponse{Configs: result}, nil
 }
 

--- a/internal/tools/pipeline/providers/cms/pipeline_cms.go
+++ b/internal/tools/pipeline/providers/cms/pipeline_cms.go
@@ -352,7 +352,26 @@ func (c *pipelineCm) BatchGetConfigs(ctx context.Context, req *pb.CmsNsConfigsBa
 		}(config)
 	}
 	wait.Wait()
-	return newConfigs, nil
+	orderedConfigs := getOrderedCmsConfigs(newConfigs, cmsNsList)
+	return orderedConfigs, nil
+}
+
+// getOrderedCmsConfigs Sort by namespace
+// the final results are sorted by namespace
+// every namespace config list sort by creation time
+func getOrderedCmsConfigs(configs []*pb.PipelineCmsConfig, cmsNsList []db.PipelineCmsNs) []*pb.PipelineCmsConfig {
+	var orderedConfigs []*pb.PipelineCmsConfig
+	for _, ns := range cmsNsList {
+		var tmpConfigs []*pb.PipelineCmsConfig
+		for _, config := range configs {
+			if config.Ns.Ns == ns.Ns {
+				tmpConfigs = append(tmpConfigs, config)
+			}
+		}
+		sortResult(tmpConfigs)
+		orderedConfigs = append(orderedConfigs, tmpConfigs...)
+	}
+	return orderedConfigs
 }
 
 func getPbTimestamp(t *time.Time) *timestamppb.Timestamp {

--- a/internal/tools/pipeline/providers/cms/pipeline_cms_test.go
+++ b/internal/tools/pipeline/providers/cms/pipeline_cms_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cms
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-infra/providers/mysqlxorm"
+	"github.com/erda-project/erda-proto-go/core/pipeline/cms/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/cms/db"
+)
+
+func TestBatchGetConfigs(t *testing.T) {
+	dbClient := &db.Client{}
+	nsMap := map[uint64]string{
+		0: "ns-0",
+		1: "ns-1",
+		2: "ns-2",
+	}
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "BatchGetCmsNamespaces", func(_ *db.Client, pipelineSource string, namespaces []string, ops ...mysqlxorm.SessionOption) ([]db.PipelineCmsNs, error) {
+		res := make([]db.PipelineCmsNs, 0)
+		for idx, ns := range namespaces {
+			res = append(res, db.PipelineCmsNs{
+				ID:             uint64(idx),
+				PipelineSource: apistructs.PipelineSource(pipelineSource),
+				Ns:             ns,
+			})
+		}
+		return res, nil
+	})
+	defer pm1.Unpatch()
+	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "BatchGetCmsNsConfigs", func(_ *db.Client, cmsNsIDs []uint64, ops ...mysqlxorm.SessionOption) ([]db.PipelineCmsConfig, error) {
+		res := make([]db.PipelineCmsConfig, 0)
+		for idx, nsID := range cmsNsIDs {
+			res = append(res, db.PipelineCmsConfig{
+				ID:      uint64(idx),
+				NsID:    nsID,
+				Key:     fmt.Sprintf("key-%s", nsMap[nsID]),
+				Value:   fmt.Sprintf("value-%s", nsMap[nsID]),
+				Encrypt: &[]bool{false}[0],
+			})
+		}
+		return res, nil
+	})
+	defer pm2.Unpatch()
+	cm := pipelineCm{
+		dbClient: dbClient,
+	}
+	configs, err := cm.BatchGetConfigs(context.Background(), &pb.CmsNsConfigsBatchGetRequest{
+		PipelineSource: "dice",
+		Namespaces: []string{
+			"ns-0",
+			"ns-1",
+			"ns-2",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(configs))
+	// check order
+	assert.Equal(t, "key-ns-0", configs[0].Key)
+	assert.Equal(t, "value-ns-2", configs[2].Value)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
cms batch query configs remain the same order as namespaces


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that cms batch query configs remain the same order as namespaces（修复了cms批量查询结果保持namespaces的顺序）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that cms batch query configs remain the same order as namespaces            |
| 🇨🇳 中文    |   修复了cms批量查询结果保持namespaces的顺序           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
