### PR TITLE
fix(files): recover lost files routes for openapi proxy use

### DIFF
--- a/internal/core/openapi/legacy/api/apis/files/download.go
+++ b/internal/core/openapi/legacy/api/apis/files/download.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"net/http"
+
+	"github.com/erda-project/erda/internal/core/openapi/legacy/api/apis"
+)
+
+var DOWNLOAD = apis.ApiSpec{
+	Path:          "/api/files",
+	BackendPath:   "/api/files",
+	Host:          "erda-server.marathon.l4lb.thisdcos.directory:9095",
+	Scheme:        "http",
+	Method:        http.MethodGet,
+	CheckLogin:    false,
+	TryCheckLogin: true,
+	CheckToken:    true,
+	IsOpenAPI:     true,
+	ChunkAPI:      true,
+	Doc:           "summary: 文件下载，在 query param 中通过 file=<uuid> 指定具体文件",
+}

--- a/internal/core/openapi/legacy/api/apis/files/download_v2.go
+++ b/internal/core/openapi/legacy/api/apis/files/download_v2.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"net/http"
+
+	"github.com/erda-project/erda/internal/core/openapi/legacy/api/apis"
+)
+
+var DOWNLOAD_V2 = apis.ApiSpec{
+	Path:          "/api/files/<uuid>",
+	BackendPath:   "/api/files/<uuid>",
+	Host:          "erda-server.marathon.l4lb.thisdcos.directory:9095",
+	Scheme:        "http",
+	Method:        http.MethodGet,
+	CheckLogin:    false,
+	TryCheckLogin: true,
+	CheckToken:    true,
+	IsOpenAPI:     true,
+	ChunkAPI:      true,
+	Doc:           "summary: 文件下载，在 path 中指定具体文件",
+}

--- a/internal/core/openapi/legacy/api/apis/files/head.go
+++ b/internal/core/openapi/legacy/api/apis/files/head.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"net/http"
+
+	"github.com/erda-project/erda/internal/core/openapi/legacy/api/apis"
+)
+
+var HEAD = apis.ApiSpec{
+	Path:          "/api/files/<uuid>",
+	BackendPath:   "/api/files/<uuid>",
+	Host:          "erda-server.marathon.l4lb.thisdcos.directory:9095",
+	Scheme:        "http",
+	Method:        http.MethodHead,
+	CheckLogin:    false,
+	TryCheckLogin: true,
+	CheckToken:    true,
+	IsOpenAPI:     true,
+	Doc:           "summary: HEAD 请求，文件下载，在 path 中指定具体文件",
+}

--- a/internal/core/openapi/legacy/api/apis/files/upload.go
+++ b/internal/core/openapi/legacy/api/apis/files/upload.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files
+
+import (
+	"net/http"
+
+	"github.com/erda-project/erda/internal/core/openapi/legacy/api/apis"
+)
+
+var UPLOAD = apis.ApiSpec{
+	Path:        "/api/files",
+	BackendPath: "/api/files",
+	Host:        "erda-server.marathon.l4lb.thisdcos.directory:9095",
+	Scheme:      "http",
+	Method:      http.MethodPost,
+	CheckLogin:  true,
+	CheckToken:  true,
+	IsOpenAPI:   true,
+	ChunkAPI:    true,
+	Doc:         "summary: 文件上传",
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

recover lost files routes, for openapi proxy use.

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=331857&iterationID=1337&tab=BUG&type=BUG)
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=331858&iterationID=1337&tab=BUG&type=BUG)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   recover lost files routes for openapi proxy use           |
| 🇨🇳 中文    |   恢复删除的 files 路由，供 openapi 转发使用           |

