### PR TITLE
fix(dop): Solve the problem that the encrypted value is empty when batch update

### DIFF
--- a/internal/apps/dop/providers/cms/cicdcmsservice.go
+++ b/internal/apps/dop/providers/cms/cicdcmsservice.go
@@ -72,39 +72,9 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 	}
 
 	var updateRequest = &cmspb.CmsNsConfigsUpdateRequest{Ns: req.NamespaceName}
-	var valueMap = make(map[string]*cmspb.PipelineCmsConfigValue, len(req.Configs))
-	var keys []string
 
-	for _, config := range req.Configs {
-		if req.Batch && config.Type == db.ConfigTypeDiceFile {
-			continue
-		}
-		keys = append(keys, config.Key)
+	keys, valueMap := GetKeysAndValueMap(req)
 
-		// Encrypted and empty, do not to modify
-		if config.Encrypt && config.Value == "" {
-			continue
-		}
-
-		var operations = &cmspb.PipelineCmsConfigOperations{}
-		switch config.Type {
-		case cms.ConfigTypeDiceFile:
-			operations.CanDelete = true
-			operations.CanDownload = true
-			operations.CanEdit = true
-		default:
-			operations.CanDelete = true
-			operations.CanDownload = false
-			operations.CanEdit = true
-		}
-		valueMap[config.Key] = &cmspb.PipelineCmsConfigValue{
-			Value:       config.Value,
-			EncryptInDB: config.Encrypt,
-			Type:        config.Type,
-			Operations:  operations,
-			Comment:     config.Comment,
-		}
-	}
 	updateRequest.KVs = valueMap
 
 	appInfo, err := s.bdl.GetApp(appID)
@@ -146,6 +116,41 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 	}
 
 	return true, nil
+}
+
+func GetKeysAndValueMap(req *CICDCmsCreateOrUpdateRequest) (keys []string, valueMap map[string]*cmspb.PipelineCmsConfigValue) {
+	valueMap = make(map[string]*cmspb.PipelineCmsConfigValue, len(req.Configs))
+	for _, config := range req.Configs {
+		if req.Batch && config.Type == db.ConfigTypeDiceFile {
+			continue
+		}
+		keys = append(keys, config.Key)
+
+		// Encrypted and empty, do not to modify
+		if config.Encrypt && config.Value == "" {
+			continue
+		}
+
+		var operations = &cmspb.PipelineCmsConfigOperations{}
+		switch config.Type {
+		case cms.ConfigTypeDiceFile:
+			operations.CanDelete = true
+			operations.CanDownload = true
+			operations.CanEdit = true
+		default:
+			operations.CanDelete = true
+			operations.CanDownload = false
+			operations.CanEdit = true
+		}
+		valueMap[config.Key] = &cmspb.PipelineCmsConfigValue{
+			Value:       config.Value,
+			EncryptInDB: config.Encrypt,
+			Type:        config.Type,
+			Operations:  operations,
+			Comment:     config.Comment,
+		}
+	}
+	return
 }
 
 func (s *CICDCmsService) deleteNotNeedKeys(ctx context.Context, pipelineSource string, ns string, keys []string) error {

--- a/internal/apps/dop/providers/cms/cicdcmsservice.go
+++ b/internal/apps/dop/providers/cms/cicdcmsservice.go
@@ -79,8 +79,12 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 		if req.Batch && config.Type == db.ConfigTypeDiceFile {
 			continue
 		}
-
 		keys = append(keys, config.Key)
+
+		// Encrypted and empty, do not to modify
+		if config.Encrypt && config.Value == "" {
+			continue
+		}
 
 		var operations = &cmspb.PipelineCmsConfigOperations{}
 		switch config.Type {

--- a/internal/apps/dop/providers/cms/cicdcmsservice.go
+++ b/internal/apps/dop/providers/cms/cicdcmsservice.go
@@ -73,7 +73,7 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 
 	var updateRequest = &cmspb.CmsNsConfigsUpdateRequest{Ns: req.NamespaceName}
 
-	keys, valueMap := GetKeysAndValueMap(req)
+	keys, valueMap := getKeysAndValueMap(req)
 
 	updateRequest.KVs = valueMap
 
@@ -118,7 +118,7 @@ func (s *CICDCmsService) CICDCmsCreateOrUpdate(ctx context.Context, req *CICDCms
 	return true, nil
 }
 
-func GetKeysAndValueMap(req *CICDCmsCreateOrUpdateRequest) (keys []string, valueMap map[string]*cmspb.PipelineCmsConfigValue) {
+func getKeysAndValueMap(req *CICDCmsCreateOrUpdateRequest) (keys []string, valueMap map[string]*cmspb.PipelineCmsConfigValue) {
 	valueMap = make(map[string]*cmspb.PipelineCmsConfigValue, len(req.Configs))
 	for _, config := range req.Configs {
 		if req.Batch && config.Type == db.ConfigTypeDiceFile {

--- a/internal/apps/dop/providers/cms/cicdcmsservice_test.go
+++ b/internal/apps/dop/providers/cms/cicdcmsservice_test.go
@@ -213,7 +213,7 @@ func TestGetKeysAndValueMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotKeys, gotValueMap := GetKeysAndValueMap(tt.args.req)
+			gotKeys, gotValueMap := getKeysAndValueMap(tt.args.req)
 			if !reflect.DeepEqual(gotKeys, tt.wantKeys) {
 				t.Errorf("GetKeysAndValueMap() gotKeys = %v, want %v", gotKeys, tt.wantKeys)
 			}


### PR DESCRIPTION

#### What this PR does / why we need it:
Solve the problem that the encrypted value is empty when batch update

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=329181&iterationID=1337&pId=0&type=BUG)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Solve the problem that the encrypted value is empty when batch update         |
| 🇨🇳 中文    |      解决批量修改的时候加密value为空问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
