### PR TITLE
fix: kong sbac and csrf plugin parse for specified routeId

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy.go
@@ -105,7 +105,7 @@ func (policy Policy) UnmarshalConfig(config []byte) (apipolicy.PolicyDto, error,
 	return policyDto, nil, ""
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	res := apipolicy.PolicyConfig{}
 	policyDto, ok := dto.(*PolicyDto)
 	if !ok {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
@@ -57,7 +57,7 @@ func (policy Policy) UnmarshalConfig(config []byte) (apipolicy.PolicyDto, error,
 	return policyDto, nil, ""
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	res := apipolicy.PolicyConfig{}
 	policyDto, ok := dto.(*PolicyDto)
 	if !ok {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
@@ -57,7 +57,7 @@ func (policy Policy) UnmarshalConfig(config []byte) (apipolicy.PolicyDto, error,
 	return policyDto, nil, ""
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	res := apipolicy.PolicyConfig{}
 	policyDto, ok := dto.(*PolicyDto)
 	if !ok {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy.go
@@ -57,7 +57,8 @@ func (policy Policy) buildPluginReq(dto *PolicyDto) *kongDto.KongPluginReqDto {
 	return dto.ToPluginReqDto()
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+// forValidate 用于识别解析的目的，如果解析是用来做鱼 nginx 配置冲突相关的校验，则关于数据表、调用 kong 接口的操作都不会执行
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	l := logrus.WithField("pluginName", apipolicy.Policy_Engine_SBAC).WithField("func", "ParseConfig")
 	l.Infof("dto: %+v", dto)
 	res := apipolicy.PolicyConfig{}
@@ -91,7 +92,7 @@ func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interfa
 		return res, err
 	}
 	if !policyDto.Switch {
-		if exist != nil {
+		if exist != nil && !forValidate {
 			err = adapter.RemovePlugin(exist.PluginId)
 			if err != nil {
 				return res, err
@@ -101,44 +102,78 @@ func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interfa
 		}
 		return res, nil
 	}
+
 	req := policy.buildPluginReq(policyDto)
+	packageAPIDB, _ := db.NewGatewayPackageApiServiceImpl()
+	packageApi, err := packageAPIDB.GetByAny(&orm.GatewayPackageApi{ZoneId: zone.Id})
+	if err != nil {
+		l.WithError(err).Warnf("sbac: packageAPIDB.GetByAny(&orm.GatewayPackageApi{ZoneId: %s})", zone.Id)
+		return res, err
+	}
+	if packageApi == nil {
+		l.WithError(err).Warnf("sbac: not found packageAPIDB.GetByAny(&orm.GatewayPackageApi{ZoneId: %s})", zone.Id)
+		return res, nil
+	}
+
+	routeDb, _ := db.NewGatewayRouteServiceImpl()
+	route, err := routeDb.GetByApiId(packageApi.Id)
+	if err != nil {
+		l.WithError(err).Warnf("sbac: routeDb.GetByApiId(packageApi.Id:%s)", packageApi.Id)
+		return res, nil
+	}
+
+	if route == nil {
+		l.WithError(err).Warnf("sbac: not found routeDb.GetByApiId(packageApi.Id:%s)", packageApi.Id)
+		return res, nil
+	}
+
+	logrus.Infof("set sbac policy route ID for packageApi id=%s route=%+v\n", packageApi.Id, *route)
+	req.RouteId = route.RouteId
+	req.Route = &kongDto.KongObj{
+		Id: route.RouteId,
+	}
+
 	if exist != nil {
-		req.Id = exist.PluginId
-		resp, err := adapter.CreateOrUpdatePluginById(req)
-		if err != nil {
-			return res, err
-		}
-		configByte, err := json.Marshal(resp.Config)
-		if err != nil {
-			return res, err
-		}
-		exist.Config = configByte
-		err = policyDb.Update(exist)
-		if err != nil {
-			return res, err
+		if !forValidate {
+			req.Id = exist.PluginId
+			resp, err := adapter.CreateOrUpdatePluginById(req)
+			if err != nil {
+				return res, err
+			}
+			configByte, err := json.Marshal(resp.Config)
+			if err != nil {
+				return res, err
+			}
+			exist.Config = configByte
+			err = policyDb.Update(exist)
+			if err != nil {
+				return res, err
+			}
 		}
 	} else {
-		resp, err := adapter.AddPlugin(req)
-		if err != nil {
-			return res, err
+		if !forValidate {
+			resp, err := adapter.AddPlugin(req)
+			if err != nil {
+				return res, err
+			}
+			configByte, err := json.Marshal(resp.Config)
+			if err != nil {
+				return res, err
+			}
+			policyDao := &orm.GatewayPolicy{
+				ZoneId:     zone.Id,
+				PluginName: apipolicy.Policy_Engine_SBAC,
+				Category:   apipolicy.Policy_Category_Safety,
+				PluginId:   resp.Id,
+				Config:     configByte,
+				Enabled:    1,
+			}
+			err = policyDb.Insert(policyDao)
+			if err != nil {
+				return res, err
+			}
+			res.KongPolicyChange = true
 		}
-		configByte, err := json.Marshal(resp.Config)
-		if err != nil {
-			return res, err
-		}
-		policyDao := &orm.GatewayPolicy{
-			ZoneId:     zone.Id,
-			PluginName: apipolicy.Policy_Engine_SBAC,
-			Category:   apipolicy.Policy_Category_Safety,
-			PluginId:   resp.Id,
-			Config:     configByte,
-			Enabled:    1,
-		}
-		err = policyDb.Insert(policyDao)
-		if err != nil {
-			return res, err
-		}
-		res.KongPolicyChange = true
 	}
 	return res, nil
 }

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy.go
@@ -105,7 +105,7 @@ func (policy Policy) UnmarshalConfig(config []byte) (apipolicy.PolicyDto, error,
 	return policyDto, nil, ""
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	res := apipolicy.PolicyConfig{}
 	policyDto, ok := dto.(*PolicyDto)
 	if !ok {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
@@ -52,7 +52,7 @@ func (policy Policy) UnmarshalConfig(config []byte) (apipolicy.PolicyDto, error,
 	return policyDto, nil, ""
 }
 
-func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}) (apipolicy.PolicyConfig, error) {
+func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interface{}, forValidate bool) (apipolicy.PolicyConfig, error) {
 	res := apipolicy.PolicyConfig{}
 	policyDto, ok := dto.(*PolicyDto)
 	if !ok {

--- a/internal/tools/orchestrator/hepa/apipolicy/policy_engine.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policy_engine.go
@@ -74,7 +74,7 @@ type PolicyEngine interface {
 	GetConfig(string, string, *orm.GatewayZone, map[string]interface{}) (PolicyDto, error)
 	MergeDiceConfig(map[string]interface{}) (PolicyDto, error)
 	CreateDefaultConfig(map[string]interface{}) PolicyDto
-	ParseConfig(PolicyDto, map[string]interface{}) (PolicyConfig, error)
+	ParseConfig(PolicyDto, map[string]interface{}, bool) (PolicyConfig, error)
 	NeedResetAnnotation(PolicyDto) bool
 	UnmarshalConfig([]byte) (PolicyDto, error, string)
 	SetName(name string)

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -510,7 +510,7 @@ func (impl GatewayApiPolicyServiceImpl) executePolicyEngine(zone *orm.GatewayZon
 	if len(needDeployTag) > 0 {
 		needDeployIngress = needDeployTag[0]
 	}
-	policyConfig, err := engine.ParseConfig(dto, ctx)
+	policyConfig, err := engine.ParseConfig(dto, ctx, false)
 	if err != nil {
 		return err
 	}
@@ -1235,7 +1235,7 @@ func (impl GatewayApiPolicyServiceImpl) checkDuplicatedPolicyConfig(gatewayProvi
 		return errors.Errorf("policyEngine.UnmarshalConfig for %s error:%v\n", category, err)
 	}
 
-	policyConfig, err := policyEngine.ParseConfig(category_dto, ctx)
+	policyConfig, err := policyEngine.ParseConfig(category_dto, ctx, true)
 	if err != nil {
 		logrus.Errorf("parseConfig error:%v\n", err)
 		return errors.Errorf("parseConfig error:%v\n", err)
@@ -1275,7 +1275,7 @@ func (impl GatewayApiPolicyServiceImpl) checkDuplicatedPolicyConfig(gatewayProvi
 				return err
 			}
 
-			pc, err := pEngine.ParseConfig(sDto, ctx)
+			pc, err := pEngine.ParseConfig(sDto, ctx, true)
 			if err != nil {
 				logrus.Errorf("parseConfig for policy %s error:%v\n", ca, err)
 				return errors.Errorf("parseConfig for policy %s error:%v\n", ca, err)
@@ -1288,7 +1288,7 @@ func (impl GatewayApiPolicyServiceImpl) checkDuplicatedPolicyConfig(gatewayProvi
 				return errors.Errorf("GetPolicyEngine for policy %s error:%v\n", ca, err)
 			}
 
-			pc, err := pEngine.ParseConfig(sDto, ctx)
+			pc, err := pEngine.ParseConfig(sDto, ctx, true)
 			if err != nil {
 				logrus.Errorf("parseConfig for policy %s error:%v\n", ca, err)
 				return err


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the bug that:  when set kong sbac and csrf policy for specified API without routeId result global kong policy., so all existed APIs can not accessed。

#### Specified Reviewers:

/assign @luobily @iutx @dspo @sixther-dc 


#### ChangeLog
Bugfix： Fix the bug that when set kong sbac and csrf policy for specified API without routeId result global kong policy., so all existed APIs can not accessed（修复了 kong 设置 sbac和 csrf 策略不带 roueId 导致设置成全局变量.）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that when set kong sbac and csrf policy for specified API without routeId result global kong policy., so all existed APIs can not accessed         |
| 🇨🇳 中文    |     修复了 kong 设置 sbac和 csrf 策略不带 roueId 导致设置成全局变量         |


