### PR TITLE
fix(orchestrator): redis mysql operator deployment failure

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/mysql/mysql.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/mysql/mysql.go
@@ -193,6 +193,10 @@ func (my *MysqlOperator) Convert(sg *apistructs.ServiceGroup) interface{} {
 
 	addon.SetAddonLabelsAndAnnotations(mysql, obj.Spec.Labels, obj.Spec.Annotations)
 
+	if addonID, ok := mysql.Env["ADDON_ID"]; ok {
+		obj.Spec.Labels["ADDON_ID"] = addonID
+	}
+
 	return obj
 }
 

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/legacy/redis.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/legacy/redis.go
@@ -334,7 +334,7 @@ func (ro *RedisOperator) Update(k8syml interface{}) error {
 
 func (ro *RedisOperator) convertRedis(svc apistructs.Service) RedisSettings {
 	settings := RedisSettings{}
-	settings.Version = "3.2.12"
+	settings.Version = svc.Env["version"]
 	settings.Envs = svc.Env
 	settings.Replicas = int32(svc.Scale)
 	settings.Resources = RedisFailoverResources{

--- a/internal/tools/orchestrator/services/addon/addon_deploy.go
+++ b/internal/tools/orchestrator/services/addon/addon_deploy.go
@@ -517,6 +517,9 @@ func (a *Addon) BuildAddonRequestGroup(params *apistructs.AddonHandlerCreateItem
 			_, addonOperatorDice, err := a.GetAddonExtention(&apistructs.AddonHandlerCreateItem{
 				AddonName: apistructs.AddonRedis + "-operator",
 				Plan:      apistructs.AddonBasic,
+				Options: map[string]string{
+					"version": params.Options["version"],
+				},
 			})
 			if err != nil {
 				return nil, err

--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -1228,7 +1228,6 @@ func (a *Addon) BuildMysqlOperatorServiceItem(params *apistructs.AddonHandlerCre
 	if len(serviceItem.Labels) == 0 {
 		serviceItem.Labels = map[string]string{}
 	}
-	serviceItem.Labels["ADDON_ID"] = addonIns.ID
 	SetlabelsFromOptions(params.Options, serviceItem.Labels)
 
 	// Use volumes 代替 Binds

--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -1406,6 +1406,7 @@ func (a *Addon) BuildRedisOperatorServiceItem(options map[string]string, addonIn
 			"ADDON_ID":      addonIns.ID,
 			"ADDON_NODE_ID": a.getRandomId(),
 			"requirepass":   password,
+			"version":       addonDice.Version,
 		}
 		// set options for label
 		if len(v.Labels) == 0 {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix redis mysql operator deployment failure

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=367866&iterationID=1628&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that redis mysql operator deployment failure （修复了redis和mysql addon部署失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that redis mysql operator deployment failure            |
| 🇨🇳 中文    |    修复了redis和mysql addon部署失败的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
