### PR TITLE
fix(orchestrator):  rocketmq resource missing replicas definition

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -1149,6 +1149,7 @@ func (a *Addon) BuildRocketMQOperaotrServiceItem(params *apistructs.AddonHandler
 	//  /opt/logs volume
 	nameSrvVol02 := SetAddonVolumes(params.Options, "/opt/logs", false)
 	nameServiceItem.Volumes = diceyml.Volumes{nameSrvVol01, nameSrvVol02}
+	nameServiceItem.Deployments.Replicas = nameSrvPlan.Nodes
 	serviceMap[addonSpec.Name+"-namesrv"] = &nameServiceItem
 
 	// broker item
@@ -1158,6 +1159,7 @@ func (a *Addon) BuildRocketMQOperaotrServiceItem(params *apistructs.AddonHandler
 	if len(brokerServiceItem.Labels) == 0 {
 		brokerServiceItem.Labels = map[string]string{}
 	}
+	brokerServiceItem.Deployments.Replicas = brokerPlan.Nodes
 	brokerServiceItem.Labels["ADDON_GROUP_ID"] = addonSpec.Name + "-broker"
 	SetlabelsFromOptions(params.Options, brokerServiceItem.Labels)
 	// envs
@@ -1187,6 +1189,7 @@ func (a *Addon) BuildRocketMQOperaotrServiceItem(params *apistructs.AddonHandler
 	if len(consoleServiceItem.Labels) == 0 {
 		consoleServiceItem.Labels = map[string]string{}
 	}
+	consoleServiceItem.Deployments.Replicas = consolePlan.Nodes
 	consoleServiceItem.Labels["ADDON_GROUP_ID"] = addonSpec.Name + "-console"
 	SetlabelsFromOptions(params.Options, consoleServiceItem.Labels)
 	// envs

--- a/internal/tools/orchestrator/services/addon/addon_status_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_status_test.go
@@ -84,7 +84,7 @@ func TestBuildRocketMQOperaotrServiceItem(t *testing.T) {
 					"rocketmq-broker": {
 						CPU:   1,
 						Mem:   2048,
-						Nodes: 1,
+						Nodes: 2,
 					},
 					"rocketmq-console": {
 						CPU:   0.5,
@@ -121,6 +121,7 @@ func TestBuildRocketMQOperaotrServiceItem(t *testing.T) {
 
 	err := a.BuildRocketMQOperaotrServiceItem(params, addonIns, addonSpec, addonDice, nil, "5.0.0")
 	assert.NoError(t, err)
+	assert.Equal(t, 2, addonDice.Services["rocketmq-broker"].Deployments.Replicas)
 }
 
 func TestBuildRedisServiceItem(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix rocketmq resource missing replicas definition


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that rocketmq resource missing replicas definition（修复了rocketmq资源部署时丢失了副本数定义的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that rocketmq resource missing replicas definition           |
| 🇨🇳 中文    |     修复了rocketmq资源部署时丢失了副本数定义的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
