### PR TITLE
feat: declare pprof port for continuous profiling in erda.yaml

### DIFF
--- a/erda.yml
+++ b/erda.yml
@@ -84,6 +84,9 @@ services:
       - port: 9431
         protocol: "TCP"
         l4_protocol: "TCP"
+      - port: 7098
+        protocol: "TCP"
+        l4_protocol: "TCP"
     expose:
       - 9529
     binds:
@@ -119,6 +122,9 @@ services:
         protocol: TCP
         l4_protocol: TCP
       - port: 9095
+        protocol: TCP
+        l4_protocol: TCP
+      - port: 9093
         protocol: TCP
         l4_protocol: TCP
     envs:
@@ -209,6 +215,9 @@ services:
       - port: 7098
         protocol: "TCP"
         l4_protocol: "TCP"
+      - port: 7078
+        protocol: "TCP"
+        l4_protocol: "TCP"
     envs:
       GOLANG_PROTOBUF_REGISTRATION_CONFLICT: "ignore"
       COLLECTOR_BROWSER_SAMPLING_RATE: "100"
@@ -245,6 +254,9 @@ services:
         l4_protocol: "TCP"
         expose: true
       - port: 7098
+        protocol: "TCP"
+        l4_protocol: "TCP"
+      - port: 7078
         protocol: "TCP"
         l4_protocol: "TCP"
     envs:
@@ -370,6 +382,9 @@ services:
         protocol: "TCP"
         l4_protocol: "TCP"
       - port: 7080
+        protocol: "TCP"
+        l4_protocol: "TCP"
+      - port: 7098
         protocol: "TCP"
         l4_protocol: "TCP"
     envs:


### PR DESCRIPTION
#### What this PR does / why we need it:

declare pprof port for continuous profiling in erda.yaml


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   declare pprof port for continuous profiling in erda.yaml          |
| 🇨🇳 中文    |    在 erda.yaml 中声明 pprof 端口用于持续分析          |
