### PR TITLE
fix: fix get pod status from k8s failed due pod without runtimeId label

### DIFF
--- a/apistructs/container.go
+++ b/apistructs/container.go
@@ -152,6 +152,7 @@ type Pod struct {
 	Phase         string         `json:"phase"`
 	Message       string         `json:"message"`
 	StartedAt     string         `json:"startedAt"`
+	UpdatedAt     string         `json:"updatedAt"`
 	Service       string         `json:"service"`
 	ClusterName   string         `json:"clusterName"`
 	PodName       string         `json:"podName"`

--- a/internal/tools/orchestrator/endpoints/instance_test.go
+++ b/internal/tools/orchestrator/endpoints/instance_test.go
@@ -142,6 +142,7 @@ func TestEndpoints_getPodStatusFromK8s(t *testing.T) {
 		Phase:         "Healthy",
 		Message:       containers[0].Message,
 		StartedAt:     "2022-08-02T11:40:15+08:00",
+		UpdatedAt:     "2022-08-02T11:40:15+08:00",
 		Service:       "test",
 		ClusterName:   "local-cluster",
 		PodName:       "test-b8e0431e45-6b745f9665-xn9c5",


### PR DESCRIPTION
#### What this PR does / why we need it:
Due to some deployed runtime  about 1.5 years ago,  runtime's pod without runtimeID info in Pod Labels (which use for match pods), so get pod will get no matched pod. 

#### Specified Reviewers:

/assign @sixther-dc @luobily @iutx @sfwn 


#### ChangeLog
Bugfix： Fix the bug that runtime's pod without runtimeID info in Pod Labels  can not get matched pod （修复了  Pod 的 Labels 中无 RuntimeID 信息，导致获取重启次数无法获取）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that runtime's pod without runtimeID info in Pod Labels  can not get matched pod         |
| 🇨🇳 中文    |      修复了  Pod 的 Labels 中无 RuntimeID 信息，导致获取重启次数无法获取        |

