### PR TITLE
fix(gittar): `dice_repo_check_runs` pipelineID filed out of range value

### DIFF
--- a/.erda/migrations/gittar/20221027-gittar-alert-pipeline-id.sql
+++ b/.erda/migrations/gittar/20221027-gittar-alert-pipeline-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `dice_repo_check_runs` CHANGE COLUMN `pipeline_id` `pipeline_id` bigint(20) NOT NULL DEFAULT '0';


### PR DESCRIPTION
#### What this PR does / why we need it:
fix `dice_repo_check_runs` pipelineID filed out of range value


#### Specified Reviewers:

/assign @sfwn @Effet 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that `dice_repo_check_runs` pipelineID filed out of range value（修复了gittar `dice_repo_check_runs`表的pipelineID字段长度过短的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that `dice_repo_check_runs` pipelineID filed out of range value          |
| 🇨🇳 中文    |     修复了gittar `dice_repo_check_runs`表的pipelineID字段长度过短的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
