### PR TITLE
fix: scenes file record download url

### DIFF
--- a/internal/apps/dop/component-protocol/components/scenes-import-record/table/render.go
+++ b/internal/apps/dop/component-protocol/components/scenes-import-record/table/render.go
@@ -29,7 +29,6 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/apps/dop/component-protocol/types"
-	"github.com/erda-project/erda/internal/core/legacy/conf"
 )
 
 type ComponentAction struct {
@@ -181,7 +180,7 @@ func (ca *ComponentAction) setData() error {
 			},
 			Result: Result{
 				RenderType: "downloadUrl",
-				URL:        fmt.Sprintf("%s/api/files/%s", conf.RootDomain(), fileRecord.ApiFileUUID),
+				URL:        fmt.Sprintf("/api/files/%s", fileRecord.ApiFileUUID),
 			},
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix scenes file record download url

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda-org.erda.cloud/erda/dop/projects/387/issues/gantt?id=340373&iterationID=1403&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix：fix scenes file record download url（修复了自动化测试记录文件下载链接错误的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix scenes file record download url          |
| 🇨🇳 中文    |       修复了自动化测试记录文件下载链接错误的问题       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
