### PR TITLE
fix: clickhouse parse timestamp desc invalid

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse.go
@@ -151,7 +151,11 @@ func (p *Parser) ParseOrderByOnExpr(s influxql.SortFields, expr *goqu.SelectData
 				tailOrderExpress = append(tailOrderExpress, goqu.C(timeBucketColumn).Asc())
 				continue
 			} else if column == p.ctx.timeKey {
-				tailOrderExpress = append(tailOrderExpress, goqu.C(p.ctx.timeKey).Asc())
+				if !field.Ascending {
+					tailOrderExpress = append(tailOrderExpress, goqu.C(p.ctx.timeKey).Desc())
+				} else {
+					tailOrderExpress = append(tailOrderExpress, goqu.C(p.ctx.timeKey).Asc())
+				}
 				continue
 			}
 

--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
@@ -773,6 +773,16 @@ func TestOrderBy(t *testing.T) {
 			sql:  "select time(),service_id::tag from table GROUP BY service_id::tag,time() ORDER BY service_id::tag desc",
 			want: "SELECT toNullable(tag_values[indexOf(tag_keys,'service_id')]) AS \"service_id::tag\" FROM \"table\" ORDER BY \"service_id::tag\" DESC,\"bucket_timestamp\" ASC",
 		},
+		{
+			name: "timestamp desc",
+			sql:  "select column1 from table order by timestamp desc",
+			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"column1\" ASC, \"timestamp\" DESC",
+		},
+		{
+			name: "timestamp asc",
+			sql:  "select column1 from table order by timestamp asc",
+			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"column1\" ASC, \"timestamp\" ASC",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
 fix clickhouse parse timestamp desc invalid


#### Specified Reviewers:

/assign @tomatopunk @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix：  fix clickhouse parse timestamp desc invalid （修复clickhouse解析timestamp排序字段无效的问题）
`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix clickhouse parse timestamp desc invalid            |
| 🇨🇳 中文    |  修复clickhouse解析timestamp排序字段无效的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
