### PR TITLE
fix: pipeline try get orgName if empty

### DIFF
--- a/internal/tools/pipeline/providers/cache/interface.go
+++ b/internal/tools/pipeline/providers/cache/interface.go
@@ -31,4 +31,5 @@ type Interface interface {
 	SetPipelineSecretByPipelineID(pipelineID uint64, secret *SecretCache)
 	GetPipelineSecretByPipelineID(pipelineID uint64) (secret *SecretCache)
 	ClearPipelineSecretByPipelineID(pipelineID uint64)
+	GetOrSetOrgName(orgID uint64) string
 }

--- a/internal/tools/pipeline/providers/cache/provider.go
+++ b/internal/tools/pipeline/providers/cache/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/mysqlxorm"
 	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/internal/core/org"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/actionmgr"
 )
@@ -34,6 +35,7 @@ type provider struct {
 	Cfg       *config
 	MySQL     mysqlxorm.Interface
 	ActionMgr actionmgr.Interface
+	Org       org.ClientInterface
 
 	dbClient *dbclient.Client
 	bdl      *bundle.Bundle


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline try get orgName if empty

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that pipeline try get orgName if empty（修复了流水线请求没有带上组织名的情况下无日志的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that pipeline try get orgName if empty           |
| 🇨🇳 中文    |    修复了流水线请求没有带上组织名的情况下无日志的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
