### PR TITLE
fix(orchestrator): o11 start with admin http-server

### DIFF
--- a/cmd/orchestrator/bootstrap.yaml
+++ b/cmd/orchestrator/bootstrap.yaml
@@ -53,4 +53,6 @@ grpc-client@erda.core.org:
   addr: "${ERDA_SERVER_GRPC_ADDR:erda-server:8096}"
 erda.core.org-client: {}
 erda.core.org: {}
+http-server@admin:
+  addr: ":7098"
 pprof: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix: o11 start with admin http-server
<img width="965" alt="image" src="https://user-images.githubusercontent.com/31346321/197509796-2bdf44c8-c630-4aaa-885a-bf302cb114d1.png">


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix o11 start with admin http-server         |
| 🇨🇳 中文    |            o11 启动增加 http-server admin  |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
