### PR TITLE
fix(hepa): can not set multi ips in policy ip

### DIFF
--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -1397,8 +1397,10 @@ func getNginxConfFromPolicyConfig(p apipolicy.PolicyConfig) (map[string]string, 
 
 			key := strings.ReplaceAll(keys[l-1], "-", "_")
 			if _, ok := ret[key]; ok {
-				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page 等允许多次设置
-				if key != "more_set_headers" && key != "proxy_set_header" && key != "set" && key != "limit_req" && key != "limit_conn" && key != "error_page" {
+				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+				if key != "more_set_headers" && key != "proxy_set_header" &&
+					key != "set" && key != "limit_req" && key != "limit_conn" &&
+					key != "error_page" && key != "deny" && key != "allow" {
 					return ret, errors.Errorf("Annotation nginx conf %s duplicated", key)
 				}
 			}
@@ -1423,8 +1425,10 @@ func getNginxConfFromPolicyConfig(p apipolicy.PolicyConfig) (map[string]string, 
 			logrus.Infof("p.IngressController.ConfigOption[%s]=%v \n", k, p.IngressController.ConfigOption[k])
 			key := strings.ReplaceAll(k, "-", "_")
 			if _, ok := ret[key]; ok {
-				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page 等允许多次设置
-				if key != "more_set_headers" && key != "proxy_set_header" && key != "set" && key != "limit_req" && key != "limit_conn" && key != "error_page" {
+				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+				if key != "more_set_headers" && key != "proxy_set_header" &&
+					key != "set" && key != "limit_req" && key != "limit_conn" &&
+					key != "error_page" && key != "deny" && key != "allow" {
 					return ret, errors.Errorf("ConfigOption nginx conf %s duplicated", key)
 				}
 			}
@@ -1475,8 +1479,10 @@ func extractConfigFromString(kind, src string, ret map[string]string) error {
 			if len(kv) >= 2 {
 				key := strings.ReplaceAll(kv[0], "-", "_")
 				if _, ok := ret[key]; ok {
-					// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page 等允许多次设置
-					if key != "more_set_headers" && key != "proxy_set_header" && key != "set" && key != "limit_req" && key != "limit_conn" && key != "error_page" {
+					// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+					if key != "more_set_headers" && key != "proxy_set_header" &&
+						key != "set" && key != "limit_req" && key != "limit_conn" &&
+						key != "error_page" && key != "deny" && key != "allow" {
 						return errors.Errorf("%s nginx conf %s duplicated", kind, key)
 					}
 				}


### PR DESCRIPTION
#### What this PR does / why we need it:
when set policy ip in kong gateway case,  nginx check duplicated config will detect multi "deny  xxxx"  or  "allow xxx", so take this as duplicated config.

#### Specified Reviewers:

/assign @dspo @sixther-dc @luobily 


#### ChangeLog
Bugfix： Fix the bug that can not set multi ips in policy ip in hepa for kong gateway（修复了Kong 网关下由于校验 nginx 配置有效性错误认为多个 allow 或 deny 语句造成配置冲突的情况）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Fix the bug that can not set multi ips in policy ip in hepa for kong gateway      |
| 🇨🇳 中文    |      修复了Kong 网关下由于校验 nginx 配置有效性错误认为多个 allow 或 deny 语句造成配置冲突的情况        |


#### Need cherry-pick to release versions?

/cherry-pick release/2.3

