### PR TITLE
fix: compatible org_name is empty, compatible metric name contains `-`

### DIFF
--- a/internal/apps/msp/apm/alert/components/msp-alert-event-detail/event-history-table/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-event-detail/event-history-table/provider.go
@@ -139,7 +139,6 @@ func (p *provider) queryAlertEvents(sdk *cptype.SDK, ctx context.Context, params
 	statement := fmt.Sprintf("SELECT count(timestamp) FROM analyzer_alert " +
 		"WHERE family_id::tag=$eventId AND alert_suppressed::tag='false' ")
 	ctx = apis.GetContext(ctx, func(header *transport.Header) {
-		header.Set("terminus_key", params.ScopeId)
 	})
 	resp, err := p.Metric.QueryWithInfluxFormat(ctx, &metricpb.QueryWithInfluxFormatRequest{
 		Start:     "0",

--- a/internal/apps/msp/apm/alert/components/msp-alert-event-detail/event-overview-info/command.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-event-detail/event-overview-info/command.go
@@ -33,7 +33,6 @@ func (cp *ComponentEventOverviewInfo) countAlertEvents(ctx context.Context, even
 	}
 
 	ctx = apis.GetContext(ctx, func(header *transport.Header) {
-		header.Set("terminus_key", cp.sdk.InParams.String("scopeId"))
 	})
 
 	statement := fmt.Sprintf("SELECT count(timestamp) FROM analyzer_alert " +

--- a/internal/apps/msp/apm/alert/components/msp-alert-event-detail/monitor-data-chart/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-event-detail/monitor-data-chart/provider.go
@@ -152,7 +152,6 @@ func (p *provider) queryMetrics(sdk *cptype.SDK, inParams *common.InParams, aler
 	}
 
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 
 	resp, err := p.Metric.QueryWithInfluxFormat(ctx, request)

--- a/internal/apps/msp/apm/alert/components/msp-alert-event-list/table/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-event-list/table/provider.go
@@ -183,7 +183,6 @@ func (p *provider) queryAlertEvents(sdk *cptype.SDK, ctx context.Context, params
 	}
 
 	metricQueryCtx := apis.GetContext(ctx, func(header *transport.Header) {
-		header.Set("terminus_key", params.ScopeId)
 	})
 
 	for _, item := range events.Items {

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-duration-analysis/alert-duration-distribution/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-duration-analysis/alert-duration-distribution/provider.go
@@ -85,7 +85,6 @@ func (p *provider) getAlertDurationDistributionChart(sdk *cptype.SDK) (*bubblegr
 		Params:    params,
 	}
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 	response, err := p.Metric.QueryWithInfluxFormat(ctx, request)
 	if err != nil {

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-event-charts/groupby-level-count/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-event-charts/groupby-level-count/provider.go
@@ -87,7 +87,6 @@ func (p *provider) getAlertEventChart(sdk *cptype.SDK) (*complexgraph.Data, erro
 		Params:    params,
 	}
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 	response, err := p.Metric.QueryWithInfluxFormat(ctx, request)
 	if err != nil {

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-event-charts/groupby-type-count/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/alert-event-charts/groupby-type-count/provider.go
@@ -87,7 +87,6 @@ func (p *provider) getAlertEventChart(sdk *cptype.SDK) (*complexgraph.Data, erro
 		Params:    params,
 	}
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 	response, err := p.Metric.QueryWithInfluxFormat(ctx, request)
 	if err != nil {

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/cards/statistics.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/cards/statistics.go
@@ -48,7 +48,6 @@ func (p *provider) alertTriggerCount(sdk *cptype.SDK) (*kv.KV, error) {
 		"trigger":  structpb.NewStringValue("alert"),
 	}
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 
 	result, err := p.doQuerySql(ctx, inParams.StartTime, inParams.EndTime, statement, params)
@@ -77,7 +76,6 @@ func (p *provider) alertRecoverCount(sdk *cptype.SDK) (*kv.KV, error) {
 		"trigger":  structpb.NewStringValue("recover"),
 	}
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 	result, err := p.doQuerySql(ctx, inParams.StartTime, inParams.EndTime, statement, params)
 	if err != nil {
@@ -105,7 +103,6 @@ func (p *provider) alertReduceCount(sdk *cptype.SDK) (*kv.KV, error) {
 	}
 
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 
 	result, err := p.doQuerySql(ctx, inParams.StartTime, inParams.EndTime, statement, params)
@@ -134,7 +131,6 @@ func (p *provider) alertSilenceCount(sdk *cptype.SDK) (*kv.KV, error) {
 	}
 
 	ctx := apis.GetContext(sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 
 	result, err := p.doQuerySql(ctx, inParams.StartTime, inParams.EndTime, statement, params)

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/unrecover-alert-chart/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/unrecover-alert-chart/provider.go
@@ -97,7 +97,6 @@ func (s *SimpleChart) getUnRecoverAlertEventsChart() (*Chart, error) {
 	}
 
 	ctx := apis.GetContext(s.sdk.Ctx, func(header *transport.Header) {
-		header.Set("terminus_key", inParams.ScopeId)
 	})
 
 	response, err := s.Metric.QueryWithInfluxFormat(ctx, request)

--- a/internal/apps/msp/apm/checker/apis/checker.v1.service.go
+++ b/internal/apps/msp/apm/checker/apis/checker.v1.service.go
@@ -768,7 +768,6 @@ func (s *checkerV1Service) GetCheckerStatusV1(ctx context.Context, req *pb.GetCh
 		},
 	}
 	ctx = apis.GetContext(ctx, func(header *transport.Header) {
-		//header.Set("terminus_key", req.)
 	})
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/internal/tools/monitor/core/metric/storage/clickhouse/query.go
+++ b/internal/tools/monitor/core/metric/storage/clickhouse/query.go
@@ -58,7 +58,8 @@ func (p *provider) Query(ctx context.Context, q tsql.Query) (*model.ResultSet, e
 	}
 
 	if len(q.OrgName()) > 0 && isOrgCenterQuery == false {
-		expr = expr.Where(goqu.C("org_name").In(q.OrgName(), "erda"))
+		// compatible erda and empty, erda components sometimes use empty and erda org
+		expr = expr.Where(goqu.C("org_name").In(q.OrgName(), "erda", ""))
 	}
 	if len(q.TerminusKey()) > 0 {
 		expr = expr.Where(goqu.C("tenant_id").Eq(q.TerminusKey()))

--- a/internal/tools/monitor/oap/collector/lib/protoparser/spotmetric/spotmetric.go
+++ b/internal/tools/monitor/oap/collector/lib/protoparser/spotmetric/spotmetric.go
@@ -16,6 +16,7 @@ package spotmetric
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/erda-project/erda/internal/tools/monitor/core/metric"
@@ -55,6 +56,10 @@ func (uw *unmarshalWork) Unmarshal() {
 	}
 	if v, ok := data.Tags[lib.OrgNameKey]; ok {
 		data.OrgName = v
+	}
+
+	if strings.IndexAny(data.Name, "-") != -1 {
+		data.Name = strings.ReplaceAll(data.Name, "-", "_")
 	}
 
 	if err := uw.callback(data); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

compatible org_name is empty, compatible metric name contains `-`

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      compatible org_name is empty, compatible metric name contains `-`  |
| 🇨🇳 中文    |      兼容 org_name 为空, 以及指标名称包含中划线        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
