### PR TITLE
fix: remove redundant migration dependency package

### DIFF
--- a/.erda/migrations/cmdb/requirements.txt
+++ b/.erda/migrations/cmdb/requirements.txt
@@ -1,5 +1,4 @@
 Django==3.2.16
-mysqlclient==2.0.3
 pytz==2021.1
 sqlparse==0.4.2
 requests==2.26.0


### PR DESCRIPTION
#### What this PR does / why we need it:
remove redundant migration dependency package

mysql-client depend on mysql devel package, e.g. ‘mysql.sh’, not pure python.

In arm64, mysql use mysql-community-minimal，install mysql-community-devel will cause package conflict.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   remove redundant migration dependency package           |
| 🇨🇳 中文    |    删除 migration 中无用的依赖包          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
