### PR TITLE
fix(cmp): cmp use org.Interface because it bootstrapped on erda-server

### DIFF
--- a/internal/apps/cmp/endpoints/endpoints.go
+++ b/internal/apps/cmp/endpoints/endpoints.go
@@ -61,7 +61,7 @@ type Endpoints struct {
 
 	reportTable *resource.ReportTable
 	CronService cronpb.CronServiceServer
-	org         org.ClientInterface
+	org         org.Interface
 }
 
 type Option func(*Endpoints)
@@ -130,7 +130,7 @@ func WithClusterServiceServer(clusterSvc clusterpb.ClusterServiceServer) Option 
 	}
 }
 
-func WithOrg(org org.ClientInterface) Option {
+func WithOrg(org org.Interface) Option {
 	return func(e *Endpoints) {
 		e.org = org
 	}

--- a/internal/apps/cmp/impl/clusters/upgrade_edge_cluster.go
+++ b/internal/apps/cmp/impl/clusters/upgrade_edge_cluster.go
@@ -47,10 +47,10 @@ type Clusters struct {
 	bdl        *bundle.Bundle
 	credential tokenpb.TokenServiceServer
 	clusterSvc clusterpb.ClusterServiceServer
-	org        org.ClientInterface
+	org        org.Interface
 }
 
-func New(db *dbclient.DBClient, bdl *bundle.Bundle, c tokenpb.TokenServiceServer, clusterSvc clusterpb.ClusterServiceServer, org org.ClientInterface) *Clusters {
+func New(db *dbclient.DBClient, bdl *bundle.Bundle, c tokenpb.TokenServiceServer, clusterSvc clusterpb.ClusterServiceServer, org org.Interface) *Clusters {
 	return &Clusters{db: db, bdl: bdl, credential: c, clusterSvc: clusterSvc, org: org}
 }
 

--- a/internal/apps/cmp/impl/mns/mns.go
+++ b/internal/apps/cmp/impl/mns/mns.go
@@ -68,7 +68,7 @@ type Mns struct {
 	js         jsonstore.JsonStore
 	Config     *Config
 	ClusterSvc clusterpb.ClusterServiceServer
-	org        org.ClientInterface
+	org        org.Interface
 }
 
 type Config struct {
@@ -84,7 +84,7 @@ type Config struct {
 	BathSize        int32
 }
 
-func New(db *dbclient.DBClient, bdl *bundle.Bundle, n *nodes.Nodes, js jsonstore.JsonStore, clusterSvc clusterpb.ClusterServiceServer, org org.ClientInterface) *Mns {
+func New(db *dbclient.DBClient, bdl *bundle.Bundle, n *nodes.Nodes, js jsonstore.JsonStore, clusterSvc clusterpb.ClusterServiceServer, org org.Interface) *Mns {
 	return &Mns{db: db, bdl: bdl, nodes: n, js: js, ClusterSvc: clusterSvc, org: org}
 }
 

--- a/internal/apps/cmp/provider.go
+++ b/internal/apps/cmp/provider.go
@@ -64,7 +64,7 @@ type provider struct {
 	CPTran          i18n.I18n       `autowired:"i18n"`
 	Tran            i18n.Translator `translator:"common"`
 	SteveAggregator *steve.Aggregator
-	Org             org.ClientInterface
+	Org             org.Interface
 }
 
 // Run Run the provider


### PR DESCRIPTION
#### What this PR does / why we need it:

cmp use org.Interface to replace org.ClientInterface because it bootstrapped on erda-server


#### Specified Reviewers:

/assign @CraigMChen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  cmp use org.Interface to replace org.ClientInterface because it bootstrapped on erda-server            |
| 🇨🇳 中文    |   由于 cmp 已经由 erda-server 启动，cmp 使用 org.Interface 来替换 org.ClientInterface      |
