### PR TITLE
fix: kill pod then call get_service_pods immediately may panic

### DIFF
--- a/internal/tools/orchestrator/endpoints/instance_test.go
+++ b/internal/tools/orchestrator/endpoints/instance_test.go
@@ -168,6 +168,18 @@ func TestEndpoints_getPodStatusFromK8s(t *testing.T) {
 			want:    pods,
 			wantErr: false,
 		},
+		{
+			name: "Test_02",
+			fields: fields{
+				runtime: &runtime.Runtime{},
+			},
+			args: args{
+				runtimeID:   "1",
+				serviceName: "test2",
+			},
+			want:    []apistructs.Pod{},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
When kill pod in runtime service then call get_service_pods immediately, new pod may be in creating (for example in Phase Pending),  Pod Status has no needed info, so  processing pod.Status info may cause panic 


#### Specified Reviewers:

/assign @luobily @sixther-dc @iutx 


#### ChangeLog
Bugfix： Fix the bug that kill pod in runtime service then call get_service_pods immediately may cause panic  （修复了 在服务的 Pod 详情页面删除 Pod 之后立即调用 get_service_pods 接口获取的 Pod Status 相关字段为空导致处理逻辑 Panic）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Fix the bug that kill pod in runtime service then call get_service_pods immediately may cause panic      |
| 🇨🇳 中文    |     修复了在服务的 Pod 详情页面删除 Pod 之后立即调用 get_service_pods 接口获取的 Pod Status 相关字段为空可能导致处理逻辑 Panic 的问题    |

