### PR TITLE
chore: add `TRACE_HOOK_ENABLE` env for trace hook

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -34,6 +34,7 @@ envs:
   OTEL_TRACES_SAMPLER_ARG: 0.1
   CLUSTER_MANAGER_ADDR: cluster-manager:9094
   CLUSTER_DIALER_ADDR: cluster-manager:80
+  TRACE_HOOK_ENABLE: true
 services:
   dop:
     binds:

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/cloud-on-k8s v0.0.0-20210205172912-5ce0eca90c60
 	github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6
-	github.com/erda-project/erda-infra v1.0.8-0.20220803060014-da912e425031
+	github.com/erda-project/erda-infra v1.0.8-0.20220808101234-249f9881ed8f
 	github.com/erda-project/erda-oap-thirdparty-protocol v0.0.0-20210907135609-15886a136d5b
 	github.com/erda-project/erda-proto-go v0.0.0
 	github.com/erda-project/erda-sourcecov v0.1.0
@@ -101,6 +101,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/olivere/elastic v6.2.35+incompatible
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/otiai10/copy v1.5.0
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -146,6 +147,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.2.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
+	go.opentelemetry.io/otel/trace v1.4.1
 	go.opentelemetry.io/proto/otlp v0.11.0
 	go.uber.org/automaxprocs v1.5.1
 	go.uber.org/ratelimit v0.2.0
@@ -325,7 +327,6 @@ require (
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/paulmach/orb v0.4.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
@@ -382,7 +383,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.2.0 // indirect
 	go.opentelemetry.io/otel/internal/metric v0.25.0 // indirect
 	go.opentelemetry.io/otel/metric v0.25.0 // indirect
-	go.opentelemetry.io/otel/trace v1.4.1 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.8.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/erda-project/elastic v0.0.1-ex h1:5ajfxQ5S5YjpzFqY9LzL9hiKWCn6q/JDT4n8sNv7+pU=
 github.com/erda-project/elastic v0.0.1-ex/go.mod h1:iAVsas6fcmt9pxtge1+dErMhecv+RLSXlD4rnZRJVW0=
 github.com/erda-project/erda-infra v1.0.7/go.mod h1:H2p2acOXt282EpRaNNBDIk6XgLEzk4lylKboEee7Xbs=
-github.com/erda-project/erda-infra v1.0.8-0.20220803060014-da912e425031 h1:cf+hKQtjotVgPRnp2rPavEG4tNX6MJor49oRa3OaLz8=
-github.com/erda-project/erda-infra v1.0.8-0.20220803060014-da912e425031/go.mod h1:lZ4wZMEtTpp9S3R1O/2oTYyAAkGZE9LCwEjUMcGEizo=
+github.com/erda-project/erda-infra v1.0.8-0.20220808101234-249f9881ed8f h1:2/48qS7qUSqcmpYdW01yZpmtBUvJ8e+FmnaStwDRusk=
+github.com/erda-project/erda-infra v1.0.8-0.20220808101234-249f9881ed8f/go.mod h1:lZ4wZMEtTpp9S3R1O/2oTYyAAkGZE9LCwEjUMcGEizo=
 github.com/erda-project/erda-oap-thirdparty-protocol v0.0.0-20210907135609-15886a136d5b h1:GWf2ChasZFerFwQoTokIvjJLWH57ligTSLD2hUb7UWk=
 github.com/erda-project/erda-oap-thirdparty-protocol v0.0.0-20210907135609-15886a136d5b/go.mod h1:H/f81Thef2Tnz4nUeLt0r4VwHdOznthpyXBwT9vDWo0=
 github.com/erda-project/erda-sourcecov v0.1.0 h1:iLvoMsQ1xX81KNOW98BKr85Vs7sSazrIDEphLYdmgP4=


### PR DESCRIPTION
#### What this PR does / why we need it:
add `TRACE_HOOK_ENABLE` env

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=331979&iterationID=1337&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： add `TRACE_HOOK_ENABLE` env for trace hook（修复了agent打印infra日志）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add `TRACE_HOOK_ENABLE` env for trace hook            |
| 🇨🇳 中文    |    修复了agent打印infra日志          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
