### PR TITLE
fix: cluster-agent collect token after k8s version 1.24

### DIFF
--- a/cmd/cluster-agent/bootstrap.yaml
+++ b/cmd/cluster-agent/bootstrap.yaml
@@ -14,3 +14,4 @@ cluster-agent:
   erdaNamespace: "${DICE_NAMESPACE}"
   clusterAccessKey: "${CLUSTER_ACCESS_KEY}"
   k8sApiServerAddr: "${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+  tokenExpirationSeconds: "${TOKEN_EXPIRATION_SECONDS}"

--- a/internal/tools/cluster-agent/config/config.go
+++ b/internal/tools/cluster-agent/config/config.go
@@ -31,4 +31,5 @@ type Config struct {
 	ErdaNamespace          string `desc:"erda namespace"`
 	ClusterAccessKey       string `desc:"cluster access key, if specified will doesn't start watcher"`
 	K8SApiServerAddr       string `desc:"kube-apiserver address in cluster"`
+	TokenExpirationSeconds string `desc:"token expiration seconds"`
 }

--- a/internal/tools/cluster-agent/pkg/client/client.go
+++ b/internal/tools/cluster-agent/pkg/client/client.go
@@ -32,7 +32,6 @@ import (
 	"github.com/rancher/remotedialer"
 	"github.com/sirupsen/logrus"
 	authenticationv1 "k8s.io/api/authentication/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -211,7 +210,6 @@ func (c *Client) getClusterInfo() (map[string]interface{}, error) {
 			return nil, err
 		}
 
-		saSecret := &corev1.Secret{}
 		if len(sa.Secrets) == 0 {
 			expirationSeconds := int64(999999 * time.Hour / time.Second)
 
@@ -241,7 +239,7 @@ func (c *Client) getClusterInfo() (map[string]interface{}, error) {
 				return nil, errors.Wrapf(err, "reading %s", rootCAFile)
 			}
 		} else {
-			saSecret, err = k.ClientSet.CoreV1().Secrets(c.cfg.ErdaNamespace).Get(context.Background(),
+			saSecret, err := k.ClientSet.CoreV1().Secrets(c.cfg.ErdaNamespace).Get(context.Background(),
 				sa.Secrets[0].Name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err

--- a/internal/tools/cluster-agent/pkg/client/client.go
+++ b/internal/tools/cluster-agent/pkg/client/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -30,7 +31,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rancher/remotedialer"
 	"github.com/sirupsen/logrus"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/cluster-agent/config"
@@ -207,24 +211,51 @@ func (c *Client) getClusterInfo() (map[string]interface{}, error) {
 			return nil, err
 		}
 
+		saSecret := &corev1.Secret{}
 		if len(sa.Secrets) == 0 {
-			return nil, errors.Errorf("service account %s has non auth secret", c.cfg.ServiceAccountName)
-		}
+			expirationSeconds := int64(999999 * time.Hour / time.Second)
 
-		saSecret, err := k.ClientSet.CoreV1().Secrets(c.cfg.ErdaNamespace).Get(context.Background(),
-			sa.Secrets[0].Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
+			if c.cfg.TokenExpirationSeconds != "" {
+				expirationSeconds, err = strconv.ParseInt(c.cfg.TokenExpirationSeconds, 10, 64)
+				if err != nil {
+					return nil, errors.Wrapf(err, "illegal expiration seconds %s",
+						c.cfg.TokenExpirationSeconds)
+				}
+			}
 
-		caData = saSecret.Data[caCrtKey]
-		token = saSecret.Data[tokenSecKey]
+			resp, err := k.ClientSet.CoreV1().ServiceAccounts(c.cfg.ErdaNamespace).CreateToken(context.Background(),
+				c.cfg.ServiceAccountName, &authenticationv1.TokenRequest{
+					Spec: authenticationv1.TokenRequestSpec{
+						ExpirationSeconds: pointer.Int64(expirationSeconds),
+					},
+				}, metav1.CreateOptions{})
+			if err != nil {
+				return nil, err
+			}
+
+			logrus.Debugf("create token for serviceaccount %s, token: %s", c.cfg.ServiceAccountName, resp.Status.Token)
+
+			token = []byte(resp.Status.Token)
+			caData, err = ioutil.ReadFile(rootCAFile)
+			if err != nil {
+				return nil, errors.Wrapf(err, "reading %s", rootCAFile)
+			}
+		} else {
+			saSecret, err = k.ClientSet.CoreV1().Secrets(c.cfg.ErdaNamespace).Get(context.Background(),
+				sa.Secrets[0].Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+
+			caData = saSecret.Data[caCrtKey]
+			token = saSecret.Data[tokenSecKey]
+		}
 	default:
 		return nil, errors.Errorf("collector source %s is illegal", c.cfg.CollectSource)
 	}
 
 	logrus.Debugf("load cluster info, apiserver addr: %s, token: %s, cacert: %s", c.cfg.K8SApiServerAddr,
-		string(token), string(caData))
+		string(token), base64.StdEncoding.EncodeToString(caData))
 
 	return map[string]interface{}{
 		"address": c.cfg.K8SApiServerAddr,


### PR DESCRIPTION
Signed-off-by: iutx <root@viper.run>

#### What this PR does / why we need it:
>= kubernetes version 1.24, serviceaccount not bind secret default

use tokenCreate to suit.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=341632&iterationID=1403&type=TASK)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  cluster-agent collect token after k8s version 1.24            |
| 🇨🇳 中文    |    cluster-agent 采集 token k8s version >=1.24          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
