### PR TITLE
fix: openapi lost Content-Type header after proxy

### DIFF
--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -114,7 +114,7 @@ http-server@openapi:
   allow_cors: true
   debug: ${OPENAPI_DEBUG:false}
   log:
-    max_body_size_bytes: 1024
+    max_body_size_bytes: ${OPENAPI_LOG_MAX_BODY_SIZE_BYTES:1024}
 http-server@openapi-admin:
   addr: ":9432"
 ### openapi-interceptor

--- a/internal/core/openapi/legacy/proxy/http/modifyresponse.go
+++ b/internal/core/openapi/legacy/proxy/http/modifyresponse.go
@@ -34,7 +34,6 @@ import (
 	apispec "github.com/erda-project/erda/internal/core/openapi/legacy/api/spec"
 	"github.com/erda-project/erda/internal/core/openapi/legacy/hooks"
 	"github.com/erda-project/erda/internal/core/openapi/legacy/monitor"
-	"github.com/erda-project/erda/pkg/strutil"
 )
 
 func getModifyResponse(rw http.ResponseWriter) func(*http.Response) error {
@@ -128,18 +127,6 @@ func getModifyResponse(rw http.ResponseWriter) func(*http.Response) error {
 func handleReverseRespHeader(rw http.ResponseWriter, res *http.Response) {
 	// compatible original CORS
 	res.Header.Set(echo.HeaderAccessControlAllowOrigin, "*")
-
-	// res remove headers already exist in rw here, before do httputil.ReverseProxy.copyHeader(use add, not set)
-	// see issue: https://github.com/golang/go/issues/50730
-	newResHeader := make(http.Header)
-	for k, vv := range res.Header {
-		for _, v := range vv {
-			if !strutil.Exist(rw.Header().Values(k), v) {
-				newResHeader[k] = append(newResHeader[k], v)
-			}
-		}
-	}
-	res.Header = newResHeader
 }
 
 // getRealIP .

--- a/internal/core/openapi/legacy/proxy/http/modifyresponse_test.go
+++ b/internal/core/openapi/legacy/proxy/http/modifyresponse_test.go
@@ -50,77 +50,24 @@ func Test_getRealIP(t *testing.T) {
 		})
 	}
 }
-func Test_handleReverseRespHeader(t *testing.T) {
-	// 1. simple header with one value
+
+func Test_handleReverseRespHeader_ContentType(t *testing.T) {
+	// content-type
 	rw := mock.NewMockHTTPResponseWriter()
 	resp := &http.Response{Header: make(http.Header)}
 
 	// set rw header
-	// set cors
-	rw.Header().Set(echo.HeaderAccessControlAllowOrigin, "*")
-	// set rid
+	// set content-type
+	rw.Header().Set(echo.HeaderContentType, "application/json")
 	rw.Header().Set(echo.HeaderXRequestID, "1")
 
 	// set resp header mock after proxy
-	resp.Header.Set(echo.HeaderAccessControlAllowOrigin, "*")
+	resp.Header.Set(echo.HeaderContentType, "application/json")
 	resp.Header.Set(echo.HeaderXRequestID, "1")
 
 	handleReverseRespHeader(rw, resp)
 
 	assert.Equal(t, 2, len(rw.Header()))
-	assert.Equal(t, 0, len(resp.Header))
-
-	// 2. complex header with multiple values
-	// reset rw & resp
-	rw = mock.NewMockHTTPResponseWriter()
-	resp = &http.Response{Header: make(http.Header)}
-
-	// set rw header
-	// set cors
-	rw.Header().Set(echo.HeaderAccessControlAllowOrigin, "*")
-	// set rid
-	rw.Header().Set(echo.HeaderXRequestID, "1")
-	// set multiple value header
-	rw.Header().Set("mh", "1")
-	rw.Header().Add("mh", "2")
-
-	// set resp header mock after proxy
-	resp.Header.Set(echo.HeaderAccessControlAllowOrigin, "*")
-	resp.Header.Set(echo.HeaderXRequestID, "1")
-	resp.Header.Set("mh", "1") // just "1" exists in rw
-
-	handleReverseRespHeader(rw, resp)
-
-	assert.Equal(t, 3, len(rw.Header()))
-	assert.Equal(t, 0, len(resp.Header))
-
-	// set resp header mock after proxy
-	resp.Header = make(http.Header) // reset
-	resp.Header.Set(echo.HeaderAccessControlAllowOrigin, "*")
-	resp.Header.Set(echo.HeaderXRequestID, "1")
-	resp.Header.Set("mh", "3") // just "3" not exists in rw
-
-	handleReverseRespHeader(rw, resp)
-
-	assert.Equal(t, 3, len(rw.Header()))
-	assert.Equal(t, 1, len(resp.Header))
-	assert.Equal(t, 1, len(resp.Header.Values("mh")))
-	assert.Equal(t, "3", resp.Header.Get("mh"))
-
-	// set resp header mock after proxy
-	resp.Header = make(http.Header) // reset
-	resp.Header.Set(echo.HeaderAccessControlAllowOrigin, "*")
-	resp.Header.Set(echo.HeaderXRequestID, "1")
-	resp.Header.Set("mh", "1") // "1" exists in rw
-	resp.Header.Add("mh", "2") // "2" exists in rw
-	resp.Header.Add("mh", "3") // and "3" not exists in rw
-	resp.Header.Add("mh", "4") // and "4" not exists in rw
-
-	handleReverseRespHeader(rw, resp)
-
-	assert.Equal(t, 3, len(rw.Header()))
-	assert.Equal(t, 1, len(resp.Header))
-	assert.Equal(t, 2, len(resp.Header.Values("mh")))
-	assert.Equal(t, "3", resp.Header.Get("mh"))
-	assert.Equal(t, []string{"3", "4"}, resp.Header.Values("mh"))
+	// will add echo.HeaderAccessControlAllowOrigin
+	assert.Equal(t, 3, len(resp.Header))
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

- delete logic that res remove headers already exist in rw
- make openapi.http-server.log.max_body_size_bytes configurable through env


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=329611&iterationID=1337&tab=BUG&type=BUG)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: openapi lost Content-Type header after proxy             |
| 🇨🇳 中文    |  修复 openapi 在 proxy 后丢失 Content-Type 的问题           |
