### PR TITLE
feat: multi-arch image for erda-base:20230130

### DIFF
--- a/.erda/pipelines/ci-build-ce.yml
+++ b/.erda/pipelines/ci-build-ce.yml
@@ -42,7 +42,7 @@ stages:
       - custom-script:
           alias: build-erda
           description: 运行自定义命令
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions

--- a/.erda/pipelines/ci-deploy.yml
+++ b/.erda/pipelines/ci-deploy.yml
@@ -60,7 +60,7 @@ stages:
   - stage:
       - custom-script:
           alias: build-erda
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions
@@ -83,7 +83,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -101,7 +101,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-agent
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -138,7 +138,7 @@ stages:
             mem: 1024
       - custom-script:
           alias: build-erda-cli-linux
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)
@@ -156,7 +156,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli-mac
-          image: registry.erda.cloud/erda/((dice.arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -68,7 +68,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/amd64/erda-base:20230130
+      image: registry.erda.cloud/erda/erda-base:20230130
     needs:
       - PREPARE
     steps:
@@ -100,7 +100,7 @@ jobs:
   CODE-CHECK:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/amd64/erda-base:20230130
+      image: registry.erda.cloud/erda/erda-base:20230130
     needs:
       - PREPARE
     steps:
@@ -145,7 +145,7 @@ jobs:
   CODE-TEST:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/amd64/erda-base:20230130
+      image: registry.erda.cloud/erda/erda-base:20230130
     needs:
       - PREPARE
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run-test:
 	go run tools/gotools/go-test-sum/main.go
 
 full-test:
-	docker run --rm -ti -v $$(pwd):/go/src/output registry.erda.cloud/erda/${GOARCH}/erda-base:20230130 \
+	docker run --rm -ti -v $$(pwd):/go/src/output registry.erda.cloud/erda/erda-base:20230130 \
 		bash -c 'cd /go/src/output && build/scripts/test_in_container.sh'
 
 # docker image

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -35,7 +35,7 @@ ARCH="${ARCH:-$(go env GOARCH)}"
 VERSION="$(build/scripts/make-version.sh)"
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
 DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
-BASE_DOCKER_IMAGE="registry.erda.cloud/erda/${ARCH}/erda-base:20230130"
+BASE_DOCKER_IMAGE="registry.erda.cloud/erda/erda-base:20230130"
 DOCKERFILE=${DOCKERFILE_DEFAULT}
 
 # setup single module envionment variables

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -62,7 +62,7 @@ stages:
   - stage:
       - custom-script:
           alias: build-erda
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions
@@ -86,7 +86,7 @@ stages:
           timeout: 7200
       - custom-script:
           alias: build-erda-cli
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -105,7 +105,7 @@ stages:
           timeout: 7200
       - custom-script:
           alias: build-cluster-agent
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -134,7 +134,7 @@ stages:
             mem: 1024
       - custom-script:
           alias: build-diagnotor-agent
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -144,7 +144,7 @@ stages:
             mem: 1024
       - custom-script:
           alias: build-erda-cli-linux
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)
@@ -162,7 +162,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli-mac
-          image: registry.erda.cloud/erda/((arch))/erda-base:20230130
+          image: registry.erda.cloud/erda/erda-base:20230130
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)


### PR DESCRIPTION
#### What this PR does / why we need it:

```shell
$ docker manifest inspect registry.erda.cloud/erda/erda-base:20230130
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2851,
         "digest": "sha256:ab5a3568626efd6e066ed2178ddcf09f6d92d154769dbf61f523d186c4533650",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2851,
         "digest": "sha256:9121a4b55da4081f2dbd2fc7e7c8e49201b1c46f5d6e76f63e37dd72e2331784",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |Use multi-architecture erda-base mirroring instead of using interpolation|
| 🇨🇳 中文    | 使用多架构的 erda-base 镜像而不是使用插值 |
#### Need cherry-pick to release versions?


> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
