### PR TITLE
fix: format pipeline time in local

### DIFF
--- a/internal/apps/dop/component-protocol/components/auto-test-plan-list/components/table/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-plan-list/components/table/render.go
@@ -292,7 +292,7 @@ func convertExecuteTime(data *apistructs.TestPlanV2) string {
 		return ""
 	}
 	var executeTime string
-	executeTime = data.ExecuteTime.Format("2006-01-02 15:04:05")
+	executeTime = data.ExecuteTime.Local().Format("2006-01-02 15:04:05")
 	return executeTime
 }
 

--- a/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeHead/executeHistory/executeHistoryPop/executeHistoryTable/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeHead/executeHistory/executeHistoryPop/executeHistoryTable/render.go
@@ -255,7 +255,7 @@ func (e *ExecuteHistoryTable) setData(pipeline *apistructs.PipelinePageListData,
 			"pipelineId":  each.ID,
 			"status":      e.getStatus(each.Status),
 			"runUser":     runUser,
-			"triggerTime": each.TimeCreated.Format(timeLayoutStr),
+			"triggerTime": each.TimeCreated.Local().Format(timeLayoutStr),
 		}
 		lists = append(lists, list)
 		num--

--- a/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeInfo/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileExecute/executeInfo/render.go
@@ -126,15 +126,15 @@ func (i *ComponentFileInfo) Render(ctx context.Context, c *cptype.Component, sce
 				"pipelineID": pipelineID,
 				"status":     status,
 				"time":       h + time.Unix(int64(t.Seconds())-8*3600, 0).Format("04:05"),
-				"timeBegin":  rsp.TimeBegin.AsTime().Format(timeLayoutStr),
-				"timeEnd":    rsp.TimeEnd.AsTime().Format(timeLayoutStr),
+				"timeBegin":  rsp.TimeBegin.AsTime().Local().Format(timeLayoutStr),
+				"timeEnd":    rsp.TimeEnd.AsTime().Local().Format(timeLayoutStr),
 			}
 		} else if rsp.TimeBegin != nil {
 			var timeLayoutStr = "2006-01-02 15:04:05" //go中的时间格式化必须是这个时间
 			i.Data = map[string]interface{}{
 				"pipelineID": pipelineID,
 				"status":     status,
-				"timeBegin":  rsp.TimeBegin.AsTime().Format(timeLayoutStr),
+				"timeBegin":  rsp.TimeBegin.AsTime().Local().Format(timeLayoutStr),
 			}
 		} else {
 			i.Data = map[string]interface{}{

--- a/internal/apps/dop/component-protocol/components/auto-test-space-list/components/recordTable/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-space-list/components/recordTable/render.go
@@ -189,7 +189,7 @@ func (r *RecordTable) setData() error {
 			ID:       strconv.FormatInt(int64(fileRecord.ID), 10),
 			Type:     r.sdk.I18n(recordTypeKey),
 			Operator: operatorName,
-			Time:     fileRecord.CreatedAt.Format("2006-01-02 15:04:05"),
+			Time:     fileRecord.CreatedAt.Local().Format("2006-01-02 15:04:05"),
 			Desc:     fileRecord.Description,
 			Status: Status{
 				RenderType: "textWithBadge",

--- a/internal/apps/dop/component-protocol/components/auto-test-space-list/components/spaceList/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-space-list/components/spaceList/render.go
@@ -231,7 +231,7 @@ func (a *ComponentSpaceList) setData(projectID int64, spaces apistructs.AutoTest
 			}
 		)
 		updatedAt := each.UpdatedAt.Format("2006-01-02 15:04:05")
-		text := text.UpdatedTime(a.sdk.Ctx, each.UpdatedAt)
+		text := text.UpdatedTime(a.sdk.Ctx, each.UpdatedAt.Local())
 		item := spaceItem{
 			ID:          each.ID,
 			Title:       each.Name,

--- a/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeHistoryTable/render.go
+++ b/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeHistoryTable/render.go
@@ -267,7 +267,7 @@ func (e *ExecuteHistoryTable) setData(pipeline *apistructs.PipelinePageListData,
 			"pipelineId":  each.ID,
 			"status":      getStatus(each.Status, i18nLocale),
 			"runUser":     runUser,
-			"triggerTime": each.TimeCreated.Format(timeLayoutStr),
+			"triggerTime": each.TimeCreated.Local().Format(timeLayoutStr),
 		}
 		lists = append(lists, list)
 		num--

--- a/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeInfo/render.go
+++ b/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeInfo/render.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -32,10 +31,6 @@ import (
 	"github.com/erda-project/erda/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/i18n"
 	"github.com/erda-project/erda/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/types"
 )
-
-func init() {
-	os.Setenv("TZ", "Asia/Shanghai")
-}
 
 type ComponentFileInfo struct {
 	CtxBdl protocol.ContextBundle

--- a/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeInfo/render.go
+++ b/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/components/executeInfo/render.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -31,6 +32,10 @@ import (
 	"github.com/erda-project/erda/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/i18n"
 	"github.com/erda-project/erda/internal/core/openapi/legacy/component-protocol/scenarios/auto-test-plan-detail/types"
 )
+
+func init() {
+	os.Setenv("TZ", "Asia/Shanghai")
+}
 
 type ComponentFileInfo struct {
 	CtxBdl protocol.ContextBundle
@@ -130,15 +135,15 @@ func (i *ComponentFileInfo) Render(ctx context.Context, c *apistructs.Component,
 				"pipelineID": i.State.PipelineID,
 				"status":     i18n.TransferTaskStatus(pipelineStatus, i18nLocale),
 				"time":       h + time.Unix(int64(t.Seconds())-8*3600, 0).Format("04:05"),
-				"timeBegin":  rsp.TimeBegin.AsTime().Format(timeLayoutStr),
-				"timeEnd":    rsp.TimeEnd.AsTime().Format(timeLayoutStr),
+				"timeBegin":  rsp.TimeBegin.AsTime().Local().Format(timeLayoutStr),
+				"timeEnd":    rsp.TimeEnd.AsTime().Local().Format(timeLayoutStr),
 			}
 		} else if rsp.TimeBegin != nil {
 			var timeLayoutStr = "2006-01-02 15:04:05" //go中的时间格式化必须是这个时间
 			i.Data = map[string]interface{}{
 				"pipelineID": i.State.PipelineID,
 				"status":     i18n.TransferTaskStatus(pipelineStatus, i18nLocale),
-				"timeBegin":  rsp.TimeBegin.AsTime().Format(timeLayoutStr),
+				"timeBegin":  rsp.TimeBegin.AsTime().Local().Format(timeLayoutStr),
 			}
 		} else {
 			i.Data = map[string]interface{}{

--- a/internal/tools/pipeline/actionagent/step_prepare.go
+++ b/internal/tools/pipeline/actionagent/step_prepare.go
@@ -35,6 +35,7 @@ const (
 	EnvStdErrRegexpList = "ACTIONAGENT_STDERR_REGEXP_LIST"
 	EnvMaxCacheFileMB   = "ACTIONAGENT_MAX_CACHE_FILE_MB"
 	EnvDefaultShell     = "ACTIONAGENT_DEFAULT_SHELL"
+	EnvDefaultTimezone  = "ACTIONAGENT_DEFAULT_TIMEZONE"
 )
 
 // 对于 custom action，需要将 commands 转换为 script 来执行
@@ -131,6 +132,14 @@ func (agent *Agent) prepare() {
 
 	// 7. listen signal
 	go agent.ListenSignal()
+}
+
+// setTimezone set default timezone
+func (agent *Agent) setTimezone() {
+	timezone := os.Getenv(EnvDefaultTimezone)
+	if timezone != "" {
+		os.Setenv("TZ", timezone)
+	}
 }
 
 func (agent *Agent) convertCustomCommands() []string {

--- a/internal/tools/pipeline/actionagent/step_prepare_test.go
+++ b/internal/tools/pipeline/actionagent/step_prepare_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"bou.ke/monkey"
 
 	"github.com/erda-project/erda/pkg/filehelper"
@@ -90,4 +92,17 @@ tail
 			t.Errorf("%q. setupCommandScript() = %v, want %v", tt.name, tt.got, tt.want)
 		}
 	}
+}
+
+func Test_setTimezone(t *testing.T) {
+	// no timezone set
+	os.Setenv(EnvDefaultTimezone, "")
+	agent := &Agent{}
+	agent.setTimezone()
+	assert.Equal(t, "", os.Getenv("TZ"))
+
+	// set timezone Asia/Shanghai
+	os.Setenv(EnvDefaultTimezone, "Asia/Shanghai")
+	agent.setTimezone()
+	assert.Equal(t, "Asia/Shanghai", os.Getenv("TZ"))
 }

--- a/internal/tools/pipeline/actionagent/step_validate.go
+++ b/internal/tools/pipeline/actionagent/step_validate.go
@@ -62,7 +62,8 @@ func (agent *Agent) validate() {
 	agent.EasyUse.RunMultiStderrFilePath = "/tmp/stderr"
 	agent.setShellAndArgs()
 
-	// validate envs
+	// set timezone
+	agent.setTimezone()
 
 	// convert(XXX_PUBLIC_URL, XXX_ADDR) -> XXX_ADDR
 	agent.convertEnvsByClusterLocation()


### PR DESCRIPTION
#### What this PR does / why we need it:
format pipeline time in local

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=347386&iterationID=-1&pId=0&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that format pipeline time in local（修复了测试计划等时间展示少8小时的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that format pipeline time in local           |
| 🇨🇳 中文    |    修复了测试计划等时间展示少8小时的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
