### PR TITLE
fix(orchestrator): release not found when redeploy

### DIFF
--- a/internal/tools/orchestrator/dbclient/dbmock.go
+++ b/internal/tools/orchestrator/dbclient/dbmock.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbclient
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
+)
+
+func InitMysqlMock() (*gorm.DB, sqlmock.Sqlmock, error) {
+	db, mock, err := sqlmock.New()
+	if nil != err {
+		return nil, nil, err
+	}
+	mdb, err := gorm.Open("mysql", db)
+	if err != nil {
+		return nil, nil, err
+	}
+	return mdb, mock, err
+}

--- a/internal/tools/orchestrator/dbclient/deployment.go
+++ b/internal/tools/orchestrator/dbclient/deployment.go
@@ -304,6 +304,22 @@ func (db *DBClient) FindLastDeployment(runtimeId uint64) (*Deployment, error) {
 	return &deployment, nil
 }
 
+// FindLastSuccessDeployment find last successful deployment
+func (db *DBClient) FindLastSuccessDeployment(runtimeId uint64) (*Deployment, error) {
+	var deployment Deployment
+	r := db.Where("runtime_id = ?", runtimeId).
+		Where("status = ?", apistructs.DeploymentStatusOK).
+		Order("id desc").Limit(1).
+		Find(&deployment)
+	if r.Error != nil {
+		if r.RecordNotFound() {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(r.Error, "failed to find last deployment, runtimeId: %v", runtimeId)
+	}
+	return &deployment, nil
+}
+
 func (db *DBClient) FindTopDeployments(runtimeId uint64, limit int) ([]Deployment, error) {
 	var deployments []Deployment
 	if err := db.

--- a/internal/tools/orchestrator/services/runtime/runtime.go
+++ b/internal/tools/orchestrator/services/runtime/runtime.go
@@ -561,13 +561,13 @@ func (r *Runtime) Redeploy(operator user.ID, orgID uint64, runtimeID uint64) (*a
 	if !perm.Access {
 		return nil, apierrors.ErrDeployRuntime.AccessDenied()
 	}
-	deployment, err := r.db.FindLastDeployment(runtimeID)
+	deployment, err := r.db.FindLastSuccessDeployment(runtimeID)
 	if err != nil {
 		return nil, apierrors.ErrDeployRuntime.InternalError(err)
 	}
 	if deployment == nil {
 		// it will happen, but it often implicit some errors
-		return nil, apierrors.ErrDeployRuntime.InvalidState("last deployment not found")
+		return nil, apierrors.ErrDeployRuntime.InvalidState("last success deployment not found")
 	}
 	if deployment.ReleaseId == "" {
 		return nil, apierrors.ErrDeployRuntime.InvalidState("抱歉，检测到不兼容的部署任务，请去重新构建")


### PR DESCRIPTION
#### What this PR does / why we need it:
release not found when redeploy

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | release not found when redeploy             |
| 🇨🇳 中文    |   重启时制品获取失败           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
