### PR TITLE
fix(orchestrator): cluster recreate executor cause goroutine pool panic

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/executor.go
+++ b/internal/tools/orchestrator/scheduler/executor/executor.go
@@ -209,12 +209,12 @@ func updateOneExecutor(m *Manager, config *executorconfig.ExecutorConfig) error 
 	return createOneExecutor(m, config)
 }
 
-func (m *Manager) Pool(name executortypes.Name) *goroutinepool.GoroutinePool {
+func (m *Manager) Pool(name executortypes.Name) (string, *goroutinepool.GoroutinePool) {
 	p, ok := m.pools[name]
 	if !ok {
-		return m.pools[defaultGoPool]
+		return defaultGoPool, m.pools[defaultGoPool]
 	}
-	return p
+	return name.String(), p
 }
 
 // Get returns the executor with name.

--- a/pkg/goroutinepool/goroutinepool.go
+++ b/pkg/goroutinepool/goroutinepool.go
@@ -128,6 +128,13 @@ func (p *GoroutinePool) Stop() {
 	p.running = false
 }
 
+func (p *GoroutinePool) IsRunning() bool {
+	p.Lock()
+	defer p.Unlock()
+
+	return p.running
+}
+
 func (p *GoroutinePool) Go(f func()) error {
 	p.RLock()
 	defer p.RUnlock()

--- a/pkg/goroutinepool/goroutinepool_test.go
+++ b/pkg/goroutinepool/goroutinepool_test.go
@@ -99,6 +99,16 @@ func TestStat(t *testing.T) {
 	p.Stop()
 }
 
+func TestIsRunning(t *testing.T) {
+	p := New(10)
+	assert.Equal(t, p.IsRunning(), false)
+	p.Start()
+	p.MustGo(func() {
+		time.Sleep(1 * time.Second)
+	})
+	assert.Equal(t, p.IsRunning(), true)
+}
+
 //func TestJobPanic(t *testing.T) {
 //	job := func() {
 //		panic("panic")


### PR DESCRIPTION
#### What this PR does / why we need it:
fix cluster recreate executor cause goroutine pool panic

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix cluster recreate executor cause goroutine pool panic           |
| 🇨🇳 中文    |        修复集群重新注册导致goroutine 池panic问题      |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
