### PR TITLE
fix(dop): issues states always be default after refresh

### DIFF
--- a/internal/apps/dop/component-protocol/standard-components/issueFilter/conditions.go
+++ b/internal/apps/dop/component-protocol/standard-components/issueFilter/conditions.go
@@ -16,6 +16,7 @@ package issueFilter
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	model "github.com/erda-project/erda-infra/providers/component-protocol/components/filter/models"
@@ -64,6 +65,31 @@ type FrontendConditions struct {
 	ClosedAtStartEnd   []*int64 `json:"closedAtStartEnd,omitempty"`
 	Complexities       []string `json:"complexities,omitempty"`
 	ParticipantIDs     []string `json:"participantIDs,omitempty"`
+}
+
+func (f *FrontendConditions) IsEmpty() bool {
+	v := reflect.ValueOf(f).Elem()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+
+		switch field.Kind() {
+		case reflect.String:
+			if field.String() != "" {
+				return false
+			}
+		case reflect.Slice:
+			if field.Len() > 0 {
+				return false
+			}
+		case reflect.Ptr:
+			if !field.IsNil() {
+				return false
+			}
+		}
+	}
+
+	return true
 }
 
 func (f *IssueFilter) ConditionRetriever() ([]interface{}, error) {

--- a/internal/apps/dop/component-protocol/standard-components/issueFilter/conditions_test.go
+++ b/internal/apps/dop/component-protocol/standard-components/issueFilter/conditions_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueFilter
+
+import "testing"
+
+func TestIsEmpty(t *testing.T) {
+	testCases := []struct {
+		name       string
+		conditions FrontendConditions
+		want       bool
+	}{
+		{
+			name: "empty",
+			conditions: FrontendConditions{
+				Severities: make([]string, 0),
+			},
+			want: true,
+		},
+		{
+			name: "not empty",
+			conditions: FrontendConditions{
+				AssigneeIDs: []string{"1"},
+				Severities:  make([]string, 0),
+			},
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.conditions.IsEmpty() != tc.want {
+				t.Errorf("got %v, want %v", tc.conditions.IsEmpty(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/apps/dop/component-protocol/standard-components/issueFilter/provider.go
+++ b/internal/apps/dop/component-protocol/standard-components/issueFilter/provider.go
@@ -98,7 +98,7 @@ func (f *IssueFilter) RegisterInitializeOp() (opFunc cptype.OperationFunc) {
 				panic(err)
 			}
 		}
-		if f.State.WithStateCondition && f.State.FrontendConditionValues.States == nil {
+		if f.State.WithStateCondition && f.State.FrontendConditionValues.IsEmpty() {
 			if err := f.setDefaultState(); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix: issues states always be default after refresh


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that issues states always be default after refresh（修复了事项协同状态筛选总是在刷新后变成默认值的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that issues states always be default after refresh           |
| 🇨🇳 中文    |   修复了事项协同状态筛选总是在刷新后变成默认值的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
