### PR TITLE
fix: sort the cookie reports in order to make sure the latest cookie will be used

### DIFF
--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie.go
@@ -17,12 +17,36 @@ package autotest_cookie_keep_before
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/erda-project/erda-proto-go/core/pipeline/report/pb"
 	"github.com/erda-project/erda/pkg/apitestsv2"
 )
+
+type reports []*pb.PipelineReport
+
+func (r reports) Len() int {
+	return len(r)
+}
+
+func (r reports) Less(i, j int) bool {
+	return r[i].ID < r[j].ID
+}
+
+func (r reports) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+// getSortedReports sort the reports by ID, make sure the latest cookie will be used in next step
+func getSortedReports(reportSets *pb.PipelineReportSetQueryResponse) reports {
+	sortedReports := make(reports, 0)
+	sortedReports = append(sortedReports, reportSets.Data.Reports...)
+	sort.Sort(sortedReports)
+	return sortedReports
+}
 
 // appendOrReplaceSetCookiesToCookie
 // - append cookie item if cookie name not exist

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/cookie_test.go
@@ -149,3 +149,66 @@ func TestHandle(t *testing.T) {
 	assert.Equal(t, "H_PS_PSSID=36559_36750_36726_36454_36453_36692_36167_36695_36696_36816_36570_36530_36772_36746_36762_36768_36766_26350", cookieLst[5])
 	assert.Equal(t, "BIDUPSID=EA64A26D7004088DC84439A66DB1EC6E", cookieLst[1])
 }
+
+func Test_getSortedReports(t *testing.T) {
+	type args struct {
+		reportSet *pb.PipelineReportSetQueryResponse
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "desc reports",
+			args: args{
+				reportSet: &pb.PipelineReportSetQueryResponse{
+					Data: &pb.PipelineReportSet{
+						Reports: []*pb.PipelineReport{
+							{
+								ID:         1003,
+								PipelineID: 1,
+							},
+							{
+								ID:         1002,
+								PipelineID: 1,
+							},
+							{
+								ID:         1001,
+								PipelineID: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "asc reports",
+			args: args{
+				reportSet: &pb.PipelineReportSetQueryResponse{
+					Data: &pb.PipelineReportSet{
+						Reports: []*pb.PipelineReport{
+							{
+								ID:         1001,
+								PipelineID: 1,
+							},
+							{
+								ID:         1002,
+								PipelineID: 1,
+							},
+							{
+								ID:         1003,
+								PipelineID: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		res := getSortedReports(tt.args.reportSet)
+		for i := 1; i < len(res); i++ {
+			assert.True(t, res[i].ID > res[i-1].ID)
+		}
+	}
+}

--- a/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
+++ b/internal/tools/pipeline/aop/plugins/task/autotest_cookie_keep_before/plugin.go
@@ -56,8 +56,9 @@ func (p *provider) Handle(ctx *aoptypes.TuneContext) error {
 		rlog.TErrorf(ctx.SDK.Pipeline.ID, ctx.SDK.Task.ID, "failed to get pipeline reports, err: %", err)
 		return err
 	}
+	cookieReports := getSortedReports(reportSets)
 	var setCookies []string
-	for _, v := range reportSets.Data.Reports {
+	for _, v := range cookieReports {
 		if v.Meta == nil {
 			continue
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
sort the cookie reports in order to make sure the latest cookie will be used

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that sort the cookie reports in order to make sure the latest cookie will be used （修复了自动化测试接口没有使用最新cookie的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that sort the cookie reports in order to make sure the latest cookie will be used           |
| 🇨🇳 中文    |   修复了自动化测试接口没有使用最新cookie的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
