### PR TITLE
feat(orchestrator): set podSecurityContext for es addon

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/elasticsearch/elasticsearch.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/elasticsearch/elasticsearch.go
@@ -352,6 +352,12 @@ func (eo *ElasticsearchOperator) NodeSetsConvert(sg *apistructs.ServiceGroup, sc
 			},
 			Spec: corev1.PodSpec{
 				Affinity: &corev1.Affinity{NodeAffinity: affinity},
+				SecurityContext: &corev1.PodSecurityContext{
+					FSGroup:      &[]int64{1000}[0],
+					RunAsUser:    &[]int64{1000}[0],
+					RunAsNonRoot: &[]bool{true}[0],
+					RunAsGroup:   &[]int64{1000}[0],
+				},
 				Containers: []corev1.Container{
 					{
 						Name: "elasticsearch",

--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -28,6 +28,7 @@ import (
 	"github.com/labstack/gommon/random"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/orchestrator/dbclient"
@@ -661,6 +662,15 @@ func (a *Addon) BuildEsServiceItem(params *apistructs.AddonHandlerCreateItem, ad
 		//  /usr/share/elasticsearch/data volume
 		vol01 := SetAddonVolumes(params.Options, "/usr/share/elasticsearch/data", false)
 		serviceItem.Volumes = diceyml.Volumes{vol01}
+		serviceItem.K8SSnippet = &diceyml.K8SSnippet{
+			Container: &diceyml.ContainerSnippet{
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser:    &[]int64{1000}[0],
+					RunAsNonRoot: &[]bool{true}[0],
+					RunAsGroup:   &[]int64{1000}[0],
+				},
+			},
+		}
 
 		//health check
 		serviceItem.HealthCheck.HTTP = &diceyml.HTTPCheck{Port: 9200, Path: "/_cluster/health", Duration: 180}

--- a/internal/tools/orchestrator/services/addon/addon_status_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_status_test.go
@@ -194,3 +194,38 @@ func TestBuildRedisServiceItem(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(addonDice.Services[apistructs.RedisMasterNamePrefix].SideCars))
 }
+
+func TestBuildEsServiceItem(t *testing.T) {
+	params := &apistructs.AddonHandlerCreateItem{
+		Options: map[string]string{},
+		Plan:    "basic",
+	}
+	addonIns := &dbclient.AddonInstance{
+		ID: "1",
+	}
+	addonSpec := &apistructs.AddonExtension{
+		Name: "elasticsearch",
+		Plan: map[string]apistructs.AddonPlanItem{
+			"basic": {
+				CPU:   0.5,
+				Mem:   256,
+				Nodes: 1,
+			},
+		},
+	}
+	addonDice := &diceyml.Object{
+		Services: diceyml.Services{
+			"elasticsearch": {
+				Labels: map[string]string{},
+				Envs: map[string]string{
+					"ADDON_TYPE": "elasticsearch",
+				},
+			},
+		},
+	}
+
+	a := &Addon{}
+	err := a.BuildEsServiceItem(params, addonIns, addonSpec, addonDice, &apistructs.ClusterInfoData{})
+	assert.NoError(t, err)
+	assert.Equal(t, &[]int64{1000}[0], addonDice.Services["elasticsearch-1"].K8SSnippet.Container.SecurityContext.RunAsUser)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
set podSecurityContext for es addon

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=370993&iterationID=-1&tab=TASK&type=TASK)


#### Specified Reviewers:

/assign @sfwn @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support set podSecurityContext for es addon（orchestrator为es-addon配置容器安全上下文）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Support set podSecurityContext for es addon            |
| 🇨🇳 中文    |     orchestrator为es-addon配置容器安全上下文         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
