### PR TITLE
fix(orchestrator): order render application repeated

### DIFF
--- a/internal/tools/orchestrator/services/deployment_order/deployment_order_create_test.go
+++ b/internal/tools/orchestrator/services/deployment_order/deployment_order_create_test.go
@@ -489,3 +489,68 @@ func TestRenderDeployList(t *testing.T) {
 		}
 	}
 }
+
+func Test_renderDeployListWithCrossProject(t *testing.T) {
+	order := New()
+
+	type args struct {
+		selectedModes []string
+		releaseResp   *pb.ReleaseGetResponseData
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    [][]*pb.ApplicationReleaseSummary
+		wantErr bool
+	}{
+		{
+			name: "application repeated",
+			args: args{
+				selectedModes: []string{"A", "A2"},
+				releaseResp: &pb.ReleaseGetResponseData{
+					Modes: map[string]*pb.ModeSummary{
+						"A": {
+							DependOn: []string{},
+							ApplicationReleaseList: []*pb.ReleaseSummaryArray{
+								{List: []*pb.ApplicationReleaseSummary{
+									{ApplicationName: "A11", ReleaseID: "A11"},
+									{ApplicationName: "A12", ReleaseID: "A12"},
+								}},
+								{List: []*pb.ApplicationReleaseSummary{
+									{ApplicationName: "A21", ReleaseID: "A21"},
+									{ApplicationName: "A22", ReleaseID: "A22"},
+								}},
+							},
+						},
+						"A2": {
+							DependOn: []string{},
+							ApplicationReleaseList: []*pb.ReleaseSummaryArray{
+								{List: []*pb.ApplicationReleaseSummary{
+									{ApplicationName: "A11", ReleaseID: "A11"},
+								}},
+								{List: []*pb.ApplicationReleaseSummary{
+									{ApplicationName: "A21", ReleaseID: "A21"},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := order.renderDeployListWithCrossProject(tt.args.selectedModes, 1, "1", tt.args.releaseResp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("renderDeployListWithCrossProject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("renderDeployListWithCrossProject() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix deployment order render application repeated.

For example:
- Mode `Go` contains: `go-demo`，`go-admin-demo`
- Mode `QuickStart` contains: `go-demo`

Will cause repeated error: application `go-demo` repeated

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/31346321/185874551-b8f73c2c-f3c5-4892-8ea5-9edfc8b0b73f.png">

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  deployment order render application repeated            |
| 🇨🇳 中文    |   应用重复导致部署单渲染失败           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
