### PR TITLE
chore: set glonal env to ignore protobuf registration conflict

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -38,6 +38,7 @@ envs:
   CLUSTER_MANAGER_ADDR: cluster-manager:9094
   CLUSTER_DIALER_ADDR: cluster-manager:80
   TRACE_HOOK_ENABLE: true
+  GOLANG_PROTOBUF_REGISTRATION_CONFLICT: "ignore"
 services:
   erda-server:
     cmd: /erda/cmd/erda-server/bin


### PR DESCRIPTION
#### What this PR does / why we need it:
set glonal env to ignore protobuf registration conflict


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that set glonal env to ignore protobuf registration conflict（修复了progobuf文件冲突的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Fix the bug that set glonal env to ignore protobuf registration conflict         |
| 🇨🇳 中文    |    修复了progobuf文件冲突的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
