### PR TITLE
fix(erda-server): delete sonar tickets no rows affected

### DIFF
--- a/apistructs/ticket.go
+++ b/apistructs/ticket.go
@@ -464,3 +464,11 @@ func (i *IRComment) Scan(value interface{}) error {
 	}
 	return nil
 }
+
+func (t TicketType) String() string {
+	return string(t)
+}
+
+func (t TicketTarget) String() string {
+	return string(t)
+}

--- a/apistructs/ticket_test.go
+++ b/apistructs/ticket_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apistructs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ticketTarget(t *testing.T) {
+	app := TicketApp
+	assert.Equal(t, "application", app.String())
+
+	cluster := TicketCluster
+	assert.Equal(t, "cluster", cluster.String())
+}
+
+func Test_ticketType(t *testing.T) {
+	codeSmell := TicketCodeSmell
+	assert.Equal(t, "codeSmell", codeSmell.String())
+
+	bug := TicketBug
+	assert.Equal(t, "bug", bug.String())
+}

--- a/internal/apps/dop/endpoints/sonar.go
+++ b/internal/apps/dop/endpoints/sonar.go
@@ -682,7 +682,7 @@ func (e *Endpoints) dealTickets(so *apistructs.SonarStoreRequest, issueType stri
 	// }
 
 	//logrus.Infof("close resolved ticket, issues: %+v", nl)
-	err = e.ticket.Delete(strconv.FormatInt(so.ApplicationID, 10), string(convert2TicketType(issueType)), "application")
+	err = e.ticket.Delete(strconv.FormatInt(so.ApplicationID, 10), apistructs.TicketApp, convert2TicketType(issueType))
 	e.createTicket(tmpIssue, so, issueType)
 
 	return err

--- a/internal/apps/dop/endpoints/ticket.go
+++ b/internal/apps/dop/endpoints/ticket.go
@@ -136,7 +136,7 @@ func (e *Endpoints) DeleteTicket(ctx context.Context, r *http.Request, vars map[
 	ticketType := r.URL.Query().Get("ticketType")
 	targetType := r.URL.Query().Get("targetType")
 
-	if err := e.ticket.Delete(ticketID, targetType, ticketType); err != nil {
+	if err := e.ticket.Delete(ticketID, apistructs.TicketTarget(targetType), convert2TicketType(ticketType)); err != nil {
 		return apierrors.ErrDeleteTicket.InternalError(err).ToResp(), nil
 	}
 

--- a/internal/apps/dop/services/ticket/ticket.go
+++ b/internal/apps/dop/services/ticket/ticket.go
@@ -621,6 +621,6 @@ func (t *Ticket) getDingTalkURL(req *apistructs.TicketCreateRequest) (string, er
 }
 
 // Delete 删除工单
-func (t *Ticket) Delete(targetID, targetType, ticketType string) error {
-	return t.db.DeleteTicket(targetID, targetType, ticketType)
+func (t *Ticket) Delete(targetID string, targetType apistructs.TicketTarget, ticketType apistructs.TicketType) error {
+	return t.db.DeleteTicket(targetID, targetType.String(), ticketType.String())
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
fix delete sonar tickets no rows affected

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=313601&iterationID=-1&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that delete sonar tickets no rows affected（修复了sonar问题列表没有删除）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that delete sonar tickets no rows affected             |
| 🇨🇳 中文    |     修复了sonar问题列表没有删除         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
