### PR TITLE
fix: Add api action is https, add output for empty nodes.

### DIFF
--- a/internal/apps/dop/providers/rule/actions/api/api.go
+++ b/internal/apps/dop/providers/rule/actions/api/api.go
@@ -63,6 +63,7 @@ type APIConfig struct {
 	URL     string                 `json:"url"`
 	Headers http.Header            `json:"header"`
 	Body    map[string]interface{} `json:"body"`
+	IsHTTPS bool                   `json:"https"`
 }
 
 // outgoing API
@@ -78,8 +79,12 @@ func (a *provider) Send(api *API) (string, error) {
 	}
 
 	// call outgoing API
-	req := httpclient.New(httpclient.WithDialerKeepAlive(time.Duration(a.Cfg.DailerKeepAliveSeconds)*time.Second)).
-		Method(apiConfig.Method, parsed.Host).
+	keepalive := time.Duration(a.Cfg.DailerKeepAliveSeconds) * time.Second
+	req := httpclient.New(httpclient.WithDialerKeepAlive(keepalive)).Method(apiConfig.Method, parsed.Host)
+	if apiConfig.IsHTTPS {
+		req = httpclient.New(httpclient.WithHTTPS(), httpclient.WithDialerKeepAlive(keepalive)).Method(apiConfig.Method, parsed.Host)
+	}
+	req = req.
 		Path(parsed.Path).
 		Params(parsed.Query()).
 		Headers(apiConfig.Headers).

--- a/internal/apps/dop/providers/rule/executor/execute.go
+++ b/internal/apps/dop/providers/rule/executor/execute.go
@@ -77,13 +77,16 @@ func (e *Executor) Fire(req *pb.FireRequest) ([]bool, error) {
 
 func (e *Executor) DingTalkAction(content map[string]interface{}, params db.ActionParams) (string, error) {
 	if len(params.Nodes) == 0 {
-		return "", nil
+		return "no valid action nodes", nil
 	}
 	// TODO: multiple nodes concurrency
 	node := params.Nodes[0]
 	d := node.DingTalk
 	if d == nil {
-		return "", nil
+		return e.API.Send(&api.API{
+			Snippet: node.Snippet,
+			TLARaw:  content,
+		})
 	}
 	target := apistructs.Target{
 		Receiver: d.Webhook,

--- a/internal/apps/dop/providers/rule/executor/execute_test.go
+++ b/internal/apps/dop/providers/rule/executor/execute_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda-proto-go/dop/rule/pb"
+
+	"github.com/erda-project/erda/internal/apps/dop/providers/rule/actions/api"
+	"github.com/erda-project/erda/internal/apps/dop/providers/rule/db"
+)
+
+type MockAPI struct {
+}
+
+func (a *MockAPI) Send(api *api.API) (string, error) {
+	return "ok", nil
+}
+
+func TestExecutor_DingTalkAction(t *testing.T) {
+	type args struct {
+		content map[string]interface{}
+		params  db.ActionParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			args: args{
+				content: map[string]interface{}{
+					"k": "v",
+				},
+			},
+			want: "no valid action nodes",
+		},
+		{
+			args: args{
+				content: map[string]interface{}{
+					"k": "v",
+				},
+				params: db.ActionParams{
+					Nodes: []*pb.ActionNode{{
+						Snippet: "123",
+					}},
+				},
+			},
+			want: "ok",
+		},
+	}
+	e := &Executor{
+		API: &MockAPI{},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := e.DingTalkAction(tt.args.content, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Executor.DingTalkAction() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Executor.DingTalkAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add api action is https, add output for empty nodes.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Add api action is https, add output for empty nodes.             |
| 🇨🇳 中文    |    增加api action ishttps          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
