### PR TITLE
fix(pipeline): the waiting time of taskOP.Wait overflows when the declineRatio to loopedTimes power bigger than int64

### DIFF
--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait.go
@@ -201,7 +201,7 @@ func (w *wait) TuneTriggers() taskrun.TaskOpTuneTriggers {
 func (w *wait) calculateNextLoopTimeDuration(loopedTimes uint64) time.Duration {
 	lastSleepTime := time.Second
 	lastSleepTime = time.Duration(float64(lastSleepTime) * math.Pow(declineRatio, float64(loopedTimes)))
-	if lastSleepTime > declineLimit {
+	if lastSleepTime.Abs() > declineLimit {
 		return declineLimit
 	}
 	return lastSleepTime

--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait_test.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait_test.go
@@ -71,6 +71,14 @@ func TestCalculateNextLoopTimeDuration(t *testing.T) {
 			loopedTimes: 9,
 			want:        "10s",
 		},
+		{
+			loopedTimes: 100,
+			want:        "10s",
+		},
+		{
+			loopedTimes: 1000,
+			want:        "10s",
+		},
 	}
 
 	w := NewWait(&taskrun.TaskRun{})


### PR DESCRIPTION
#### What this PR does / why we need it:
fix the waiting time of taskOP.Wait overflows when the declineRatio to loopedTimes power bigger than int64

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=371566&iterationID=1628&tab=TASK&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that the waiting time of taskOP.Wait overflows when the declineRatio to loopedTimes power bigger than int64（修复了流水线查询任务状态的时间间隔大小溢出导致频率过高的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that the waiting time of taskOP.Wait overflows when the declineRatio to loopedTimes power bigger than int64           |
| 🇨🇳 中文    |    修复了流水线查询任务状态的时间间隔大小溢出导致频率过高的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
