### PR TITLE
fix(core-services): websocket route use ** as wildcard

### DIFF
--- a/internal/core/legacy/initialize.go
+++ b/internal/core/legacy/initialize.go
@@ -87,7 +87,7 @@ func (p *provider) Initialize() error {
 	go func() {
 		wsi.Start(nil)
 	}()
-	server.Router().PathPrefix("/api/dice/eventbox").Path("/ws/{any:.*}").
+	server.Router().PathPrefix("/api/dice/eventbox").Path("/ws/**").
 		Handler(sockjs.NewHandler("/api/dice/eventbox/ws", sockjs.DefaultOptions, wsi.HTTPHandle))
 	return server.RegisterToNewHttpServerRouter(p.Router)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

core-services websocket route use ** as wildcard

caused by: [#5467](https://github.com/erda-project/erda/pull/5467/files#diff-4cf51b0897a2dbafb7bacd9cccea88db27dc43a644ffd0bcaf4ab6888c330f4fR54)

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=344988&iterationID=1440&type=BUG)


#### Specified Reviewers:

/assign @chengjoey @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   core-services websocket route use ** as wildcard           |
| 🇨🇳 中文    |  core-services websocket 路由使用 ** 作为通配符            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.3-beta.7` when this PR is merged.
