### PR TITLE
fix: metric use es meta panic

### DIFF
--- a/internal/tools/monitor/core/metric/query/metricmeta/manager.go
+++ b/internal/tools/monitor/core/metric/query/metricmeta/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) Init() error {
 		m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 	}
 
-	if m.sources[ClickhouseMetaSource] {
+	if m.sources[ClickhouseMetaSource] && m.ckMetaLoader != nil {
 		gp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
 		if err != nil {
 			return err

--- a/internal/tools/monitor/core/metric/query/metricmeta/manager.go
+++ b/internal/tools/monitor/core/metric/query/metricmeta/manager.go
@@ -128,19 +128,17 @@ func (m *Manager) Init() error {
 		m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 	}
 
-	if m.sources[ClickhouseMetaSource] {
-		if m.ckMetaLoader != nil {
-			gp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
-			if err != nil {
-				return err
-			}
-			m.groupProviders = append(m.groupProviders, func() GroupProvider { return gp })
-			mp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
-			if err != nil {
-				return err
-			}
-			m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
+	if m.sources[ClickhouseMetaSource] && m.ckMetaLoader != nil {
+		gp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
+		if err != nil {
+			return err
 		}
+		m.groupProviders = append(m.groupProviders, func() GroupProvider { return gp })
+		mp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
+		if err != nil {
+			return err
+		}
+		m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 	}
 	return nil
 }

--- a/internal/tools/monitor/core/metric/query/metricmeta/manager.go
+++ b/internal/tools/monitor/core/metric/query/metricmeta/manager.go
@@ -128,17 +128,19 @@ func (m *Manager) Init() error {
 		m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 	}
 
-	if m.sources[ClickhouseMetaSource] && m.ckMetaLoader != nil {
-		gp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
-		if err != nil {
-			return err
+	if m.sources[ClickhouseMetaSource] {
+		if m.ckMetaLoader != nil {
+			gp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
+			if err != nil {
+				return err
+			}
+			m.groupProviders = append(m.groupProviders, func() GroupProvider { return gp })
+			mp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
+			if err != nil {
+				return err
+			}
+			m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 		}
-		m.groupProviders = append(m.groupProviders, func() GroupProvider { return gp })
-		mp, err := NewMetaClickhouseGroupProvider(m.ckMetaLoader)
-		if err != nil {
-			return err
-		}
-		m.metricProviders = append(m.metricProviders, func() MetricMetaProvider { return mp })
 	}
 	return nil
 }

--- a/internal/tools/monitor/core/metric/query/metricmeta/manager_test.go
+++ b/internal/tools/monitor/core/metric/query/metricmeta/manager_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotClickhouseMetaInit(t *testing.T) {
+	manage := Manager{}
+	manage.sources = make(map[MetaSource]bool)
+	manage.sources[ClickhouseMetaSource] = true
+	require.NoError(t, manage.Init())
+}

--- a/internal/tools/monitor/core/metric/query/metricmeta/manager_test.go
+++ b/internal/tools/monitor/core/metric/query/metricmeta/manager_test.go
@@ -26,3 +26,11 @@ func TestNotClickhouseMetaInit(t *testing.T) {
 	manage.sources[ClickhouseMetaSource] = true
 	require.NoError(t, manage.Init())
 }
+
+func TestClickhouseMetaInit(t *testing.T) {
+	manage := Manager{}
+	manage.sources = make(map[MetaSource]bool)
+	manage.sources[ClickhouseMetaSource] = true
+	manage.ckMetaLoader = mockMeta{}
+	require.NoError(t, manage.Init())
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix metric use es meta panic

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix metric use es meta panic          |
| 🇨🇳 中文    |        指标使用 es 时, meta 造成 panic      |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
