### PR TITLE
fix: erda-cli need org Header and openapi  host

### DIFF
--- a/tools/cli/cmd/project_deployment_stop.go
+++ b/tools/cli/cmd/project_deployment_stop.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
-	"github.com/erda-project/erda/pkg/http/httputil"
 	"github.com/erda-project/erda/tools/cli/command"
 	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
@@ -151,13 +150,15 @@ func RunStopProjectInWorkspace(ctx *command.Context, org, project, workspace str
 	}
 
 	if len(addonIds) > 0 {
-		ctx.Info("Begin to stop project's addons for addon IDs:%v\n", addonIds)
+		ctx.Info("project's addons for addon IDs:%v\n", addonIds)
 		// TODO: STOP Addons
-		if err = StopProjectWorkspaceAddons(ctx, addonIds, params); err != nil {
-			return err
-		}
+		/*
+				if err = StopProjectWorkspaceAddons(ctx, addonIds, params); err != nil {
+					return err
+				}
+			ctx.Succ("project-deployment stop project's addons success\n")
+		*/
 	}
-	ctx.Succ("project-deployment stop project's addons success\n")
 
 	return nil
 }
@@ -181,7 +182,8 @@ func StopProjectWorkspaceRuntimes(ctx *command.Context, runtimeIds []string, par
 	}
 
 	response, err := ctx.Put().Path(fmt.Sprintf("/api/runtimes/actions/batch-update-pre-overlay?scale_action=scaleDown")).
-		Header(httputil.OrgHeader, params.orgId).
+		//Header(httputil.OrgHeader, params.orgId).
+		Header("org", params.orgId).
 		JSONBody(req).Do().JSON(&rsp)
 
 	if err != nil {
@@ -215,7 +217,8 @@ func StopProjectWorkspaceAddons(ctx *command.Context, addonIds []string, params 
 	req.AddonRoutingIDs = addonIds
 
 	response, err := ctx.Post().Path(fmt.Sprintf("/api/addons?scale_action=scaleDown")).
-		Header(httputil.OrgHeader, params.orgId).
+		//Header(httputil.OrgHeader, params.orgId).
+		Header("org", params.orgId).
 		JSONBody(req).Do().JSON(&rsp)
 
 	if err != nil {
@@ -252,7 +255,8 @@ func GetProjectApplicationIds(ctx *command.Context, params PDParameters) ([]stri
 	var listResp apistructs.ApplicationListResponse
 
 	response, err := ctx.Get().Path(fmt.Sprintf("/api/applications")).
-		Header(httputil.OrgHeader, params.orgId).
+		//Header(httputil.OrgHeader, params.orgId).
+		Header("org", params.orgId).
 		Param("projectId", params.projectId).
 		Param("pageSize", strconv.FormatUint(PAGE_SIZE, 10)).
 		Param("pageNo", "1").
@@ -274,7 +278,8 @@ func GetProjectApplicationIds(ctx *command.Context, params PDParameters) ([]stri
 
 	for page := 2; listResp.Data.Total > int(PAGE_SIZE)*(page-1); page++ {
 		response, err := ctx.Get().Path(fmt.Sprintf("/api/applications")).
-			Header(httputil.OrgHeader, params.orgId).
+			//Header(httputil.OrgHeader, params.orgId).
+			Header("org", params.orgId).
 			Param("projectId", params.projectId).
 			Param("pageSize", strconv.FormatUint(PAGE_SIZE, 10)).
 			Param("pageNo", strconv.FormatInt(int64(page), 10)).
@@ -301,7 +306,8 @@ func GetProjectApplicationRuntimesIDsForStopOrStart(ctx *command.Context, params
 
 	response, err := ctx.Get().Path("/api/runtimes").
 		Param("applicationId", applicationId).
-		Header("Org-ID", params.orgId).
+		//Header("Org-ID", params.orgId).
+		Header("org", params.orgId).
 		Do().
 		JSON(&listResp)
 	if err != nil {
@@ -341,7 +347,8 @@ func checkProjectRuntimes(ctx *command.Context, applicationId string, params PDP
 
 	response, err := ctx.Get().Path("/api/runtimes").
 		Param("applicationId", applicationId).
-		Header("Org-ID", params.orgId).
+		//Header("Org-ID", params.orgId).
+		Header("org", params.orgId).
 		Do().
 		JSON(&listResp)
 	if err != nil {
@@ -423,7 +430,8 @@ func GetProjectAddonsRoutingKeysForStopOrStart(ctx *command.Context, params PDPa
 	var listResp apistructs.AddonListResponse
 
 	response, err := ctx.Get().Path(fmt.Sprintf("/api/addons")).
-		Header("Org-ID", params.orgId).
+		//Header("Org-ID", params.orgId).
+		Header("org", params.orgId).
 		Param("type", "project").
 		Param("value", params.projectId).
 		Do().

--- a/tools/cli/command/context.go
+++ b/tools/cli/command/context.go
@@ -135,6 +135,7 @@ func (ctx *Context) FetchOpenapi() error {
 	ctx.Hepaapi = new(url.URL)
 	*ctx.Hepaapi = *ctx.Openapi
 	ctx.Hepaapi.Host = strings.Replace(ctx.Openapi.Host, "openapi.", "hepa.", 1)
+	ctx.CurrentHost = ctx.Openapi.String()
 	ctx.Info(`erda openapi info:
 	domain: %s
 	openapi: %s

--- a/tools/cli/common/org.go
+++ b/tools/cli/common/org.go
@@ -35,7 +35,7 @@ func GetOrgDetail(ctx *command.Context, orgIDorName string) (apistructs.OrgDTO, 
 			"invalid required parameter organization", false))
 	}
 
-	response, err := ctx.Get().Path(fmt.Sprintf("/api/orgs/%s", orgIDorName)).Do().Body(&b)
+	response, err := ctx.Get().Header("org", orgIDorName).Path(fmt.Sprintf("/api/orgs/%s", orgIDorName)).Do().Body(&b)
 	if err != nil {
 		return apistructs.OrgDTO{}, fmt.Errorf(utils.FormatErrMsg(
 			"get organization detail", "failed to request ("+err.Error()+")", false))

--- a/tools/cli/common/project.go
+++ b/tools/cli/common/project.go
@@ -196,7 +196,7 @@ func ListMyProjectInOrg(ctx *command.Context, orgId string, projectName string) 
 		Param("joined", "true").
 		Param("name", projectName).
 		Param("pageSize", strconv.Itoa(1000)).
-		Header("Org-ID", orgId).
+		Header("org", orgId).
 		Do().Body(&b)
 	if err != nil {
 		return nil, fmt.Errorf(


### PR DESCRIPTION
#### What this PR does / why we need it:

New erda ui and erda-server need erda-cli  adjust http header to org, need to call openapi  api through openapi addr



#### Specified Reviewers:

/assign @iutx @sixther-dc @luobily 

#### ChangeLog
Bugfix： Fix the bug that  new erda ui and erda-server need erda-cli  adjust http header to org, need to call openapi  api through openapi addr（修复了  erda  ui 和 erda-server 调整导致 erda-cli 工具无法正常运行的问题）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that  new erda ui and erda-server need erda-cli  adjust http header to org, need to call openapi  api through openapi addr        |
| 🇨🇳 中文    |      修复了  erda  ui 和 erda-server 调整导致 erda-cli 工具无法正常运行的问题        |

