### PR TITLE
fix: legacyhttpserver try to get muxVars from infrahttpserver

### DIFF
--- a/pkg/http/httpserver/server.go
+++ b/pkg/http/httpserver/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	infrahttpserver "github.com/erda-project/erda-infra/providers/httpserver"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/crypto/uuid"
 	"github.com/erda-project/erda/pkg/goroutine_context"
@@ -156,6 +157,9 @@ func (s *Server) internal(handler func(context.Context, *http.Request, map[strin
 
 		// Manual decoding url var
 		muxVars := mux.Vars(r)
+		if muxVars == nil {
+			muxVars = infrahttpserver.Vars(r)
+		}
 		for k, v := range muxVars {
 			decodedVar, err := url.QueryUnescape(v)
 			if err != nil {

--- a/pkg/http/httpserver/vars.go
+++ b/pkg/http/httpserver/vars.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+
+	infrahttpserver "github.com/erda-project/erda-infra/providers/httpserver"
+)
+
+var infrahttpserverVars = infrahttpserver.Vars
+
+func getVars(r *http.Request) (vars map[string]string) {
+	// defer decode vars
+	defer func() {
+		for k, v := range vars {
+			decodedVar, err := url.QueryUnescape(v)
+			if err != nil {
+				continue
+			}
+			vars[k] = decodedVar
+		}
+	}()
+	// get from mux firstly
+	vars = mux.Vars(r)
+	if len(vars) > 0 {
+		return
+	}
+	// try get from infrahttpserver when legacyhttpserver only be used as Router, so no vars inject logic executed.
+	vars = infrahttpserverVars(r)
+	return
+}

--- a/pkg/http/httpserver/vars_test.go
+++ b/pkg/http/httpserver/vars_test.go
@@ -15,6 +15,7 @@
 package httpserver
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -74,11 +75,15 @@ func Test_getVars(t *testing.T) {
 			wantVars: map[string]string{"id": "1"},
 		},
 		{
-			name: "vars encoded",
+			name: "vars url escaped",
 			args: args{
 				r: func() *http.Request {
 					r := &http.Request{}
-					r = mux.SetURLVars(r, map[string]string{"id": url.QueryEscape("Asia/Shanghai")})
+					escapedVar := url.QueryEscape("Asia/Shanghai")
+					if escapedVar != "Asia%2FShanghai" {
+						panic(fmt.Errorf("just to prove `escapedVar` is truly escaped"))
+					}
+					r = mux.SetURLVars(r, map[string]string{"id": escapedVar})
 					return r
 				}(),
 			},

--- a/pkg/http/httpserver/vars_test.go
+++ b/pkg/http/httpserver/vars_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	infrahttpserver "github.com/erda-project/erda-infra/providers/httpserver"
+)
+
+func Test_getVars(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name          string
+		args          args
+		beforeGetVars func(r *http.Request)
+		wantVars      map[string]string
+	}{
+		{
+			name: "no vars",
+			args: args{
+				r: func() *http.Request {
+					return &http.Request{}
+				}(),
+			},
+			beforeGetVars: nil,
+			wantVars:      nil,
+		},
+		{
+			name: "vars from legacyhttpserver",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{}
+					r = mux.SetURLVars(r, map[string]string{"id": "1"})
+					return r
+				}(),
+			},
+			beforeGetVars: nil,
+			wantVars:      map[string]string{"id": "1"},
+		},
+		{
+			name: "vars from infrahttpserver",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{}
+					return r
+				}(),
+			},
+			beforeGetVars: func(r *http.Request) {
+				mockedInfrahttpserverVars := func(r *http.Request) map[string]string {
+					return map[string]string{"id": "1"}
+				}
+				infrahttpserverVars = mockedInfrahttpserverVars
+			},
+			wantVars: map[string]string{"id": "1"},
+		},
+		{
+			name: "vars encoded",
+			args: args{
+				r: func() *http.Request {
+					r := &http.Request{}
+					r = mux.SetURLVars(r, map[string]string{"id": url.QueryEscape("Asia/Shanghai")})
+					return r
+				}(),
+			},
+			beforeGetVars: nil,
+			wantVars:      map[string]string{"id": "Asia/Shanghai"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// reset infrahttpserverVars for each case
+			infrahttpserverVars = infrahttpserver.Vars
+			if tt.beforeGetVars != nil {
+				tt.beforeGetVars(tt.args.r)
+			}
+			assert.Equalf(t, tt.wantVars, getVars(tt.args.r), "getVars(%v)", tt.args.r)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

legacyhttpserver try to get muxVars from infrahttpserver. Because in somecases, legacyhttpserver only be used as router, not httpserver, so no vars handle logic executed.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=333366&iterationID=1354&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  legacyhttpserver try to get muxVars from infrahttpserver            |
| 🇨🇳 中文    |  legacyhttpserver 尝试从 infrahttpserver 中获取路径变量            |
