### PR TITLE
fix: memory chart no incorrect

### DIFF
--- a/internal/apps/msp/apm/service/components/resources-runtime-monitor-java/runtime/provider.go
+++ b/internal/apps/msp/apm/service/components/resources-runtime-monitor-java/runtime/provider.go
@@ -57,7 +57,7 @@ type provider struct {
 }
 
 func (p *provider) getMemoryHeapLineGraph(ctx context.Context, startTime, endTime int64, tenantId, instanceId, serviceId string) ([]*model.LineGraphMetaData, error) {
-	statement := fmt.Sprintf("SELECT round_float(avg(committed::field), 2),round_float(avg(init::field), 2),round_float(max(max::field), 2),round_float(avg(used::field), 2) " +
+	statement := fmt.Sprintf("SELECT round_float(max(committed::field), 2),round_float(max(init::field), 2),round_float(max(max::field), 2),round_float(max(used::field), 2) " +
 		"FROM jvm_memory " +
 		"WHERE terminus_key::tag=$terminus_key " +
 		"AND service_id::tag=$service_id " +
@@ -116,7 +116,7 @@ func (p *provider) getMemoryHeapLineGraph(ctx context.Context, startTime, endTim
 }
 
 func (p *provider) getMemoryNonHeapLineGraph(ctx context.Context, startTime, endTime int64, tenantId, instanceId, serviceId string) ([]*model.LineGraphMetaData, error) {
-	statement := fmt.Sprintf("SELECT round_float(avg(committed::field), 2),round_float(avg(init::field), 2),round_float(avg(used::field), 2) " +
+	statement := fmt.Sprintf("SELECT round_float(max(committed::field), 2),round_float(max(init::field), 2),round_float(max(used::field), 2) " +
 		"FROM jvm_memory " +
 		"WHERE terminus_key::tag=$terminus_key " +
 		"AND service_id::tag=$service_id " +
@@ -168,7 +168,7 @@ func (p *provider) getMemoryNonHeapLineGraph(ctx context.Context, startTime, end
 }
 
 func (p *provider) getMemoryEdenSpaceLineGraph(ctx context.Context, startTime, endTime int64, tenantId, instanceId, serviceId string) ([]*model.LineGraphMetaData, error) {
-	statement := fmt.Sprintf("SELECT round_float(avg(committed::field), 2),round_float(avg(init::field), 2),round_float(max(max::field), 2),round_float(avg(used::field), 2) " +
+	statement := fmt.Sprintf("SELECT round_float(max(committed::field), 2),round_float(max(init::field), 2),round_float(max(max::field), 2),round_float(max(used::field), 2) " +
 		"FROM jvm_memory " +
 		"WHERE terminus_key::tag=$terminus_key " +
 		"AND service_id::tag=$service_id " +


### PR DESCRIPTION
#### What this PR does / why we need it:

fix memory graph of the container monitor is inconsistent with the memory graph of the instance monitor

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix: memory chart no true           |
| 🇨🇳 中文    |     修复内存图表不准确         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
