### PR TITLE
fix(collector): missing `oomkilled` metric after collect metrics from cadvisor

### DIFF
--- a/cmd/monitor/collector/bootstrap.yaml
+++ b/cmd/monitor/collector/bootstrap.yaml
@@ -335,6 +335,25 @@ erda.oap.collector.processor.aggregator@cpu-usage:
       args: [ "cpu_usage_percent", 100 ]
       target_key: "cpu_usage_percent"
 
+erda.oap.collector.processor.aggregator@oomkilled:
+  keypass:
+    name: [ "docker_container_summary" ]
+  keydrop:
+    container: [ "POD" ]
+  keyinclude:
+    - "name"
+    - "fields.container_oom_events_total"
+    - "tags.cluster_name"
+    - "tags.id"
+
+  rules:
+    - func: "rate"
+      args: [ "container_oom_events_total" ]
+      target_key: "oomkilled"
+    - func: ">"
+      args: [ "oomkilled", 0 ]
+      target_key: "oomkilled"
+
 erda.oap.collector.processor.aggregator@mem-percent:
   keypass:
     name: [ "docker_container_summary" ]

--- a/internal/tools/monitor/oap/collector/plugins/processors/aggregator/functions.go
+++ b/internal/tools/monitor/oap/collector/plugins/processors/aggregator/functions.go
@@ -114,7 +114,7 @@ func (r *ruler) parseFunction(name string) (functionCall, error) {
 	switch name {
 	case "rate":
 		return r.rateCall, nil
-	case "+", "-", "*", "/":
+	case "+", "-", "*", "/", ">":
 		return r.binaryFactory(name), nil
 	default:
 		return nil, fmt.Errorf("invalide func: %s", name)
@@ -196,6 +196,12 @@ func (r *ruler) binaryFactory(op string) functionCall {
 			cur.Fields[r.Alias] = p1 + p2
 		case "-":
 			cur.Fields[r.Alias] = p1 - p2
+		case ">":
+			if p1 > p2 {
+				cur.Fields[r.Alias] = true
+			} else {
+				delete(cur.Fields, r.Alias)
+			}
 		}
 		return cur
 	}

--- a/internal/tools/monitor/oap/collector/plugins/processors/aggregator/provider_test.go
+++ b/internal/tools/monitor/oap/collector/plugins/processors/aggregator/provider_test.go
@@ -127,6 +127,13 @@ func Test_provider_add(t *testing.T) {
 							"counter_a": float64(3),
 						},
 					},
+					{
+						Name:      "name",
+						Timestamp: int64(time.Second * 1649397603),
+						Fields: map[string]interface{}{
+							"counter_a": float64(3),
+						},
+					},
 				},
 			},
 			want: []*metric.Metric{
@@ -151,6 +158,96 @@ func Test_provider_add(t *testing.T) {
 					Fields: map[string]interface{}{
 						"counter_a": float64(3),
 						"rate_a":    float64(100),
+					},
+				},
+				{
+					Name:      "name",
+					Timestamp: int64(1649397603 * time.Second),
+					Fields: map[string]interface{}{
+						"counter_a": float64(3),
+						"rate_a":    float64(0),
+					},
+				},
+			},
+		},
+		{
+			fields: fields{
+				Cfg: &config{
+					Rules: []RuleConfig{
+						{
+							Func:      "rate",
+							Args:      []interface{}{"container_oom_events_total"},
+							TargetKey: "oomkilled",
+						},
+						{
+							Func:      ">",
+							Args:      []interface{}{"oomkilled", 0},
+							TargetKey: "oomkilled",
+						},
+					},
+				},
+			},
+			args: args{
+				in: []*metric.Metric{
+					{
+						Name:      "name",
+						Timestamp: int64(time.Second * 1649397600),
+						Fields: map[string]interface{}{
+							"container_oom_events_total": float64(0),
+						},
+					},
+					{
+						Name:      "name",
+						Timestamp: int64(time.Second * 1649397601),
+						Fields: map[string]interface{}{
+							"container_oom_events_total": float64(1),
+						},
+					},
+					{
+						Name:      "name",
+						Timestamp: int64(time.Second * 1649397602),
+						Fields: map[string]interface{}{
+							"container_oom_events_total": float64(1),
+						},
+					},
+					{
+						Name:      "name",
+						Timestamp: int64(time.Second * 1649397603),
+						Fields: map[string]interface{}{
+							"container_oom_events_total": float64(2),
+						},
+					},
+				},
+			},
+			want: []*metric.Metric{
+				{
+					Name:      "name",
+					Timestamp: int64(1649397600 * time.Second),
+					Fields: map[string]interface{}{
+						"container_oom_events_total": float64(0),
+					},
+				},
+				{
+					Name:      "name",
+					Timestamp: int64(1649397601 * time.Second),
+					Fields: map[string]interface{}{
+						"container_oom_events_total": float64(1),
+						"oomkilled":                  true,
+					},
+				},
+				{
+					Name:      "name",
+					Timestamp: int64(1649397602 * time.Second),
+					Fields: map[string]interface{}{
+						"container_oom_events_total": float64(1),
+					},
+				},
+				{
+					Name:      "name",
+					Timestamp: int64(1649397603 * time.Second),
+					Fields: map[string]interface{}{
+						"container_oom_events_total": float64(2),
+						"oomkilled":                  true,
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
fix missing `oomkilled` metric after collect metrics from cadvisor

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=366248&iterationID=-1&tab=TASK&type=TASK)


#### Specified Reviewers:

/assign @sfwn @tomatopunk 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： fix(collector) missing `oomkilled` metric after collect metrics from cadvisor（修复了oom类告警由于丢失`oomkilled`指标无法发出的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix(collector) missing `oomkilled` metric after collect metrics from cadvisor          |
| 🇨🇳 中文    |     修复了oom类告警由于丢失`oomkilled`指标无法发出的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
