### PR TITLE
feat(orchestrator): check k8s cluster support pod autoscaler

### DIFF
--- a/api/proto/orchestrator/runtime/runtime.proto
+++ b/api/proto/orchestrator/runtime/runtime.proto
@@ -48,6 +48,8 @@ message Extra {
   uint64 applicationID = 1 [json_name = "applicationId"] ;
   uint64 buildID = 2 [json_name = "buildId"];
   string workspace = 3;
+  bool supportHPA = 4 [json_name ="isHPASupported"];
+  bool supportVPA = 5 [json_name ="isVPASupported"];
 }
 
 message ErrorResponse {

--- a/internal/tools/orchestrator/components/runtime/runtime.service_test.go
+++ b/internal/tools/orchestrator/components/runtime/runtime.service_test.go
@@ -154,6 +154,7 @@ func TestService_GetRuntime(t *testing.T) {
 			StatusDesc: apistructs.StatusDesc{
 				Status: apistructs.StatusFailed,
 			},
+			Extra: map[string]string{"K8S_SERVER_VERSION": "1.17"},
 			Dice: apistructs.Dice{
 				Services: []apistructs.Service{
 					{

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -665,6 +665,15 @@ func (k *Kubernetes) Inspect(ctx context.Context, specObj interface{}) (interfac
 		return nil, err
 	}
 
+	k8sServerVersion, err := k.k8sClient.ClientSet.Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	if runtime.Extra == nil {
+		runtime.Extra = make(map[string]string)
+	}
+	runtime.Extra["K8S_SERVER_VERSION"] = fmt.Sprintf("%s.%s", k8sServerVersion.Major, k8sServerVersion.Minor)
+
 	operator, ok := runtime.Labels["USE_OPERATOR"]
 	if ok {
 		op, err := k.whichOperator(operator)

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset_test.go
@@ -29,6 +29,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/deployment"
@@ -40,6 +41,7 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/toleration"
 	"github.com/erda-project/erda/pkg/http/httpclient"
+	"github.com/erda-project/erda/pkg/k8sclient"
 	"github.com/erda-project/erda/pkg/parser/diceyml"
 	"github.com/erda-project/erda/pkg/strutil"
 )
@@ -264,9 +266,12 @@ func TestStatefulset(t *testing.T) {
 	assert.NotNil(t, err)
 
 	kubernetes := &Kubernetes{
-		name:      "whatever",
-		addr:      "10.167.0.248:8080",
-		client:    httpclient.New(),
+		name:   "whatever",
+		addr:   "10.167.0.248:8080",
+		client: httpclient.New(),
+		k8sClient: &k8sclient.K8sClient{
+			ClientSet: fakeclientset.NewSimpleClientset(),
+		},
 		deploy:    deployment.New(deployment.WithCompleteParams("10.167.0.248:8080", httpclient.New())),
 		ingress:   ingress.New(ingress.WithCompleteParams("10.167.0.248:8080", httpclient.New())),
 		namespace: namespace.New(),


### PR DESCRIPTION
#### What this PR does / why we need it:
Erda support HPA by KEDA v2.7.1 which compatible for k8s v1.17.0+, for support HPA  Advance Behavior, need  k8s v1.18.0+
Erda support VPA  by https://github.com/kubernetes/autoscaler, for vertical-pod-autoscaler  v0.11.0 use autoscaling.k8s.io/v1 need k8s v1.16.0+

When GetRuntime return data include info about whether the cluster support HPA or VPA, can Enable/Disable Pod Autoscaler Entry.



#### Specified Reviewers:

/assign @luobily @sixther-dc @iutx 


#### ChangeLog

Feature: Optimize GetRuntime return data include info about whether the cluster support HPA or VPA（优化了 GetRuntime 
 的返回结果，其中包含底层集群版本是否支持 HPA 或 VPA 的功能）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Optimize GetRuntime return data include info about whether the cluster support HPA or VPA       |
| 🇨🇳 中文    |        优化了 GetRuntime  的返回结果，其中包含底层集群版本是否支持 HPA 或 VPA 的功能      |


