### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/fntlnz/mountinfo v0.0.0-20171106231217-40cb42681fad
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/getkin/kin-openapi v0.76.0
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gin-gonic/gin v1.7.0
 	github.com/go-echarts/go-echarts/v2 v2.2.4
 	github.com/go-eden/routine v1.0.1
@@ -281,6 +280,7 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/frankban/quicktest v1.14.5 // indirect
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.6.1 // indirect

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodeDetail/yamlFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-nodeDetail/yamlFileEditor/render.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-podDetail/yamlFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-podDetail/yamlFileEditor/render.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFileEditor/render.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/yamlFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/yamlFileEditor/render.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workload-detail/yamlFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workload-detail/yamlFileEditor/render.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/yamlFileEditor/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/yamlFileEditor/render.go
@@ -19,9 +19,9 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"

--- a/internal/apps/cmp/steve/predefined/init.go
+++ b/internal/apps/cmp/steve/predefined/init.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/bundle"
 )

--- a/internal/apps/dop/endpoints/task.go
+++ b/internal/apps/dop/endpoints/task.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/apps/dop/pipeline/pipelineyml"

--- a/internal/apps/dop/pipeline/pipelineyml/pipeline.go
+++ b/internal/apps/dop/pipeline/pipelineyml/pipeline.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 type PipelineYml struct {

--- a/internal/apps/dop/providers/publishitem/db/publish_item_version.go
+++ b/internal/apps/dop/providers/publishitem/db/publish_item_version.go
@@ -18,10 +18,10 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-proto-go/dop/publishitem/pb"
 	"github.com/erda-project/erda/apistructs"

--- a/internal/apps/msp/resource/deploy/handlers/generalability/general_ability.go
+++ b/internal/apps/msp/resource/deploy/handlers/generalability/general_ability.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"google.golang.org/grpc/metadata"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/pkg/transport"
 	"github.com/erda-project/erda-proto-go/core/dicehub/release/pb"

--- a/internal/pkg/extension/db/extension.go
+++ b/internal/pkg/extension/db/extension.go
@@ -19,10 +19,10 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/jinzhu/gorm"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-proto-go/core/extension/pb"
 	"github.com/erda-project/erda/pkg/expression"

--- a/internal/tools/monitor/core/alert/alert-apis/provider.go
+++ b/internal/tools/monitor/core/alert/alert-apis/provider.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"

--- a/pkg/k8s/node/drain/node_test.go
+++ b/pkg/k8s/node/drain/node_test.go
@@ -20,7 +20,7 @@ package drain
 //	"io/ioutil"
 //	"testing"
 //
-//	"github.com/ghodss/yaml"
+//	"sigs.k8s.io/yaml"
 //	"github.com/sirupsen/logrus"
 //	"github.com/stretchr/testify/assert"
 //	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/parser/pipelineyml/pipelineymlv1/gogenerate/builtin_action_spec.go
+++ b/pkg/parser/pipelineyml/pipelineymlv1/gogenerate/builtin_action_spec.go
@@ -25,7 +25,7 @@ package main
 //	"path"
 //
 //	"github.com/bitly/go-simplejson"
-//	"github.com/ghodss/yaml"
+//	"sigs.k8s.io/yaml"
 //)
 //
 //const (

--- a/pkg/parser/pipelineyml/pipelineymlv1/pipelineyml.go
+++ b/pkg/parser/pipelineyml/pipelineymlv1/pipelineyml.go
@@ -21,10 +21,10 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/pkg/metadata"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml/pipelineymlv1/pipelineymlvars"

--- a/pkg/parser/pipelineyml/pipelineymlv1/taskconfig_decode.go
+++ b/pkg/parser/pipelineyml/pipelineymlv1/taskconfig_decode.go
@@ -17,9 +17,9 @@ package pipelineymlv1
 import (
 	"reflect"
 
-	"github.com/ghodss/yaml"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/pkg/parser/pipelineyml/pipelineymlv1/pipelineymlvars"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml/pipelineymlv1/steptasktype"

--- a/tools/cli/cmd/extensions_push.go
+++ b/tools/cli/cmd/extensions_push.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/tools/cli/command"

--- a/tools/cli/cmd/extensions_retag.go
+++ b/tools/cli/cmd/extensions_retag.go
@@ -21,8 +21,8 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/yaml"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/tools/cli/command"


### PR DESCRIPTION
#### What this PR does / why we need it:

The `github.com/ghodss/yaml` package is no longer being actively maintained. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

The notable change is that `github.com/ghodss/yaml` uses `gopkg.in/yaml.v2 v2.2.2`, while `sigs.k8s.io/yaml` uses `gopkg.in/yaml.v2 v2.4.0`. You can see the changes between the two versions here: [v2.2.2...v2.4.0](https://github.com/go-yaml/yaml/compare/v2.2.2...v2.4.0), which mostly consists of bug fixes.
#### Which issue(s) this PR fixes:


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Replace unmaintained `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`             |
| 🇨🇳 中文    | 将不再积极维护中的 `github.com/ghodss/yaml` 依赖替换为 `sigs.k8s.io/yaml`             |


#### Need cherry-pick to release versions?

