### PR TITLE
chore: enlarge default clickhouse max_open_conns for spikes

### DIFF
--- a/cmd/monitor/monitor/bootstrap.yaml
+++ b/cmd/monitor/monitor/bootstrap.yaml
@@ -70,7 +70,7 @@ clickhouse:
   conn_open_strategy: "round_robin"
   conn_max_lifetime: "${CLICKHOUSE_CONN_MAX_LIFETIME:1m}"
   max_idle_conns: "${CLICKHOUSE_MAX_IDLE_CONNS:10}"
-  max_open_conns: "${CLICKHOUSE_MAX_OPEN_CONNS:20}"
+  max_open_conns: "${CLICKHOUSE_MAX_OPEN_CONNS:200}"
   dail_timeout: "${CLICKHOUSE_DAIL_TIMEOUT:1s}"
   debug: ${CLICKHOUSE_DEBUG:false}
 

--- a/cmd/monitor/streaming/bootstrap.yaml
+++ b/cmd/monitor/streaming/bootstrap.yaml
@@ -75,7 +75,7 @@ clickhouse:
   conn_open_strategy: "round_robin"
   conn_max_lifetime: "${CLICKHOUSE_CONN_MAX_LIFETIME:1m}"
   max_idle_conns: "${CLICKHOUSE_MAX_IDLE_CONNS:10}"
-  max_open_conns: "${CLICKHOUSE_MAX_OPEN_CONNS:20}"
+  max_open_conns: "${CLICKHOUSE_MAX_OPEN_CONNS:200}"
   dail_timeout: "${CLICKHOUSE_DAIL_TIMEOUT:1s}"
 
 


### PR DESCRIPTION
#### What this PR does / why we need it:

enlarge default clickhouse max_open_conns (20->200) for streaming & monitor spikes


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/gantt?id=364093&iterationID=1580&pId=0&type=TASK)


#### Specified Reviewers:

/assign @tomatopunk 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    enlarge default clickhouse max_open_conns for spikes          |
| 🇨🇳 中文    |   为应对峰值情况，增加ClickHouse的默认最大连接数           |
