### PR TITLE
fix(dicehub): import release repeat in mode

### DIFF
--- a/internal/apps/dop/dicehub/release/release.go
+++ b/internal/apps/dop/dicehub/release/release.go
@@ -1025,6 +1025,9 @@ func (s *ReleaseService) parseReleaseFile(req *pb.ReleaseUploadRequest, file io.
 					UpdatedAt:        now,
 					IsLatest:         true,
 				})
+
+				// cache application name union version to release id
+				cacheAppVersion2ID[fmt.Sprintf("%s_%s", appName, version)] = id
 			}
 		}
 		modes[name] = apistructs.ReleaseDeployMode{


### PR DESCRIPTION
#### What this PR does / why we need it:
import release repeat in mode

before fix:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/31346321/187331763-76d47fc7-603d-4b3a-92b4-13a730db8f1e.png">


after fix:
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/31346321/187331390-98a3b8c2-fb1f-4d7b-b125-49fc4df317f4.png">


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=336727&iterationID=1403&type=BUG)


#### Specified Reviewers:

/assign @sixther-dc @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   import release repeat in mode           |
| 🇨🇳 中文    |   导入模式制品会存在重复           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
