### PR TITLE
feat(orchestrator): o11 suite ingress networking/v1

### DIFF
--- a/apistructs/issue_test.go
+++ b/apistructs/issue_test.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2021 Terminus, Inc.
 //
-// This program is free software: you can use, redistribute, and/or modify
-// it under the terms of the GNU Affero General Public License, version 3
-// or later ("AGPL"), as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package apistructs
 

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common/parse.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common/parse.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "strings"
+
+const (
+	LabelHAProxyVHost = "HAPROXY_0_VHOST"
+)
+
+func ParsePublicHostsFromLabel(labels map[string]string) []string {
+	v, ok := labels[LabelHAProxyVHost]
+	// No external domain name
+	if !ok {
+		return []string{}
+	}
+	// Forward the domain name/vip set corresponding to HAPROXY_0_VHOST in the label to the 0th port of the service
+	return strings.Split(v, ",")
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common/parse_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common/parse_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_ParsePublicHostsFromLabel(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "none",
+			args: args{
+				labels: map[string]string{},
+			},
+			want: []string{},
+		},
+		{
+			name: "parse",
+			args: args{
+				labels: map[string]string{
+					LabelHAProxyVHost: "test1.erda.cloud,test2.erda.cloud",
+				},
+			},
+			want: []string{
+				"test1.erda.cloud",
+				"test2.erda.cloud",
+			},
+		},
+		{
+			name: "single",
+			args: args{
+				labels: map[string]string{
+					LabelHAProxyVHost: "test.erda.cloud",
+				},
+			},
+			want: []string{
+				"test.erda.cloud",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParsePublicHostsFromLabel(tt.args.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParsePublicHostsFromLabel got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/extension/v1beta1/ingress_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/extension/v1beta1/ingress_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
+)
+
+const (
+	projectNamespace = "project-ut-dev"
+)
+
+func Test_CreateIfNotExists(t *testing.T) {
+	type args struct {
+		client v1beta1.ExtensionsV1beta1Interface
+		svc    *apistructs.Service
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		created bool
+		wantErr bool
+	}{
+		{
+			name: "create",
+			args: args{
+				client: func() v1beta1.ExtensionsV1beta1Interface {
+					return fakeclientset.NewSimpleClientset().ExtensionsV1beta1()
+				}(),
+				svc: &apistructs.Service{
+					Name: "web",
+					Labels: map[string]string{
+						common.LabelHAProxyVHost: "localhost,ut.erda.cloud",
+					},
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			created: true,
+		},
+		{
+			name: "service nil",
+			args: args{
+				client: func() v1beta1.ExtensionsV1beta1Interface {
+					return fakeclientset.NewSimpleClientset().ExtensionsV1beta1()
+				}(),
+				svc: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ingress existed",
+			args: args{
+				client: func() v1beta1.ExtensionsV1beta1Interface {
+					return fakeclientset.NewSimpleClientset(&extensionsv1beta1.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "web",
+							Namespace: projectNamespace,
+						},
+					}).ExtensionsV1beta1()
+				}(),
+				svc: &apistructs.Service{
+					Name: "web",
+					Labels: map[string]string{
+						common.LabelHAProxyVHost: "localhost,ut.erda.cloud",
+					},
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "none need ingress",
+			args: args{
+				client: func() v1beta1.ExtensionsV1beta1Interface {
+					return fakeclientset.NewSimpleClientset().ExtensionsV1beta1()
+				}(),
+				svc: &apistructs.Service{
+					Name:      "web",
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ing := NewIngress(tt.args.client)
+			err := ing.CreateIfNotExists(tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateIfNotExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			_, err = tt.args.client.Ingresses(projectNamespace).Get(context.Background(), "web", metav1.GetOptions{})
+			if tt.created && !k8serrors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/ingress.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/ingress.go
@@ -12,157 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package ingress manipulates the k8s api of ingress object
 package ingress
 
 import (
-	"bytes"
-	"encoding/json"
-
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/client-go/kubernetes"
 
-	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8serror"
-	"github.com/erda-project/erda/pkg/http/httpclient"
+	"github.com/erda-project/erda/apistructs"
+	ingv1beta1 "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/extension/v1beta1"
+	ingv1 "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/networking/v1"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/util"
 )
 
-// Ingress is the object to manipulate k8s api of ingress
-type Ingress struct {
-	addr   string
-	client *httpclient.HTTPClient
+type Interface interface {
+	CreateIfNotExists(svc *apistructs.Service) error
 }
 
-// Option configures an Ingress
-type Option func(*Ingress)
-
-// New news an Ingress
-func New(options ...Option) *Ingress {
-	ns := &Ingress{}
-
-	for _, op := range options {
-		op(ns)
-	}
-
-	return ns
-}
-
-// WithCompleteParams provides an Option
-func WithCompleteParams(addr string, client *httpclient.HTTPClient) Option {
-	return func(i *Ingress) {
-		i.addr = addr
-		i.client = client
-	}
-}
-
-// Create creates a k8s ingress object
-func (n *Ingress) Create(ing *extensionsv1beta1.Ingress) error {
-	var b bytes.Buffer
-	resp, err := n.client.Post(n.addr).
-		Path("/apis/extensions/v1beta1/namespaces/" + ing.Namespace + "/ingresses").
-		JSONBody(ing).
-		Do().
-		Body(&b)
-
+// New TODO: Instead of operate resource ingress to hepa component
+func New(c kubernetes.Interface) (Interface, error) {
+	ok, err := util.VersionHas(c, extensionsv1beta1.SchemeGroupVersion.String())
 	if err != nil {
-		return errors.Errorf("failed to create ingress, name: %s, (%v)", ing.Name, err)
-	}
-
-	if !resp.IsOK() {
-		return errors.Errorf("failed to create ingress, statuscode: %v, body: %v", resp.StatusCode(), b.String())
-	}
-	return nil
-}
-
-// Delete deletes a k8s ingress object
-func (n *Ingress) Delete(namespace, name string) error {
-	var b bytes.Buffer
-	resp, err := n.client.Delete(n.addr).
-		Path("/apis/extensions/v1beta1/namespaces/" + namespace + "/ingresses/" + name).
-		Do().
-		Body(&b)
-
-	if err != nil {
-		return errors.Errorf("failed to delete ingress, name: %s, (%v)", name, err)
-	}
-
-	if !resp.IsOK() {
-		if resp.IsNotfound() {
-			// The ingress does not exist, the deletion is considered successful
-			logrus.Debugf("ingress not found, name: %s", name)
-			return nil
-		}
-		return errors.Errorf("failed to delete ingress, name: %s, statuscode: %v, body: %v", name, resp.StatusCode(), b.String())
-	}
-	return nil
-}
-
-// Update update a k8s ingress object
-func (n *Ingress) Update(ing *extensionsv1beta1.Ingress) error {
-	var b bytes.Buffer
-	resp, err := n.client.Put(n.addr).
-		Path("/apis/extensions/v1beta1/namespaces/" + ing.Namespace + "/ingresses/" + ing.Name).
-		JSONBody(ing).
-		Do().
-		Body(&b)
-	if err != nil {
-		return errors.Errorf("failed to update ingress, name: %v, err: %v", ing.Name, err)
-	}
-	if !resp.IsOK() {
-		return errors.Errorf("failed to update ingress, statuscode: %v, body: %v", resp.StatusCode(), b.String())
-	}
-	return nil
-}
-
-// Get get a k8s ingress object
-func (n *Ingress) Get(namespace, name string) (*extensionsv1beta1.Ingress, error) {
-	var (
-		b       bytes.Buffer
-		ingress extensionsv1beta1.Ingress
-	)
-
-	resp, err := n.client.Get(n.addr).
-		Path("/apis/extensions/v1beta1/namespaces/" + namespace + "/ingresses/" + name).
-		Do().
-		Body(&b)
-	if err != nil {
-		return nil, errors.Errorf("failed to get ingress, namespace: %s, name: %v, err: %v", namespace, name, err)
-	}
-	if !resp.IsOK() {
-		if resp.IsNotfound() {
-			logrus.Debugf("ingress not found, namespace: %s, name: %s", namespace, name)
-			return nil, k8serror.ErrNotFound
-		}
-
-		return nil, errors.Errorf("failed to get ingress, namespace: %s, name: %s, statuscode: %v, body: %v",
-			namespace, name, resp.StatusCode(), b.String())
-	}
-
-	if err := json.NewDecoder(&b).Decode(&ingress); err != nil {
 		return nil, err
 	}
-
-	return &ingress, nil
-}
-
-// CreateOrUpdate create or update a k8s ingress object
-func (n *Ingress) CreateOrUpdate(ing *extensionsv1beta1.Ingress) error {
-	var getErr error
-
-	_, getErr = n.Get(ing.Namespace, ing.Name)
-	if getErr == k8serror.ErrNotFound {
-		return n.Create(ing)
+	if ok {
+		logrus.Infof("ingress helper use version: %s", extensionsv1beta1.SchemeGroupVersion.String())
+		return ingv1beta1.NewIngress(c.ExtensionsV1beta1()), nil
 	}
-	return n.Update(ing)
-}
 
-// DeleteIfExists delete if k8s ingress exists
-func (n *Ingress) DeleteIfExists(namespace, name string) error {
-	var getErr error
-
-	_, getErr = n.Get(namespace, name)
-	if getErr == k8serror.ErrNotFound {
-		return nil
-	}
-	return n.Delete(namespace, name)
+	logrus.Infof("ingress helper use version: %s", networkingv1.SchemeGroupVersion.String())
+	return ingv1.NewIngress(c.NetworkingV1()), nil
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/networking/v1/ingress.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/networking/v1/ingress.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1client "k8s.io/client-go/kubernetes/typed/networking/v1"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common"
+)
+
+type Ingress struct {
+	c networkingv1client.NetworkingV1Interface
+}
+
+func NewIngress(c networkingv1client.NetworkingV1Interface) *Ingress {
+	return &Ingress{c: c}
+}
+
+func (i *Ingress) CreateIfNotExists(svc *apistructs.Service) error {
+	if svc == nil {
+		return errors.New("service is nil")
+	}
+
+	ing, err := buildIngress(svc)
+	if err != nil || ing == nil {
+		return err
+	}
+
+	existedIng, err := i.c.Ingresses(ing.Namespace).Get(context.Background(), ing.Name, metav1.GetOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if existedIng != nil {
+		logrus.Warnf("ingress %s in namespace %s already existed", svc.Name, svc.Namespace)
+		return nil
+	}
+
+	if _, err = i.c.Ingresses(svc.Namespace).Create(context.Background(), ing,
+		metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func buildIngress(svc *apistructs.Service) (*networkingv1.Ingress, error) {
+	publicHosts := common.ParsePublicHostsFromLabel(svc.Labels)
+	if len(publicHosts) == 0 {
+		return nil, nil
+	}
+
+	// create ingress
+	rules := buildRules(publicHosts, svc.Name, svc.Ports[0].Port)
+	tls := buildTLS(publicHosts)
+
+	return &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS:   tls,
+			Rules: rules,
+		},
+	}, nil
+}
+
+func buildRules(publicHosts []string, name string, port int) []networkingv1.IngressRule {
+	rules := make([]networkingv1.IngressRule, len(publicHosts))
+	for i, host := range publicHosts {
+		rules[i].Host = host
+		rules[i].HTTP = &networkingv1.HTTPIngressRuleValue{
+			Paths: []networkingv1.HTTPIngressPath{
+				{
+					//TODO: add Path
+					// Path:
+					Backend: networkingv1.IngressBackend{
+						Service: &networkingv1.IngressServiceBackend{
+							Name: name,
+							Port: networkingv1.ServiceBackendPort{
+								Number: int32(port),
+							},
+						},
+					},
+					PathType: pointerPathType(networkingv1.PathTypeImplementationSpecific),
+				},
+			},
+		}
+	}
+	return rules
+}
+
+func buildTLS(publicHosts []string) []networkingv1.IngressTLS {
+	tls := make([]networkingv1.IngressTLS, 1)
+	tls[0].Hosts = make([]string, len(publicHosts))
+	for i, host := range publicHosts {
+		tls[0].Hosts[i] = host
+	}
+	return tls
+}
+
+func pointerPathType(pathType networkingv1.PathType) *networkingv1.PathType {
+	return &pathType
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/networking/v1/ingress_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/networking/v1/ingress_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/client-go/kubernetes/typed/networking/v1"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress/common"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
+)
+
+const (
+	projectNamespace = "project-ut-dev"
+)
+
+func Test_CreateIfNotExists(t *testing.T) {
+	type args struct {
+		client v1.NetworkingV1Interface
+		svc    *apistructs.Service
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		created bool
+		wantErr bool
+	}{
+		{
+			name: "create",
+			args: args{
+				client: func() v1.NetworkingV1Interface {
+					return fakeclientset.NewSimpleClientset().NetworkingV1()
+				}(),
+				svc: &apistructs.Service{
+					Name: "web",
+					Labels: map[string]string{
+						common.LabelHAProxyVHost: "localhost,ut.erda.cloud",
+					},
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			created: true,
+		},
+		{
+			name: "service nil",
+			args: args{
+				client: func() v1.NetworkingV1Interface {
+					return fakeclientset.NewSimpleClientset().NetworkingV1()
+				}(),
+				svc: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ingress existed",
+			args: args{
+				client: func() v1.NetworkingV1Interface {
+					return fakeclientset.NewSimpleClientset(&networkingv1.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "web",
+							Namespace: projectNamespace,
+						},
+					}).NetworkingV1()
+				}(),
+				svc: &apistructs.Service{
+					Name: "web",
+					Labels: map[string]string{
+						common.LabelHAProxyVHost: "localhost,ut.erda.cloud",
+					},
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "none need ingress",
+			args: args{
+				client: func() v1.NetworkingV1Interface {
+					return fakeclientset.NewSimpleClientset().NetworkingV1()
+				}(),
+				svc: &apistructs.Service{
+					Name:      "web",
+					Namespace: projectNamespace,
+					Ports: []diceyml.ServicePort{
+						{
+							Port: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ing := NewIngress(tt.args.client)
+			err := ing.CreateIfNotExists(tt.args.svc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateIfNotExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			_, err = tt.args.client.Ingresses(projectNamespace).Get(context.Background(), "web", metav1.GetOptions{})
+			if tt.created && !k8serrors.IsNotFound(err) {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -54,7 +54,6 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/deployment"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/event"
 	erdahpa "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/hpa"
-	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/job"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8serror"
@@ -194,7 +193,6 @@ type Kubernetes struct {
 	deploy       *deployment.Deployment
 	job          *job.Job
 	ds           *ds.Daemonset
-	ingress      *ingress.Ingress
 	namespace    *namespace.Namespace
 	service      *k8sservice.Service
 	pvc          *persistentvolumeclaim.PersistentVolumeClaim
@@ -364,7 +362,6 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 	deploy := deployment.New(deployment.WithClientSet(k8sClient.ClientSet))
 	job := job.New(job.WithCompleteParams(addr, client))
 	ds := ds.New(ds.WithCompleteParams(addr, client))
-	ing := ingress.New(ingress.WithCompleteParams(addr, client))
 	ns := namespace.New(namespace.WithKubernetesClient(k8sClient.ClientSet))
 	svc := k8sservice.New(k8sservice.WithCompleteParams(addr, client))
 	pvc := persistentvolumeclaim.New(persistentvolumeclaim.WithCompleteParams(addr, client))
@@ -420,7 +417,6 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 		deploy:                   deploy,
 		job:                      job,
 		ds:                       ds,
-		ingress:                  ing,
 		namespace:                ns,
 		service:                  svc,
 		pvc:                      pvc,

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_test.go
@@ -36,7 +36,6 @@ import (
 	ds "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/daemonset"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/deployment"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/event"
-	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/job"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8sservice"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/namespace"
@@ -358,7 +357,6 @@ func TestKubernetes_DeployInEdgeCluster(t *testing.T) {
 		deploy                     *deployment.Deployment
 		job                        *job.Job
 		ds                         *ds.Daemonset
-		ingress                    *ingress.Ingress
 		namespace                  *namespace.Namespace
 		service                    *k8sservice.Service
 		pvc                        *persistentvolumeclaim.PersistentVolumeClaim
@@ -424,7 +422,6 @@ func TestKubernetes_DeployInEdgeCluster(t *testing.T) {
 				deploy:                     tt.fields.deploy,
 				job:                        tt.fields.job,
 				ds:                         tt.fields.ds,
-				ingress:                    tt.fields.ingress,
 				namespace:                  tt.fields.namespace,
 				service:                    tt.fields.service,
 				pvc:                        tt.fields.pvc,

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/deployment"
-	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/ingress"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8sservice"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/namespace"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/persistentvolumeclaim"
@@ -268,7 +267,6 @@ func TestStatefulset(t *testing.T) {
 		addr:      "10.167.0.248:8080",
 		client:    httpclient.New(),
 		deploy:    deployment.New(),
-		ingress:   ingress.New(ingress.WithCompleteParams("10.167.0.248:8080", httpclient.New())),
 		namespace: namespace.New(),
 		service:   k8sservice.New(k8sservice.WithCompleteParams("10.167.0.248:8080", httpclient.New())),
 		pvc:       persistentvolumeclaim.New(persistentvolumeclaim.WithCompleteParams("10.167.0.248:8080", httpclient.New())),

--- a/internal/tools/orchestrator/scheduler/executor/util/discovery.go
+++ b/internal/tools/orchestrator/scheduler/executor/util/discovery.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+)
+
+func VersionHas(c kubernetes.Interface, v string) (bool, error) {
+	serverVersions := sets.String{}
+	groups, err := c.Discovery().ServerGroups()
+	if err != nil {
+		return false, err
+	}
+
+	versions := metav1.ExtractGroupVersions(groups)
+	for _, v := range versions {
+		serverVersions.Insert(v)
+	}
+
+	return serverVersions.Has(v), nil
+}


### PR DESCRIPTION
Signed-off-by: iutx <root@viper.run>

#### What this PR does / why we need it:
1. o11 suite ingress networking/v1.
2. clean up ingress code in scheduler.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  o11 suite ingress networking/v1             |
| 🇨🇳 中文    |   协调器适配 ingress  networking/v1            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
