### PR TITLE
feat: BooleanFieldLinter do not applied to uc module

### DIFF
--- a/.erda/migrations/config.yml
+++ b/.erda/migrations/config.yml
@@ -152,6 +152,8 @@
 # 布尔值命名与类型校验
 - name: BooleanFieldLinter
   white:
+    modules:
+      - uc
     patterns:
       - ".*-base$"
 


### PR DESCRIPTION
#### What this PR does / why we need it:
feat: BooleanFieldLinter do not applied to uc module

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | BooleanFieldLinter do not applied to UC module |
| 🇨🇳 中文    | feat: BooleanFieldLinter 不约束 UC 模块 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
