### PR TITLE
fix(cmp): cmp server panic due to steveServer not initialized

### DIFF
--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/podTable/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/podTable/render.go
@@ -28,7 +28,8 @@ import (
 
 var steveServer cmp.SteveServer
 
-func (pt *PodInfoTable) Init(sdk *cptype.SDK) {
+func (pt *PodInfoTable) Init(sdk *cptype.SDK, steveSrv cmp.SteveServer) {
+	steveServer = steveSrv
 	pt.SDK = sdk
 }
 

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/podTable/render_test.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/podTable/render_test.go
@@ -18,8 +18,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	"github.com/erda-project/erda-infra/providers/i18n"
+	"github.com/erda-project/erda/internal/apps/cmp"
 	"github.com/erda-project/erda/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/common/table"
 )
 
@@ -31,6 +34,10 @@ func (t NopTranslator) Text(lang i18n.LanguageCodes, key string) string { return
 
 func (t NopTranslator) Sprintf(lang i18n.LanguageCodes, key string, args ...interface{}) string {
 	return fmt.Sprintf(key, args...)
+}
+
+type mockSteveServer struct {
+	cmp.SteveServer
 }
 
 func TestPodInfoTable_getProps(t *testing.T) {
@@ -59,4 +66,11 @@ func TestPodInfoTable_getProps(t *testing.T) {
 			ct.GetProps()
 		})
 	}
+}
+
+func TestInit(t *testing.T) {
+	pt := &PodInfoTable{}
+	pt.Init(nil, &mockSteveServer{})
+
+	assert.NotNil(t, steveServer)
 }

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/table/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodes/table/render.go
@@ -48,7 +48,7 @@ func (t *Table) initTables() {
 	ct.Init(t.SDK)
 	t.CpuTable = ct
 	pt := &podTable.PodInfoTable{}
-	pt.Init(t.SDK)
+	pt.Init(t.SDK, steveServer)
 	t.PodTable = pt
 }
 func (t *Table) Init(ctx servicehub.Context) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix cmp server panic due to steveServer not initialized

#### Specified Reviewers:

/assign @sfwn @dspo 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that cmp server panic due to steveServer not initialized（修复了cmp由于服务没初始化完全造成的panic问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that cmp server panic due to steveServer not initialized           |
| 🇨🇳 中文    |   修复了cmp由于服务没初始化完全造成的panic问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
