### PR TITLE
feat(pipeline): pipeline render extension image for different architecture

### DIFF
--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -100,6 +100,14 @@ func (info ClusterInfoData) Get(key ClusterInfoMapKey) string {
 	return info[key]
 }
 
+func (info ClusterInfoData) ToMap() map[string]string {
+	dat := make(map[string]string)
+	for k, v := range info {
+		dat[k.String()] = v
+	}
+	return dat
+}
+
 // {DICE_PROTOCOL}://{组件名}.{DICE_ROOT_DOMAIN}:{DICE_HTTP_PORT or DICE_HTTPS_PORT}
 func (info ClusterInfoData) MustGetPublicURL(component string) string {
 	// default is `http`

--- a/apistructs/cluster_info.go
+++ b/apistructs/cluster_info.go
@@ -100,8 +100,8 @@ func (info ClusterInfoData) Get(key ClusterInfoMapKey) string {
 	return info[key]
 }
 
-func (info ClusterInfoData) ToMap() map[string]string {
-	dat := make(map[string]string)
+func (info ClusterInfoData) ToStringMap() map[string]string {
+	dat := make(map[string]string, len(info))
 	for k, v := range info {
 		dat[k.String()] = v
 	}

--- a/internal/tools/pipeline/providers/actionmgr/impl.go
+++ b/internal/tools/pipeline/providers/actionmgr/impl.go
@@ -61,7 +61,12 @@ func (s *provider) SearchActions(items []string, ops ...OpOption) (map[string]*d
 			}
 			diceYmlStr = string(rendered)
 		}
-		diceYml, err := diceyml.New([]byte(diceYmlStr), false)
+
+		diceYmlOps := make([]diceyml.Options, 0)
+		if so.ClusterInfo != nil {
+			diceYmlOps = append(diceYmlOps, diceyml.WithPlatformInfo(so.ClusterInfo))
+		}
+		diceYml, err := diceyml.New([]byte(diceYmlStr), false, diceYmlOps...)
 		if err != nil {
 			errMsg := fmt.Sprintf("failed to parse action's dice.yml, action: %s, err: %v", nameVersion, err)
 			logrus.Errorf("[alert] %s, action's dice.yml: %#v", errMsg, action.Dice)

--- a/internal/tools/pipeline/providers/actionmgr/interface.go
+++ b/internal/tools/pipeline/providers/actionmgr/interface.go
@@ -31,6 +31,7 @@ type Interface interface {
 type SearchOption struct {
 	NeedRender   bool
 	Placeholders map[string]string
+	ClusterInfo  map[string]string
 }
 type OpOption func(*SearchOption)
 
@@ -38,5 +39,11 @@ func SearchOpWithRender(placeholders map[string]string) OpOption {
 	return func(so *SearchOption) {
 		so.NeedRender = true
 		so.Placeholders = placeholders
+	}
+}
+
+func SearchOpWithClusterInfo(clusterInfo map[string]string) OpOption {
+	return func(so *SearchOption) {
+		so.ClusterInfo = clusterInfo
 	}
 }

--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
@@ -203,21 +203,3 @@ func Test_contextVolumes(t *testing.T) {
 	fields := contextVolumes(taskContext)
 	assert.Equal(t, 2, len(fields))
 }
-
-func Test_renderActionImage(t *testing.T) {
-	pre := &prepare{}
-	secrets := map[string]string{
-		"dice.arch": "amd64",
-	}
-	image, err := pre.renderActionImage("erda.cloud/((dice.arch))/custom-script-action:latest", secrets)
-	assert.NoError(t, err)
-	assert.Equal(t, "erda.cloud/amd64/custom-script-action:latest", image)
-
-	image, err = pre.renderActionImage("erda.cloud/custom-script-action:latest", secrets)
-	assert.NoError(t, err)
-	assert.Equal(t, "erda.cloud/custom-script-action:latest", image)
-
-	image, err = pre.renderActionImage("erda.cloud/((dice.xxx))/custom-script-action:latest", secrets)
-	assert.NoError(t, err)
-	assert.Equal(t, "erda.cloud/((dice.xxx))/custom-script-action:latest", image)
-}

--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/prepare_test.go
@@ -203,3 +203,21 @@ func Test_contextVolumes(t *testing.T) {
 	fields := contextVolumes(taskContext)
 	assert.Equal(t, 2, len(fields))
 }
+
+func Test_renderActionImage(t *testing.T) {
+	pre := &prepare{}
+	secrets := map[string]string{
+		"dice.arch": "amd64",
+	}
+	image, err := pre.renderActionImage("erda.cloud/((dice.arch))/custom-script-action:latest", secrets)
+	assert.NoError(t, err)
+	assert.Equal(t, "erda.cloud/amd64/custom-script-action:latest", image)
+
+	image, err = pre.renderActionImage("erda.cloud/custom-script-action:latest", secrets)
+	assert.NoError(t, err)
+	assert.Equal(t, "erda.cloud/custom-script-action:latest", image)
+
+	image, err = pre.renderActionImage("erda.cloud/((dice.xxx))/custom-script-action:latest", secrets)
+	assert.NoError(t, err)
+	assert.Equal(t, "erda.cloud/((dice.xxx))/custom-script-action:latest", image)
+}

--- a/internal/tools/pipeline/providers/secret/platform_secret.go
+++ b/internal/tools/pipeline/providers/secret/platform_secret.go
@@ -82,11 +82,13 @@ func (s *provider) FetchPlatformSecrets(ctx context.Context, p *spec.Pipeline, i
 		storageURL = strings.Replace(storageURL, convertURL.Path, filepath.Join(mountPoint, convertURL.Path), -1)
 	}
 
+	arch := strutil.FirstNoneEmpty(clusterInfo.CM.Get(apistructs.DICE_ARCH), s.Cfg.DefaultDiceArch, "amd64")
+
 	r = map[string]string{
 		// dice version
 		"dice.version": version.Version,
 		// dice
-		"dice.arch":                strutil.FirstNoneEmpty(clusterInfo.CM.Get(apistructs.DICE_ARCH), s.Cfg.DefaultDiceArch, "amd64"),
+		"dice.arch":                arch,
 		"dice.org.id":              p.Labels[apistructs.LabelOrgID],
 		"dice.org.name":            p.GetOrgName(),
 		"dice.project.id":          p.Labels[apistructs.LabelProjectID],
@@ -129,6 +131,9 @@ func (s *provider) FetchPlatformSecrets(ctx context.Context, p *spec.Pipeline, i
 		// collector 用于主动日志上报(action-agent)
 		"collector.addr":       discover.Collector(),
 		"collector.public.url": conf.CollectorPublicURL(),
+
+		// arch
+		"arch": arch,
 
 		// others
 		"date.YYYYMMDD": time.Now().Format("20060102"),


### PR DESCRIPTION
#### What this PR does / why we need it:
pipeline render extension image for different architecture


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support pipeline render extension image for different architecture（pipeline支持extension的镜像根据架构进行渲染）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Support pipeline render extension image for different architecture          |
| 🇨🇳 中文    |    Support pipeline render extension image for different architecture          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
