### PR TITLE
fix: metric query head time bucket not full, time is not true

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse.go
@@ -300,9 +300,8 @@ func (p *Parser) parseQueryDimensionsByExpr(exprSelect *goqu.SelectDataset, dime
 				timeBucketColumn := fmt.Sprintf("bucket_%s", p.ctx.TimeKey())
 				intervalSeconds := interval / int64(tsql.Second)
 
-				exprSelect = exprSelect.SelectAppend(goqu.L(fmt.Sprintf("toDateTime64(toStartOfInterval(timestamp, toIntervalSecond(%v)),9)", intervalSeconds)).As(timeBucketColumn))
-
-				exprList = append(exprList, timeBucketColumn)
+				exprSelect = exprSelect.SelectAppend(goqu.MIN("timestamp").As(timeBucketColumn))
+				exprList = append(exprList, fmt.Sprintf("intDiv(toRelativeSecondNum(timestamp), %v)", intervalSeconds))
 
 				var newHandler []*SQLColumnHandler
 
@@ -313,7 +312,6 @@ func (p *Parser) parseQueryDimensionsByExpr(exprSelect *goqu.SelectDataset, dime
 					},
 					ctx: p.ctx,
 				})
-				columns[timeBucketColumn] = _column{asName: timeBucketColumn, isNoArrayKey: true, isTimeKey: true}
 				newHandler = append(newHandler, *handler...)
 				*handler = newHandler
 				p.ctx.dimensions[timeBucketColumn] = true


### PR DESCRIPTION
#### What this PR does / why we need it:

metric query head time bucket not full, time is not true

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    metric query head time bucket not full, time is not true          |
| 🇨🇳 中文    |      指标查询, 头部 time bucket 未满时, 时间错误        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
