### PR TITLE
fix: missing reource type when check owner permission

### DIFF
--- a/internal/apps/dop/services/pipeline/pipeline.go
+++ b/internal/apps/dop/services/pipeline/pipeline.go
@@ -466,10 +466,11 @@ func (p *Pipeline) getPipelineOwnerUser(app *apistructs.ApplicationDTO, pv1 *api
 // checkOwnerPermission checks if the user has permission to get app
 func (p *Pipeline) checkOwnerPermission(userID string, app *apistructs.ApplicationDTO) error {
 	access, err := p.bdl.CheckPermission(&apistructs.PermissionCheckRequest{
-		UserID:  userID,
-		Scope:   apistructs.AppScope,
-		ScopeID: app.ID,
-		Action:  apistructs.GetAction,
+		UserID:   userID,
+		Scope:    apistructs.AppScope,
+		ScopeID:  app.ID,
+		Resource: apistructs.AppResource,
+		Action:   apistructs.GetAction,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What this PR does / why we need it:
missing reource type when check owner permission

#### Specified Reviewers:

/assign @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that missing reource type when check owner permission （修复了查询owner权限时少了resource）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that missing reource type when check owner permission           |
| 🇨🇳 中文    |      修复了查询owner权限时少了resource        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
