### PR TITLE
fix: issue export set empty value for custom property column if value not set

### DIFF
--- a/internal/apps/dop/providers/issue/core/query/convert.go
+++ b/internal/apps/dop/providers/issue/core/query/convert.go
@@ -384,11 +384,13 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 		relations := propertyMap[i.Id]
 		// 获取每个自定义字段的值
 		for _, pro := range property {
+			haveValue := false
 			// 根据字段类型将数据放入表格
 			if common.IsOptions(pro.PropertyType.String()) == false {
 				for _, rel := range relations {
 					if rel.PropertyID == pro.PropertyID {
 						r[index+1] = append(r[index+1], rel.ArbitraryValue)
+						haveValue = true
 						break
 					}
 				}
@@ -396,6 +398,7 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 				for _, rel := range relations {
 					if rel.PropertyID == pro.PropertyID {
 						r[index+1] = append(r[index+1], mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
+						haveValue = true
 						break
 					}
 				}
@@ -407,7 +410,12 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 						str = append(str, mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
 					}
 				}
+				haveValue = true
 				r[index+1] = append(r[index+1], strutil.Join(str, ","))
+			}
+			if !haveValue {
+				// add empty value for this column
+				r[index+1] = append(r[index+1], "")
 			}
 		}
 	}

--- a/internal/apps/dop/providers/issue/core/query/convert.go
+++ b/internal/apps/dop/providers/issue/core/query/convert.go
@@ -410,8 +410,8 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 						str = append(str, mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
 					}
 				}
-				haveValue = true
 				r[index+1] = append(r[index+1], strutil.Join(str, ","))
+				haveValue = true
 			}
 			if !haveValue {
 				// add empty value for this column

--- a/internal/apps/dop/providers/issue/core/query/convert.go
+++ b/internal/apps/dop/providers/issue/core/query/convert.go
@@ -253,6 +253,11 @@ func (p *provider) getIssueExportDataI18n(locale, i18nKey string) []string {
 	return strutil.Split(t, ",")
 }
 
+type pair struct {
+	PropertyID int64
+	valueID    int64
+}
+
 func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.IssuePropertyIndex, projectID uint64, isDownload bool, stageMap map[IssueStage]string, locale string) ([][]string, error) {
 	// 默认字段列名
 	r := [][]string{p.getIssueExportDataI18n(locale, i18n.I18nKeyIssueExportTitles)}
@@ -263,10 +268,6 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 	// 下载模版
 	if isDownload {
 		return r, nil
-	}
-	type pair struct {
-		PropertyID int64
-		valueID    int64
 	}
 	// 构建自定义字段枚举值map
 	mp := make(map[pair]string)
@@ -382,42 +383,45 @@ func (p *provider) convertIssueToExcelList(issues []*pb.Issue, property []*pb.Is
 			fmt.Sprintf("%d", i.ReopenCount),
 		}))
 		relations := propertyMap[i.Id]
-		// 获取每个自定义字段的值
+		// get value of each custom field
 		for _, pro := range property {
-			haveValue := false
-			// 根据字段类型将数据放入表格
-			if common.IsOptions(pro.PropertyType.String()) == false {
-				for _, rel := range relations {
-					if rel.PropertyID == pro.PropertyID {
-						r[index+1] = append(r[index+1], rel.ArbitraryValue)
-						haveValue = true
-						break
-					}
-				}
-			} else if pro.PropertyType == pb.PropertyTypeEnum_Select {
-				for _, rel := range relations {
-					if rel.PropertyID == pro.PropertyID {
-						r[index+1] = append(r[index+1], mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
-						haveValue = true
-						break
-					}
-				}
-			} else if pro.PropertyType == pb.PropertyTypeEnum_MultiSelect || pro.PropertyType == pb.PropertyTypeEnum_CheckBox {
-				// 多选类型的全部已选项的名字拼接成一个字符串放入表格
-				var str []string
-				for _, rel := range relations {
-					if rel.PropertyID == pro.PropertyID {
-						str = append(str, mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
-					}
-				}
-				r[index+1] = append(r[index+1], strutil.Join(str, ","))
-				haveValue = true
-			}
-			if !haveValue {
-				// add empty value for this column
-				r[index+1] = append(r[index+1], "")
-			}
+			columnValue := getCustomPropertyColumnValue(pro, relations, mp)
+			r[index+1] = append(r[index+1], columnValue)
 		}
 	}
 	return r, nil
+}
+
+func getCustomPropertyColumnValue(pro *pb.IssuePropertyIndex, relations []dao.IssuePropertyRelation, mp map[pair]string) string {
+	if pro == nil || len(relations) == 0 {
+		return ""
+	}
+	if mp == nil {
+		mp = make(map[pair]string)
+	}
+	// according to the field type, put the data into the table
+	if common.IsOptions(pro.PropertyType.String()) == false {
+		for _, rel := range relations {
+			if rel.PropertyID == pro.PropertyID {
+				return rel.ArbitraryValue
+			}
+		}
+	} else if pro.PropertyType == pb.PropertyTypeEnum_Select {
+		for _, rel := range relations {
+			if rel.PropertyID == pro.PropertyID {
+				return mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}]
+			}
+		}
+	} else if pro.PropertyType == pb.PropertyTypeEnum_MultiSelect || pro.PropertyType == pb.PropertyTypeEnum_CheckBox {
+		// for multiple selection type, all selected options are concatenated into a string and put into the table
+		var str []string
+		for _, rel := range relations {
+			if rel.PropertyID == pro.PropertyID {
+				str = append(str, mp[pair{PropertyID: pro.PropertyID, valueID: rel.PropertyValueID}])
+			}
+		}
+		return strutil.Join(str, ",")
+	}
+	// add empty value for this column
+	return ""
 }

--- a/internal/apps/dop/providers/issue/core/query/convert_test.go
+++ b/internal/apps/dop/providers/issue/core/query/convert_test.go
@@ -221,3 +221,16 @@ func Test_provider_BatchConvert(t *testing.T) {
 	_, err := p.BatchConvert([]dao.Issue{{ProjectID: 1}}, []string{"TASK", "BUG"})
 	assert.NoError(t, err)
 }
+
+func Test_rangePropertyMap(t *testing.T) {
+	propertyMap := make(map[int64][]dao.IssuePropertyRelation)
+	properties := []dao.IssuePropertyRelation{{PropertyID: 1, IssueID: 1}, {PropertyID: 2, IssueID: 2}}
+	for _, v := range properties {
+		propertyMap[v.IssueID] = append(propertyMap[v.IssueID], v)
+	}
+	assert.Equal(t, 2, len(propertyMap))
+	assert.Equal(t, int64(1), propertyMap[1][0].IssueID)
+	assert.Equal(t, int64(1), propertyMap[1][0].PropertyID)
+	assert.Equal(t, int64(2), propertyMap[2][0].IssueID)
+	assert.Equal(t, int64(2), propertyMap[2][0].PropertyID)
+}

--- a/internal/apps/dop/providers/issue/core/query/convert_test.go
+++ b/internal/apps/dop/providers/issue/core/query/convert_test.go
@@ -234,3 +234,170 @@ func Test_rangePropertyMap(t *testing.T) {
 	assert.Equal(t, int64(2), propertyMap[2][0].IssueID)
 	assert.Equal(t, int64(2), propertyMap[2][0].PropertyID)
 }
+
+func Test_getCustomPropertyColumnValue(t *testing.T) {
+	type args struct {
+		pro       *pb.IssuePropertyIndex
+		relations []dao.IssuePropertyRelation
+		mp        map[pair]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no property, no panic",
+			args: args{pro: nil},
+			want: "",
+		},
+		{
+			name: "no relation, no panic",
+			args: args{pro: &pb.IssuePropertyIndex{}},
+			want: "",
+		},
+		{
+			name: "no mp, no panic",
+			args: args{
+				pro:       &pb.IssuePropertyIndex{PropertyID: 1},
+				relations: []dao.IssuePropertyRelation{{PropertyID: 1}},
+				mp:        nil,
+			},
+			want: "",
+		},
+		{
+			name: "arbitrary value",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_Text,
+				},
+				relations: []dao.IssuePropertyRelation{{PropertyID: 1, ArbitraryValue: "text"}},
+				mp:        nil,
+			},
+			want: "text",
+		},
+		{
+			name: "arbitrary value, but not match",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_Text,
+				},
+				relations: []dao.IssuePropertyRelation{{PropertyID: 2, ArbitraryValue: "text"}},
+				mp:        nil,
+			},
+			want: "",
+		},
+		{
+			name: "select",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_Select,
+				},
+				relations: []dao.IssuePropertyRelation{{PropertyID: 1, PropertyValueID: 1}},
+				mp: map[pair]string{
+					pair{
+						PropertyID: 1,
+						valueID:    1,
+					}: "select value",
+				},
+			},
+			want: "select value",
+		},
+		{
+			name: "select, but not match",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_Select,
+				},
+				relations: []dao.IssuePropertyRelation{{PropertyID: 1, PropertyValueID: 1}},
+				mp: map[pair]string{
+					pair{PropertyID: 1, valueID: 2}: "select value",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "multi select",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_MultiSelect,
+				},
+				relations: []dao.IssuePropertyRelation{
+					{PropertyID: 1, PropertyValueID: 1},
+					{PropertyID: 1, PropertyValueID: 2},
+				},
+				mp: map[pair]string{
+					pair{PropertyID: 1, valueID: 1}: "m11",
+					pair{PropertyID: 1, valueID: 2}: "m12",
+				},
+			},
+			want: "m11,m12",
+		},
+		{
+			name: "multi select, but no match",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_MultiSelect,
+				},
+				relations: []dao.IssuePropertyRelation{
+					{PropertyID: 2, PropertyValueID: 1},
+					{PropertyID: 2, PropertyValueID: 2},
+				},
+				mp: map[pair]string{
+					pair{PropertyID: 1, valueID: 1}: "m11",
+					pair{PropertyID: 1, valueID: 2}: "m12",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "check box",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_CheckBox,
+				},
+				relations: []dao.IssuePropertyRelation{
+					{PropertyID: 1, PropertyValueID: 1},
+					{PropertyID: 1, PropertyValueID: 2},
+				},
+				mp: map[pair]string{
+					pair{PropertyID: 1, valueID: 1}: "m11",
+					pair{PropertyID: 1, valueID: 2}: "m12",
+				},
+			},
+			want: "m11,m12",
+		},
+		{
+			name: "check box, but no match",
+			args: args{
+				pro: &pb.IssuePropertyIndex{
+					PropertyID:   1,
+					PropertyType: pb.PropertyTypeEnum_CheckBox,
+				},
+				relations: []dao.IssuePropertyRelation{
+					{PropertyID: 2, PropertyValueID: 1},
+					{PropertyID: 2, PropertyValueID: 2},
+				},
+				mp: map[pair]string{
+					pair{PropertyID: 1, valueID: 1}: "m11",
+					pair{PropertyID: 1, valueID: 2}: "m12",
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getCustomPropertyColumnValue(tt.args.pro, tt.args.relations, tt.args.mp); got != tt.want {
+				t.Errorf("getCustomPropertyColumnValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

issue export set empty value for custom property column if value not set. 
otherwise, row columns will mismatch with title.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=338304&iterationID=1389&type=BUG)


#### Specified Reviewers:

/assign @chengjoey @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   issue export set empty value for custom property column if value not set           |
| 🇨🇳 中文    |  事项导出时，如果自定义字段未设置值，则置空值，否则列会匹配不上            |
