### PR TITLE
fix(cmp): cmp steve route use ** as wildcard

### DIFF
--- a/internal/apps/cmp/initialize.go
+++ b/internal/apps/cmp/initialize.go
@@ -190,8 +190,8 @@ func (p *provider) do(ctx context.Context) (*httpserver.Server, error) {
 		auditor.AuditMiddleWare,
 	}
 
-	server.Router().Path("/api/k8s/clusters/{clusterName}/*").Handler(middlewares.Handler(ep.SteveAggregator))
-	server.Router().Path("/api/apim/metrics/*").Handler(endpoints.InternalReverseHandler(endpoints.ProxyMetrics))
+	server.Router().Path("/api/k8s/clusters/{clusterName}/**").Handler(middlewares.Handler(ep.SteveAggregator))
+	server.Router().Path("/api/apim/metrics/**").Handler(endpoints.InternalReverseHandler(endpoints.ProxyMetrics))
 
 	logrus.Info("starting cmp instance")
 


### PR DESCRIPTION
#### What this PR does / why we need it:

cmp steve route use ** as wildcard

<img width="792" alt="image" src="https://user-images.githubusercontent.com/13919034/188352976-8adbe922-bc54-472d-929d-cdc66d3140ec.png">


#### Specified Reviewers:

/assign @CraigMChen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   cmp steve route use ** as wildcard           |
| 🇨🇳 中文    |   cmp steve 路由使用 ** 作为通配符           |
