### PR TITLE
fix(erda-server): project label permission leak

### DIFF
--- a/internal/core/legacy/endpoints/label.go
+++ b/internal/core/legacy/endpoints/label.go
@@ -17,6 +17,7 @@ package endpoints
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -41,6 +42,9 @@ func (e *Endpoints) CreateLabel(ctx context.Context, r *http.Request, vars map[s
 	}
 	req.IdentityInfo = identityInfo
 	logrus.Debugf("create label request body: %+v", req)
+	if err := e.checkProjectPermission(identityInfo, req.ProjectID, apistructs.UpdateAction); err != nil {
+		return errorresp.ErrResp(err)
+	}
 
 	labelID, err := e.label.Create(&req)
 	if err != nil {
@@ -59,9 +63,18 @@ func (e *Endpoints) DeleteLabel(ctx context.Context, r *http.Request, vars map[s
 		return apierrors.ErrDeleteLabel.InvalidParameter(err).ToResp(), nil
 	}
 
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
+		return apierrors.ErrDeleteLabel.NotLogin().ToResp(), nil
+	}
+
 	label, err := e.label.GetByID(labelID)
 	if err != nil {
-		logrus.Errorf("when get label for audit faild %v", err)
+		return apierrors.ErrDeleteLabel.InternalError(err).ToResp(), nil
+	}
+
+	if err := e.checkProjectPermission(identityInfo, label.ProjectID, apistructs.UpdateAction); err != nil {
+		return errorresp.ErrResp(err)
 	}
 
 	if err := e.label.Delete(labelID); err != nil {
@@ -96,6 +109,21 @@ func (e *Endpoints) UpdateLabel(ctx context.Context, r *http.Request, vars map[s
 
 	req.ID = labelID
 
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
+		return apierrors.ErrUpdateLabel.NotLogin().ToResp(), nil
+	}
+	req.IdentityInfo = identityInfo
+
+	label, err := e.label.GetByID(labelID)
+	if err != nil {
+		return apierrors.ErrUpdateLabel.InternalError(err).ToResp(), nil
+	}
+
+	if err := e.checkProjectPermission(identityInfo, label.ProjectID, apistructs.UpdateAction); err != nil {
+		return errorresp.ErrResp(err)
+	}
+
 	// 更新label至DB
 	if err = e.label.Update(&req); err != nil {
 		return errorresp.ErrResp(err)
@@ -107,13 +135,18 @@ func (e *Endpoints) UpdateLabel(ctx context.Context, r *http.Request, vars map[s
 // ListLabel 获取标签列表
 func (e *Endpoints) ListLabel(ctx context.Context, r *http.Request, vars map[string]string) (
 	httpserver.Responser, error) {
-	if _, err := user.GetIdentityInfo(r); err != nil {
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
 		return apierrors.ErrGetLabels.NotLogin().ToResp(), nil
 	}
 
 	var req apistructs.ProjectLabelListRequest
 	if err := e.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
 		return apierrors.ErrGetLabels.InvalidParameter(err).ToResp(), nil
+	}
+
+	if err := e.checkProjectPermission(identityInfo, req.ProjectID, apistructs.GetAction); err != nil {
+		return errorresp.ErrResp(err)
 	}
 
 	total, labels, err := e.label.List(&req)
@@ -135,7 +168,8 @@ func (e *Endpoints) ListLabel(ctx context.Context, r *http.Request, vars map[str
 // GetLabel 通过id获取label
 func (e *Endpoints) GetLabel(ctx context.Context, r *http.Request, vars map[string]string) (
 	httpserver.Responser, error) {
-	if _, err := user.GetIdentityInfo(r); err != nil {
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
 		return apierrors.ErrGetLabels.NotLogin().ToResp(), nil
 	}
 
@@ -150,19 +184,28 @@ func (e *Endpoints) GetLabel(ctx context.Context, r *http.Request, vars map[stri
 		return errorresp.ErrResp(err)
 	}
 
+	if err := e.checkProjectPermission(identityInfo, label.ProjectID, apistructs.GetAction); err != nil {
+		return errorresp.ErrResp(err)
+	}
+
 	return httpserver.OkResp(label)
 }
 
 // ListByNamesAndProjectID list label by names and projectID
 func (e *Endpoints) ListByNamesAndProjectID(ctx context.Context, r *http.Request, vars map[string]string) (
 	httpserver.Responser, error) {
-	if _, err := user.GetIdentityInfo(r); err != nil {
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
 		return apierrors.ErrListByNamesAndProjectID.NotLogin().ToResp(), nil
 	}
 
 	var req apistructs.ListByNamesAndProjectIDRequest
 	if err := e.queryStringDecoder.Decode(&req, r.URL.Query()); err != nil {
 		return apierrors.ErrListByNamesAndProjectID.InvalidParameter(err).ToResp(), nil
+	}
+
+	if err := e.checkProjectPermission(identityInfo, req.ProjectID, apistructs.GetAction); err != nil {
+		return errorresp.ErrResp(err)
 	}
 
 	labels, err := e.label.ListByNamesAndProjectID(req)
@@ -176,7 +219,8 @@ func (e *Endpoints) ListByNamesAndProjectID(ctx context.Context, r *http.Request
 // ListLabelByIDs list label by ids
 func (e *Endpoints) ListLabelByIDs(ctx context.Context, r *http.Request, vars map[string]string) (
 	httpserver.Responser, error) {
-	if _, err := user.GetIdentityInfo(r); err != nil {
+	identityInfo, err := user.GetIdentityInfo(r)
+	if err != nil {
 		return apierrors.ErrListLabelByIDs.NotLogin().ToResp(), nil
 	}
 
@@ -190,5 +234,41 @@ func (e *Endpoints) ListLabelByIDs(ctx context.Context, r *http.Request, vars ma
 		return errorresp.ErrResp(err)
 	}
 
+	projectIDMap := make(map[uint64]struct{})
+	for _, label := range labels {
+		projectIDMap[label.ProjectID] = struct{}{}
+	}
+	for id := range projectIDMap {
+		if err := e.checkProjectPermission(identityInfo, id, apistructs.GetAction); err != nil {
+			return errorresp.ErrResp(err)
+		}
+	}
+
 	return httpserver.OkResp(labels)
+}
+
+func (e *Endpoints) checkProjectPermission(identityInfo apistructs.IdentityInfo, projectID uint64, action string) error {
+	if projectID == 0 {
+		return apierrors.ErrCheckPermission.InvalidParameter(fmt.Errorf("no projectID"))
+	}
+	if identityInfo.IsInternalClient() {
+		return nil
+	}
+	access, err := e.permission.CheckPermission(&apistructs.PermissionCheckRequest{
+		UserID:       identityInfo.UserID,
+		Scope:        apistructs.ProjectScope,
+		ScopeID:      projectID,
+		Resource:     apistructs.ProjectResource,
+		Action:       action,
+		ResourceRole: "",
+	})
+	if err != nil {
+		logrus.Errorf("failed to check project permission, userID: %s, projectID: %d, action: %s, err: %v", identityInfo.UserID, projectID, action, err)
+		// return 403. Do Not disclose specific errors to clients, such as: project not found
+		return apierrors.ErrCheckPermission.AccessDenied()
+	}
+	if !access {
+		return apierrors.ErrCheckPermission.AccessDenied()
+	}
+	return nil
 }

--- a/internal/core/legacy/endpoints/label_test.go
+++ b/internal/core/legacy/endpoints/label_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func TestEndpoints_checkProjectPermission(t *testing.T) {
+	e := Endpoints{}
+
+	// no projectID
+	err := e.checkProjectPermission(apistructs.IdentityInfo{}, 0, "")
+	assert.Error(t, err)
+
+	// internal-client
+	err = e.checkProjectPermission(apistructs.IdentityInfo{InternalClient: "test"}, 1, "")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix project label permission leak

Tested on erda daily. Now, code will check operator's **PROJECT UPDATE** permission for write operations(create / delete / update), and check **PROJECT GET** permission for read operations(get / list).


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=358748&iterationID=1501&type=TASK)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix project label permission leak            |
| 🇨🇳 中文    |   修复项目标签越权           |