### PR TITLE
fix: add apk content-type `application/vnd.android.package-archive` to whitelist

### DIFF
--- a/internal/core/legacy/services/filesvc/download_test.go
+++ b/internal/core/legacy/services/filesvc/download_test.go
@@ -51,3 +51,35 @@ func Test_bytesToHexString(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFileContentType(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		ext  string
+		want string
+	}{
+		{
+			name: "xss svg",
+			path: "./example/xss-svg.svg",
+			ext:  ".svg",
+			want: "application/octet-stream",
+		},
+		{
+			name: "normal png",
+			path: "./example/normal.png",
+			ext:  ".png",
+			want: headerContentTypePng,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.Open(tt.path)
+			assert.NoError(t, err)
+			defer f.Close()
+			if got := GetFileContentType(f, tt.ext); got != tt.want {
+				t.Errorf("bytesToHexString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
add apk content-type `application/vnd.android.package-archive` to whitelist


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： add apk content-type `application/vnd.android.package-archive` to whitelist （下载apk文件时返回正确的content-type）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   add apk content-type `application/vnd.android.package-archive` to whitelist           |
| 🇨🇳 中文    |   下载apk文件时返回正确的content-type           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
