### PR TITLE
fix: cluster-agent doesn't exit when start failed

### DIFF
--- a/internal/tools/cluster-agent/provider.go
+++ b/internal/tools/cluster-agent/provider.go
@@ -71,6 +71,7 @@ func (p *provider) Run(ctx context.Context) error {
 		OnStartedLeading: func(ctx context.Context) {
 			if err := c.Start(ctx); err != nil {
 				logrus.Errorf("failed to start cluster agent: %v", err)
+				os.Exit(1)
 			}
 		},
 		OnNewLeaderFun: func(newLeaderIdentity string) {


### PR DESCRIPTION
#### What this PR does / why we need it:
cluster-agent doesn't exit when start failed

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  cluster-agent doesn't exit when start failed            |
| 🇨🇳 中文    |    修复 cluster-agent 启动失败未退出          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
