### PR TITLE
fix: erda-server service addr env inject error

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -93,6 +93,7 @@ services:
       - port: 9095
         protocol: TCP
         l4_protocol: TCP
+        default: true
       - port: 8096
         protocol: TCP
         l4_protocol: TCP


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix erda-server service addr env inject error.
> Envs level: public component generate(gittar, collector, erda-server) > global envs

If doesn't set default port, will inject `ERDA_SERVER_ADDR` use first port `9529` in dice-operator.

Port `9529` already expose in ingress when use erda on erda.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign # @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  erda-server service addr env inject error        |
| 🇨🇳 中文    |   erda-server 服务地址环境变量中注入错误          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
