### PR TITLE
fix: domain-policy regex

### DIFF
--- a/internal/tools/orchestrator/hepa/services/openapi_rule/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_rule/impl/impl.go
@@ -392,7 +392,7 @@ func (impl GatewayOpenapiRuleServiceImpl) SetPackageKongPolicies(pack *orm.Gatew
 		domainPolicies.Enables = strings.Join(enables, ",")
 		domainPolicies.Disables = strings.Join(disables, ",")
 		domainPolicies.Id = pack.ZoneId
-		domainPolicies.Regex = "^(" + strings.Join(regexDomains, "|") + ")"
+		domainPolicies.Regex = "^(" + strings.Join(regexDomains, "|") + ")" + `(\/[^.]*)?$`
 		domainPolicies.Priority = priority
 		domainPolicies.PackageName = pack.PackageName
 		err = (*impl.zoneBiz).SetZoneKongPoliciesWithoutDomainPolicy(pack.ZoneId, &domainPolicies, helper)


### PR DESCRIPTION
#### What this PR does / why we need it:

fix: domain policy regex

网关的鉴权模型, 会使用正则表达式去匹配 http 请求的域名, 如果能匹配上, 则将鉴权策略应用于该次请求.
鉴权模型里有个 "^(xxx\\.com)" 这样的正则表达式, 当请求 xxx.com.cn 这个域名时, 也会被这个正则表达式命中, 因此对 xxx.com.cn 这个域名的请求会被鉴权策略拦截.

本 PR 修复 erda 上关于这段正则表达式生成的部分代码, 使其正确匹配请求的域名.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: domain policy regex |
| 🇨🇳 中文    | 修复 domain-policy 正则表达式错误的问题 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
