### PR TITLE
fix: modify enable env of clickhouse.table.initializer@log

### DIFF
--- a/cmd/monitor/streaming/bootstrap.yaml
+++ b/cmd/monitor/streaming/bootstrap.yaml
@@ -79,7 +79,7 @@ storage-retention-strategy@span:
   default_ttl: "${SPAN_TTL:168h}"
 
 clickhouse.table.initializer@log:
-  _enable: ${CLICKHOUSE_ENABLE:true}
+  _enable: ${WRITE_LOG_TO_CLICKHOUSE_ENABLE:true}
   table_prefix: "logs"
   ttl_sync_interval: "${CLICKHOUSE_TABLE_TTL_SYNC_INTERVAL:24h}"
   default_ddl_files:


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: modify enable env of clickhouse.table.initializer@log

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: modify enable env of clickhouse.table.initializer@log |
| 🇨🇳 中文    | 修改启用 clickhouse.table.initializer@log 的环境变量 |
