### PR TITLE
feat(orchestrator): redis addon sts add exporter sidecar

### DIFF
--- a/apistructs/addon.go
+++ b/apistructs/addon.go
@@ -213,6 +213,7 @@ const (
 	RedisMasterNamePrefix    string = "redis-master"
 	RedisSlaveNamePrefix     string = "redis-slave"
 	RedisSentinelNamePrefix  string = "redis-sentinel"
+	RedisExporterNamePrefix  string = "redis-exporter"
 	RedisSentinelQuorum      string = "2"
 	RedisSentinelDownAfter   string = "12000"
 	RedisSentinelFailover    string = "12000"

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_stateful.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8s_stateful.go
@@ -318,7 +318,7 @@ func (k *Kubernetes) createStatefulService(sg *apistructs.ServiceGroup) error {
 	svc := sg.Services[0]
 
 	svc.Name = statefulsetName(sg)
-	k8sSvc := newService(&svc, nil)
+	k8sSvc := newService(&svc, svc.Labels)
 
 	if err := k.service.Create(k8sSvc); err != nil {
 		return err

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/statefulset.go
@@ -195,6 +195,8 @@ func (k *Kubernetes) createStatefulSet(ctx context.Context, info StatefulsetInfo
 	}
 
 	set.Spec.Template.Spec.Containers = []apiv1.Container{*container}
+	sidecars := k.generateSidecarContainers(service.SideCars)
+	set.Spec.Template.Spec.Containers = append(set.Spec.Template.Spec.Containers, sidecars...)
 
 	// ECI Pod inject fluent-bit sidecar container
 	useECI := UseECI(set.Labels, set.Spec.Template.Labels)


### PR DESCRIPTION
#### What this PR does / why we need it:
redis addon sts add exporter sidecar


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support redis addon sts add exporter sidecar （redis addon支持监控exporter的sidecar）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Support redis addon sts add exporter sidecar          |
| 🇨🇳 中文    |   redis addon支持监控exporter的sidecar           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
