### PR TITLE
fix: kong data field created_at unmarshal

### DIFF
--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto.go
@@ -14,6 +14,8 @@
 
 package dto
 
+import "encoding/json"
+
 type KongUpstreamStatusRespDto struct {
 	Data []KongTargetDto `json:"data"`
 }
@@ -22,8 +24,18 @@ type KongTargetDto struct {
 	Id     string `json:"id,omitempty"`
 	Target string `json:"target"`
 	// 默认是100
-	Weight     int64  `json:"weight,omitempty"`
-	UpstreamId string `json:"upstream_id,omitempty"`
-	CreatedAt  int64  `json:"created_at,omitempty"`
-	Health     string `json:"health,omitempty"`
+	Weight     int64       `json:"weight,omitempty"`
+	UpstreamId string      `json:"upstream_id,omitempty"`
+	CreatedAt  json.Number `json:"created_at,omitempty"`
+	Health     string      `json:"health,omitempty"`
+}
+
+func (dto KongTargetDto) GetCreatedAt() int64 {
+	if i, err := dto.CreatedAt.Int64(); err == nil {
+		return i
+	}
+	if i, err := dto.CreatedAt.Float64(); err == nil {
+		return int64(i)
+	}
+	return 0
 }

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Terminus, Inc.
+//
+// This program is free software: you can use, redistribute, and/or modify
+// it under the terms of the GNU Affero General Public License, version 3
+// or later ("AGPL"), as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package dto_test
+
+import (
+	"encoding/json"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
+	"testing"
+)
+
+func TestKongTargetDto_JSONUnmarshal(t *testing.T) {
+	var body = `{"created_at":1679018347.926,"id":"39c8ae64-5b4c-476c-a44d-1c850c00d433","tags":null,"weight":100,"target":"172.16.142.209:8080","upstream":{"id":"397a3af9-f77b-4e1c-92f3-2dfef6034229"}}`
+	var data dto.KongTargetDto
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%+v", data)
+	t.Logf("createdAt: %v", data.GetCreatedAt())
+}

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
@@ -16,8 +16,9 @@ package dto_test
 
 import (
 	"encoding/json"
-	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
 	"testing"
+
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong/dto"
 )
 
 func TestKongTargetDto_JSONUnmarshal(t *testing.T) {

--- a/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/kong/dto/kong_target_dto_test.go
@@ -1,15 +1,16 @@
-// Copyright (c) 2023 Terminus, Inc.
+// Copyright (c) 2021 Terminus, Inc.
 //
-// This program is free software: you can use, redistribute, and/or modify
-// it under the terms of the GNU Affero General Public License, version 3
-// or later ("AGPL"), as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package dto_test
 

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter.go
@@ -15,6 +15,8 @@
 package mse
 
 import (
+	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -460,7 +462,7 @@ func (impl *MseAdapterImpl) AddUpstreamTarget(upstreamId string, req *KongTarget
 		Target:     req.Target,
 		Weight:     req.Weight,
 		UpstreamId: upstreamId,
-		CreatedAt:  time.Now().Unix(),
+		CreatedAt:  json.Number(strconv.FormatInt(time.Now().Unix(), 10)),
 		Health:     req.Health,
 	}, nil
 }

--- a/internal/tools/orchestrator/hepa/services/legacy_upstream_lb/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/legacy_upstream_lb/impl/impl.go
@@ -205,7 +205,7 @@ func (impl GatewayUpstreamLbServiceImpl) clearStaleOnNewDeploy(gatewayAdapter ga
 	var readyToDels []orm.GatewayUpstreamLbTarget
 	var freshAllHealthy *bool
 	for _, targetDto := range resp.Data {
-		if targetDto.CreatedAt > freshTime {
+		if targetDto.GetCreatedAt() > freshTime {
 			log.Infof("target is newer than fresh, targetDto:%+v freshTime:%d",
 				targetDto, freshTime)
 			continue
@@ -281,7 +281,7 @@ func (impl GatewayUpstreamLbServiceImpl) clearUnhealthyOnUnexpectDeploy(gatewayA
 		return err
 	}
 	for _, targetDto := range resp.Data {
-		if targetDto.CreatedAt > freshTime {
+		if targetDto.GetCreatedAt() > freshTime {
 			log.Infof("target is newer than fresh, targetDto:%+v freshTime:%d",
 				targetDto, freshTime)
 			continue
@@ -373,7 +373,7 @@ func (impl GatewayUpstreamLbServiceImpl) UpstreamTargetOnline(dto *gw.UpstreamLb
 		if err != nil {
 			return
 		}
-		freshTime = kongTargetResp.CreatedAt
+		freshTime = kongTargetResp.GetCreatedAt()
 		if freshTime == 0 {
 			err = errors.Errorf("invalid kongTargetResp, resp:%+v", kongTargetResp)
 			return


### PR DESCRIPTION
#### What this PR does / why we need it:

请求 /upstreams/{upstreamId}/targets 相关接口时, 返回如下错误

```text
statusCode:400 response body: {"success":false,"err":{"code":"400","msg":"parameter request error invalid: json: cannot unmarshal number 1679018347.926 into Go struct field KongTargetDto.created_at of type int64","ctx":"/api/gateway/target/online"}}2023-03-17 09:59:11.600INFO[admin-web] ---  - [main] utoConfigurationReportLoggingInitializer: Error starting ApplicationContext. To display the auto-configuration report re-run your application with 'debug' enabled.2023-03-17 09:59:11.618ERROR[admin-web] ---  - [main] o.s.boot.SpringApplication              : Application startup failed
```

是由于 hepa 没有正确 unmarshal kong 返回的结果.

kong 协议文档中 created_at 示例是整数类型,

![image](https://user-images.githubusercontent.com/25881576/225853034-67219095-9de2-43c0-b042-c5cfca0e7b0d.png)

因此 hepa 中定义的也是整数类型,

![image](https://user-images.githubusercontent.com/25881576/225853131-0027af97-8a4b-4889-a95f-7dbc16173f54.png)

但 kong 接口返回的却可能是小数,

![image](https://user-images.githubusercontent.com/25881576/225853216-e54e2a04-0225-4264-8a7b-75edd16bd138.png)

因此将 `CreatedAt int64` 类型改成 `CreatedAt json.Number` 类型以兼容这种情况.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix an error when deserializing kong response  |
| 🇨🇳 中文    | 修复反序列化 kong 接口响应时出错的问题 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
