### PR TITLE
fix: add addon id for mysql label

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -1228,6 +1228,7 @@ func (a *Addon) BuildMysqlOperatorServiceItem(params *apistructs.AddonHandlerCre
 	if len(serviceItem.Labels) == 0 {
 		serviceItem.Labels = map[string]string{}
 	}
+	serviceItem.Labels["ADDON_ID"] = addonIns.ID
 	SetlabelsFromOptions(params.Options, serviceItem.Labels)
 
 	// Use volumes 代替 Binds


### PR DESCRIPTION
#### What this PR does / why we need it:
add addon id for mysql addon label

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=366260&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that add addon id for mysql label（修复了mysql丢失addonid以致于监控无法采集的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that add addon id for mysql label             |
| 🇨🇳 中文    |    修复了mysql丢失addonid以致于监控无法采集的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
