### PR TITLE
ci: remove useless git unshallow after fetching all

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: unshallow
-        run: git fetch --unshallow origin
       - name: add remote
         run: git remote add mirror https://${{ secrets.ERDA_CLOUD_MIRROR_GIT_USERNAME }}:${{ secrets.ERDA_CLOUD_MIRROR_GIT_PASSWORD }}@erda.cloud/erda/dop/erda-project/erda
       - name: push
@@ -36,7 +34,6 @@ jobs:
           fetch-depth: 0
       - name: unshallow
         run: |
-          git fetch --unshallow origin
           ss=${{ steps.list.outputs.pullRequestNumbers }}
           ss=${ss:1:${#ss}-2}
           IFS=', ' read -r -a arr <<< "$ss"


### PR DESCRIPTION
#### What this PR does / why we need it:

remove useless git unshallow after fetching all


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  CI remove useless git unshallow after fetching all           |
| 🇨🇳 中文    |   CI 在拉取仓库所有历史后删除无用的 git unshallow     |
