### PR TITLE
fix: hepa get cluster info failed

### DIFF
--- a/internal/tools/orchestrator/hepa/repository/service/gateway_az_info_service.go
+++ b/internal/tools/orchestrator/hepa/repository/service/gateway_az_info_service.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common/vars"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/orm"
 	"github.com/erda-project/erda/pkg/discover"
+	"github.com/erda-project/erda/pkg/http/httputil"
 )
 
 type AdminProjectDto struct {
@@ -160,7 +161,7 @@ func (impl *GatewayAzInfoServiceImpl) GetAzInfo(cond *orm.GatewayAzInfo) (*orm.G
 		return info, nil
 	}
 	code, body, err := util.CommonRequest("GET", discover.ErdaServer()+"/api/projects/"+cond.ProjectId, nil,
-		map[string]string{"Internal-Client": "hepa-gateway"})
+		map[string]string{"Internal-Client": "hepa-gateway", httputil.OrgHeader: cond.OrgId})
 	if err != nil {
 		err = errors.WithMessage(err, "request dice admin failed")
 		goto failback


### PR DESCRIPTION
#### What this PR does / why we need it:

erda-server  api  /api/projects/{projectId}  need set Header "Org-ID", heap call erda-server for this api not set Header "Org-ID"

#### Specified Reviewers:

/assign @iutx @sixther-dc 


#### ChangeLog
Bugfix： Fix the bug that heap call erda-server for this api not set Header "Org-ID" （修复了 heap 调用 erda-server 接口未设置 Header "Org-ID" 导致 tb_gateway_az_info 无法插入数据）


| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |         Fix the bug that heap call erda-server for this api not set Header "Org-ID"     |
| 🇨🇳 中文    |      修复了 heap 调用 erda-server 接口未设置 Header "Org-ID" 导致 tb_gateway_az_info 无法插入数据        |


