### PR TITLE
fix: manual scale not update addon attachment

### DIFF
--- a/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale.go
+++ b/internal/tools/orchestrator/components/horizontalpodscaler/manual_scale.go
@@ -35,6 +35,7 @@ func (s *hpscalerService) processRuntimeScaleRecord(rsc pb.RuntimeScaleRecord, a
 		Workspace:     rsc.Workspace,
 		Name:          rsc.Name,
 	}
+	serviceManualScale := false
 	logrus.Infof("[processRuntimeScaleRecord] process runtime scale for runtime %#v", uniqueId)
 
 	hpaRules, err := s.db.GetRuntimeHPARulesByServices(uniqueId, nil)
@@ -148,6 +149,7 @@ func (s *hpscalerService) processRuntimeScaleRecord(rsc pb.RuntimeScaleRecord, a
 
 		// 未设置 action，则需要自行判断用于执行 scale 操作之后的 runtime 状态更新
 		if action == "" {
+			serviceManualScale = true
 			// 如果所有的 serice 的副本数都调整为0，则是停止操作，Runtime 状态应该为 Stopped，否则不是停止操作，Runtime 状态应该为 Healthy
 			action = apistructs.ScaleActionDown
 			for _, svc := range sg.Services {
@@ -166,7 +168,7 @@ func (s *hpscalerService) processRuntimeScaleRecord(rsc pb.RuntimeScaleRecord, a
 			return nil, err
 		}
 
-		if action == apistructs.ScaleActionDown || action == apistructs.ScaleActionUp {
+		if (action == apistructs.ScaleActionDown || action == apistructs.ScaleActionUp) && !serviceManualScale {
 			addons, err := s.db.GetUnDeletableAttachMentsByRuntimeID(runtime.ID)
 			if err != nil {
 				logrus.Warnf("[processRuntimeScaleRecord] process runtime scale successed, but update runtime referenced addon attact_count for runtime %#v failed, err: %v", uniqueId, err)
@@ -219,7 +221,6 @@ func (s *hpscalerService) processRuntimeScaleRecord(rsc pb.RuntimeScaleRecord, a
 				}
 			}
 		}
-		s.db.UpdateRuntime(runtime)
 	}
 
 	// 保留非停止状态下的副本数


### PR DESCRIPTION
#### What this PR does / why we need it:

If manual scale down to zero update addon attachement to status 'S', when redeploy runtime before delete runtime, will result addon referenced more than once, so display repeated addons on runtime detail web page.


#### Specified Reviewers:

/assign @sixther-dc @iutx 


#### ChangeLog
Bugfix： manual scale not update addon attachment（修复了 手动缩容服务副本数到0，修改 addon attachment 表导致不删除runtime直接重新部署的情况下 addon 重复显示）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     manual scale not update addon attachment         |
| 🇨🇳 中文    |        修复了 手动缩容服务副本数到0，修改 addon attachment 表导致不删除runtime直接重新部署的情况下 addon 重复显示      |

