### PR TITLE
chore: default pipeline.yml use ((target_arch)) instead of ((arch))

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -62,7 +62,7 @@ stages:
   - stage:
       - custom-script:
           alias: build-erda
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions
@@ -72,7 +72,7 @@ stages:
             - cp -r ${{ dirs.erda-addons-enterprise }} extensions
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
             - make prepare
-            - ARCH=((arch)) make build-push-all # can specify arch=xxx or arch=((dice.arch))
+            - ARCH=((target_arch)) make build-push-all
           loop:
             break: task_status == 'Success'
             strategy:
@@ -86,12 +86,12 @@ stages:
           timeout: 7200
       - custom-script:
           alias: build-erda-cli
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
             - make prepare-cli
-            - ARCH=((arch)) make build-push-image MODULE_PATH=cli
+            - ARCH=((target_arch)) make build-push-image MODULE_PATH=cli
           loop:
             break: task_status == 'Success'
             strategy:
@@ -105,11 +105,11 @@ stages:
           timeout: 7200
       - custom-script:
           alias: build-cluster-agent
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
-            - ARCH=((arch)) MODULE_PATH=cluster-agent make build-push-image
+            - ARCH=((target_arch)) MODULE_PATH=cluster-agent make build-push-image
           loop:
             break: task_status == 'Success'
             strategy:
@@ -128,23 +128,23 @@ stages:
             - make ci-build-local -e SKIP_TEST=true
             - cd ${{ dirs.erda }}
             - cp -r ${{ dirs.erda-java-extensions }}/dist/erda-java-agent ./build/java-agent
-            - ARCH=((arch)) make build-push-image MODULE_PATH=monitor/agent-injector
+            - ARCH=((target_arch)) make build-push-image MODULE_PATH=monitor/agent-injector
           resources:
             cpu: 1
             mem: 1024
       - custom-script:
           alias: build-diagnotor-agent
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
-            - ARCH=((arch)) make build-push-image MODULE_PATH=monitor/diagnotor-agent
+            - ARCH=((target_arch)) make build-push-image MODULE_PATH=monitor/diagnotor-agent
           resources:
             cpu: 1
             mem: 1024
       - custom-script:
           alias: build-erda-cli-linux
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)
@@ -162,7 +162,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli-mac
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)


### PR DESCRIPTION
#### What this PR does / why we need it:
default pipelineYml use ((target_arch)) instead of ((arch))


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Chore: default pipelineYml use ((target_arch)) instead of ((arch)) （用target_arch代替流水线arch变量）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   default pipelineYml use ((target_arch)) instead of ((arch))          |
| 🇨🇳 中文    |    用target_arch代替流水线arch变量          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
