### PR TITLE
fix: get service_pods return different runtime's pods 

### DIFF
--- a/internal/tools/orchestrator/components/runtime/mock/mock_sg.go
+++ b/internal/tools/orchestrator/components/runtime/mock/mock_sg.go
@@ -108,18 +108,18 @@ func (mr *MockServiceGroupMockRecorder) Info(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // InspectRuntimeServicePods mocks base method.
-func (m *MockServiceGroup) InspectRuntimeServicePods(arg0, arg1, arg2 string) (*apistructs.ServiceGroup, error) {
+func (m *MockServiceGroup) InspectRuntimeServicePods(arg0, arg1, arg2, arg3 string) (*apistructs.ServiceGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InspectRuntimeServicePods", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InspectRuntimeServicePods", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*apistructs.ServiceGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InspectRuntimeServicePods indicates an expected call of InspectRuntimeServicePods.
-func (mr *MockServiceGroupMockRecorder) InspectRuntimeServicePods(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockServiceGroupMockRecorder) InspectRuntimeServicePods(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectRuntimeServicePods", reflect.TypeOf((*MockServiceGroup)(nil).InspectRuntimeServicePods), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectRuntimeServicePods", reflect.TypeOf((*MockServiceGroup)(nil).InspectRuntimeServicePods), arg0, arg1, arg2, arg3)
 }
 
 // InspectServiceGroupWithTimeout mocks base method.

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
@@ -475,3 +475,53 @@ func TestKubernetes_DeployInEdgeCluster(t *testing.T) {
 		})
 	}
 }
+
+func Test_runtimeIDMatch(t *testing.T) {
+	type args struct {
+		podRuntimeID string
+		labels       map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test_01",
+			args: args{
+				podRuntimeID: "1",
+				labels: map[string]string{
+					"DICE_RUNTIME": "1",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test_02",
+			args: args{
+				podRuntimeID: "1",
+				labels: map[string]string{
+					"DICE_RUNTIME_ID": "1",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test_03",
+			args: args{
+				podRuntimeID: "",
+				labels: map[string]string{
+					"DICE_RUNTIME_ID": "1",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimeIDMatch(tt.args.podRuntimeID, tt.args.labels); got != tt.want {
+				t.Errorf("runtimeIDMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/scheduler/impl/servicegroup/operations.go
+++ b/internal/tools/orchestrator/scheduler/impl/servicegroup/operations.go
@@ -379,7 +379,7 @@ func (s ServiceGroupImpl) InspectServiceGroupWithTimeout(namespace, name string)
 	}
 }
 
-func (s ServiceGroupImpl) InspectRuntimeServicePods(namespace, name, serviceName string) (*apistructs.ServiceGroup, error) {
+func (s ServiceGroupImpl) InspectRuntimeServicePods(namespace, name, serviceName, runtimeID string) (*apistructs.ServiceGroup, error) {
 	var (
 		sg  apistructs.ServiceGroup
 		err error
@@ -394,6 +394,7 @@ func (s ServiceGroupImpl) InspectRuntimeServicePods(namespace, name, serviceName
 	}
 
 	sg.Labels["GET_RUNTIME_STATELESS_SERVICE_POD"] = serviceName
+	sg.Labels["GET_RUNTIME_STATELESS_SERVICE_POD_RUNTIME_ID"] = runtimeID
 	result, err := s.handleServiceGroup(context.Background(), &sg, task.TaskInspect)
 	if err != nil {
 		return &sg, err

--- a/internal/tools/orchestrator/scheduler/impl/servicegroup/servicegroup.go
+++ b/internal/tools/orchestrator/scheduler/impl/servicegroup/servicegroup.go
@@ -61,7 +61,7 @@ type ServiceGroup interface {
 	KillPod(ctx context.Context, namespace string, name string, podname string) error
 	Scale(sg *apistructs.ServiceGroup) (interface{}, error)
 	InspectServiceGroupWithTimeout(namespace, name string) (*apistructs.ServiceGroup, error)
-	InspectRuntimeServicePods(namespace, name, serviceName string) (*apistructs.ServiceGroup, error)
+	InspectRuntimeServicePods(namespace, name, serviceName, runtimeID string) (*apistructs.ServiceGroup, error)
 }
 
 type ServiceGroupImpl struct {

--- a/internal/tools/orchestrator/services/runtime/runtime.go
+++ b/internal/tools/orchestrator/services/runtime/runtime.go
@@ -1880,7 +1880,7 @@ func (r *Runtime) GetRuntimeServiceCurrentPods(runtimeID uint64, serviceName str
 		return nil, errors.New("empty namespace or name or serviceName")
 	}
 
-	return r.serviceGroupImpl.InspectRuntimeServicePods(runtime.ScheduleName.Namespace, runtime.ScheduleName.Name, serviceName)
+	return r.serviceGroupImpl.InspectRuntimeServicePods(runtime.ScheduleName.Namespace, runtime.ScheduleName.Name, serviceName, fmt.Sprintf("%d", runtimeID))
 }
 
 // TODO: this work is weird


### PR DESCRIPTION

#### What this PR does / why we need it:

get service_pods return different runtime's pods in the same k8s namespace but with different runtimeID

#### Specified Reviewers:

/assign @sixther-dc @iutx 


#### ChangeLog

Bugfix： Fix the bug that get service_pods return different runtime's pods in the same k8s namespace but with different runtimeID（修复了 get service_pods 接口返回同一个namespace 下具有相同 serviceName 的不同 runtimeID 的 pods ）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that get service_pods return different runtime's pods in the same k8s namespace but with different runtimeID        |
| 🇨🇳 中文    |      修复了 get service_pods 接口返回同一个namespace 下具有相同 serviceName 的不同 runtimeID 的 pods         |


#### Need cherry-pick to release versions?


