### PR TITLE
fix: agent change dir to task workdir before run commands

### DIFF
--- a/internal/tools/pipeline/actionagent/step_logic.go
+++ b/internal/tools/pipeline/actionagent/step_logic.go
@@ -60,6 +60,12 @@ func (agent *Agent) actionRun() {
 }
 
 func (agent *Agent) runCommands() {
+	// go to ${WORKDIR}
+	if err := os.Chdir(agent.EasyUse.ContainerWd); err != nil {
+		agent.AppendError(err)
+		return
+	}
+
 	args := make([]string, len(agent.Arg.ShellArgs))
 	copy(args, agent.Arg.ShellArgs)
 	args = append(args, agent.EasyUse.CommandScript)

--- a/internal/tools/pipeline/actionagent/step_logic_test.go
+++ b/internal/tools/pipeline/actionagent/step_logic_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actionagent
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_runCommands(t *testing.T) {
+	agent := &Agent{
+		EasyUse: EasyUse{
+			ContainerWd:    "./",
+			RunMultiStdout: os.Stdout,
+			RunMultiStderr: os.Stderr,
+			CommandScript:  "./command",
+		},
+		Arg: &AgentArg{
+			Shell: "sh",
+		},
+	}
+	agent.runCommands()
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
agent change dir to task workdir before run commands


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that agent change dir to task workdir before run commands（agent执行commands前切换到workdir）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that agent change dir to task workdir before run commands          |
| 🇨🇳 中文    |   agent执行commands前切换到workdir           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
