### PR TITLE
fix(dop): update edge gittar repo proto to avoid 302

### DIFF
--- a/internal/apps/dop/utils/gittar.go
+++ b/internal/apps/dop/utils/gittar.go
@@ -22,18 +22,18 @@ import (
 )
 
 func GetGittarRepoURL(clusterName, repoAbbr string) string {
-	return getCenterOrEdgeURL(conf.DiceClusterName(), clusterName, httpclientutil.WrapHttp(discover.Gittar()), httpclientutil.WrapHttp(conf.GittarPublicURL())) + "/" + repoAbbr
+	return getCenterOrEdgeURL(conf.DiceClusterName(), clusterName, httpclientutil.WrapHttp(discover.Gittar()), httpclientutil.WrapProto(conf.GittarPublicURL())) + "/" + repoAbbr
 }
 
-func getCenterOrEdgeURL(diceCluster, requestCluster, center, sass string) string {
-	if sass == "" {
+func getCenterOrEdgeURL(diceCluster, requestCluster, center, saas string) string {
+	if saas == "" {
 		return center
 	}
 	// 如果和 daemon 在一个集群，则用内网地址
 	if diceCluster == requestCluster {
 		return center
 	}
-	return sass
+	return saas
 }
 
 func GetGittarSecrets(clusterName, branch string, detail apistructs.CommitDetail) map[string]string {

--- a/internal/apps/dop/utils/gittar_test.go
+++ b/internal/apps/dop/utils/gittar_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func Test_getCenterOrEdgeURL(t *testing.T) {
+	type args struct {
+		diceCluster    string
+		requestCluster string
+		center         string
+		saas           string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test with saas",
+			args: args{
+				diceCluster:    "erda",
+				requestCluster: "erda1",
+				center:         "http://gittar.default.svc.cluster.local",
+				saas:           "https://gittar.erda.cloud",
+			},
+			want: "https://gittar.erda.cloud",
+		},
+		{
+			name: "test with center1",
+			args: args{
+				diceCluster:    "erda",
+				requestCluster: "erda",
+				center:         "http://gittar.default.svc.cluster.local",
+				saas:           "",
+			},
+			want: "http://gittar.default.svc.cluster.local",
+		},
+		{
+			name: "test with cente2",
+			args: args{
+				diceCluster:    "erda",
+				requestCluster: "erda",
+				center:         "http://gittar.default.svc.cluster.local",
+				saas:           "https://gittar.erda.cloud",
+			},
+			want: "http://gittar.default.svc.cluster.local",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getCenterOrEdgeURL(tt.args.diceCluster, tt.args.requestCluster, tt.args.center, tt.args.saas); got != tt.want {
+				t.Errorf("getCenterOrEdgeURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix(dop): update edge gittar repo url to avoid 302

The curl change seems to be from 620ea2141 (transfer: redirects to other
protocols or ports clear auth, 2022-04-25). The goal is to avoid leaking
credentials between ports: https://curl.se/docs/CVE-2022-27774.html

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    update edge gittar repo proto to avoid 302          |
| 🇨🇳 中文    |     修改边缘集群gittar地址的协议，避免302         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
