### PR TITLE
chore: golangci-lint skip cache

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -134,6 +134,7 @@ jobs:
           version: v1.46
           args: --timeout=10m
           skip-go-installation: true
+          skip-cache: true
           skip-pkg-cache: false
           skip-build-cache: false
 

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -134,9 +134,9 @@ jobs:
           version: v1.46
           args: --timeout=10m
           skip-go-installation: true
-          skip-cache: true
-          skip-pkg-cache: false
-          skip-build-cache: false
+          #skip-cache: true # not available in v2.5.2
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   CODE-TEST:
     runs-on: ubuntu-latest

--- a/internal/tools/pipeline/actionagent/callback.go
+++ b/internal/tools/pipeline/actionagent/callback.go
@@ -40,6 +40,7 @@ const (
 	EnvFileStreamTimeoutSec = "ACTIONAGENT_FILE_STREAM_TIMEOUT_SEC"
 )
 
+// Callback .
 func (agent *Agent) Callback() {
 	cb := &Callback{}
 	defer func() {


### PR DESCRIPTION
#### What this PR does / why we need it:

golangci-lint skip cache, because cache is too big to upload (more than 5GB)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  golangci-lint skip cache            |
| 🇨🇳 中文    |   golangci-lint 跳过缓存           |
