### PR TITLE
fix(openapi): fix "index out of range" issue of orgNameRetriever when domain is empty

### DIFF
--- a/internal/core/openapi/legacy/util/org.go
+++ b/internal/core/openapi/legacy/util/org.go
@@ -41,9 +41,9 @@ func GetOrgByDomain(domain string) (string, error) {
 	return "", nil
 }
 
-func orgNameRetriever(domainWithoutPort, rootDomain string) string {
+func orgNameRetriever(domain, rootDomain string) string {
 	// trim port if have
-	domainWithoutPort = strutil.Split(domainWithoutPort, ":", false)[0]
+	domainWithoutPort := strutil.Split(domain, ":", false)[0]
 	// remove suffix '-org.${rootDomain}' to get org
 	orgSuffix := strutil.Concat("-org.", rootDomain)
 	if strutil.HasSuffixes(domainWithoutPort, orgSuffix) {

--- a/internal/core/openapi/legacy/util/org.go
+++ b/internal/core/openapi/legacy/util/org.go
@@ -43,7 +43,7 @@ func GetOrgByDomain(domain string) (string, error) {
 
 func orgNameRetriever(domainWithoutPort, rootDomain string) string {
 	// trim port if have
-	domainWithoutPort = strutil.Split(domainWithoutPort, ":", true)[0]
+	domainWithoutPort = strutil.Split(domainWithoutPort, ":", false)[0]
 	// remove suffix '-org.${rootDomain}' to get org
 	orgSuffix := strutil.Concat("-org.", rootDomain)
 	if strutil.HasSuffixes(domainWithoutPort, orgSuffix) {

--- a/internal/core/openapi/legacy/util/org_test.go
+++ b/internal/core/openapi/legacy/util/org_test.go
@@ -28,4 +28,5 @@ func Test_orgNameRetriever(t *testing.T) {
 	assert.Equal(t, "", orgNameRetriever(domains[2], domainRoots[0]))
 
 	assert.Equal(t, "", orgNameRetriever("erda.daily.terminus.io", "daily.terminus.io"))
+	assert.Equal(t, "", orgNameRetriever("", "daily.terminus.io"))
 }

--- a/internal/core/openapi/legacy/util/org_test.go
+++ b/internal/core/openapi/legacy/util/org_test.go
@@ -29,4 +29,5 @@ func Test_orgNameRetriever(t *testing.T) {
 
 	assert.Equal(t, "", orgNameRetriever("erda.daily.terminus.io", "daily.terminus.io"))
 	assert.Equal(t, "", orgNameRetriever("", "daily.terminus.io"))
+	assert.Equal(t, "erda", orgNameRetriever("erda-org.erda.cloud:443", "erda.cloud"))
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

fix "index out of range" issue of orgNameRetriever when domain is empty


#### Specified Reviewers:

/assign @shuofan 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix "index out of range" issue of orgNameRetriever when domain is empty           |
| 🇨🇳 中文    |   修复当 domain 为空时 orgNameRetriever 的数组越界问题           |
