### PR TITLE
fix(dop): filter empty string when query pipelines

### DIFF
--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -195,8 +195,6 @@ func (e *Endpoints) pipelineList(ctx context.Context, r *http.Request, vars map[
 		PageNum:                    oriReq.EnsurePageNo(),
 		PageSize:                   oriReq.PageSize,
 		YmlNames:                   make([]string, 0),
-		Sources:                    []apistructs.PipelineSource{apistructs.PipelineSource(oriReq.Sources)},
-		Statuses:                   []string{oriReq.Statuses},
 		MustMatchLabelsQueryParams: queryParams,
 	}
 
@@ -204,6 +202,12 @@ func (e *Endpoints) pipelineList(ctx context.Context, r *http.Request, vars map[
 		for _, yml := range strings.Split(oriReq.YmlNames, ",") {
 			req.YmlNames = append(req.YmlNames, yml)
 		}
+	}
+	if oriReq.Statuses != "" {
+		req.Statuses = []string{oriReq.Statuses}
+	}
+	if oriReq.Sources != "" {
+		req.Sources = []apistructs.PipelineSource{apistructs.PipelineSource(oriReq.Sources)}
 	}
 
 	pageResult, err := e.bdl.PageListPipeline(req)


### PR DESCRIPTION
#### What this PR does / why we need it:
filter empty string when query pipelines

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?filter__urlQuery=eyJhc3NpZ25lZSI6WyIxMDAxMjA1Il19&id=327651&iterationID=1321&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that filter empty string when query pipelines（修复了查询cicd流水线为空）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that filter empty string when query pipelines             |
| 🇨🇳 中文    |   修复了查询cicd流水线为空           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
