### PR TITLE
fix: project-pipeline add orgName label for monitor collector

### DIFF
--- a/internal/apps/dop/endpoints/project_pipeline.go
+++ b/internal/apps/dop/endpoints/project_pipeline.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	pipelinepb "github.com/erda-project/erda-proto-go/core/pipeline/pipeline/pb"
-
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/apps/dop/services/apierrors"
 	"github.com/erda-project/erda/internal/pkg/user"
@@ -79,6 +78,11 @@ func (e *Endpoints) projectPipelineCreate(ctx context.Context, r *http.Request, 
 
 	createReq.UserID = identityInfo.UserID
 	createReq.InternalClient = identityInfo.InternalClient
+	if createReq.NormalLabels == nil {
+		createReq.NormalLabels = make(map[string]string)
+	}
+	createReq.NormalLabels[apistructs.LabelOrgName] = createReq.Labels[apistructs.LabelOrgName]
+	createReq.NormalLabels[apistructs.LabelOrgID] = createReq.Labels[apistructs.LabelOrgID]
 
 	spec, err := pipelineyml.New([]byte(createReq.PipelineYml))
 	if err != nil {
@@ -96,6 +100,7 @@ func (e *Endpoints) projectPipelineCreate(ctx context.Context, r *http.Request, 
 			}
 			action.SnippetConfig.Labels[apistructs.LabelProjectID] = createReq.Labels[apistructs.LabelProjectID]
 			action.SnippetConfig.Labels[apistructs.LabelOrgID] = createReq.Labels[apistructs.LabelOrgID]
+			action.SnippetConfig.Labels[apistructs.LabelOrgName] = createReq.Labels[apistructs.LabelOrgName]
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
project-pipeline add orgName label for monitor collector


#### Specified Reviewers:

/assign @sfwn @CraigMChen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that project-pipeline add orgName label for monitor collector（修复了新监控采集项目流水线日志时，缺失orgName的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that project-pipeline add orgName label for monitor collector            |
| 🇨🇳 中文    |   修复了新监控采集项目流水线日志时，缺失orgName的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
