### PR TITLE
fix(pipeline): leader pipeline too many network connections due to query is edge cluster

### DIFF
--- a/internal/tools/pipeline/providers/edgepipeline_register/interface.go
+++ b/internal/tools/pipeline/providers/edgepipeline_register/interface.go
@@ -94,12 +94,15 @@ func (p *provider) CanProxyToEdge(source apistructs.PipelineSource, clusterName 
 	if !findInWhitelist {
 		return false
 	}
-	isEdge, err := p.bdl.IsClusterManagerClientRegistered(apistructs.ClusterManagerClientTypePipeline, clusterName)
-	if !isEdge || err != nil {
-		return false
+
+	p.Lock()
+	_, ok := p.edgeClients[clusterName]
+	p.Unlock()
+	if ok {
+		return true
 	}
 
-	return true
+	return false
 }
 
 func (p *provider) GetDialContextByClusterName(clusterName string) clusterdialer.DialContextFunc {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix leader pipeline too many network connections due to query is edge cluster


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that leader pipeline too many network connections due to query is edge cluster （修复了pipeline的定时补偿由于大量查询边缘集群导致的链接数太多问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that leader pipeline too many network connections due to query is edge cluster          |
| 🇨🇳 中文    |    修复了pipeline的定时补偿由于大量查询边缘集群导致的链接数太多问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
