### PR TITLE
polish: build-image: image tag add arch; use docker build, not buildx

### DIFF
--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -31,10 +31,10 @@ ACTION=$2
 cd $(git rev-parse --show-toplevel)
 
 # image version and url
-VERSION="$(build/scripts/make-version.sh)"
-IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
-DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
 ARCH="${ARCH:-$(go env GOARCH)}"
+VERSION="$(build/scripts/make-version.sh)"
+IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}-${ARCH}"
+DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
 BASE_DOCKER_IMAGE="registry.erda.cloud/erda/${ARCH}/erda-base:20230130"
 DOCKERFILE=${DOCKERFILE_DEFAULT}
 
@@ -99,7 +99,7 @@ docker_login() {
 
 # build docker image
 build_image()  {
-    DOCKER_BUILDKIT=1 docker buildx build --pull --platform "linux/${ARCH}" --progress=plain -t "${DOCKER_IMAGE}" \
+    DOCKER_BUILDKIT=1 docker build --pull --platform "linux/${ARCH}" --progress=plain -t "${DOCKER_IMAGE}" \
         --label "branch=$(git rev-parse --abbrev-ref HEAD)" \
         --label "commit=$(git rev-parse HEAD)" \
         --label "build-time=$(date '+%Y-%m-%d %T%z')" \
@@ -110,7 +110,6 @@ build_image()  {
         --build-arg "MAKE_BUILD_CMD=${MAKE_BUILD_CMD}" \
         --build-arg "GO_BUILD_OPTIONS=${GO_BUILD_OPTIONS}" \
         --build-arg GOPROXY="${GOPROXY}" \
-        --push \
         -f "${DOCKERFILE}" .
 }
 
@@ -130,7 +129,7 @@ push_image() {
 # build and push
 build_push_image() {
     build_image
-#    push_image
+    push_image
     echo "action meta: image=${DOCKER_IMAGE}"
     echo "action meta: tag=${IMAGE_TAG}"
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

polish image-build script:

- image tag add arch
- use docker build, not buildx


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  polish: build-image: image tag add arch; use docker build, not buildx            |
| 🇨🇳 中文    |   优化镜像构建脚本，tag 增加 arch 标识；使用 docker build 而不是 buildx           |
