### PR TITLE
fix: leaderwork failed to init assign map due to context cancel

### DIFF
--- a/internal/tools/pipeline/providers/dispatcher/consistent.go
+++ b/internal/tools/pipeline/providers/dispatcher/consistent.go
@@ -25,6 +25,12 @@ import (
 
 func (p *provider) initConsistentUntilSuccess(ctx context.Context) {
 	for {
+		select {
+		case <-ctx.Done():
+			p.Log.Warnf("exit initConsistentUntilSuccess because context done, err: %v", ctx.Err())
+			return
+		default:
+		}
 		// init new one
 		c, err := p.makeConsistent(ctx)
 		if err != nil {

--- a/internal/tools/pipeline/providers/leaderworker/leader_listen_worker_task.go
+++ b/internal/tools/pipeline/providers/leaderworker/leader_listen_worker_task.go
@@ -112,6 +112,12 @@ func (p *provider) leaderInitTaskWorkerAssignMap(ctx context.Context) {
 
 outLoop:
 	for {
+		select {
+		case <-ctx.Done():
+			p.Log.Warnf("exit init task worker assign map because context done, err: %v", ctx.Err())
+			return
+		default:
+		}
 		workers, err := p.listWorkers(ctx)
 		if err != nil {
 			p.Log.Errorf("failed to list workers for leaderInitTaskWorkerAssignMap(auto retry), err: %v", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
fix leaderwork failed to init assign map due to context cancel


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that leaderwork failed to init assign map due to context cancel（修复了context done造成重复失败的问题  ）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that leaderwork failed to init assign map due to context cancel          |
| 🇨🇳 中文    |     修复了context done造成重复失败的问题    |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
