### PR TITLE
feat: support rocketmq operator executor

### DIFF
--- a/apistructs/service.go
+++ b/apistructs/service.go
@@ -843,6 +843,7 @@ type CapacityInfoData struct {
 	CanalOperator         bool `json:"canalOperator"`
 	DaemonsetOperator     bool `json:"daemonsetOperator"`
 	SourcecovOperator     bool `json:"sourcecovOperator"`
+	RocketMQOperator      bool `json:"rocketMQOperator"`
 }
 
 type ComponentInfoResponse struct {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	bou.ke/monkey v1.0.2
+	erda.cloud/rocketmq v0.0.0-20221216094959-4f1e33965edc
 	github.com/360EntSecGroup-Skylar/excelize/v2 v2.3.2
 	github.com/ClickHouse/clickhouse-go/v2 v2.2.0
 	github.com/DATA-DOG/go-sqlmock v1.5.0
@@ -190,7 +191,7 @@ require (
 	k8s.io/kubernetes v1.21.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	modernc.org/mathutil v1.0.0
-	sigs.k8s.io/controller-runtime v0.13.0
+	sigs.k8s.io/controller-runtime v0.13.1
 	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -445,6 +446,7 @@ require (
 )
 
 replace (
+	erda.cloud/rocketmq => github.com/erda-project/rocketmq-operator v0.0.0-20221222075906-f28c42d7bf23
 	github.com/coreos/bbolt => go.etcd.io/bbolt v1.3.5
 	github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 	github.com/erda-project/erda-infra => github.com/erda-project/erda-infra v0.0.0-20220928061127-9fca81f05238

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ github.com/erda-project/influxql v1.1.0-ex h1:NgP5+S5Qo234IVSIJ3N/egvzCNYJURfMAe
 github.com/erda-project/influxql v1.1.0-ex/go.mod h1:gHp9y86a/pxhjJ+zMjNXiQAA197Xk9wLxaz+fGG+kWk=
 github.com/erda-project/remotedialer v0.2.6-0.20210713103000-da03eb9e4b23 h1:NaKo6voQVqZM6DMBVhcTT4gjd+lr1C3zE17RROspfg0=
 github.com/erda-project/remotedialer v0.2.6-0.20210713103000-da03eb9e4b23/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
+github.com/erda-project/rocketmq-operator v0.0.0-20221222075906-f28c42d7bf23 h1:A2cod4X3yK1YIBbTIf7q1b8+/S6iLwyNVtQ/SOYflQo=
+github.com/erda-project/rocketmq-operator v0.0.0-20221222075906-f28c42d7bf23/go.mod h1:NOglgj931lh7myfNFa00hb3UIiRlxhbMjCv/Ek5RJA8=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
@@ -1329,7 +1331,7 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/rocketmq/rocketmq.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/rocketmq/rocketmq.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rocketmq
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	rocketmqv1alpha1 "erda.cloud/rocketmq/api/v1alpha1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8sapi"
+	"github.com/erda-project/erda/pkg/http/httpclient"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
+	"github.com/erda-project/erda/pkg/schedule/schedulepolicy/constraintbuilders"
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+var (
+	svcNameSrv = "rocketmq-namesrv"
+	svcBroker  = "rocketmq-broker"
+	svcConsole = "rocketmq-console"
+)
+
+var (
+	scStorageMode = "StorageClass"
+)
+
+type RocketMQOperator struct {
+	k8s        addon.K8SUtil
+	ns         addon.NamespaceUtil
+	client     *httpclient.HTTPClient
+	overcommit addon.OvercommitUtil
+}
+
+func New(k8s addon.K8SUtil, ns addon.NamespaceUtil, client *httpclient.HTTPClient, overcommit addon.OvercommitUtil) *RocketMQOperator {
+	return &RocketMQOperator{
+		k8s:        k8s,
+		ns:         ns,
+		client:     client,
+		overcommit: overcommit,
+	}
+}
+
+func (r *RocketMQOperator) IsSupported() bool {
+	resp, err := r.client.Get(r.k8s.GetK8SAddr()).
+		Path("/apis/addons.erda.cloud/v1alpha1").
+		Do().
+		DiscardBody()
+	if err != nil {
+		logrus.Errorf("failed to query /apis/addons.erda.cloud/v1alpha1, host: %v, err: %v",
+			r.k8s.GetK8SAddr(), err)
+		return false
+	}
+	if !resp.IsOK() {
+		return false
+	}
+	return true
+}
+
+func (r *RocketMQOperator) Validate(sg *apistructs.ServiceGroup) error {
+	operator, ok := sg.Labels["USE_OPERATOR"]
+	if !ok {
+		return fmt.Errorf("[BUG] sg need USE_OPERATOR label")
+	}
+	if strutil.ToLower(operator) != "rocketmq" {
+		return fmt.Errorf("[BUG] value of label USE_OPERATOR should be 'rocketmq'")
+	}
+	if len(sg.Services) != 3 {
+		return fmt.Errorf("illegal services num: %d", len(sg.Services))
+	}
+	if _, ok := sg.Labels["VERSION"]; !ok {
+		return fmt.Errorf("[BUG] sg need VERSION label")
+	}
+	return nil
+}
+
+// Convert sg to cr, which is kubernetes yaml
+func (r *RocketMQOperator) Convert(sg *apistructs.ServiceGroup) interface{} {
+	var nameSrvSpec rocketmqv1alpha1.NameServiceSpec
+	var brokerSpec rocketmqv1alpha1.BrokerSpec
+	var consoleSpec rocketmqv1alpha1.ConsoleSpec
+
+	scheinfo := sg.ScheduleInfo2
+	scheinfo.Stateful = true
+	affinity := constraintbuilders.K8S(&scheinfo, nil, nil, nil).Affinity.NodeAffinity
+
+	for i := range sg.Services {
+		switch sg.Services[i].Name {
+		case svcNameSrv:
+			nameSrvSpec = r.convertNameSrv(sg.Services[i], affinity)
+		case svcBroker:
+			brokerSpec = r.convertBroker(sg.Services[i], affinity)
+		case svcConsole:
+			consoleSpec = r.convertConsole(sg.Services[i], affinity)
+		}
+	}
+	rocketMQ := rocketmqv1alpha1.RocketMQ{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RocketMQ",
+			APIVersion: "addons.erda.cloud/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sg.ID,
+			Namespace: genK8SNamespace(sg.Type, sg.ID),
+		},
+		Spec: rocketmqv1alpha1.RocketMQSpec{
+			NameServiceSpec: nameSrvSpec,
+			BrokerSpec:      brokerSpec,
+			ConsoleSpec:     consoleSpec,
+		},
+	}
+	return rocketMQ
+}
+
+func (r *RocketMQOperator) Create(k8syml interface{}) error {
+	rocketMQ, ok := k8syml.(rocketmqv1alpha1.RocketMQ)
+	if !ok {
+		return fmt.Errorf("invalid type, the k8syml should be RocketMQ")
+	}
+	if err := r.ns.Exists(rocketMQ.Namespace); err != nil {
+		if err := r.ns.Create(rocketMQ.Namespace, nil); err != nil {
+			return err
+		}
+	}
+	var b bytes.Buffer
+	resp, err := r.client.Post(r.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/addons.erda.cloud/v1alpha1/namespaces/%s/rocketmqs", rocketMQ.Namespace)).
+		JSONBody(rocketMQ).
+		Do().
+		Body(&b)
+	if err != nil {
+		return fmt.Errorf("failed to create rocketmq, %s/%s, err: %v, body: %v", rocketMQ.Namespace, rocketMQ.Name, err, b.String())
+	}
+	if !resp.IsOK() {
+		return fmt.Errorf("failed to create rocketmq, %s/%s, statuscode: %v, body: %v",
+			rocketMQ.Namespace, rocketMQ.Name, resp.StatusCode(), b.String())
+	}
+
+	return nil
+}
+
+func (r *RocketMQOperator) Inspect(sg *apistructs.ServiceGroup) (*apistructs.ServiceGroup, error) {
+	rocketMQ, err := r.getRocketMQ(genK8SNamespace(sg.Type, sg.ID), sg.ID)
+	if err != nil {
+		return nil, err
+	}
+	var rocketMQService *apistructs.Service
+	var consoleService *apistructs.Service
+	for i := range sg.Services {
+		if sg.Services[i].Name == svcNameSrv {
+			rocketMQService = &sg.Services[i]
+		}
+		if sg.Services[i].Name == svcConsole {
+			consoleService = &sg.Services[i]
+		}
+	}
+	rocketMQService.Vip = strutil.Join([]string{rocketMQ.Spec.NameServiceSpec.Name, rocketMQ.Namespace, "svc.cluster.local"}, ".")
+	consoleService.Vip = strutil.Join([]string{rocketMQ.Spec.ConsoleSpec.Name, rocketMQ.Namespace, "svc.cluster.local"}, ".")
+	switch rocketMQ.Status.ConditionStatus {
+	case rocketmqv1alpha1.ConditionReady:
+		sg.Status = apistructs.StatusHealthy
+	case rocketmqv1alpha1.ConditionFailed:
+		sg.Status = apistructs.StatusUnHealthy
+	default:
+	}
+	return sg, nil
+}
+
+func (r *RocketMQOperator) Remove(sg *apistructs.ServiceGroup) error {
+	ns := genK8SNamespace(sg.Type, sg.ID)
+	var b bytes.Buffer
+	resp, err := r.client.Delete(r.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/addons.erda.cloud/v1alpha1/namespaces/%s/rocketmqs/%s", ns, sg.ID)).
+		JSONBody(k8sapi.DeleteOptions).
+		Do().
+		Body(&b)
+	if err != nil {
+		return fmt.Errorf("failed to delete rocketmq, %s/%s, err: %v", ns, sg.ID, err)
+	}
+	if !resp.IsOK() {
+		if resp.IsNotfound() {
+			return nil
+		}
+		return fmt.Errorf("failed to delete rocketmq, %s/%s, statuscode: %v, body: %v", ns, sg.ID, resp.StatusCode(), b.String())
+	}
+	if err := r.ns.Delete(ns); err != nil {
+		return fmt.Errorf("failed to delete namespace, %s, err: %v", ns, err)
+	}
+	return nil
+}
+
+func (r *RocketMQOperator) Update(k8syml interface{}) error {
+	rocketMQ, ok := k8syml.(rocketmqv1alpha1.RocketMQ)
+	if !ok {
+		return fmt.Errorf("invalid type, the k8syml should be RocketMQ")
+	}
+	if err := r.ns.Exists(rocketMQ.Namespace); err != nil {
+		return err
+	}
+
+	ro, err := r.getRocketMQ(rocketMQ.Namespace, rocketMQ.Name)
+	if err != nil {
+		return err
+	}
+
+	rocketMQ.ResourceVersion = ro.ResourceVersion
+	rocketMQ.Annotations = ro.Annotations
+
+	var b bytes.Buffer
+	resp, err := r.client.Put(r.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/addons.erda.cloud/v1alpha1/namespaces/%s/rocketmqs/%s", rocketMQ.Namespace, rocketMQ.Name)).
+		JSONBody(rocketMQ).
+		Do().
+		Body(&b)
+	if err != nil {
+		return fmt.Errorf("failed to update rocketmq, %s/%s, err: %v, body: %v", rocketMQ.Namespace, rocketMQ.Name, err, b.String())
+	}
+	if !resp.IsOK() {
+		return fmt.Errorf("failed to update rocketmq, %s/%s, statuscode: %v, body: %v",
+			rocketMQ.Namespace, rocketMQ.Name, resp.StatusCode(), b.String())
+	}
+	return nil
+}
+
+func (r *RocketMQOperator) getRocketMQ(namespace, name string) (*rocketmqv1alpha1.RocketMQ, error) {
+	var b bytes.Buffer
+	resp, err := r.client.Get(r.k8s.GetK8SAddr()).
+		Path(fmt.Sprintf("/apis/addons.erda.cloud/v1alpha1/namespaces/%s/rocketmqs/%s", namespace, name)).
+		Do().
+		Body(&b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rocketmq, %s/%s, err: %v, body: %v", namespace, name, err, b.String())
+	}
+	if !resp.IsOK() {
+		return nil, fmt.Errorf("failed to get rocketmq, %s/%s, statuscode: %v, body: %v",
+			namespace, name, resp.StatusCode(), b.String())
+	}
+	var rocketMQ rocketmqv1alpha1.RocketMQ
+	if err := json.NewDecoder(&b).Decode(&rocketMQ); err != nil {
+		return nil, err
+	}
+	return &rocketMQ, nil
+}
+
+func (r *RocketMQOperator) convertNameSrv(svc apistructs.Service, affinity *corev1.NodeAffinity) rocketmqv1alpha1.NameServiceSpec {
+	var nameSrvSpec rocketmqv1alpha1.NameServiceSpec
+	nameSrvSpec.Name = svc.Name
+	nameSrvSpec.Image = svc.Image
+	nameSrvSpec.Affinity = &corev1.Affinity{NodeAffinity: affinity}
+	nameSrvSpec.Size = int32(svc.Scale)
+	nameSrvSpec.StorageMode = scStorageMode
+	nameSrvSpec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*r.overcommit.CPUOvercommit(svc.Resources.Cpu)))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", r.overcommit.MemoryOvercommit(int(svc.Resources.Mem)))),
+		},
+		Limits: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*svc.Resources.Cpu))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", int(svc.Resources.Mem))),
+		},
+	}
+	scname, capacity := getStorageCapacity(svc)
+	nameSrvSpec.Env = convertEnvs(svc.Env)
+	nameSrvSpec.Labels = svc.Labels
+	nameSrvSpec.Labels["ADDON_ID"] = svc.Env["ADDON_ID"]
+	nameSrvSpec.Labels[apistructs.DICE_CLUSTER_NAME.String()] = svc.Env[apistructs.DICE_CLUSTER_NAME.String()]
+	nameSrvSpec.Labels[apistructs.EnvDiceOrgName] = svc.Env[apistructs.EnvDiceOrgName]
+	nameSrvSpec.Labels[apistructs.EnvDiceOrgID] = svc.Env[apistructs.EnvDiceOrgID]
+	nameSrvSpec.EnableMetrics = true
+	nameSrvSpec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "namesrv-log-storage",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scname,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"storage": resource.MustParse(capacity),
+					},
+				},
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+		},
+	}
+	return nameSrvSpec
+}
+
+func (r *RocketMQOperator) convertBroker(svc apistructs.Service, affinity *corev1.NodeAffinity) rocketmqv1alpha1.BrokerSpec {
+	var brokerSpec rocketmqv1alpha1.BrokerSpec
+	brokerSpec.Name = svc.Name
+	brokerSpec.Image = svc.Image
+	brokerSpec.Affinity = &corev1.Affinity{NodeAffinity: affinity}
+	brokerSpec.Size = int32(svc.Scale)
+	brokerSpec.StorageMode = scStorageMode
+	brokerSpec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*r.overcommit.CPUOvercommit(svc.Resources.Cpu)))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", r.overcommit.MemoryOvercommit(int(svc.Resources.Mem)))),
+		},
+		Limits: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*svc.Resources.Cpu))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", int(svc.Resources.Mem))),
+		},
+	}
+	scname, capacity := getStorageCapacity(svc)
+	brokerSpec.Env = convertEnvs(svc.Env)
+	brokerSpec.Labels = svc.Labels
+	brokerSpec.Labels["ADDON_ID"] = svc.Env["ADDON_ID"]
+	brokerSpec.Labels[apistructs.DICE_CLUSTER_NAME.String()] = svc.Env[apistructs.DICE_CLUSTER_NAME.String()]
+	brokerSpec.Labels[apistructs.EnvDiceOrgName] = svc.Env[apistructs.EnvDiceOrgName]
+	brokerSpec.Labels[apistructs.EnvDiceOrgID] = svc.Env[apistructs.EnvDiceOrgID]
+	brokerSpec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "broker-data-storage",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scname,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"storage": resource.MustParse(capacity),
+					},
+				},
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+		},
+	}
+	return brokerSpec
+}
+
+func (r *RocketMQOperator) convertConsole(svc apistructs.Service, affinity *corev1.NodeAffinity) rocketmqv1alpha1.ConsoleSpec {
+	var consoleSpec rocketmqv1alpha1.ConsoleSpec
+	consoleSpec.Name = svc.Name
+	consoleSpec.Image = svc.Image
+	consoleSpec.Affinity = &corev1.Affinity{NodeAffinity: affinity}
+	consoleSpec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*r.overcommit.CPUOvercommit(svc.Resources.Cpu)))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", r.overcommit.MemoryOvercommit(int(svc.Resources.Mem)))),
+		},
+		Limits: corev1.ResourceList{
+			"cpu": resource.MustParse(
+				fmt.Sprintf("%dm", int(1000*svc.Resources.Cpu))),
+			"memory": resource.MustParse(
+				fmt.Sprintf("%dMi", int(svc.Resources.Mem))),
+		},
+	}
+	return consoleSpec
+}
+
+func convertEnvs(envs map[string]string) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+	for k, v := range envs {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  k,
+			Value: v,
+		})
+	}
+	return envVars
+}
+
+func getStorageCapacity(svc apistructs.Service) (string, string) {
+	scName := apistructs.DiceLocalVolumeSC
+	capacity := "20Gi"
+	if len(svc.Volumes) > 0 {
+		if svc.Volumes[0].SCVolume.Capacity >= diceyml.AddonVolumeSizeMin && svc.Volumes[0].SCVolume.Capacity <= diceyml.AddonVolumeSizeMax {
+			capacity = fmt.Sprintf("%dGi", svc.Volumes[0].SCVolume.Capacity)
+		}
+
+		if svc.Volumes[0].SCVolume.Capacity > diceyml.AddonVolumeSizeMax {
+			capacity = fmt.Sprintf("%dGi", diceyml.AddonVolumeSizeMax)
+		}
+		if svc.Volumes[0].SCVolume.StorageClassName != "" {
+			scName = svc.Volumes[0].SCVolume.StorageClassName
+		}
+	}
+	return scName, capacity
+}
+
+func genK8SNamespace(namespace, name string) string {
+	return strutil.Concat(namespace, "--", name)
+}

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s.go
@@ -49,6 +49,7 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/elasticsearch"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/mysql"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis"
+	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/rocketmq"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/sourcecov"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/clusterinfo"
 	ds "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/daemonset"
@@ -228,6 +229,7 @@ type Kubernetes struct {
 	canaloperator         addon.AddonOperator
 	daemonsetoperator     addon.AddonOperator
 	sourcecovoperator     addon.AddonOperator
+	rocketmqoperator      addon.AddonOperator
 
 	// instanceinfoSyncCancelFunc
 	instanceinfoSyncCancelFunc context.CancelFunc
@@ -460,6 +462,8 @@ func New(name executortypes.Name, clusterName string, options map[string]string)
 	daemonsetoperator := daemonset.New(k, ns, k, k, ds, k)
 	k.daemonsetoperator = daemonsetoperator
 	k.sourcecovoperator = sourcecov.New(k, client, k, ns)
+	rocketmqoperator := rocketmq.New(k, ns, client, k)
+	k.rocketmqoperator = rocketmqoperator
 	return k, nil
 }
 
@@ -718,6 +722,7 @@ func (k *Kubernetes) CapacityInfo() apistructs.CapacityInfoData {
 	r.CanalOperator = k.canaloperator.IsSupported()
 	r.DaemonsetOperator = k.daemonsetoperator.IsSupported()
 	r.SourcecovOperator = k.sourcecovoperator.IsSupported()
+	r.RocketMQOperator = k.rocketmqoperator.IsSupported()
 	return r
 }
 
@@ -1320,6 +1325,8 @@ func (k *Kubernetes) whichOperator(operator string) (addon.AddonOperator, error)
 		return k.daemonsetoperator, nil
 	case apistructs.AddonSourcecov:
 		return k.sourcecovoperator, nil
+	case apistructs.AddonRocketMQ:
+		return k.rocketmqoperator, nil
 	}
 	return nil, fmt.Errorf("not found")
 }

--- a/internal/tools/orchestrator/services/addon/addon.go
+++ b/internal/tools/orchestrator/services/addon/addon.go
@@ -1975,7 +1975,12 @@ func (a *Addon) doAddonScale(addonInstance *dbclient.AddonInstance, addonInstanc
 }
 
 func addonCanScale(addonName, addonId, plan, version, status, action string) error {
-	if addonName == apistructs.AddonES && (action == apistructs.ScaleActionDown || action == apistructs.ScaleActionUp) && (version == "6.8.9" || version == "6.8.22") {
+	if addonName == apistructs.AddonES && (action == apistructs.ScaleActionDown || action == apistructs.ScaleActionUp) && (version == "6.8.9" || version == "6.8.22" || version == "7.17.7") {
+		errMsg := fmt.Sprintf("scale addon failed: addon %s is an operator which can not do %s", addonName, action)
+		return errors.New(errMsg)
+	}
+
+	if addonName == apistructs.AddonRocketMQ && (action == apistructs.ScaleActionDown || action == apistructs.ScaleActionUp) && (version == "5.0.0") {
 		errMsg := fmt.Sprintf("scale addon failed: addon %s is an operator which can not do %s", addonName, action)
 		return errors.New(errMsg)
 	}

--- a/internal/tools/orchestrator/services/addon/addon_deploy.go
+++ b/internal/tools/orchestrator/services/addon/addon_deploy.go
@@ -575,8 +575,12 @@ func (a *Addon) BuildAddonRequestGroup(params *apistructs.AddonHandlerCreateItem
 			buildErr = a.BuildEsServiceItem(params, addonIns, addonSpec, addonDice, &clusterInfo)
 		}
 	case apistructs.AddonRocketMQ:
-		addonDeployGroup.GroupLabels["ADDON_GROUPS"] = "3"
-		buildErr = a.BuildRocketMqServiceItem(params, addonIns, addonSpec, addonDice, &clusterInfo)
+		if capacity.RocketMQOperator && version.Compare(addonSpec.Version, "5.0.0", ">=") {
+			buildErr = a.BuildRocketMQOperaotrServiceItem(params, addonIns, addonSpec, addonDice, &clusterInfo, addonSpec.Version)
+		} else {
+			addonDeployGroup.GroupLabels["ADDON_GROUPS"] = "3"
+			buildErr = a.BuildRocketMqServiceItem(params, addonIns, addonSpec, addonDice, &clusterInfo)
+		}
 	case apistructs.AddonKafka:
 		addonDeployGroup.GroupLabels["ADDON_GROUPS"] = "2"
 		buildErr = a.BuildKafkaServiceItem(params, addonIns, addonSpec, addonDice, &clusterInfo)

--- a/internal/tools/orchestrator/services/addon/addon_status_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_status_test.go
@@ -18,7 +18,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/tools/orchestrator/dbclient"
+	"github.com/erda-project/erda/pkg/parser/diceyml"
 )
 
 func TestSetlabelsFromOptions(t *testing.T) {
@@ -52,4 +56,64 @@ func TestSetlabelsFromOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildRocketMQOperaotrServiceItem(t *testing.T) {
+	params := &apistructs.AddonHandlerCreateItem{
+		Options: map[string]string{},
+		Plan:    "basic",
+	}
+	addonIns := &dbclient.AddonInstance{
+		ID: "1",
+	}
+	addonSpec := &apistructs.AddonExtension{
+		Name: "rocketmq",
+		Plan: map[string]apistructs.AddonPlanItem{
+			"basic": {
+				InsideMoudle: map[string]apistructs.AddonPlanItem{
+					"rocketmq-namesrv": {
+						CPU:   1,
+						Mem:   2048,
+						Nodes: 1,
+					},
+					"rocketmq-broker": {
+						CPU:   1,
+						Mem:   2048,
+						Nodes: 1,
+					},
+					"rocketmq-console": {
+						CPU:   0.5,
+						Mem:   1024,
+						Nodes: 1,
+					},
+				},
+			},
+		},
+	}
+	addonDice := &diceyml.Object{
+		Services: diceyml.Services{
+			"rocketmq-namesrv": {
+				Labels: map[string]string{},
+				Envs: map[string]string{
+					"ADON_TYPE": "rocketmq",
+				},
+			},
+			"rocketmq-broker": {
+				Labels: map[string]string{},
+				Envs: map[string]string{
+					"ADON_TYPE": "rocketmq",
+				},
+			},
+			"rocketmq-console": {
+				Labels: map[string]string{},
+				Envs: map[string]string{
+					"ADON_TYPE": "rocketmq",
+				},
+			},
+		},
+	}
+	a := &Addon{}
+
+	err := a.BuildRocketMQOperaotrServiceItem(params, addonIns, addonSpec, addonDice, nil, "5.0.0")
+	assert.NoError(t, err)
 }

--- a/internal/tools/orchestrator/services/addon/middleware.go
+++ b/internal/tools/orchestrator/services/addon/middleware.go
@@ -88,6 +88,9 @@ func isOperatorAddon(addon dbclient.AddonInstance) bool {
 	if addon.AddonName == "terminus-elasticsearch" && version.Compare(addon.Version, "6.8.9", ">=") {
 		return true
 	}
+	if addon.AddonName == "rocketmq" && version.Compare(addon.Version, "5.0.0", ">=") {
+		return true
+	}
 	return false
 }
 

--- a/pkg/k8sclient/scheme/register.go
+++ b/pkg/k8sclient/scheme/register.go
@@ -15,6 +15,7 @@
 package scheme
 
 import (
+	rocketmqv1alpha1 "erda.cloud/rocketmq/api/v1alpha1"
 	sparkoperatorv1beta2 "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	elasticsearchv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	flinkoperatoryv1beta1 "github.com/spotify/flink-on-k8s-operator/apis/flinkcluster/v1beta1"
@@ -43,4 +44,5 @@ var LocalSchemeBuilder = runtime.SchemeBuilder{
 	istiosecv1beta1.AddToScheme,
 	flinkoperatoryv1beta1.AddToScheme,
 	apiextensions.AddToScheme,
+	rocketmqv1alpha1.AddToScheme,
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
support rocketmq operator executor

1. create rocketmq cluster by operator where version >= 5.0.0
2. auto enable rocketmq exporter for metrics


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Suppor rocketmq operator executor on orchestrator（实现rocketmq operator的executor，支持5.0.0版本用operator创建集群 ）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Suppor rocketmq operator executor on orchestrator             |
| 🇨🇳 中文    |    实现rocketmq operator的executor，支持5.0.0版本用operator创建集群          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
