### PR TITLE
fix(hepa): mse csrf validate allow RefreshTTL<=0

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/dto.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
+	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
 
 type PolicyDto struct {
@@ -53,7 +54,7 @@ func (dto PolicyDto) IsValidDto(gatewayProvider string) (bool, string) {
 	if dto.ValidTTL <= 0 {
 		return false, "token过期时间需要大于0"
 	}
-	if dto.RefreshTTL <= 0 {
+	if dto.RefreshTTL <= 0 && gatewayProvider != mseCommon.MseProviderName {
 		return false, "token更新周期需要大于0"
 	}
 	if dto.ErrStatus < 100 || dto.ErrStatus >= 600 {


### PR DESCRIPTION
#### What this PR does / why we need it:

Adjust web info about mse gateway csrf policy, which will not set  RefreshTTL.



#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Adjust web info about mse gateway csrf policy, allow  not set  RefreshTTL in config    |
| 🇨🇳 中文    |      前端页面适配 MSE csrf 策略，不再支持设置  RefreshTTL，因此后端在其为 MSE 网关的情况想要允许设置为0       |


#### Need cherry-pick to release versions?

/cherry-pick release/2.3