### PR TITLE
feat(dop): issue-manager default show unfinished state tickets

### DIFF
--- a/internal/apps/dop/component-protocol/standard-components/issueFilter/provider.go
+++ b/internal/apps/dop/component-protocol/standard-components/issueFilter/provider.go
@@ -291,9 +291,10 @@ func (f *IssueFilter) setDefaultState() error {
 		"TASK":        {pb.IssueStateBelongEnum_OPEN.String(), pb.IssueStateBelongEnum_WORKING.String()},
 		"REQUIREMENT": {pb.IssueStateBelongEnum_OPEN.String(), pb.IssueStateBelongEnum_WORKING.String()},
 		"BUG":         common.UnfinishedStateBelongs,
+		"TICKET":      common.UnfinishedStateBelongs,
 		"ALL":         common.UnfinishedStateBelongs,
 	}[f.InParams.FrontendFixedIssueType]
-	types := []string{pb.IssueTypeEnum_REQUIREMENT.String(), pb.IssueTypeEnum_TASK.String(), pb.IssueTypeEnum_BUG.String()}
+	types := []string{pb.IssueTypeEnum_REQUIREMENT.String(), pb.IssueTypeEnum_TASK.String(), pb.IssueTypeEnum_BUG.String(), pb.IssueTypeEnum_TICKET.String()}
 	res := make(map[string][]int64)
 	res["ALL"] = make([]int64, 0)
 	for _, v := range types {

--- a/internal/apps/dop/component-protocol/standard-components/issueFilter/provider_test.go
+++ b/internal/apps/dop/component-protocol/standard-components/issueFilter/provider_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueFilter
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/pkg/mock"
+)
+
+func Test_setDefaultState(t *testing.T) {
+	filter := &IssueFilter{}
+	issueSvc := mock.NewMockIssueQuery(gomock.NewController(t))
+	issueSvc.EXPECT().GetIssueStateIDs(gomock.Any()).AnyTimes().Return([]int64{1, 2}, nil)
+	filter.issueSvc = issueSvc
+	filter.InParams = InParams{
+		FrontendFixedIssueType: "TICKET",
+	}
+	err := filter.setDefaultState()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(filter.State.DefaultStateValues))
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
issue-manager default show unfinished state tickets

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=373953&iterationID=1628&tab=REQUIREMENT&type=REQUIREMENT)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support issue-manager default show unfinished state tickets（工单页默认展示 “未解决事项”）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Support issue-manager default show unfinished state tickets          |
| 🇨🇳 中文    |      工单页默认展示 “未解决事项”        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
