### PR TITLE
fix(msp): alert overview empty result error

### DIFF
--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/cards/statistics.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/cards/statistics.go
@@ -203,7 +203,7 @@ func (p *provider) doQuerySql(ctx context.Context, startTime, endTime int64, sta
 	}
 	rows := response.Results[0].Series[0].Rows
 	if len(rows) == 0 || len(rows[0].Values) == 0 {
-		return 0, errors.NewInternalServerErrorMessage("empty query result")
+		return 0, nil
 	}
 
 	val := rows[0].Values[0].GetNumberValue()

--- a/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/unrecover-alert-chart/provider.go
+++ b/internal/apps/msp/apm/alert/components/msp-alert-overview/composite-header/unrecover-alert-chart/provider.go
@@ -105,7 +105,10 @@ func (s *SimpleChart) getUnRecoverAlertEventsChart() (*Chart, error) {
 	}
 	rows := response.Results[0].Series[0].Rows
 	if len(rows) == 0 {
-		return nil, errors.NewInternalServerErrorMessage("empty query result")
+		return &Chart{
+			XAxis:  make([]string, 0),
+			Series: make([]SeriesData, 0),
+		}, nil
 	}
 
 	var xAxis []string

--- a/internal/apps/msp/apm/browser/components/browser-overview/kv_card/statistics.go
+++ b/internal/apps/msp/apm/browser/components/browser-overview/kv_card/statistics.go
@@ -245,11 +245,11 @@ func (p *provider) doQuerySql(ctx context.Context, statement string, params map[
 	if response != nil && len(response.Results) > 0 && len(response.Results[0].Series) > 0 {
 		rows := response.Results[0].Series[0].Rows
 		if len(rows) == 0 || len(rows[0].Values) == 0 {
-			return 0, errors.NewInternalServerErrorMessage("empty query result")
+			return 0, nil
 		}
 
 		val := rows[0].Values[0].GetNumberValue()
 		return val, nil
 	}
-	return 0, errors.NewInternalServerErrorMessage("empty query result")
+	return 0, nil
 }

--- a/internal/apps/msp/apm/service/view/card/card.go
+++ b/internal/apps/msp/apm/service/view/card/card.go
@@ -72,7 +72,10 @@ func (b *BaseCard) QueryAsServiceCard(ctx context.Context, statement string, par
 
 	rows := response.Results[0].Series[0].Rows
 	if len(rows) == 0 || len(rows[0].Values) == 0 {
-		return nil, errors.NewInternalServerErrorMessage("empty query result")
+		return &ServiceCard{
+			Name: name,
+			Unit: unit,
+		}, nil
 	}
 
 	val := rows[0].Values[0].GetNumberValue()


### PR DESCRIPTION
#### What this PR does / why we need it:
fix msp alert overview empty result error

ignore empty result, treat empty results as valid results.

before:
<img width="454" alt="image" src="https://user-images.githubusercontent.com/30427474/223706510-c0b88d27-241f-4412-8e36-f9eb52972c38.png">

after:
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/30427474/223706581-30eb0eb6-a4fd-4c7c-a17b-22aba4aa555b.png">



#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that  alert overview empty result error（修复了告警概览由于没有数据造成报错的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that  alert overview empty result error          |
| 🇨🇳 中文    |     修复了告警概览由于没有数据造成报错的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
