### PR TITLE
fix(pipeline): flinkcluster executor idempotent deletion task failure due to the returned type error

### DIFF
--- a/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sflink/flink.go
+++ b/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sflink/flink.go
@@ -297,7 +297,8 @@ func (k *K8sFlink) GetFlinkClusterInfo(ctx context.Context, data apistructs.Bigd
 		Namespace: data.Namespace,
 	}, &flinkCluster)
 	if err != nil {
-		return nil, fmt.Errorf("get flinkcluster %s in ns %s is err: %s", data.Name, data.Namespace, err.Error())
+		logrus.Errorf("%s failed to get flinkcluster %s in ns %s, err: %v", K8SFlinkLogPrefix, data.Name, data.Namespace, err)
+		return nil, err
 	}
 
 	return &flinkCluster, nil


### PR DESCRIPTION
#### What this PR does / why we need it:
fix flinkcluster idempotent deletion task failure due to the returned type error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=371332&iterationID=1580&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that flinkcluster executor idempotent deletion task failure due to the returned type error（修复了flinkcluster由于返回类型错误导致的幂等删除任务失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that flinkcluster executor idempotent deletion task failure due to the returned type error             |
| 🇨🇳 中文    |   修复了flinkcluster由于返回类型错误导致的幂等删除任务失败的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
