### PR TITLE
fix(dop): set `isUpdate` false value when add test

### DIFF
--- a/internal/apps/dop/component-protocol/components/auto-test-plan-list/components/addButton/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-plan-list/components/addButton/render.go
@@ -31,6 +31,7 @@ func (tpm *TestPlanManageAddButton) Render(ctx context.Context, c *cptype.Compon
 			c.State = make(map[string]interface{}, 0)
 		}
 		c.State["addTest"] = true
+		c.State["isUpdate"] = false
 	}
 
 	return nil

--- a/internal/apps/dop/component-protocol/scenarios/auto-test-plan-list.yml
+++ b/internal/apps/dop/component-protocol/scenarios/auto-test-plan-list.yml
@@ -39,6 +39,8 @@ rendering:
       state:
         - name: "addTest"
           value: "{{ addButton.addTest }}"
+        - name: "isUpdate"
+          value: "{{ addButton.isUpdate }}"
 
   __DefaultRendering__:
     - name: autoTestPlan


### PR DESCRIPTION
#### What this PR does / why we need it:
set `isUpdate` false value when add test

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=327132&iterationID=1354&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix：set `isUpdate` false value when add test （修复了自动化测试计划创建失败）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   set `isUpdate` false value when add test           |
| 🇨🇳 中文    |    修复了自动化测试计划创建失败          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
