### PR TITLE
fix(openapi): enable openapiv1 hooks

### DIFF
--- a/internal/core/openapi/openapi-ng/routes/openapi-v1/provider.go
+++ b/internal/core/openapi/openapi-ng/routes/openapi-v1/provider.go
@@ -54,7 +54,7 @@ type provider struct {
 func (p *provider) Init(ctx servicehub.Context) (err error) {
 	p.proxy.Log = p.Log
 	p.proxy.Discover = p.Discover
-	hooks.Enable = false
+	hooks.Enable = true
 	conf.Load()
 	srv, err := openapiv1.NewServer(p.TokenService)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

openapiv1 enable hooks to filter invalid headers like org-id and user-id.


#### Issues

- [Related Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=340579&iterationID=-1&type=TASK)


#### Specified Reviewers:

/assign @chengjoey @dspo 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   openapiv1 enable hooks to filter invalid headers like org-id and user-id          |
| 🇨🇳 中文    |   openapiv1 启用 hooks 来过滤非法请求头，比如 org-id 和 user-id           |
