### PR TITLE
fix(monitor): no need to do orderby on selected-column, in the case of already sorted by time

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
@@ -776,12 +776,12 @@ func TestOrderBy(t *testing.T) {
 		{
 			name: "timestamp desc",
 			sql:  "select column1 from table order by timestamp desc",
-			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"column1\" ASC, \"timestamp\" DESC",
+			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"timestamp\" DESC",
 		},
 		{
 			name: "timestamp asc",
 			sql:  "select column1 from table order by timestamp asc",
-			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"column1\" ASC, \"timestamp\" ASC",
+			want: "SELECT toNullable(number_field_values[indexOf(number_field_keys,'column1')]) AS \"column1\" FROM \"table\" ORDER BY \"timestamp\" ASC",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:
no need to do orderby on selected-column, in the case of already sorted by time

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/iteration/1737/all?id=380220&iterationID=1737&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn @sixther-dc @tomatopunk 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that no need to do orderby on selected-column, in the case of already sorted by time（修复了 在已经按时间排序的情况下仍然对select的column做排序的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that no need to do orderby on selected-column, in the case of already sorted by time           |
| 🇨🇳 中文    |  修复了 在已经按时间排序的情况下仍然对select的column做排序的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
