### PR TITLE
fix: create table tb_gateway_credential if not exist

### DIFF
--- a/.erda/migrations/hepa/20230331-hepa-gateway-consumer-credential.sql
+++ b/.erda/migrations/hepa/20230331-hepa-gateway-consumer-credential.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `tb_gateway_credential`
+CREATE TABLE IF NOT EXISTS `tb_gateway_credential`
 (
     `id`                      VARCHAR(36)   NOT NULL DEFAULT '' COMMENT '唯一id',
     `create_time`             DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',


### PR DESCRIPTION
#### What this PR does / why we need it:

create table tb_gateway_credential if not exist



#### Specified Reviewers:

/assign @dspo @sixther-dc 


#### ChangeLog
Bugfix： Fix the bug that reate table tb_gateway_credential if not exist（修复了 表存在重复创建失败的问题  ）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Fix the bug that reate table tb_gateway_credential if not exist          |
| 🇨🇳 中文    |    修复了 表 tb_gateway_credential 存在重复创建失败的问题           |


#### Need cherry-pick to release versions?

/cherry-pick release/2.3

