### PR TITLE
chore: pkg time/ticker support execAtBegin configurable

### DIFF
--- a/internal/apps/cmp/initialize.go
+++ b/internal/apps/cmp/initialize.go
@@ -167,7 +167,7 @@ func (p *provider) do(ctx context.Context) (*httpserver.Server, error) {
 		tasks.DailyQuotaCollectorWithBundle(bdl),
 		tasks.DailyQuotaCollectorWithCMPAPI(p),
 	)
-	tic := ticker.New(time.Hour, dailyCollector.Task)
+	tic := ticker.New(time.Hour, dailyCollector.Task, ticker.WithExecAtBegin(false))
 	go tic.Run()
 
 	if conf.EnableEss() {

--- a/pkg/time/ticker/ticker.go
+++ b/pkg/time/ticker/ticker.go
@@ -35,14 +35,14 @@ type Ticker struct {
 	Task     func() (stop bool, err error)
 	done     chan bool
 
-	execAtBegin bool
+	ExecAtBegin bool
 }
 
 type Option func(d *Ticker)
 
 func WithExecAtBegin(exec bool) Option {
 	return func(d *Ticker) {
-		d.execAtBegin = exec
+		d.ExecAtBegin = exec
 	}
 }
 
@@ -51,7 +51,7 @@ func New(interval time.Duration, task Task, opts ...Option) *Ticker {
 		Interval:    interval,
 		Task:        task,
 		done:        make(chan bool),
-		execAtBegin: true,
+		ExecAtBegin: true,
 	}
 	for _, opt := range opts {
 		opt(d)
@@ -67,7 +67,7 @@ func (d *Ticker) Run() error {
 		err      error
 		finished bool
 	)
-	if d.execAtBegin {
+	if d.ExecAtBegin {
 		fmt.Printf("the interval task %s is running right now: %s\n", d.Name, time.Now().Format(time.RFC3339))
 		finished, err = d.Task()
 		fmt.Printf("the interval task %s is complete this time, err: %v\n", d.Name, err)

--- a/pkg/time/ticker/ticker_test.go
+++ b/pkg/time/ticker/ticker_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda/pkg/time/ticker"
 )
@@ -43,4 +44,15 @@ func TestTicker_Close(t *testing.T) {
 		return false, nil
 	})
 	ti.Run()
+}
+
+func TestTicker_New(t *testing.T) {
+	task := func() (finished bool, err error) {
+		return true, nil
+	}
+	d := ticker.New(time.Millisecond*200, task)
+	assert.True(t, d.ExecAtBegin, "default behaviour")
+
+	d = ticker.New(time.Millisecond*200, task, ticker.WithExecAtBegin(false))
+	assert.False(t, d.ExecAtBegin)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

pkg time/ticker support execAtBegin configurable


#### Specified Reviewers:

/assign @dspo 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  pkg time/ticker support execAtBegin configurable            |
| 🇨🇳 中文    |   包 pkg/ticker 支持 "开始时立即执行" 可配置           |
