### PR TITLE
fix(pipeline): pipeline and actionmgr provider transaction session competing mysql connections

### DIFF
--- a/internal/tools/pipeline/providers/pipeline/provider.go
+++ b/internal/tools/pipeline/providers/pipeline/provider.go
@@ -70,9 +70,15 @@ type provider struct {
 
 func (p *provider) Init(ctx servicehub.Context) error {
 	bdl := bundle.New(bundle.WithErdaServer())
+	// create new dbclient to avoid pipeline and actionmgr provider transaction session compete mysql connections
+	// see provider/pipeline/create_v2.go: 175
+	dbClient, err := dbclient.New()
+	if err != nil {
+		return err
+	}
 	p.pipelineService = &pipelineService{
 		p:        p,
-		dbClient: &dbclient.Client{Engine: p.MySQL.DB()},
+		dbClient: dbClient,
 		bdl:      bdl,
 
 		appSvc:       p.App,


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline and actionmgr provider transaction session competing mysql links


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that pipeline and actionmgr provider transaction session competing mysql links （修复了pipeline和actionmgr provider互相竞争mysql链接的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that pipeline and actionmgr provider transaction session competing mysql links            |
| 🇨🇳 中文    |   修复了pipeline和actionmgr provider互相竞争mysql链接的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
