### PR TITLE
fix: openapi miss pipeline-yml-graph route

### DIFF
--- a/api/proto/core/pipeline/graph/graph.proto
+++ b/api/proto/core/pipeline/graph/graph.proto
@@ -22,6 +22,9 @@ service GraphService {
     option (google.api.http) = {
       post: "/api/pipelines/actions/pipeline-yml-graph",
     };
+    option (erda.common.openapi) = {
+      path: "/api/pipelines/actions/pipeline-yml-graph",
+    };
   }
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
openapi miss pipeline-yml-graph route


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that openapi miss pipeline-yml-graph route （修复了openapi丢失graph路由的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that openapi miss pipeline-yml-graph route           |
| 🇨🇳 中文    |   修复了openapi丢失graph路由的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
