### PR TITLE
fix: jvm gc time unit should be ms

### DIFF
--- a/internal/apps/msp/apm/service/components/resources-runtime-monitor-java/runtime/provider.go
+++ b/internal/apps/msp/apm/service/components/resources-runtime-monitor-java/runtime/provider.go
@@ -547,7 +547,7 @@ func (p *provider) RegisterInitializeOp() (opFunc cptype.OperationFunc) {
 			if err != nil {
 				return nil
 			}
-			line := model.HandleLineGraphMetaData(sdk.Lang, p.I18n, jvmGcTime, structure.Time, "ns", graph)
+			line := model.HandleLineGraphMetaData(sdk.Lang, p.I18n, jvmGcTime, structure.Time, structure.Millisecond, graph)
 			return &impl.StdStructuredPtr{StdDataPtr: line}
 		case jvmClassLoader:
 			graph, err := p.getClassCountLineGraph(ctx, startTime, endTime, tenantId, instanceId, serviceId)


### PR DESCRIPTION
#### What this PR does / why we need it:

ref: https://github.com/erda-project/erda-java-extensions/blob/master/agent-plugins/agent-jvm-plugin/src/main/java/cloud/erda/agent/plugin/jvm/GCStatsProvider.java#L51
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/13919034/226269152-9cec7452-2bcf-48f0-afa7-850e489180f7.png">


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=369141&iterationID=-1&type=TICKET)


#### Specified Reviewers:

/assign @tomatopunk 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: jvm gc time unit should be ms            |
| 🇨🇳 中文    |   修复：JVM GC 时间单位应为毫秒           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.3` when this PR is merged.
