### PR TITLE
fix: action-runner upload target result timeout

### DIFF
--- a/cmd/action-runner/config.json
+++ b/cmd/action-runner/config.json
@@ -12,5 +12,6 @@
     "export SASS_BINARY_SITE=https://npm.taobao.org/mirrors/node-sass/",
     "security unlock-keychain -p {{user_password}} {{osx_keychains_path}}",
     "security set-key-partition-list -S apple-tool:,apple: -s -k \"{{user_password}}\"  ~/Library/Keychains/login.keychain"
-  ]
+  ],
+  "upload_timeout_sec": 500
 }

--- a/cmd/action-runner/main.go
+++ b/cmd/action-runner/main.go
@@ -67,6 +67,10 @@ func readConfig(path string) *actionrunner.Conf {
 		conf.FailedTaskKeepHours = 3
 	}
 	conf.MaxTask = convInt(getEnv("MAX_TASK", strconv.Itoa(conf.MaxTask)))
+	// set default 500 seconds timeout
+	if conf.UploadTimeoutSec == 0 {
+		conf.UploadTimeoutSec = 500
+	}
 	return &conf
 }
 

--- a/internal/tools/pipeline/action-runner/apis.go
+++ b/internal/tools/pipeline/action-runner/apis.go
@@ -105,7 +105,7 @@ func (w *worker) uploadFile(filePath, token string) (string, error) {
 	}
 
 	request := httpclient.New(httpclient.WithCompleteRedirect(),
-		httpclient.WithTimeout(15*time.Second, 300*time.Second)).Post(w.r.Conf.OpenAPI).
+		httpclient.WithTimeout(15*time.Second, time.Duration(w.conf.UploadTimeoutSec)*time.Second)).Post(w.r.Conf.OpenAPI).
 		Path("/api/files").
 		Param("fileFrom", "runner-cli").
 		Param("expiredIn", "3600s").

--- a/internal/tools/pipeline/action-runner/conf.go
+++ b/internal/tools/pipeline/action-runner/conf.go
@@ -23,4 +23,5 @@ type Conf struct {
 	FailedTaskKeepHours int               `json:"failed_task_keep_hours"`
 	Params              map[string]string `json:"params"`
 	StartupCommands     []string          `json:"startup_commands"`
+	UploadTimeoutSec    uint64            `json:"upload_timeout_sec"`
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
fix action-runner upload target result timeout

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=358863&iterationID=-1&type=TICKET)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that action-runner upload target result timeout （修复了action-runner上传构建产物超时的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that action-runner upload target result timeout          |
| 🇨🇳 中文    |      修复了action-runner上传构建产物超时的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
