### PR TITLE
feat: support MSE Gateway

### DIFF
--- a/api/proto/core/hepa/endpoint_api/endpoint_api.proto
+++ b/api/proto/core/hepa/endpoint_api/endpoint_api.proto
@@ -252,6 +252,7 @@ message Endpoint {
   string aclType = 6;
   string scene = 7;
   string description = 8;
+  string gatewayProvider = 9;
 }
 
 message GetEndpointsNameResponse {

--- a/apistructs/msp.go
+++ b/apistructs/msp.go
@@ -114,4 +114,5 @@ type GatewayTenantRequest struct {
 	InnerAddr       string `json:"innerAddr"`
 	ServiceName     string `json:"serviceName"`
 	InstanceId      string `json:"instanceId"`
+	GatewayProvider string `json:"gatewayProvider,omitempty"`
 }

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -35,6 +35,8 @@ FROM --platform=$TARGETPLATFORM ${BASE_DOCKER_IMAGE}
 ARG MODULE_PATH
 ENV MODULE_PATH=${MODULE_PATH}
 
+ARG ARCH
+
 # use for ops
 RUN curl -o /usr/bin/orgalorg https://terminus-dice.oss.aliyuncs.com/installer/orgalorg && \
     chmod 755 /usr/bin/orgalorg
@@ -42,6 +44,9 @@ RUN curl -o /usr/bin/orgalorg https://terminus-dice.oss.aliyuncs.com/installer/o
 RUN \
     npm i -g jackson-converter@1.0.10 && \
     pip3 install dicttoxml xmindparser
+
+RUN wget  https://terminus-dice.oss-cn-hangzhou.aliyuncs.com/installer/nginx_1.20.2-1~bullseye_${ARCH}.deb && \
+        dpkg -i nginx_1.20.2-1~bullseye_${ARCH}.deb
 
 COPY --from=app-handler /erda-handled /erda
 

--- a/internal/apps/msp/resource/deploy/handlers/apigateway/apigateway_test.go
+++ b/internal/apps/msp/resource/deploy/handlers/apigateway/apigateway_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apigateway
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jinzhu/gorm"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-proto-go/core/pipeline/pipeline/pb"
+	"github.com/erda-project/erda/internal/apps/msp/resource/deploy/handlers"
+)
+
+func Test_provider_CheckIfHasCustomConfig(t *testing.T) {
+	type fields struct {
+		DefaultDeployHandler *handlers.DefaultDeployHandler
+		Cfg                  *config
+		Log                  logs.Logger
+		DB                   *gorm.DB
+		PipelineSvc          pb.PipelineServiceServer
+	}
+	type args struct {
+		clusterConfig map[string]string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]string
+		want1  bool
+	}{
+		{
+			name: "Test_01",
+			fields: fields{
+				DefaultDeployHandler: nil,
+				Cfg: &config{
+					MainClusterInfo: struct {
+						Name       string `file:"name"`
+						RootDomain string `file:"root_domain"`
+						Protocol   string `file:"protocol"`
+						HttpPort   string `file:"http_port"`
+						HttpsPort  string `file:"https_port"`
+					}(struct {
+						Name       string
+						RootDomain string
+						Protocol   string
+						HttpPort   string
+						HttpsPort  string
+					}{Name: "xxx", RootDomain: "mse-daily.terminus.io", Protocol: "https", HttpPort: "80", HttpsPort: "443"})},
+				Log:         nil,
+				DB:          nil,
+				PipelineSvc: nil,
+			},
+			args: args{
+				clusterConfig: map[string]string{
+					handlers.GatewayProviderVendorKey: "MSE",
+					handlers.GatewayEndpoint:          "mse-daily.terminus.io",
+				},
+			},
+			want: map[string]string{
+				"HEPA_GATEWAY_HOST": "https://hepa.mse-daily.terminus.io",
+				"HEPA_GATEWAY_PORT": "443",
+				"GATEWAY_ENDPOINT":  "mse-daily.terminus.io",
+			},
+			want1: true,
+		},
+		{
+			name: "Test_02",
+			fields: fields{
+				DefaultDeployHandler: nil,
+				Cfg: &config{
+					MainClusterInfo: struct {
+						Name       string `file:"name"`
+						RootDomain string `file:"root_domain"`
+						Protocol   string `file:"protocol"`
+						HttpPort   string `file:"http_port"`
+						HttpsPort  string `file:"https_port"`
+					}(struct {
+						Name       string
+						RootDomain string
+						Protocol   string
+						HttpPort   string
+						HttpsPort  string
+					}{Name: "xxx", RootDomain: "mse-daily.terminus.io", Protocol: "http", HttpPort: "80", HttpsPort: "443"})},
+				Log:         nil,
+				DB:          nil,
+				PipelineSvc: nil,
+			},
+			args: args{
+				clusterConfig: map[string]string{
+					handlers.GatewayProviderVendorKey: "MSE",
+					handlers.GatewayEndpoint:          "mse-daily.terminus.io",
+				},
+			},
+			want: map[string]string{
+				"HEPA_GATEWAY_HOST": "http://hepa.mse-daily.terminus.io",
+				"HEPA_GATEWAY_PORT": "80",
+				"GATEWAY_ENDPOINT":  "mse-daily.terminus.io",
+			},
+			want1: true,
+		},
+		{
+			name: "Test_03",
+			fields: fields{
+				DefaultDeployHandler: nil,
+				Cfg: &config{
+					MainClusterInfo: struct {
+						Name       string `file:"name"`
+						RootDomain string `file:"root_domain"`
+						Protocol   string `file:"protocol"`
+						HttpPort   string `file:"http_port"`
+						HttpsPort  string `file:"https_port"`
+					}(struct {
+						Name       string
+						RootDomain string
+						Protocol   string
+						HttpPort   string
+						HttpsPort  string
+					}{Name: "xxx", RootDomain: "mse-daily.terminus.io", Protocol: "http", HttpPort: "80", HttpsPort: "443"})},
+				Log:         nil,
+				DB:          nil,
+				PipelineSvc: nil,
+			},
+			args: args{
+				clusterConfig: map[string]string{
+					handlers.GatewayProviderVendorKey: "MSE",
+					"DICE_ROOT_DOMAIN":                "mse-daily.terminus.io",
+				},
+			},
+			want: map[string]string{
+				"HEPA_GATEWAY_HOST": "http://hepa.mse-daily.terminus.io",
+				"HEPA_GATEWAY_PORT": "80",
+				"GATEWAY_ENDPOINT":  "mse-daily.terminus.io",
+			},
+			want1: true,
+		},
+		{
+			name: "Test_04",
+			fields: fields{
+				DefaultDeployHandler: nil,
+				Cfg: &config{
+					MainClusterInfo: struct {
+						Name       string `file:"name"`
+						RootDomain string `file:"root_domain"`
+						Protocol   string `file:"protocol"`
+						HttpPort   string `file:"http_port"`
+						HttpsPort  string `file:"https_port"`
+					}(struct {
+						Name       string
+						RootDomain string
+						Protocol   string
+						HttpPort   string
+						HttpsPort  string
+					}{Name: "xxx", RootDomain: "mse-daily.terminus.io", Protocol: "http", HttpPort: "80", HttpsPort: "443"})},
+				Log:         nil,
+				DB:          nil,
+				PipelineSvc: nil,
+			},
+			args: args{
+				clusterConfig: map[string]string{
+					"DICE_ROOT_DOMAIN": "mse-daily.terminus.io",
+				},
+			},
+			want:  nil,
+			want1: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				DefaultDeployHandler: tt.fields.DefaultDeployHandler,
+				Cfg:                  tt.fields.Cfg,
+				Log:                  tt.fields.Log,
+				DB:                   tt.fields.DB,
+				PipelineSvc:          tt.fields.PipelineSvc,
+			}
+			got, got1 := p.CheckIfHasCustomConfig(tt.args.clusterConfig)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CheckIfHasCustomConfig() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("CheckIfHasCustomConfig() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/internal/apps/msp/resource/deploy/handlers/handler.go
+++ b/internal/apps/msp/resource/deploy/handlers/handler.go
@@ -64,6 +64,13 @@ const (
 )
 
 const (
+	GatewayProviderVendorKey = "GATEWAY_PROVIDER"
+	GatewayEndpoint          = "PROVIDER_GATEWAY_ENDPOINT"
+	// Aliyun MSE Gateway
+	GatewayProviderMSE = "MSE"
+)
+
+const (
 	DeployModeSAAS = "SAAS"
 	DeployModePAAS = "PAAS"
 )

--- a/internal/pkg/extension/extension.service_test.go
+++ b/internal/pkg/extension/extension.service_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-proto-go/core/extension/pb"
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/pkg/extension/db"
 	"github.com/erda-project/erda/pkg/i18n"
 )
@@ -164,7 +165,8 @@ jobs:
 		},
 	}
 	p := &provider{
-		db: cli,
+		db:  cli,
+		bdl: &bundle.Bundle{},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/cors/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/cors/dto.go
@@ -18,15 +18,6 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
 )
 
-const (
-	ANNOTATION_CORS_ENABLE      = "nginx.ingress.kubernetes.io/enable-cors"
-	ANNOTATION_CORS_METHODS     = "nginx.ingress.kubernetes.io/cors-allow-methods"
-	ANNOTATION_CORS_HEADERS     = "nginx.ingress.kubernetes.io/cors-allow-headers"
-	ANNOTATION_CORS_ORIGIN      = "nginx.ingress.kubernetes.io/cors-allow-origin"
-	ANNOTATION_CORS_CREDENTIALS = "nginx.ingress.kubernetes.io/cors-allow-credentials"
-	ANNOTATION_CORS_MAXAGE      = "nginx.ingress.kubernetes.io/cors-max-age"
-)
-
 type PolicyDto struct {
 	apipolicy.BaseDto
 	Methods     string `json:"methods"`

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
+	annotationscommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common"
+)
+
+func TestPolicy_setIngressAnnotations(t *testing.T) {
+	type fields struct {
+		BasePolicy apipolicy.BasePolicy
+	}
+	type args struct {
+		gatewayProvider string
+		policyDto       *PolicyDto
+		locationSnippet string
+	}
+
+	corsEnable := "true"
+	corsMethods := "GET, PUT, POST, DELETE, PATCH, OPTIONS"
+	corsHeaders := "$http_access_control_request_headers"
+	corsOrigin := "$from_request_origin_or_referer"
+	corsCredentials := "true"
+	corsMaxage := "86400"
+	lSnippet := "xxxxx"
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *apipolicy.IngressAnnotation
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{BasePolicy: apipolicy.BasePolicy{PolicyName: "cors"}},
+			args: args{
+				gatewayProvider: "MSE",
+				policyDto: &PolicyDto{
+					BaseDto:     apipolicy.BaseDto{},
+					Methods:     "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+					Headers:     "$http_access_control_request_headers",
+					Origin:      "$from_request_origin_or_referer",
+					Credentials: true,
+					MaxAge:      86400,
+				},
+				locationSnippet: "xxxxx",
+			},
+			want: &apipolicy.IngressAnnotation{
+				Annotation: map[string]*string{
+					string(annotationscommon.AnnotationEnableCORS):           &corsEnable,
+					string(annotationscommon.AnnotationCORSAllowMethods):     &corsMethods,
+					string(annotationscommon.AnnotationCORSAllowHeaders):     &corsHeaders,
+					string(annotationscommon.AnnotationCORSAllowOrigin):      &corsOrigin,
+					string(annotationscommon.AnnotationCORSAllowCredentials): &corsCredentials,
+					string(annotationscommon.AnnotationCORSMaxAge):           &corsMaxage,
+				},
+				LocationSnippet: &lSnippet,
+			},
+		},
+		{
+			name:   "Test_01",
+			fields: fields{BasePolicy: apipolicy.BasePolicy{PolicyName: "cors"}},
+			args: args{
+				gatewayProvider: "",
+				policyDto: &PolicyDto{
+					BaseDto:     apipolicy.BaseDto{},
+					Methods:     "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+					Headers:     "$http_access_control_request_headers",
+					Origin:      "$from_request_origin_or_referer",
+					Credentials: true,
+					MaxAge:      86400,
+				},
+				locationSnippet: "xxxxx",
+			},
+			want: &apipolicy.IngressAnnotation{
+				Annotation: map[string]*string{
+					string(annotationscommon.AnnotationEnableCORS):           nil,
+					string(annotationscommon.AnnotationCORSAllowMethods):     nil,
+					string(annotationscommon.AnnotationCORSAllowHeaders):     nil,
+					string(annotationscommon.AnnotationCORSAllowOrigin):      nil,
+					string(annotationscommon.AnnotationCORSAllowCredentials): nil,
+					string(annotationscommon.AnnotationCORSMaxAge):           nil,
+				},
+				LocationSnippet: &lSnippet,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := Policy{
+				BasePolicy: tt.fields.BasePolicy,
+			}
+			if got := policy.setIngressAnnotations(tt.args.gatewayProvider, tt.args.policyDto, tt.args.locationSnippet); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("setIngressAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/dto.go
@@ -18,16 +18,6 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
 )
 
-const (
-	ANNOTATION_REQ_BUFFER         = "nginx.ingress.kubernetes.io/proxy-request-buffering"
-	ANNOTATION_RESP_BUFFER        = "nginx.ingress.kubernetes.io/proxy-buffering"
-	ANNOTATION_REQ_LIMIT          = "nginx.ingress.kubernetes.io/proxy-body-size"
-	ANNOTATION_PROXY_REQ_TIMEOUT  = "nginx.ingress.kubernetes.io/proxy-send-timeout"
-	ANNOTATION_PROXY_RESP_TIMEOUT = "nginx.ingress.kubernetes.io/proxy-read-timeout"
-	ANNOTATION_SERVER_SNIPPET     = "nginx.ingress.kubernetes.io/server-snippet"
-	ANNOTATION_SSL_REDIRECT       = "nginx.ingress.kubernetes.io/ssl-redirect"
-)
-
 type PolicyDto struct {
 	apipolicy.BaseDto
 	ReqBuffer         bool  `json:"reqBuffer"`

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/dto.go
@@ -44,7 +44,7 @@ func (pc PolicyDto) IsValidDto() error {
 
 func (pc PolicyDto) ToPluginReqDto() *kongDto.KongPluginReqDto {
 	var req = &kongDto.KongPluginReqDto{
-		Name:    Name,
+		Name:    apipolicy.Policy_Engine_SBAC,
 		Enabled: &pc.Switch,
 		Config: map[string]interface{}{
 			"access_control_api": pc.AccessControlAPI,

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/dto.go
@@ -41,6 +41,7 @@ var allowsCors = `
 type PolicyDto struct {
 	apipolicy.BaseDto
 	MaxTps         int64  `json:"maxTps,omitempty"`
+	Busrt          int64  `json:"burst,omitempty"`
 	ExtraLatency   int64  `json:"extraLatency,omitempty"`
 	RefuseCode     int64  `json:"refuseCode,omitempty"`
 	RefuseResponse string `json:"refuseResponse,omitempty"`

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverguard
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
+)
+
+func Test_setMSEIngressAnnotation(t *testing.T) {
+	type args struct {
+		policyDto          *PolicyDto
+		ingressAnnotations *apipolicy.IngressAnnotation
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		// TODO: Add test cases.
+		{
+			name: "Test_01",
+			args: args{
+				policyDto: &PolicyDto{
+					BaseDto:        apipolicy.BaseDto{},
+					MaxTps:         0,
+					Busrt:          2,
+					ExtraLatency:   0,
+					RefuseCode:     0,
+					RefuseResponse: "",
+				},
+				ingressAnnotations: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
+		})
+	}
+}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/waf/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/waf/dto.go
@@ -23,11 +23,9 @@ import (
 )
 
 const (
-	WAF_SWITCH_ON       = "on"
-	WAF_SWITCH_OFF      = "off"
-	WAF_SWITCH_WATCH    = "watch"
-	MODSECURITY_SNIPPET = "nginx.ingress.kubernetes.io/modsecurity-snippet"
-	MODSECURITY_ENABLE  = "nginx.ingress.kubernetes.io/enable-modsecurity"
+	WAF_SWITCH_ON    = "on"
+	WAF_SWITCH_OFF   = "off"
+	WAF_SWITCH_WATCH = "watch"
 )
 
 type PolicyDto struct {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
+	annotationscommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common"
 )
 
 type Policy struct {
@@ -85,19 +86,19 @@ SecAuditLog /dev/stderr
 	if policyDto.RemoveRules != "" && modSnippet != nil {
 		*modSnippet = *modSnippet + fmt.Sprintf("SecRuleRemoveById %s\n", policyDto.RemoveRules)
 	}
-	res.IngressAnnotation.Annotation[MODSECURITY_SNIPPET] = modSnippet
+	res.IngressAnnotation.Annotation[string(annotationscommon.AnnotationModsecuritySnippet)] = modSnippet
 	if modSnippet != nil {
 		enable := "true"
-		res.IngressAnnotation.Annotation[MODSECURITY_ENABLE] = &enable
+		res.IngressAnnotation.Annotation[string(annotationscommon.AnnotationEnableModsecurity)] = &enable
 	} else {
-		res.IngressAnnotation.Annotation[MODSECURITY_ENABLE] = nil
+		res.IngressAnnotation.Annotation[string(annotationscommon.AnnotationEnableModsecurity)] = nil
 	}
 	return res, nil
 
 }
 
 func init() {
-	err := apipolicy.RegisterPolicyEngine("safety-waf", &Policy{})
+	err := apipolicy.RegisterPolicyEngine(apipolicy.Policy_Engine_WAF, &Policy{})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/tools/orchestrator/hepa/common/vars/vars.go
+++ b/internal/tools/orchestrator/hepa/common/vars/vars.go
@@ -46,6 +46,8 @@ var (
 	KONG_SERVICE_PORT       = 8000
 	BIND_DOMAIN_INGRESS_TAG = "-domain"
 	INNER_INGRESS_TAG       = "-inner"
+
+	DEFALUT_SERVICE_PORT = 80
 )
 
 type StandardErrorCode struct {
@@ -97,6 +99,7 @@ var (
 	CONSUMER_EXIST                     = StandardErrorCode{"GW_100043", "consumer 已经存在"}
 	CONSUMER_ID_MISS                   = StandardErrorCode{"GW_100044", "consumerId 缺失"}
 	CONSUMER_PARAMS_MISS               = StandardErrorCode{"GW_100045", "参数缺失"}
+	CONSUMER_NOT_SUPPORT               = StandardErrorCode{"GW_100046", "mse 不支持创建 consumer"}
 
 	//业务网关注册
 	TRANSFORM_REGIS_NO_SOLUTION = StandardErrorCode{"GW_200001", "solution 为空"}
@@ -110,13 +113,14 @@ var (
 	CLUSTER_NOT_K8S   = StandardErrorCode{"GW_400003", "非k8s集群不支持此功能"}
 	DOMAIN_EXIST      = StandardErrorCode{"GW_400004", "域名已经被占用"}
 
-	PACKAGE_IN_CONSUMER  = StandardErrorCode{"GW_400005", "请取消该流量入口的所有授权后再删除"}
-	PACKAGE_EXIST        = StandardErrorCode{"GW_400006", "已存在同名流量入口"}
-	DICE_API_NOT_MUTABLE = StandardErrorCode{"GW_400007", "不可修改依赖服务API的路由信息"}
-	INVALID_LIMIT_RULE   = StandardErrorCode{"GW_400008", "流量限制参数错误"}
-	INVALID_LIMIT_API    = StandardErrorCode{"GW_400009", "只能限制流量入口中已存在的API"}
-	API_IN_PACKAGE       = StandardErrorCode{"GW_400010", "API被其他流量入口引用,不可更改或删除"}
-	LIMIT_RULE_EXIST     = StandardErrorCode{"GW_400011", "该规则已存在，请直接编辑"}
+	PACKAGE_IN_CONSUMER         = StandardErrorCode{"GW_400005", "请取消该流量入口的所有授权后再删除"}
+	PACKAGE_EXIST               = StandardErrorCode{"GW_400006", "已存在同名流量入口"}
+	DICE_API_NOT_MUTABLE        = StandardErrorCode{"GW_400007", "不可修改依赖服务API的路由信息"}
+	INVALID_LIMIT_RULE          = StandardErrorCode{"GW_400008", "流量限制参数错误"}
+	INVALID_LIMIT_API           = StandardErrorCode{"GW_400009", "只能限制流量入口中已存在的API"}
+	API_IN_PACKAGE              = StandardErrorCode{"GW_400010", "API被其他流量入口引用,不可更改或删除"}
+	LIMIT_RULE_EXIST            = StandardErrorCode{"GW_400011", "该规则已存在，请直接编辑"}
+	DELETE_API_IN_PACKAGE_ERROR = StandardErrorCode{"GW_400012", "删除 API 失败, 请稍后重试"}
 )
 
 type PolicyCategory struct {

--- a/internal/tools/orchestrator/hepa/endpoint/endpoint_factory.go
+++ b/internal/tools/orchestrator/hepa/endpoint/endpoint_factory.go
@@ -33,6 +33,7 @@ type EndpointMaterial struct {
 	ProjectNamespace      string
 	IngressName           string
 	K8SRouteOptions       k8s.RouteOptions
+	GatewayProvider       string
 }
 
 type EndpointFactory interface {

--- a/internal/tools/orchestrator/hepa/endpoint/factories/edas.go
+++ b/internal/tools/orchestrator/hepa/endpoint/factories/edas.go
@@ -51,7 +51,7 @@ func (impl EdasFactory) TouchRoute(material endpoint.EndpointMaterial) error {
 		ServicePort: material.ServicePort,
 	}
 	_, err := impl.k8sAdapter.CreateOrUpdateIngress("default", serviceName,
-		k8sRoutes, backend, material.K8SRouteOptions)
+		k8sRoutes, backend, material.GatewayProvider, material.K8SRouteOptions)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (impl EdasFactory) TouchComponentRoute(material endpoint.EndpointMaterial) 
 	if material.K8SNamespace != "" {
 		namespace = material.K8SNamespace
 	}
-	_, err := impl.k8sAdapter.CreateOrUpdateIngress(namespace, material.IngressName, k8sRoutes, backend, material.K8SRouteOptions)
+	_, err := impl.k8sAdapter.CreateOrUpdateIngress(namespace, material.IngressName, k8sRoutes, backend, material.GatewayProvider, material.K8SRouteOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/orchestrator/hepa/endpoint/factories/k8s.go
+++ b/internal/tools/orchestrator/hepa/endpoint/factories/k8s.go
@@ -61,7 +61,7 @@ func (impl K8SFactory) TouchRoute(material endpoint.EndpointMaterial) error {
 		ServicePort: material.ServicePort,
 	}
 	_, err := impl.k8sAdapter.CreateOrUpdateIngress(impl.k8sNamespace(material),
-		serviceName, k8sRoutes, backend, material.K8SRouteOptions)
+		serviceName, k8sRoutes, backend, material.GatewayProvider, material.K8SRouteOptions)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (impl K8SFactory) TouchComponentRoute(material endpoint.EndpointMaterial) e
 	if material.K8SNamespace != "" {
 		namespace = material.K8SNamespace
 	}
-	_, err := impl.k8sAdapter.CreateOrUpdateIngress(namespace, material.IngressName, k8sRoutes, backend, material.K8SRouteOptions)
+	_, err := impl.k8sAdapter.CreateOrUpdateIngress(namespace, material.IngressName, k8sRoutes, backend, material.GatewayProvider, material.K8SRouteOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/orchestrator/hepa/gateway-providers/gateway_adpter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/gateway_adpter.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kong
+package gateway_providers
 
 import (
 	. "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
 )
 
-type KongAdapter interface {
-	KongExist() bool
+type GatewayAdapter interface {
+	GatewayProviderExist() bool
 	GetVersion() (string, error)
 	CheckPluginEnabled(pluginName string) (bool, error)
 	CreateConsumer(req *KongConsumerReqDto) (*KongConsumerRespDto, error)

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/base/kong_adapter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/base/kong_adapter.go
@@ -49,7 +49,7 @@ type KongAdapterImpl struct {
 	Client   *http.Client
 }
 
-func (impl *KongAdapterImpl) KongExist() bool {
+func (impl *KongAdapterImpl) GatewayProviderExist() bool {
 	return impl != nil
 }
 

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/kong_adapter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/kong_adapter.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/config"
+	gateway_providers "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/base"
 	v2 "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/v2"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/orm"
@@ -46,7 +47,7 @@ var (
 	ErrInvalidReq = errors.New("kongAdapter: invalid request")
 )
 
-func newKongAdapter(kongAddr string, client *http.Client) KongAdapter {
+func newKongAdapter(kongAddr string, client *http.Client) gateway_providers.GatewayAdapter {
 	var empty *base.KongAdapterImpl
 	base := &base.KongAdapterImpl{
 		KongAddr: kongAddr,
@@ -68,7 +69,7 @@ func newKongAdapter(kongAddr string, client *http.Client) KongAdapter {
 	return empty
 }
 
-func NewKongAdapter(kongAddr string) KongAdapter {
+func NewKongAdapter(kongAddr string) gateway_providers.GatewayAdapter {
 	client := &http.Client{Timeout: time.Second * 30}
 	if config.ServerConf.KongDebug {
 		return newKongAdapter(config.ServerConf.KongDebugAddr, client)
@@ -76,7 +77,7 @@ func NewKongAdapter(kongAddr string) KongAdapter {
 	return newKongAdapter(kongAddr, client)
 }
 
-func NewKongAdapterForConsumer(consumer *orm.GatewayConsumer) KongAdapter {
+func NewKongAdapterForConsumer(consumer *orm.GatewayConsumer) gateway_providers.GatewayAdapter {
 	client := &http.Client{}
 	if config.ServerConf.KongDebug {
 		return newKongAdapter(config.ServerConf.KongDebugAddr, client)
@@ -98,7 +99,7 @@ func NewKongAdapterForConsumer(consumer *orm.GatewayConsumer) KongAdapter {
 	return NewKongAdapterForProject(az, consumer.Env, consumer.ProjectId)
 }
 
-func NewKongAdapterForProject(az, env, projectId string) KongAdapter {
+func NewKongAdapterForProject(az, env, projectId string) gateway_providers.GatewayAdapter {
 	client := &http.Client{}
 	if config.ServerConf.KongDebug {
 		return newKongAdapter(config.ServerConf.KongDebugAddr, client)
@@ -124,7 +125,7 @@ func NewKongAdapterForProject(az, env, projectId string) KongAdapter {
 	return newKongAdapter(kong.KongAddr, client)
 }
 
-func NewKongAdapterByConsumerId(consumerDb service.GatewayConsumerService, consumerId string) KongAdapter {
+func NewKongAdapterByConsumerId(consumerDb service.GatewayConsumerService, consumerId string) gateway_providers.GatewayAdapter {
 	client := &http.Client{}
 	if config.ServerConf.KongDebug {
 		return newKongAdapter(config.ServerConf.KongDebugAddr, client)

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/v2/kong_adapter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/v2/kong_adapter.go
@@ -47,7 +47,7 @@ type KongAdapterImpl struct {
 	*base.KongAdapterImpl
 }
 
-func (impl *KongAdapterImpl) KongExist() bool {
+func (impl *KongAdapterImpl) GatewayProviderExist() bool {
 	if impl == nil || impl.KongAdapterImpl == nil {
 		return false
 	}

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter.go
@@ -1,0 +1,486 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mse
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	. "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common/vars"
+	gateway_providers "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers"
+	. "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/hepautils"
+)
+
+const (
+	Mse_Version                               = "mse-1.0.5"
+	Mse_Provider_Name                         = "MSE"
+	MseBurstMultiplier                        = "2"
+	Mse_Ingress_Controller_ACK_Namespace      = "mse-ingress-controller"
+	Mse_Ingress_Controller_ACK_DeploymentName = "ack-mse-ingress-controller"
+	Mse_Need_Drop_Annotation                  = "need_drop_annotation"
+)
+
+type MseAdapterImpl struct {
+	ProviderName string
+}
+
+func NewMseAdapter() gateway_providers.GatewayAdapter {
+	return &MseAdapterImpl{
+		ProviderName: Mse_Provider_Name,
+	}
+}
+
+func (impl *MseAdapterImpl) GatewayProviderExist() bool {
+	//TODO:
+	// check Deployment mse-ingress-controller/ack-mse-ingress-controller in k8s cluster
+	if impl == nil || impl.ProviderName != Mse_Provider_Name {
+		return false
+	}
+	return true
+}
+
+func (impl *MseAdapterImpl) GetVersion() (string, error) {
+	log.Debugf("GetVersion is not implemented in Mse gateway provider.")
+	return Mse_Version, nil
+}
+
+func (impl *MseAdapterImpl) CheckPluginEnabled(pluginName string) (bool, error) {
+	log.Debugf("CheckPluginEnabled is not implemented in Mse gateway provider.")
+	return true, nil
+}
+
+func (impl *MseAdapterImpl) CreateConsumer(req *KongConsumerReqDto) (*KongConsumerRespDto, error) {
+	log.Debugf("CreateConsumer is not really implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate id for CreateConsumer")
+	}
+
+	return &KongConsumerRespDto{
+		CustomId:  req.CustomId,
+		CreatedAt: time.Now().Unix(),
+		Id:        uuid.String(),
+	}, nil
+}
+
+func (impl *MseAdapterImpl) DeleteConsumer(id string) error {
+	log.Debugf("DeleteConsumer is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) CreateOrUpdateRoute(req *KongRouteReqDto) (*KongRouteRespDto, error) {
+	log.Debugf("CreateOrUpdateRoute is not really implemented in Mse gateway provider.")
+	timeNow := time.Now()
+	defer func() {
+		log.Infof("*MseAdapterImpl.CreateOrUpdateRoute costs %dms", time.Now().Sub(timeNow).Milliseconds())
+	}()
+
+	if impl == nil {
+		return nil, errors.New("kong can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	req.Adjust(Versioning(impl))
+	for i := 0; i < len(req.Paths); i++ {
+		pth, err := hepautils.RenderKongUri(req.Paths[i])
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to render service path")
+		}
+		req.Paths[i] = pth
+	}
+
+	routeId := ""
+	if len(req.RouteId) != 0 {
+		routeId = req.RouteId
+	} else {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate id for Route")
+		}
+		req.RouteId = uuid.String()
+	}
+
+	return &KongRouteRespDto{
+		Id:        routeId,
+		Protocols: req.Protocols,
+		Methods:   req.Methods,
+		Hosts:     req.Hosts,
+		Paths:     req.Paths,
+		Service:   Service{Id: req.Service.Id},
+	}, nil
+}
+
+func (impl *MseAdapterImpl) DeleteRoute(routeId string) error {
+	log.Debugf("DeleteRoute is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) UpdateRoute(req *KongRouteReqDto) (*KongRouteRespDto, error) {
+	return &KongRouteRespDto{}, nil
+}
+
+func (impl *MseAdapterImpl) CreateOrUpdateService(req *KongServiceReqDto) (*KongServiceRespDto, error) {
+	log.Debugf("CreateOrUpdateService is not really implemented in Mse gateway provider.")
+	timeNow := time.Now()
+	defer func() {
+		log.Infof("*MseAdapterImpl.CreateOrUpdateService costs %dms", time.Now().Sub(timeNow).Milliseconds())
+	}()
+
+	if impl == nil {
+		return nil, errors.New("kong can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	pth, err := hepautils.RenderKongUri(req.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to render service path")
+	}
+	req.Path = pth
+	serviceId := ""
+	if len(req.ServiceId) != 0 {
+		serviceId = req.ServiceId
+	} else {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate id for Service")
+		}
+		serviceId = uuid.String()
+	}
+
+	port := 80
+	if req.Port > 0 {
+		port = req.Port
+	}
+	return &KongServiceRespDto{
+		Id:       serviceId,
+		Name:     req.Name,
+		Protocol: req.Protocol,
+		Host:     req.Host,
+		Port:     port,
+		Path:     req.Path,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) DeleteService(serviceId string) error {
+	log.Debugf("DeletePluginIfExist is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) DeletePluginIfExist(req *KongPluginReqDto) error {
+	log.Debugf("DeletePluginIfExist is not really implemented in Mse gateway provider.")
+	enabled, err := impl.CheckPluginEnabled(req.Name)
+	if err != nil {
+		return err
+	}
+	if !enabled {
+		log.Warnf("plugin %s not enabled, req:%+v", req.Name, req)
+		return nil
+	}
+	exist, err := impl.GetPlugin(req)
+	if err != nil {
+		return err
+	}
+	if exist == nil {
+		return nil
+	}
+	return impl.RemovePlugin(exist.Id)
+}
+
+func (impl *MseAdapterImpl) CreateOrUpdatePluginById(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("CreateOrUpdatePluginById is not really implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	if len(req.Id) != 0 {
+		req.CreatedAt = time.Now().Unix() * 1000
+	}
+	if len(req.PluginId) == 0 {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate id for CreateOrUpdatePluginById")
+		}
+		req.PluginId = uuid.String()
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	return &KongPluginRespDto{
+		Id:         req.PluginId,
+		ServiceId:  req.ServiceId,
+		RouteId:    req.RouteId,
+		ConsumerId: req.ConsumerId,
+		Route:      req.Route,
+		Service:    req.Service,
+		Consumer:   req.Consumer,
+		Name:       req.Name,
+		Config:     req.Config,
+		Enabled:    enabled,
+		CreatedAt:  time.Now().Unix(),
+		PolicyId:   req.Id,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) GetPlugin(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("GetPlugin is not  really implemented in Mse gateway provider.")
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	return &KongPluginRespDto{
+		Id:         req.PluginId,
+		ServiceId:  req.ServiceId,
+		RouteId:    req.RouteId,
+		ConsumerId: req.ConsumerId,
+		Route:      req.Route,
+		Service:    req.Service,
+		Consumer:   req.Consumer,
+		Name:       req.Name,
+		Config:     req.Config,
+		Enabled:    enabled,
+		CreatedAt:  req.CreatedAt,
+		PolicyId:   req.Id,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) CreateOrUpdatePlugin(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("CreateOrUpdatePlugin is not implemented in Mse gateway provider.")
+	timeNow := time.Now()
+	defer func() {
+		log.Infof("*MseAdapterImpl.CreateOrUpdatePlugin costs %dms", time.Now().Sub(timeNow).Milliseconds())
+	}()
+
+	enabled, err := impl.CheckPluginEnabled(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		log.Warnf("plugin %s not enabled, req:%+v", req.Name, req)
+		return nil, nil
+	}
+	exist, err := impl.GetPlugin(req)
+	if err != nil {
+		return nil, err
+	}
+	if exist == nil {
+		return impl.AddPlugin(req)
+	}
+	req.Id = exist.Id
+	req.PluginId = exist.Id
+	return impl.PutPlugin(req)
+}
+
+func (impl *MseAdapterImpl) AddPlugin(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("AddPlugin is not implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	enabled, err := impl.CheckPluginEnabled(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		log.Warnf("plugin %s not enabled, req:%+v", req.Name, req)
+		return nil, nil
+	}
+	pluginEnabled := true
+	if req.Enabled != nil {
+		pluginEnabled = *req.Enabled
+	}
+
+	return &KongPluginRespDto{
+		Id:         req.Id,
+		ServiceId:  req.ServiceId,
+		RouteId:    req.RouteId,
+		ConsumerId: req.ConsumerId,
+		Route:      req.Route,
+		Service:    req.Service,
+		Consumer:   req.Consumer,
+		Name:       req.Name,
+		Config:     req.Config,
+		Enabled:    pluginEnabled,
+		CreatedAt:  time.Now().Unix(),
+		PolicyId:   req.PluginId,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) PutPlugin(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("PutPlugin is not implemented in Mse gateway provider.")
+	return nil, nil
+}
+
+func (impl *MseAdapterImpl) UpdatePlugin(req *KongPluginReqDto) (*KongPluginRespDto, error) {
+	log.Debugf("UpdatePlugin is not really implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	return &KongPluginRespDto{
+		Id:         req.Id,
+		ServiceId:  req.ServiceId,
+		RouteId:    req.RouteId,
+		ConsumerId: req.ConsumerId,
+		Route:      req.Route,
+		Service:    req.Service,
+		Consumer:   req.Consumer,
+		Name:       req.Name,
+		Config:     req.Config,
+		Enabled:    enabled,
+		CreatedAt:  req.CreatedAt,
+		PolicyId:   req.PluginId,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) RemovePlugin(id string) error {
+	log.Debugf("RemovePlugin is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) CreateCredential(req *KongCredentialReqDto) (*KongCredentialDto, error) {
+	log.Debugf("CreateCredential is not really implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	if req.PluginName == "hmac-auth" {
+		req.Config.ToHmacReq()
+	}
+	return &KongCredentialDto{
+		ConsumerId:   req.ConsumerId,
+		CreatedAt:    time.Now().Unix(),
+		Id:           req.Config.Id,
+		Key:          req.Config.Key,
+		RedirectUrl:  req.Config.RedirectUrl,
+		RedirectUrls: req.Config.RedirectUrls,
+		Name:         req.PluginName,
+		ClientId:     req.Config.ClientId,
+		ClientSecret: req.Config.ClientSecret,
+		Secret:       req.Config.Secret,
+		Username:     req.Config.Username,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) DeleteCredential(consumerId, pluginName, credentialId string) error {
+	log.Debugf("DeleteCredential is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) GetCredentialList(consumerId, pluginName string) (*KongCredentialListDto, error) {
+	log.Debugf("GetCredentialList is not implemented in Mse gateway provider.")
+	return &KongCredentialListDto{}, nil
+}
+
+func (impl *MseAdapterImpl) CreateAclGroup(consumerId, customId string) error {
+	log.Debugf("CreateAclGroup is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) CreateUpstream(req *KongUpstreamDto) (*KongUpstreamDto, error) {
+	log.Debugf("CreateUpstream is not really implemented in Mse gateway provider.")
+	if impl == nil {
+		return nil, errors.New("mse can't be attached")
+	}
+	if req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	if req.Id == "" {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate id for CreateUpstream")
+		}
+		req.Id = uuid.String()
+	}
+	return req, nil
+}
+
+func (impl *MseAdapterImpl) GetUpstreamStatus(upstreamId string) (*KongUpstreamStatusRespDto, error) {
+	log.Debugf("GetUpstreamStatus is not really implemented in Mse gateway provider.")
+	return &KongUpstreamStatusRespDto{
+		Data: []KongTargetDto{},
+	}, nil
+}
+
+func (impl *MseAdapterImpl) AddUpstreamTarget(upstreamId string, req *KongTargetDto) (*KongTargetDto, error) {
+	log.Debugf("AddUpstreamTarget is not really implemented in Mse gateway provider.")
+	if upstreamId == "" || req == nil {
+		return nil, errors.New(ERR_INVALID_ARG)
+	}
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate id for UpstreamTarget")
+	}
+
+	return &KongTargetDto{
+		Id:         uuid.String(),
+		Target:     req.Target,
+		Weight:     req.Weight,
+		UpstreamId: upstreamId,
+		CreatedAt:  time.Now().Unix(),
+		Health:     req.Health,
+	}, nil
+}
+
+func (impl *MseAdapterImpl) DeleteUpstreamTarget(upstreamId, targetId string) error {
+	log.Debugf("DeleteUpstreamTarget is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) TouchRouteOAuthMethod(id string) error {
+	log.Debugf("TouchRouteOAuthMethod is not implemented in Mse gateway provider.")
+	return nil
+}
+
+func (impl *MseAdapterImpl) GetRoutes() ([]KongRouteRespDto, error) {
+	log.Debugf("GetRoutes is not implemented in Mse gateway provider.")
+	return []KongRouteRespDto{}, nil
+}
+
+func (impl *MseAdapterImpl) GetRoutesWithTag(tag string) ([]KongRouteRespDto, error) {
+	log.Debugf("GetRoutesWithTag is not implemented in Mse gateway provider.")
+	return []KongRouteRespDto{}, nil
+}

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter_test.go
@@ -1,0 +1,1208 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mse
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	gateway_providers "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers"
+	. "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
+)
+
+func TestNewMseAdapter(t *testing.T) {
+	tests := []struct {
+		name string
+		want gateway_providers.GatewayAdapter
+	}{
+		{
+			name: "Test_01",
+			want: &MseAdapterImpl{
+				ProviderName: Mse_Provider_Name,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewMseAdapter(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewMseAdapter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GatewayProviderExist(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "Test_01",
+			fields: fields{
+				ProviderName: "MSE",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if got := impl.GatewayProviderExist(); got != tt.want {
+				t.Errorf("GatewayProviderExist() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GetVersion(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			want:    Mse_Version,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.GetVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CheckPluginEnabled(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		pluginName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{pluginName: "cors"},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CheckPluginEnabled(tt.args.pluginName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPluginEnabled() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CheckPluginEnabled() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeleteConsumer(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{id: "1"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeleteConsumer(tt.args.id); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteConsumer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateOrUpdateRoute(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongRouteReqDto
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongRouteRespDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{req: &KongRouteReqDto{
+				Protocols:     []string{"http", "https"},
+				Methods:       []string{"GET, PUT, POST, DELETE, PATCH, OPTIONS"},
+				Hosts:         []string{"test.io"},
+				Paths:         []string{"/test"},
+				StripPath:     nil,
+				PreserveHost:  nil,
+				Service:       &Service{Id: "1"},
+				RegexPriority: 0,
+				RouteId:       "1",
+				PathHandling:  nil,
+				Tags:          nil,
+			}},
+			want: &KongRouteRespDto{
+				Id:        "1",
+				Protocols: []string{"http", "https"},
+				Methods:   []string{"GET, PUT, POST, DELETE, PATCH, OPTIONS"},
+				Hosts:     []string{"test.io"},
+				Paths:     []string{"/test"},
+				Service:   Service{Id: "1"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateOrUpdateRoute(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateRoute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateOrUpdateRoute() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeleteRoute(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		routeId string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{routeId: "1"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeleteRoute(tt.args.routeId); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteRoute() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_UpdateRoute(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongRouteReqDto
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongRouteRespDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{req: &KongRouteReqDto{
+				Protocols:     []string{"http", "https"},
+				Methods:       []string{"GET, PUT, POST, DELETE, PATCH, OPTIONS"},
+				Hosts:         []string{"test.io"},
+				Paths:         []string{"/test"},
+				StripPath:     nil,
+				PreserveHost:  nil,
+				Service:       &Service{Id: "1"},
+				RegexPriority: 0,
+				RouteId:       "1",
+				PathHandling:  nil,
+				Tags:          nil,
+			}},
+			want:    &KongRouteRespDto{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.UpdateRoute(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateRoute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateRoute() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateCredential(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongCredentialReqDto
+	}
+	tTime := time.Now().Unix()
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongCredentialDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				req: &KongCredentialReqDto{
+					ConsumerId: "1",
+					PluginName: "cors",
+					Config: &KongCredentialDto{
+						ConsumerId:   "1",
+						CreatedAt:    0,
+						Id:           "1",
+						Key:          "xx",
+						RedirectUrl:  "/test",
+						RedirectUrls: []string{"/test"},
+						Name:         "xxx",
+						ClientId:     "1",
+						ClientSecret: "xxyyzz",
+						Secret:       "xxxyyy",
+						Username:     "aaa",
+					},
+				},
+			},
+			want: &KongCredentialDto{
+				ConsumerId:   "1",
+				CreatedAt:    tTime,
+				Id:           "1",
+				Key:          "xx",
+				RedirectUrl:  "/test",
+				RedirectUrls: []string{"/test"},
+				Name:         "cors",
+				ClientId:     "1",
+				ClientSecret: "xxyyzz",
+				Secret:       "xxxyyy",
+				Username:     "aaa",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateCredential(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateCredential() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateCredential() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateOrUpdatePluginById(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	tTime := time.Now().Unix()
+	enable := true
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongPluginRespDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				req: &KongPluginReqDto{
+					Name:       "xxx",
+					ServiceId:  "1",
+					RouteId:    "1",
+					ConsumerId: "1",
+					Route:      &KongObj{Id: "1"},
+					Service:    &KongObj{Id: "1"},
+					Consumer:   &KongObj{Id: "1"},
+					Config:     nil,
+					Enabled:    &enable,
+					Id:         "1",
+					PluginId:   "1",
+				},
+			},
+			want: &KongPluginRespDto{
+				Id:         "1",
+				ServiceId:  "1",
+				RouteId:    "1",
+				ConsumerId: "1",
+				Route:      &KongObj{Id: "1"},
+				Service:    &KongObj{Id: "1"},
+				Consumer:   &KongObj{Id: "1"},
+				Name:       "xxx",
+				Config:     nil,
+				Enabled:    true,
+				CreatedAt:  tTime,
+				PolicyId:   "1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateOrUpdatePluginById(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdatePluginById() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateOrUpdatePluginById() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateOrUpdateService(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongServiceReqDto
+	}
+	retry := 5
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongServiceRespDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				req: &KongServiceReqDto{
+					Name:           "xxx",
+					Url:            "/test",
+					Protocol:       "http",
+					Host:           "test.io",
+					Port:           8080,
+					Path:           "/test",
+					Retries:        &retry,
+					ConnectTimeout: 1000,
+					WriteTimeout:   500,
+					ReadTimeout:    500,
+					ServiceId:      "1",
+				},
+			},
+			want: &KongServiceRespDto{
+				Id:       "1",
+				Name:     "xxx",
+				Protocol: "http",
+				Host:     "test.io",
+				Port:     8080,
+				Path:     "/test",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateOrUpdateService(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateService() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateOrUpdateService() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeleteService(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		serviceId string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{serviceId: "1"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeleteService(tt.args.serviceId); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteService() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeletePluginIfExist(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				req: &KongPluginReqDto{
+					Name:       "xxx",
+					ServiceId:  "1",
+					RouteId:    "1",
+					ConsumerId: "1",
+					Route:      &KongObj{Id: "1"},
+					Service:    &KongObj{Id: "1"},
+					Consumer:   &KongObj{Id: "1"},
+					Config:     nil,
+					Id:         "1",
+					PluginId:   "1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeletePluginIfExist(tt.args.req); (err != nil) != tt.wantErr {
+				t.Errorf("DeletePluginIfExist() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateOrUpdatePlugin(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	enable := true
+	tTime := time.Now().Unix()
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongPluginRespDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{req: &KongPluginReqDto{
+				Name:       "xxx",
+				ServiceId:  "1",
+				RouteId:    "1",
+				ConsumerId: "1",
+				Route:      &KongObj{Id: "1"},
+				Service:    &KongObj{Id: "1"},
+				Consumer:   &KongObj{Id: "1"},
+				Enabled:    &enable,
+				Config:     nil,
+				Id:         "1",
+				CreatedAt:  tTime,
+				PluginId:   "1",
+			}},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateOrUpdatePlugin(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdatePlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateOrUpdatePlugin() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_AddPlugin(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	tTime := time.Now().Unix()
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongPluginRespDto
+		wantErr bool
+	}{
+		{
+			name: "Test_01",
+			fields: fields{
+				ProviderName: "MSE",
+			},
+			args: args{
+				req: &KongPluginReqDto{
+					Name:       "xxx",
+					ServiceId:  "1",
+					RouteId:    "1",
+					ConsumerId: "1",
+					Route:      nil,
+					Service:    nil,
+					Consumer:   nil,
+					Enabled:    nil,
+					Config:     nil,
+					Id:         "001",
+					CreatedAt:  0,
+					PluginId:   "x0001",
+				},
+			},
+			want: &KongPluginRespDto{
+				Id:         "001",
+				ServiceId:  "1",
+				RouteId:    "1",
+				ConsumerId: "1",
+				Route:      nil,
+				Service:    nil,
+				Consumer:   nil,
+				Name:       "xxx",
+				Config:     nil,
+				Enabled:    true,
+				CreatedAt:  tTime,
+				PolicyId:   "x0001",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.AddPlugin(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddPlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddPlugin() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_PutPlugin(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongPluginRespDto
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.PutPlugin(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PutPlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PutPlugin() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_UpdatePlugin(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongPluginReqDto
+	}
+	enable := true
+	tTime := time.Now().Unix()
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongPluginRespDto
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{req: &KongPluginReqDto{
+				Name:       "xxx",
+				ServiceId:  "1",
+				RouteId:    "1",
+				ConsumerId: "1",
+				Route:      &KongObj{Id: "1"},
+				Service:    &KongObj{Id: "1"},
+				Consumer:   &KongObj{Id: "1"},
+				Enabled:    &enable,
+				Config:     nil,
+				Id:         "1",
+				CreatedAt:  tTime,
+				PluginId:   "1",
+			}},
+			want: &KongPluginRespDto{
+				Id:         "1",
+				ServiceId:  "1",
+				RouteId:    "1",
+				ConsumerId: "1",
+				Route:      &KongObj{Id: "1"},
+				Service:    &KongObj{Id: "1"},
+				Consumer:   &KongObj{Id: "1"},
+				Name:       "xxx",
+				Config:     nil,
+				Enabled:    true,
+				CreatedAt:  tTime,
+				PolicyId:   "1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.UpdatePlugin(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdatePlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdatePlugin() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_RemovePlugin(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{id: "1"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.RemovePlugin(tt.args.id); (err != nil) != tt.wantErr {
+				t.Errorf("RemovePlugin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeleteCredential(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		consumerId   string
+		pluginName   string
+		credentialId string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				consumerId:   "1",
+				pluginName:   "cors",
+				credentialId: "1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeleteCredential(tt.args.consumerId, tt.args.pluginName, tt.args.credentialId); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteCredential() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GetCredentialList(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		consumerId string
+		pluginName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongCredentialListDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				consumerId: "1",
+				pluginName: "cors",
+			},
+			want:    &KongCredentialListDto{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.GetCredentialList(tt.args.consumerId, tt.args.pluginName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCredentialList() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCredentialList() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateAclGroup(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		consumerId string
+		customId   string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				consumerId: "1",
+				customId:   "1",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.CreateAclGroup(tt.args.consumerId, tt.args.customId); (err != nil) != tt.wantErr {
+				t.Errorf("CreateAclGroup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_CreateUpstream(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		req *KongUpstreamDto
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongUpstreamDto
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{req: &KongUpstreamDto{
+				Id:           "1",
+				Name:         "xx",
+				Healthchecks: HealthchecksDto{},
+			}},
+			want: &KongUpstreamDto{
+				Id:           "1",
+				Name:         "xx",
+				Healthchecks: HealthchecksDto{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.CreateUpstream(tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateUpstream() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateUpstream() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GetUpstreamStatus(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		upstreamId string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *KongUpstreamStatusRespDto
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args:   args{upstreamId: "1"},
+			want: &KongUpstreamStatusRespDto{
+				Data: []KongTargetDto{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.GetUpstreamStatus(tt.args.upstreamId)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetUpstreamStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetUpstreamStatus() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_DeleteUpstreamTarget(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		upstreamId string
+		targetId   string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{ProviderName: "MSE"},
+			args: args{
+				upstreamId: "",
+				targetId:   "",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.DeleteUpstreamTarget(tt.args.upstreamId, tt.args.targetId); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteUpstreamTarget() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_TouchRouteOAuthMethod(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			args:    args{id: "1"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			if err := impl.TouchRouteOAuthMethod(tt.args.id); (err != nil) != tt.wantErr {
+				t.Errorf("TouchRouteOAuthMethod() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GetRoutes(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []KongRouteRespDto
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{ProviderName: "MSE"},
+			want:    []KongRouteRespDto{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.GetRoutes()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetRoutes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRoutes() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMseAdapterImpl_GetRoutesWithTag(t *testing.T) {
+	type fields struct {
+		ProviderName string
+	}
+	type args struct {
+		tag string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []KongRouteRespDto
+		wantErr bool
+	}{
+		{
+			name:    "Test_01",
+			fields:  fields{},
+			args:    args{tag: "xxx"},
+			want:    []KongRouteRespDto{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := &MseAdapterImpl{
+				ProviderName: tt.fields.ProviderName,
+			}
+			got, err := impl.GetRoutesWithTag(tt.args.tag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetRoutesWithTag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRoutesWithTag() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/hepa/gateway/dto/dice_args_dto.go
+++ b/internal/tools/orchestrator/hepa/gateway/dto/dice_args_dto.go
@@ -34,6 +34,8 @@ type DiceArgsDto struct {
 	PageSize    int64
 	SortField   string
 	SortType    string
+	Namespace   string
+	ServiceName string
 }
 
 func (impl DiceArgsDto) GenSelectOptions() []orm.SelectOption {

--- a/internal/tools/orchestrator/hepa/gateway/dto/openapi_req_dto.go
+++ b/internal/tools/orchestrator/hepa/gateway/dto/openapi_req_dto.go
@@ -56,6 +56,7 @@ type OpenapiDto struct {
 	Env                string   `json:"-"`
 	RuntimeServiceId   string   `json:"-"`
 	Hosts              []string `json:"hosts"`
+	GatewayProvider    string   `json:"gatewayProvider"`
 }
 
 func (dto OpenapiDto) ToEndpointApi() *pb.EndpointApi {

--- a/internal/tools/orchestrator/hepa/gateway/dto/package_info_dto.go
+++ b/internal/tools/orchestrator/hepa/gateway/dto/package_info_dto.go
@@ -51,14 +51,15 @@ func (list SortBySceneList) Less(i, j int) bool {
 
 func (dto PackageInfoDto) ToEndpoint() *pb.Endpoint {
 	return &pb.Endpoint{
-		Id:          dto.Id,
-		CreateAt:    dto.CreateAt,
-		Name:        dto.Name,
-		BindDomain:  dto.BindDomain,
-		AuthType:    dto.AuthType,
-		AclType:     dto.AclType,
-		Scene:       dto.Scene,
-		Description: dto.Description,
+		Id:              dto.Id,
+		CreateAt:        dto.CreateAt,
+		Name:            dto.Name,
+		BindDomain:      dto.BindDomain,
+		AuthType:        dto.AuthType,
+		AclType:         dto.AclType,
+		Scene:           dto.Scene,
+		Description:     dto.Description,
+		GatewayProvider: dto.GatewayProvider,
 	}
 }
 

--- a/internal/tools/orchestrator/hepa/gateway/dto/package_req_dto.go
+++ b/internal/tools/orchestrator/hepa/gateway/dto/package_req_dto.go
@@ -45,6 +45,7 @@ type PackageDto struct {
 	Scene            string   `json:"scene"`
 	Description      string   `json:"description"`
 	NeedBindCloudapi bool     `json:"needBindCloudapi"`
+	GatewayProvider  string   `json:"gatewayProvider"` // "MSE" 或 ""
 }
 
 func (dto PackageDto) CheckValid() error {

--- a/internal/tools/orchestrator/hepa/k8s/k8s_adapter_test.go
+++ b/internal/tools/orchestrator/hepa/k8s/k8s_adapter_test.go
@@ -209,7 +209,7 @@ func TestK8SAdapterImpl_CreateOrUpdateIngress(t *testing.T) {
 				ingressesHelper: tt.fields.ingressesHelper,
 				pool:            tt.fields.pool,
 			}
-			got, err := impl.CreateOrUpdateIngress(tt.args.namespace, tt.args.name, tt.args.routes, tt.args.backend, tt.args.options...)
+			got, err := impl.CreateOrUpdateIngress(tt.args.namespace, tt.args.name, tt.args.routes, tt.args.backend, "", tt.args.options...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("K8SAdapterImpl.CreateOrUpdateIngress() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/tools/orchestrator/hepa/providers/legacy_upstream/upstream.service.go
+++ b/internal/tools/orchestrator/hepa/providers/legacy_upstream/upstream.service.go
@@ -43,6 +43,7 @@ func (s *upstreamService) Register(ctx context.Context, req *pb.RegisterRequest)
 		err = erdaErr.NewInvalidParameterError(vars.TODO_PARAM, "invalid request")
 		return
 	}
+	logrus.Infof("Call /api/gateway/register_async with Req: %+v\n", *(req.GetUpstream()))
 	if req.GetUpstream().GetRuntimeId() == "" || req.GetUpstream().GetOnlyRuntimePath() {
 		return s.register(ctx, req)
 	}
@@ -91,6 +92,8 @@ func (s *upstreamService) register(ctx context.Context, req *pb.RegisterRequest)
 // AsyncRegister PUT /api/gateway/register_async
 func (s *upstreamService) AsyncRegister(ctx context.Context, req *pb.AsyncRegisterRequest) (resp *pb.AsyncRegisterResponse, err error) {
 	ctx = context1.WithLoggerIfWithout(ctx, logrus.StandardLogger())
+	l := ctx.(*context1.LogContext).Entry()
+	l.WithError(nil).Infof("Call /api/gateway/register_async with Req: %+v\n", *(req.GetUpstream()))
 
 	if req.Upstream == nil {
 		err = erdaErr.NewInvalidParameterError(vars.TODO_PARAM, "invalid request")
@@ -141,7 +144,6 @@ func (s *upstreamService) asyncRegister(ctx context.Context, req *pb.AsyncRegist
 		Data: result,
 	}
 	return
-
 }
 
 func (s *upstreamService) patchHubInfo(ctx context.Context, reqDto *dto.UpstreamRegisterDto) error {

--- a/internal/tools/orchestrator/hepa/providers/openapi_rule/openapi.rule.service.go
+++ b/internal/tools/orchestrator/hepa/providers/openapi_rule/openapi.rule.service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/common/vars"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway/dto"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/openapi_rule"
+	"github.com/erda-project/erda/pkg/common/apis"
 	erdaErr "github.com/erda-project/erda/pkg/common/errors"
 )
 
@@ -54,11 +55,13 @@ func (s *openapiRuleService) GetLimits(ctx context.Context, req *pb.GetLimitsReq
 	}
 	return
 }
+
 func (s *openapiRuleService) CreateLimit(ctx context.Context, req *pb.CreateLimitRequest) (resp *pb.CreateLimitResponse, err error) {
 	service := openapi_rule.Service.Clone(ctx)
 	result, existed, err := service.CreateLimitRule(&dto.DiceArgsDto{
 		ProjectId: req.ProjectId,
 		Env:       req.Env,
+		OrgId:     apis.GetOrgID(ctx),
 	}, dto.FromLimitRequest(req.LimitRequest))
 	if existed {
 		err = erdaErr.NewAlreadyExistsError("rule")
@@ -73,6 +76,7 @@ func (s *openapiRuleService) CreateLimit(ctx context.Context, req *pb.CreateLimi
 	}
 	return
 }
+
 func (s *openapiRuleService) UpdateLimit(ctx context.Context, req *pb.UpdateLimitRequest) (resp *pb.UpdateLimitResponse, err error) {
 	service := openapi_rule.Service.Clone(ctx)
 	result, err := service.UpdateLimitRule(req.RuleId, dto.FromLimitRequest(req.LimitRequest))
@@ -96,6 +100,7 @@ func (s *openapiRuleService) UpdateLimit(ctx context.Context, req *pb.UpdateLimi
 	}
 	return
 }
+
 func (s *openapiRuleService) DeleteLimit(ctx context.Context, req *pb.DeleteLimitRequest) (resp *pb.DeleteLimitResponse, err error) {
 	service := openapi_rule.Service.Clone(ctx)
 	result, err := service.DeleteLimitRule(req.RuleId)

--- a/internal/tools/orchestrator/hepa/repository/service/interface.go
+++ b/internal/tools/orchestrator/hepa/repository/service/interface.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	ZONE_TYPE_DICE_APP    = "diceApp" //已废弃
-	ZONE_TYPE_PACKAGE     = "package" // 老的入口
-	ZONE_TYPE_PACKAGE_NEW = "packageNew"
-	ZONE_TYPE_PACKAGE_API = "packageApi"
-	ZONE_TYPE_UNITY       = "unity"
+	ZONE_TYPE_DICE_APP       = "diceApp" //已废弃
+	ZONE_TYPE_PACKAGE        = "package" // 老的入口
+	ZONE_TYPE_PACKAGE_NEW    = "packageNew"
+	ZONE_TYPE_PACKAGE_API    = "packageApi"
+	ZONE_TYPE_UNITY          = "unity"
+	ZONE_TYPE_UNITY_Provider = "unityProvider"
 )
 
 var GLOBAL_REGIONS = []string{"option", "main", "http", "server"}
@@ -331,7 +332,7 @@ type GatewayUpstreamRegisterRecordService interface {
 
 type GatewayAzInfoService interface {
 	GetAz(*GatewayAzInfo) (string, error)
-	GetAzInfoByClusterName(name string) (*orm.GatewayAzInfo, error)
+	GetAzInfoByClusterName(name string) (*orm.GatewayAzInfo, *ClusterInfoDto, error)
 	GetAzInfo(*GatewayAzInfo) (*GatewayAzInfo, error)
 	SelectByAny(*GatewayAzInfo) ([]GatewayAzInfo, error)
 	SelectValidAz() ([]GatewayAzInfo, error)

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package impl
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
+)
+
+func Test_hasDuplicatedConfig(t *testing.T) {
+	type args struct {
+		p1 apipolicy.PolicyConfig
+		p2 apipolicy.PolicyConfig
+	}
+
+	proxy_next_upstream := "error timeout http_429 non_idempotent"
+	annos1 := make(map[string]*string)
+	annos1["proxy-next-upstream"] = &proxy_next_upstream
+	proxy_read_timeout := "120"
+	annos1["proxy-read-timeout"] = &proxy_read_timeout
+
+	//ls1 := "\n  proxy_intercept_errors on;\n"
+
+	annos2 := make(map[string]*string)
+	annos2["proxy-next-upstream"] = &proxy_next_upstream
+	ls1 := "\n  send_timeout 120s; \n"
+	ls2 := "\n  proxy_intercept_errors on;\n"
+
+	pn1 := &apipolicy.IngressAnnotation{
+		Annotation:      annos1,
+		LocationSnippet: &ls1,
+	}
+
+	pn2 := &apipolicy.IngressAnnotation{
+		Annotation:      annos2,
+		LocationSnippet: &ls2,
+	}
+
+	ls3 := "\n  proxy_read_timeout 600s;\n   proxy_connect_timeout 600s;\n   proxy_send_timeout 600s;\n"
+	pn3 := &apipolicy.IngressAnnotation{
+		Annotation:      nil,
+		LocationSnippet: &ls3,
+	}
+
+	co := make(map[string]*string)
+	co["proxy-next-upstream"] = &proxy_next_upstream
+	pc2 := &apipolicy.IngressController{
+		ConfigOption: co,
+	}
+
+	ms := "\n     proxy_next_upstream error timeout http_581 non_idempotent;\n" +
+		"     more_set_headers  'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';\n" +
+		"     more_set_headers  'Access-Control-Allow-Headers: $http_access_control_request_headers'; \n"
+	pc3 := &apipolicy.IngressController{
+		MainSnippet: &ms,
+	}
+
+	hs := `
+location @LIMIT-xxxxxx {
+    log_by_lua_block {
+        plugins.run()
+    }
+    more_set_headers 'Access-Control-Allow-Origin: $from_request_origin_or_referer';
+    more_set_headers 'Access-Control-Allow-Methods: GET, PUT, POST, DELETE, PATCH, OPTIONS';
+    more_set_headers 'Access-Control-Allow-Headers: $http_access_control_request_headers';
+    more_set_headers 'Access-Control-Allow-Credentials: true';
+    more_set_headers 'Access-Control-Max-Age: 86400';
+    more_set_headers 'Content-Type: text/plain charset=UTF-8';
+    return 200;
+}
+`
+	pc4 := &apipolicy.IngressController{
+		HttpSnippet: &hs,
+	}
+
+	pc5 := &apipolicy.IngressController{
+		ServerSnippet: &hs,
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Test_01",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: pn2,
+					IngressController: nil,
+				},
+			},
+			want:    "proxy_next_upstream=error timeout http_429 non_idempotent",
+			wantErr: false,
+		},
+		{
+			name: "Test_02",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: nil,
+					IngressController: pc2,
+				},
+			},
+			want:    "proxy_next_upstream=error timeout http_429 non_idempotent",
+			wantErr: false,
+		},
+		{
+			name: "Test_03",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: nil,
+					IngressController: pc3,
+				},
+			},
+			want:    "proxy_next_upstream=error timeout http_581 non_idempotent",
+			wantErr: false,
+		},
+		{
+			name: "Test_04",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: nil,
+					IngressController: pc4,
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test_05",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: nil,
+					IngressController: pc5,
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test_06",
+			args: args{
+				p1: apipolicy.PolicyConfig{
+					IngressAnnotation: pn1,
+					IngressController: nil,
+				},
+				p2: apipolicy.PolicyConfig{
+					IngressAnnotation: pn3,
+				},
+			},
+			want:    "proxy_read_timeout=600s",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hasDuplicatedConfig(tt.args.p1, tt.args.p2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("hasDuplicatedConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("hasDuplicatedConfig() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validateCustomNginxConf(t *testing.T) {
+	type args struct {
+		category string
+		config   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "Test_01",
+			args: args{
+				category: "custom",
+				config:   "/n    xxxx 123;\n",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateCustomNginxConf(tt.args.category, tt.args.config); (err != nil) != tt.wantErr {
+				t.Errorf("validateCustomNginxConf() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/hepa/services/api_policy/interface.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/interface.go
@@ -29,7 +29,8 @@ type GatewayApiPolicyService interface {
 	SetPackageDefaultPolicyConfig(category, packageId string, az *orm.GatewayAzInfo, config []byte, helper ...*service.SessionHelper) (string, error)
 	GetPolicyConfig(category, packageId, packageApiId string) (interface{}, error)
 	SetPolicyConfig(category, packageId, packageApiId string, config []byte) (interface{}, error)
-	RefreshZoneIngress(zone orm.GatewayZone, az orm.GatewayAzInfo) error
-	SetZonePolicyConfig(zone *orm.GatewayZone, category string, config []byte, helper *service.SessionHelper, needDeployTag ...bool) (apipolicy.PolicyDto, string, error)
-	SetZoneDefaultPolicyConfig(packageId string, zone *orm.GatewayZone, az *orm.GatewayAzInfo, session ...*service.SessionHelper) (map[string]*string, *string, *service.SessionHelper, error)
+	RefreshZoneIngress(zone orm.GatewayZone, az orm.GatewayAzInfo, namespace string, useKong bool) error
+	GetGatewayProvider(clusterName string) (string, error)
+	SetZonePolicyConfig(zone *orm.GatewayZone, runtimeService *orm.GatewayRuntimeService, category string, config []byte, helper *service.SessionHelper, needDeployTag ...bool) (apipolicy.PolicyDto, string, error)
+	SetZoneDefaultPolicyConfig(packageId string, runtimeService *orm.GatewayRuntimeService, zone *orm.GatewayZone, az *orm.GatewayAzInfo, session ...*service.SessionHelper) (map[string]*string, *string, *service.SessionHelper, error)
 }

--- a/internal/tools/orchestrator/hepa/services/domain/interface.go
+++ b/internal/tools/orchestrator/hepa/services/domain/interface.go
@@ -43,4 +43,5 @@ type GatewayDomainService interface {
 	TouchPackageDomain(orgId, packageId, clusterName string, domains []string, session *service.SessionHelper) ([]string, error)
 	GetPackageDomains(packageId string, session ...*service.SessionHelper) ([]string, error)
 	IsPackageDomainsDiff(packageId, clusterName string, domains []string, session *service.SessionHelper) (bool, error)
+	GetGatewayProvider(clusterName string) (string, error)
 }

--- a/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl_test.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl_test.go
@@ -15,9 +15,175 @@
 package impl
 
 import (
+	"context"
+	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/orm"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/service"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/api_policy"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/domain"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/endpoint_api"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/global"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/micro_api"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/openapi_consumer"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/openapi_rule"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/zone"
 )
 
 func TesthubExists(t *testing.T) {
 
+}
+
+func TestGatewayOpenapiServiceImpl_touchServiceForExternalService(t *testing.T) {
+	type fields struct {
+		packageDb       service.GatewayPackageService
+		packageApiDb    service.GatewayPackageApiService
+		zoneInPackageDb service.GatewayZoneInPackageService
+		apiInPackageDb  service.GatewayApiInPackageService
+		packageInDb     service.GatewayPackageInConsumerService
+		serviceDb       service.GatewayServiceService
+		routeDb         service.GatewayRouteService
+		consumerDb      service.GatewayConsumerService
+		apiDb           service.GatewayApiService
+		upstreamApiDb   service.GatewayUpstreamApiService
+		azDb            service.GatewayAzInfoService
+		kongDb          service.GatewayKongInfoService
+		hubInfoDb       service.GatewayHubInfoService
+		apiBiz          *micro_api.GatewayApiService
+		zoneBiz         *zone.GatewayZoneService
+		ruleBiz         *openapi_rule.GatewayOpenapiRuleService
+		consumerBiz     *openapi_consumer.GatewayOpenapiConsumerService
+		globalBiz       *global.GatewayGlobalService
+		policyBiz       *api_policy.GatewayApiPolicyService
+		runtimeDb       service.GatewayRuntimeServiceService
+		domainBiz       *domain.GatewayDomainService
+		ctx             context.Context
+		reqCtx          context.Context
+	}
+	type args struct {
+		info endpoint_api.PackageApiInfo
+		z    orm.GatewayZone
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *corev1.Service
+		wantErr bool
+	}{
+		{
+			name:   "Test_01",
+			fields: fields{},
+			args: args{
+				info: endpoint_api.PackageApiInfo{
+					GatewayPackageApi: &orm.GatewayPackageApi{
+						PackageId:        "066523a826ac4e81afa908a1f1e25115",
+						ApiPath:          "/test/for-inner/urls",
+						Method:           "",
+						RedirectAddr:     "http://bbb-151f3a62c7.project-5846-test.svc.cluster.local:80/",
+						RedirectPath:     "/",
+						Description:      "",
+						DiceApp:          "bbb",
+						DiceService:      "bbb",
+						AclType:          "",
+						Origin:           "custom",
+						DiceApiId:        "",
+						RedirectType:     "url",
+						RuntimeServiceId: "",
+						ZoneId:           "1f242ca6d45e43d2b52124eec2138f4d",
+						CloudapiApiId:    "",
+						BaseRow: orm.BaseRow{
+							Id:        "5ba4b3809d6143c9ac426f96756c1f04",
+							IsDeleted: "N",
+						},
+					},
+					Hosts:               []string{"bbb-151f3a62c7.project-5846-test.svc.cluster.local"},
+					ProjectId:           "5846",
+					Env:                 "test",
+					Az:                  "test",
+					InjectRuntimeDomain: false,
+				},
+				z: orm.GatewayZone{
+					Name: "dice-test-5846-api-5ba4b3809d6143c9ac426f96756c1f04-1f2f4d",
+					BaseRow: orm.BaseRow{
+						Id:        "1f242ca6d45e43d2b52124eec2138f4d",
+						IsDeleted: "N",
+					},
+				},
+			},
+			want: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dice-test-5846-api-5ba4b3809d6143c9ac426f96756c1f04-1f2f4d",
+					Namespace: "project-5846-test",
+					Labels: map[string]string{
+						"packageId":                "066523a826ac4e81afa908a1f1e25115",
+						"erda.gateway.projectId":   "5846",
+						"erda.gateway.appName":     "bbb",
+						"erda.gateway.serviceName": "bbb",
+						"erda.gateway.workspace":   "test",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalName: "bbb-151f3a62c7.project-5846-test.svc.cluster.local",
+					Type:         corev1.ServiceTypeExternalName,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "target",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			impl := GatewayOpenapiServiceImpl{
+				packageDb:       tt.fields.packageDb,
+				packageApiDb:    tt.fields.packageApiDb,
+				zoneInPackageDb: tt.fields.zoneInPackageDb,
+				apiInPackageDb:  tt.fields.apiInPackageDb,
+				packageInDb:     tt.fields.packageInDb,
+				serviceDb:       tt.fields.serviceDb,
+				routeDb:         tt.fields.routeDb,
+				consumerDb:      tt.fields.consumerDb,
+				apiDb:           tt.fields.apiDb,
+				upstreamApiDb:   tt.fields.upstreamApiDb,
+				azDb:            tt.fields.azDb,
+				kongDb:          tt.fields.kongDb,
+				hubInfoDb:       tt.fields.hubInfoDb,
+				apiBiz:          tt.fields.apiBiz,
+				zoneBiz:         tt.fields.zoneBiz,
+				ruleBiz:         tt.fields.ruleBiz,
+				consumerBiz:     tt.fields.consumerBiz,
+				globalBiz:       tt.fields.globalBiz,
+				policyBiz:       tt.fields.policyBiz,
+				runtimeDb:       tt.fields.runtimeDb,
+				domainBiz:       tt.fields.domainBiz,
+				ctx:             tt.fields.ctx,
+				reqCtx:          tt.fields.reqCtx,
+			}
+			got, err := impl.touchServiceForExternalService(tt.args.info, tt.args.z)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("touchServiceForExternalService() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("touchServiceForExternalService() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/tools/orchestrator/hepa/services/endpoint_api/interface.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/interface.go
@@ -44,7 +44,7 @@ type GatewayOpenapiService interface {
 	TouchRuntimePackageMeta(*orm.GatewayRuntimeService, *service.SessionHelper) (string, bool, error)
 	RefreshRuntimePackage(string, *orm.GatewayRuntimeService, *service.SessionHelper) error
 	CreateUnityPackageZone(string, *service.SessionHelper) (*orm.GatewayZone, error)
-	CreateTenantPackage(string, *service.SessionHelper) error
+	CreateTenantPackage(string, string, *service.SessionHelper) error
 	CreateTenantHubPackages(ctx context.Context, tenantID string, session *service.SessionHelper) error
 	CreatePackage(context.Context, *dto.DiceArgsDto, *dto.PackageDto) (*dto.PackageInfoDto, string, error)
 	GetPackages(context.Context, *dto.GetPackagesDto) (common.NewPageQuery, error)

--- a/internal/tools/orchestrator/hepa/services/global/interface.go
+++ b/internal/tools/orchestrator/hepa/services/global/interface.go
@@ -27,6 +27,7 @@ var Service GatewayGlobalService
 
 type GatewayGlobalService interface {
 	Clone(context.Context) GatewayGlobalService
+	GetGatewayProvider(string) (string, error)
 	GetDiceHealth() dto.DiceHealthDto
 	GenTenantGroup(projectId, env, clusterName string) (string, error)
 	GetGatewayFeatures(clusterName string) map[string]string

--- a/internal/tools/orchestrator/hepa/services/legacy_consumer/interface.go
+++ b/internal/tools/orchestrator/hepa/services/legacy_consumer/interface.go
@@ -34,4 +34,5 @@ type GatewayConsumerService interface {
 	UpdateConsumerInfo(string, *dto.ConsumerDto) *common.StandardResult
 	GetConsumerList(string, string, string) *common.StandardResult
 	DeleteConsumer(string) *common.StandardResult
+	GetGatewayProvider(string) (string, error)
 }

--- a/internal/tools/orchestrator/hepa/services/legacy_upstream/interface.go
+++ b/internal/tools/orchestrator/hepa/services/legacy_upstream/interface.go
@@ -26,4 +26,5 @@ type GatewayUpstreamService interface {
 	Clone(context.Context) GatewayUpstreamService
 	UpstreamRegister(context.Context, *dto.UpstreamRegisterDto) (bool, error)
 	UpstreamRegisterAsync(context.Context, *dto.UpstreamRegisterDto) (bool, error)
+	GetGatewayProvider(string) (string, error)
 }

--- a/internal/tools/orchestrator/hepa/services/micro_api/interface.go
+++ b/internal/tools/orchestrator/hepa/services/micro_api/interface.go
@@ -40,4 +40,5 @@ type GatewayApiService interface {
 	DeleteUpstreamBindApi(*orm.GatewayUpstreamApi) error
 	TouchRuntimeApi(*orm.GatewayRuntimeService, *service.SessionHelper, bool) error
 	ClearRuntimeApi(*orm.GatewayRuntimeService) error
+	GetGatewayProvider(az string) (string, error)
 }

--- a/internal/tools/orchestrator/hepa/services/openapi_consumer/interface.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_consumer/interface.go
@@ -35,6 +35,7 @@ type GatewayOpenapiConsumerService interface {
 	UpdateConsumer(string, *dto.OpenConsumerDto) (*dto.OpenConsumerInfoDto, error)
 	DeleteConsumer(string) (bool, error)
 	GetConsumerCredentials(string) (dto.ConsumerCredentialsDto, error)
+	GetGatewayProvider(string) (string, error)
 	UpdateConsumerCredentials(string, *dto.ConsumerCredentialsDto) (dto.ConsumerCredentialsDto, string, error)
 	GetConsumerAcls(string) ([]dto.ConsumerAclInfoDto, error)
 	UpdateConsumerAcls(string, *dto.ConsumerAclsDto) (bool, error)

--- a/internal/tools/orchestrator/hepa/services/openapi_rule/interface.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_rule/interface.go
@@ -43,5 +43,6 @@ type GatewayOpenapiRuleService interface {
 	DeleteByPackage(*orm.GatewayPackage) error
 	DeleteByPackageApi(*orm.GatewayPackage, *orm.GatewayPackageApi) error
 	SetPackageKongPolicies(*orm.GatewayPackage, *service.SessionHelper) error
-	SetPackageApiKongPolicies(packageApi *orm.GatewayPackageApi, session *service.SessionHelper) error
+	SetPackageApiKongPolicies(packageApi *orm.GatewayPackageApi, useKong bool, session *service.SessionHelper) error
+	GetGatewayProvider(az string) (string, error)
 }

--- a/internal/tools/orchestrator/hepa/services/runtime_service/inteface.go
+++ b/internal/tools/orchestrator/hepa/services/runtime_service/inteface.go
@@ -40,9 +40,10 @@ type GatewayRuntimeServiceService interface {
 	GetServiceRuntimes(projectId, env, app, service string) ([]orm.GatewayRuntimeService, error)
 	// 获取指定服务的API前缀
 	GetServiceApiPrefix(*dto.ApiPrefixReqDto) ([]string, error)
+	GetGatewayProvider(string) (string, error)
 }
 
-func MakeEndpointMaterial(runtimeService *orm.GatewayRuntimeService) (endpoint.EndpointMaterial, error) {
+func MakeEndpointMaterial(runtimeService *orm.GatewayRuntimeService, gatewayProvider string) (endpoint.EndpointMaterial, error) {
 	material := endpoint.EndpointMaterial{}
 	material.ServiceName = runtimeService.ServiceName
 	material.ServicePort = runtimeService.ServicePort
@@ -61,5 +62,6 @@ func MakeEndpointMaterial(runtimeService *orm.GatewayRuntimeService) (endpoint.E
 	case "fastcgi":
 		material.K8SRouteOptions.BackendProtocol = &[]k8s.BackendProtocl{k8s.FCGI}[0]
 	}
+	material.GatewayProvider = gatewayProvider
 	return material, nil
 }

--- a/internal/tools/orchestrator/hepa/services/zone/interface.go
+++ b/internal/tools/orchestrator/hepa/services/zone/interface.go
@@ -33,11 +33,13 @@ type ZoneRoute struct {
 
 type ZoneConfig struct {
 	*ZoneRoute
-	Name      string
-	ProjectId string
-	Env       string
-	Az        string
-	Type      string
+	Name        string
+	ProjectId   string
+	Env         string
+	Az          string
+	Type        string
+	Namespace   string
+	ServiceName string
 }
 
 var Service GatewayZoneService
@@ -45,13 +47,14 @@ var Service GatewayZoneService
 type GatewayZoneService interface {
 	CreateZoneWithoutIngress(ZoneConfig, ...*service.SessionHelper) (*orm.GatewayZone, error)
 	CreateZone(ZoneConfig, ...*service.SessionHelper) (*orm.GatewayZone, error)
-	DeleteZoneRoute(string, ...*service.SessionHelper) error
-	UpdateZoneRoute(string, ZoneRoute, ...*service.SessionHelper) (bool, error)
+	DeleteZoneRoute(string, string, ...*service.SessionHelper) error
+	UpdateZoneRoute(string, ZoneRoute, *orm.GatewayRuntimeService, string, ...*service.SessionHelper) (bool, error)
 	// trigger domain-policy update
 	SetZoneKongPolicies(string, dto.ZoneKongPolicies, *service.SessionHelper) error
 	SetZoneKongPoliciesWithoutDomainPolicy(zoneId string, policies *dto.ZoneKongPolicies, helper *service.SessionHelper) error
 	UpdateKongDomainPolicy(az, projectId, env string, helper *service.SessionHelper) error
-	DeleteZone(string) error
+	GetGatewayProvider(az string) (string, error)
+	DeleteZone(string, string) error
 	UpdateBuiltinPolicies(string) error
 	GetZone(string, ...*service.SessionHelper) (*orm.GatewayZone, error)
 }

--- a/pkg/k8s/typed/extensions/v1beta1/ingress.go
+++ b/pkg/k8s/typed/extensions/v1beta1/ingress.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	. "k8s.io/api/extensions/v1beta1"
@@ -81,6 +82,9 @@ func (ing IngressHelper) NewIngress(material union_interface.IngressMaterial) in
 			},
 		})
 	}
+	if material.GatewayProvider != "" {
+		ingress.Spec.IngressClassName = &material.GatewayProvider
+	}
 	return ingress
 }
 
@@ -92,7 +96,14 @@ func (ing IngressHelper) IngressAnnotationBatchSet(ingress interface{}, kvs map[
 	if len(instance.Annotations) == 0 {
 		instance.Annotations = map[string]string{}
 	}
+	if len(instance.Labels) == 0 {
+		instance.Labels = map[string]string{}
+	}
 	for key, value := range kvs {
+		if strings.HasPrefix(key, "erda.gateway.") {
+			instance.Labels[key] = value
+			continue
+		}
 		instance.Annotations[key] = value
 	}
 	return nil

--- a/pkg/k8s/typed/networking/v1/ingress.go
+++ b/pkg/k8s/typed/networking/v1/ingress.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	. "k8s.io/api/networking/v1"
@@ -86,6 +87,9 @@ func (ing IngressHelper) NewIngress(material union_interface.IngressMaterial) in
 			},
 		})
 	}
+	if material.GatewayProvider != "" {
+		ingress.Spec.IngressClassName = &material.GatewayProvider
+	}
 	return ingress
 }
 
@@ -96,6 +100,16 @@ func (ing IngressHelper) IngressAnnotationBatchSet(ingress interface{}, kvs map[
 	}
 	if len(instance.Annotations) == 0 {
 		instance.Annotations = map[string]string{}
+	}
+	if len(instance.Labels) == 0 {
+		instance.Labels = map[string]string{}
+	}
+	for key, value := range kvs {
+		if strings.HasPrefix(key, "erda.gateway.") {
+			instance.Labels[key] = value
+			continue
+		}
+		instance.Annotations[key] = value
 	}
 	for key, value := range kvs {
 		instance.Annotations[key] = value

--- a/pkg/k8s/typed/networking/v1beta1/ingress.go
+++ b/pkg/k8s/typed/networking/v1beta1/ingress.go
@@ -16,6 +16,7 @@ package v1beta1
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	. "k8s.io/api/networking/v1beta1"
@@ -83,6 +84,9 @@ func (ing IngressHelper) NewIngress(material union_interface.IngressMaterial) in
 			},
 		})
 	}
+	if material.GatewayProvider != "" {
+		ingress.Spec.IngressClassName = &material.GatewayProvider
+	}
 	return ingress
 }
 
@@ -93,6 +97,16 @@ func (ing IngressHelper) IngressAnnotationBatchSet(ingress interface{}, kvs map[
 	}
 	if len(instance.Annotations) == 0 {
 		instance.Annotations = map[string]string{}
+	}
+	if len(instance.Labels) == 0 {
+		instance.Labels = map[string]string{}
+	}
+	for key, value := range kvs {
+		if strings.HasPrefix(key, "erda.gateway.") {
+			instance.Labels[key] = value
+			continue
+		}
+		instance.Annotations[key] = value
 	}
 	for key, value := range kvs {
 		instance.Annotations[key] = value

--- a/pkg/k8s/union_interface/ingress.go
+++ b/pkg/k8s/union_interface/ingress.go
@@ -41,11 +41,12 @@ type IngressBackend struct {
 }
 
 type IngressMaterial struct {
-	Name      string
-	Namespace string
-	Routes    []IngressRoute
-	Backend   IngressBackend
-	NeedTLS   bool
+	Name            string
+	Namespace       string
+	Routes          []IngressRoute
+	Backend         IngressBackend
+	NeedTLS         bool
+	GatewayProvider string
 }
 
 type IngressesHelper interface {


### PR DESCRIPTION
#### What this PR does / why we need it:
Erda hepa support MSE Gateway by set dice-cluster-info with config GATEWAY_PROVIDER and PROVIDER_GATEWAY_ENDPOINT.

If set GATEWAY_PROVIDER as "" or not set, Erda use Nginx-Kong as API Gateway as usual.

If set GATEWAY_PROVIDER as "MSE", Erda use Aliyun MSE as API Gateway in Aliyun ACK cluster.


#### Specified Reviewers:

/assign @chengjoey @sfwn @sixther-dc @luobily @iutx 


#### ChangeLog
Feature: Support Aliyun MSE Gateway in Erda hepa （Erda hepa 支持阿里云 MSE Gateway 网关）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Support Aliyun MSE Gateway in Erda hepa     |
| 🇨🇳 中文    |      Erda hepa 支持阿里云 MSE Gateway 网关        |


#### Need cherry-pick to release versions?

