### PR TITLE
fix: autotest download url

### DIFF
--- a/internal/apps/dop/component-protocol/components/auto-test-space-list/components/recordTable/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-space-list/components/recordTable/render.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/apps/dop/component-protocol/components/auto-test-space-list/i18n"
 	"github.com/erda-project/erda/internal/apps/dop/component-protocol/types"
-	"github.com/erda-project/erda/internal/core/legacy/conf"
 )
 
 type Column struct {
@@ -198,7 +197,7 @@ func (r *RecordTable) setData() error {
 			},
 			Result: Result{
 				RenderType: "downloadUrl",
-				URL:        fmt.Sprintf("%s/api/files/%s", conf.RootDomain(), fileRecord.ApiFileUUID),
+				URL:        fmt.Sprintf("/api/files/%s", fileRecord.ApiFileUUID),
 			},
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix autotest download url

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=362449&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that autotest download url（修复了接口测试导出为html的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that autotest download url           |
| 🇨🇳 中文    |       修复了接口测试导出为html的问题       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
