### PR TITLE
fix(orchestrator): addons deployment failure due to failed to get clusterinfo

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_deploy.go
+++ b/internal/tools/orchestrator/services/addon/addon_deploy.go
@@ -520,6 +520,7 @@ func (a *Addon) BuildAddonRequestGroup(params *apistructs.AddonHandlerCreateItem
 				Options: map[string]string{
 					"version": params.Options["version"],
 				},
+				ClusterName: params.ClusterName,
 			})
 			if err != nil {
 				return nil, err
@@ -550,9 +551,10 @@ func (a *Addon) BuildAddonRequestGroup(params *apistructs.AddonHandlerCreateItem
 			}
 
 			operatorSpec, operatorDice, err := a.GetAddonExtention(&apistructs.AddonHandlerCreateItem{
-				AddonName: params.AddonName,
-				Plan:      params.Plan,
-				Options:   params.Options,
+				AddonName:   params.AddonName,
+				Plan:        params.Plan,
+				Options:     params.Options,
+				ClusterName: params.ClusterName,
 			})
 			if err != nil {
 				return nil, err

--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -992,6 +992,7 @@ func (a *Addon) BuildMysqlServiceItem(params *apistructs.AddonHandlerCreateItem,
 		}
 
 		SetlabelsFromOptions(params.Options, serviceItem.Labels)
+		serviceItem.Labels["ADDON_ID"] = addonIns.ID
 
 		/*
 			// volume信息


### PR DESCRIPTION
#### What this PR does / why we need it:
fix addons deployment failure due to failed to get clusterinfo

this bug is start at [5724](https://github.com/erda-project/erda/pull/5724)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=367866&iterationID=1580&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that addons deployment failure due to failed to get clusterinfo （修复了由于无集群名称参数造成的mysql,redis部署失败问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that addons deployment failure due to failed to get clusterinfo           |
| 🇨🇳 中文    |  修复了由于无集群名称参数造成的mysql,redis部署失败问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
