### PR TITLE
fix: extend the length limit of the field `includes` `excludes`

### DIFF
--- a/.erda/migrations/cmdb/20221213-code-coverage-include-exclude.sql
+++ b/.erda/migrations/cmdb/20221213-code-coverage-include-exclude.sql
@@ -1,0 +1,2 @@
+ALTER TABLE erda_code_coverage_setting MODIFY COLUMN `includes` text COMMENT '包含的package';
+ALTER TABLE erda_code_coverage_setting MODIFY COLUMN `excludes` text COMMENT '排除的package';


### PR DESCRIPTION
#### What this PR does / why we need it:
extend the length limit of the field `includes` `excludes`


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that extend the length limit of the field `includes` `excludes`（修复了覆盖率部分字段长度限制太短的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |Fix the bug that extend the length limit of the field `includes` `excludes`              |
| 🇨🇳 中文    |   修复了覆盖率部分字段长度限制太短的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
