### PR TITLE
fix: cluster access key render auth fail

### DIFF
--- a/internal/apps/cmp/endpoints/cluster_credential.go
+++ b/internal/apps/cmp/endpoints/cluster_credential.go
@@ -50,9 +50,14 @@ func (e *Endpoints) GetAccessKey(ctx context.Context, r *http.Request, vars map[
 	}
 
 	// permission check
-	err = e.PermissionCheck(i.UserID, i.OrgID, "", apistructs.GetAction)
+	err = e.CloudResourcePermissionCheck(ctx, i.UserID, i.OrgID, clusterName, apistructs.GetAction)
 	if err != nil {
-		return
+		return mkResponse(&apistructs.ClusterGetAkResponse{
+			Header: apistructs.Header{
+				Success: false,
+				Error:   apistructs.ErrorResponse{Msg: err.Error()},
+			},
+		})
 	}
 
 	res, err := e.clusters.GetAccessKey(clusterName)
@@ -96,9 +101,14 @@ func (e *Endpoints) CreateAccessKey(ctx context.Context, r *http.Request, vars m
 	}
 
 	// permission check
-	err = e.PermissionCheck(i.UserID, i.OrgID, "", apistructs.CreateAction)
+	err = e.CloudResourcePermissionCheck(ctx, i.UserID, i.OrgID, req.ClusterName, apistructs.CreateAction)
 	if err != nil {
-		return
+		return mkResponse(&apistructs.ClusterGetAkResponse{
+			Header: apistructs.Header{
+				Success: false,
+				Error:   apistructs.ErrorResponse{Msg: err.Error()},
+			},
+		})
 	}
 
 	res, err := e.clusters.GetOrCreateAccessKeyWithRecord(ctx, req.ClusterName, i.UserID, i.OrgID)
@@ -134,9 +144,14 @@ func (e *Endpoints) ResetAccessKey(ctx context.Context, r *http.Request, vars ma
 	}
 
 	// permission check
-	err = e.PermissionCheck(i.UserID, i.OrgID, "", apistructs.CreateAction)
+	err = e.CloudResourcePermissionCheck(ctx, i.UserID, i.OrgID, req.ClusterName, apistructs.UpdateAction)
 	if err != nil {
-		return
+		return mkResponse(&apistructs.ClusterGetAkResponse{
+			Header: apistructs.Header{
+				Success: false,
+				Error:   apistructs.ErrorResponse{Msg: err.Error()},
+			},
+		})
 	}
 
 	res, err := e.clusters.ResetAccessKeyWithRecord(ctx, req.ClusterName, i.UserID, i.OrgID)

--- a/internal/apps/cmp/endpoints/commone_test.go
+++ b/internal/apps/cmp/endpoints/commone_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+
+	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/internal/pkg/mock"
+)
+
+type OrgMock struct {
+	mock.OrgMock
+}
+
+func (m OrgMock) GetOrgClusterRelationsByOrg(ctx context.Context, request *orgpb.GetOrgClusterRelationsByOrgRequest) (*orgpb.GetOrgClusterRelationsByOrgResponse, error) {
+	return &orgpb.GetOrgClusterRelationsByOrgResponse{
+		Data: []*orgpb.OrgClusterRelation{
+			{
+				OrgID:       1,
+				ClusterName: "cluster",
+			},
+			{
+				OrgID:       2,
+				ClusterName: "cluster-2",
+			},
+		},
+	}, nil
+}
+
+func TestCloudResourcePermissionCheck(t *testing.T) {
+	bdl := bundle.New()
+	orgSvc := &OrgMock{}
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "CheckPermission", func(_ *bundle.Bundle,
+		req *apistructs.PermissionCheckRequest) (*apistructs.PermissionCheckResponseData, error) {
+		access := true
+		if req.UserID == "1001" && req.ScopeID == 2 {
+			access = false
+		}
+		return &apistructs.PermissionCheckResponseData{
+			Access: access,
+		}, nil
+	})
+
+	defer monkey.UnpatchAll()
+
+	ctx := context.WithValue(context.Background(), "i18nPrinter", message.NewPrinter(language.SimplifiedChinese))
+
+	ep := Endpoints{
+		org: orgSvc,
+		bdl: bdl,
+	}
+
+	type args struct {
+		clusterName string
+		userId      string
+		orgId       string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "permission denied",
+			args: args{
+				clusterName: "cluster",
+				userId:      "10001",
+				orgId:       "1",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ep.CloudResourcePermissionCheck(ctx, tt.args.userId, tt.args.orgId,
+				tt.args.clusterName, apistructs.GetAction); (err != nil) != tt.wantErr {
+				t.Errorf("CheckPermission() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err != nil && tt.wantErr {
+				t.Log(err)
+			}
+		})
+	}
+}

--- a/internal/apps/cmp/i18n/i18n.go
+++ b/internal/apps/cmp/i18n/i18n.go
@@ -20,6 +20,9 @@ import (
 )
 
 func InitI18N() {
+	// common
+	message.SetString(language.SimplifiedChinese, "permissionDenied", "无权限")
+
 	// ops record
 	message.SetString(language.SimplifiedChinese, "addAliECSEdgeCluster", "添加阿里云集群")
 	message.SetString(language.SimplifiedChinese, "addAliACKEdgeCluster", "添加阿里云容器服务集群") // TODO remove


### PR DESCRIPTION
Signed-off-by: iutx <root@viper.run>

#### What this PR does / why we need it:
fix cluster access key render auth fail

<img width="934" alt="image" src="https://user-images.githubusercontent.com/31346321/207776698-0112f46a-dc4a-415a-8fae-aa335b567808.png">


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix cluster access key render auth fail             |
| 🇨🇳 中文    | 修复渲染 集群 ak 鉴权失败             |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
