### PR TITLE
feat: compatible the span data from erda java-agent to otlp java-agent

### DIFF
--- a/internal/tools/monitor/oap/collector/interceptor/constants.go
+++ b/internal/tools/monitor/oap/collector/interceptor/constants.go
@@ -61,6 +61,11 @@ var (
 	TAG_JAEGER                  = "jaeger"
 	TAG_JAEGER_VERSION          = "jaeger_version"
 
+	//use to compatible the span data from erda java-agent to otlp java-agent
+	TAG_IS_FROM_ERDA   = "is_from_erda"
+	TAG_TRACE_ID       = "trace_id"
+	TAG_PARENT_SPAN_ID = "parent_span_id"
+
 	TAG_ERDA_ENV_ID    = "erda_env_id"
 	TAG_ERDA_ENV_TOKEN = "erda_env_token"
 	TAG_ERDA_ORG       = "erda_org"

--- a/internal/tools/monitor/oap/collector/plugins/receivers/opentelemetry/interceptor.go
+++ b/internal/tools/monitor/oap/collector/plugins/receivers/opentelemetry/interceptor.go
@@ -122,6 +122,11 @@ func convertSpans(tracesData *otlpv1.TracesData) []*tracepb.Span {
 							if otlpSpan.ParentSpanId != nil {
 								span.ParentSpanID = hex.EncodeToString(otlpSpan.ParentSpanId[:])
 							}
+
+							if attributes[interceptor.TAG_IS_FROM_ERDA] == "true" {
+								span.TraceID = attributes[interceptor.TAG_TRACE_ID]
+								span.ParentSpanID = attributes[interceptor.TAG_PARENT_SPAN_ID]
+							}
 							spans = append(spans, span)
 						}
 					}


### PR DESCRIPTION
#### What this PR does / why we need it:

Since the trace-id of the otlp javaagent is 32 bits, when the upstream is erda java-agent and the downstream is otlp javaagent, the traceid (uuid format) of erda java-agent cannot be recognized by the oltp java-agent, so the method of using attr to store in the otlp javaagent and then performing data replacement at the collector is adopted.


由于otlp javaagent的 trace-id 为32位，当上游是erda java-agent，下游是otlp javaagent时，erda java-agent 的 traceid （uuid格式）无法被oltp java-agent识别，因此采用在otlp javaagent使用attr来存储， 然后再collector处再进行数据替换的方法。

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       compatible the span data from erda java-agent to otlp java-agent       |
| 🇨🇳 中文    |           兼容来自于erda-agent的oltp java-agent span数据   |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
