### PR TITLE
fix: cluster agent token expire in kubernetes >= 1.21

### DIFF
--- a/cmd/cluster-agent/bootstrap.yaml
+++ b/cmd/cluster-agent/bootstrap.yaml
@@ -1,5 +1,7 @@
 cluster-agent:
   debug: ${DEBUG:false}
+  collectSource: "${COLLECT_SOURCE:secret}"
+  serviceAccountName: "${SERVICE_ACCOUNT_NAME:cluster-agent}"
   leaderElection: "${LEADER_ELECTION:true}"
   leaderElectionID: "${LEADER_ELECTION_ID:cluster-agent.erda.cloud}"
   leasesResourceLockType: "${LEASES_RESOURCE_LOCK_TYPE:leases}"

--- a/go.mod
+++ b/go.mod
@@ -150,7 +150,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cast v1.3.1
-	github.com/spf13/cobra v1.4.0
+	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.7.1
 	github.com/t-tiger/gorm-bulk-insert v1.3.0
 	github.com/tealeg/xlsx v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -407,7 +407,7 @@ github.com/corona10/goimagehash v1.0.2/go.mod h1:/l9umBhvcHQXVtQO1V6Gp1yD20STawk
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -1706,8 +1706,8 @@ github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
-github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
-github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/tools/cluster-agent/config/config.go
+++ b/internal/tools/cluster-agent/config/config.go
@@ -17,6 +17,8 @@ package config
 type Config struct {
 	Debug                  bool   `default:"false" desc:"enable debug logging"`
 	CollectClusterInfo     bool   `default:"true" desc:"enable collect cluster info"`
+	CollectSource          string `default:"secret" desc:"collect source, secret or file"`
+	ServiceAccountName     string `default:"cluster-agent" desc:"component service account name"`
 	LeaderElection         bool   `default:"true" desc:"leader election"`
 	LeaderElectionID       string `default:"cluster-agent.erda.cloud" desc:"leader election id"`
 	LeasesResourceLockType string `default:"leases" desc:"leases resource lock type"`

--- a/internal/tools/cluster-agent/pkg/client/client_test.go
+++ b/internal/tools/cluster-agent/pkg/client/client_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/erda-project/erda/internal/tools/cluster-agent/config"
+	"github.com/erda-project/erda/pkg/k8sclient"
+)
+
+func Test_getClusterInfo(t *testing.T) {
+	fakeSa := "cluster-agent"
+
+	defer monkey.UnpatchAll()
+	monkey.Patch(k8sclient.NewForInCluster,
+		func(...k8sclient.Option) (*k8sclient.K8sClient, error) {
+			return &k8sclient.K8sClient{
+				ClientSet: fakeclientset.NewSimpleClientset(&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fakeSa,
+					},
+					Secrets: []corev1.ObjectReference{
+						{
+							Name: "cluster-agent-token-mvp6d",
+						},
+					},
+				}, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-agent-token-mvp6d",
+					},
+					Data: map[string][]byte{
+						caCrtKey:    []byte("fake ca data"),
+						tokenSecKey: []byte("fake token data"),
+					},
+				}),
+			}, nil
+		},
+	)
+	c := New(WithConfig(&config.Config{
+		CollectClusterInfo: true,
+		CollectSource:      collectSourceSecret,
+		ServiceAccountName: fakeSa,
+	}))
+	_, err := c.getClusterInfo()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
cluster agent token expire in kubernetes >= 1.21

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign  @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   cluster agent token expire in kubernetes >= 1.21           |
| 🇨🇳 中文    |    cluster-agent token 在 kubernetes 1.21 版本及以上过期问题修复          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
