### PR TITLE
refactor: manual trigger mode pipeline use run-user permission

### DIFF
--- a/internal/apps/dop/component-protocol/components/project-pipeline-exec-list/myPage/tabsTable/pipelineTable/provider.go
+++ b/internal/apps/dop/component-protocol/components/project-pipeline-exec-list/myPage/tabsTable/pipelineTable/provider.go
@@ -246,7 +246,7 @@ func (p *provider) pipelineToRow(exec *pb.PipelineExecHistory) table.Row {
 			}).Build(),
 			ColumnApplicationName: table.NewTextCell(exec.AppName).Build(),
 			ColumnBranch:          table.NewTextCell(exec.Branch).Build(),
-			ColumnExecutor:        table.NewUserCell(commodel.User{ID: exec.Executor}).Build(),
+			ColumnExecutor:        table.NewUserCell(commodel.User{ID: p.getPipelineHistoryExecutor(exec)}).Build(),
 			ColumnStartTimeOrder:  table.NewTextCell(timeFormatFromProtobuf(exec.TimeBegin)).Build(),
 			ColumnOwner:           table.NewUserCell(commodel.User{ID: exec.Owner}).Build(),
 			ColumnTriggerMode:     table.NewTextCell(util.DisplayTriggerModeText(p.sdk.Ctx, exec.TriggerMode)).Build(),
@@ -255,6 +255,13 @@ func (p *provider) pipelineToRow(exec *pb.PipelineExecHistory) table.Row {
 			table.OpRowSelect{}.OpKey(): cputil.NewOpBuilder().Build(),
 		},
 	}
+}
+
+func (p *provider) getPipelineHistoryExecutor(exec *pb.PipelineExecHistory) string {
+	if exec.TriggerMode == apistructs.PipelineTriggerModeCron.String() {
+		return ""
+	}
+	return exec.Executor
 }
 
 func timeFormatFromProtobuf(t *timestamppb.Timestamp) string {

--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -128,6 +128,7 @@ func (e *Endpoints) pipelineCreate(ctx context.Context, r *http.Request, vars ma
 		return errorresp.ErrResp(err)
 	}
 	reqPipeline.DefinitionID = definitionID
+	reqPipeline.NormalLabels[apistructs.LabelPipelineTriggerMode] = apistructs.PipelineTriggerModeManual.String()
 
 	// update CmsNsConfigs
 	if err = e.UpdateCmsNsConfigs(identityInfo.UserID, app.OrgID); err != nil {

--- a/internal/tools/pipeline/spec/pipeline.go
+++ b/internal/tools/pipeline/spec/pipeline.go
@@ -115,8 +115,13 @@ func (p *Pipeline) GetOwnerUserID() string {
 
 // GetOwnerOrRunUserID get userID to execute pipeline
 // permissions for the task belong to the executor userID
+// if it's triggered by manual, run user is used
 // first to get owner userID,if not exists, to get run userID
 func (p *Pipeline) GetOwnerOrRunUserID() string {
+	switch p.TriggerMode {
+	case apistructs.PipelineTriggerModeManual, "":
+		return p.GetRunUserID()
+	}
 	if p.Extra.OwnerUser != nil && p.Extra.OwnerUser.ID != nil {
 		return fmt.Sprintf("%v", p.Extra.OwnerUser.ID)
 	}

--- a/internal/tools/pipeline/spec/pipeline_test.go
+++ b/internal/tools/pipeline/spec/pipeline_test.go
@@ -344,3 +344,79 @@ func TestGetUserID(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOwnerOrRunUserID(t *testing.T) {
+	type args struct {
+		extra       PipelineExtra
+		triggerMode apistructs.PipelineTriggerMode
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test with empty owner user",
+			args: args{
+				extra: PipelineExtra{},
+			},
+			want: "",
+		},
+		{
+			name: "with owner user",
+			args: args{
+				extra: PipelineExtra{
+					Extra: PipelineExtraInfo{
+						OwnerUser: &apistructs.PipelineUser{
+							ID: "1",
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "with run user",
+			args: args{
+				extra: PipelineExtra{
+					Extra: PipelineExtraInfo{
+						RunUser: &apistructs.PipelineUser{
+							ID: "2",
+						},
+					},
+				},
+			},
+			want: "2",
+		},
+		{
+			name: "cron with owner user",
+			args: args{
+				extra: PipelineExtra{
+					Extra: PipelineExtraInfo{
+						RunUser: &apistructs.PipelineUser{
+							ID: "2",
+						},
+						OwnerUser: &apistructs.PipelineUser{
+							ID: "1",
+						},
+					},
+				},
+				triggerMode: apistructs.PipelineTriggerModeCron,
+			},
+			want: "1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pipeline{
+				PipelineBase: PipelineBase{
+					TriggerMode: tt.args.triggerMode,
+				},
+				PipelineExtra: tt.args.extra,
+			}
+			if got := p.GetOwnerOrRunUserID(); got != tt.want {
+				t.Errorf("GetOwnerOrRunUserID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
manual trigger mode pipeline use run-user permission

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=331588&iterationID=1354&pId=0&type=REQUIREMENT)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: manual trigger mode pipeline use run-user permission （手动触发的流水线所有节点按执行者权限决定）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   manual trigger mode pipeline use run-user permission           |
| 🇨🇳 中文    |      手动触发的流水线所有节点按执行者权限决定        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
