### PR TITLE
fix: gateway policy csrf and sbac added config for mse not allowed for kong

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy.go
@@ -111,10 +111,12 @@ func (policy Policy) buildPluginReq(dto *PolicyDto, gatewayProvider, zoneName st
 	tokenSecret := fmt.Sprintf("%x", sha.Sum(nil))
 	req.Config["jwt_secret"] = tokenSecret[:16] + tokenSecret[48:]
 
-	if dto.Switch {
-		req.Config[mseCommon.MseErdaCSRFRouteSwitch] = true
-	} else {
-		req.Config[mseCommon.MseErdaCSRFRouteSwitch] = false
+	if gatewayProvider == mseCommon.MseProviderName {
+		if dto.Switch {
+			req.Config[mseCommon.MseErdaCSRFRouteSwitch] = true
+		} else {
+			req.Config[mseCommon.MseErdaCSRFRouteSwitch] = false
+		}
 	}
 
 	return req

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/dto.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/dto.go
@@ -81,7 +81,9 @@ func (pc PolicyDto) ToPluginReqDto(gatewayProvider, zoneName string) *providerDt
 	var headersKeys = make(map[string]struct{})
 	if pc.WithCookie {
 		headersKeys[textproto.CanonicalMIMEHeaderKey("cookie")] = struct{}{}
-		req.Config["with_cookie"] = true
+		if gatewayProvider == mseCommon.MseProviderName {
+			req.Config["with_cookie"] = true
+		}
 	}
 	for _, header := range pc.WithHeaders {
 		if gatewayProvider == mseCommon.MseProviderName {
@@ -98,10 +100,12 @@ func (pc PolicyDto) ToPluginReqDto(gatewayProvider, zoneName string) *providerDt
 		req.Config["with_headers"] = headers
 	}
 
-	if pc.Switch {
-		req.Config[mseCommon.MseErdaSBACRouteSwitch] = true
-	} else {
-		req.Config[mseCommon.MseErdaSBACRouteSwitch] = false
+	if gatewayProvider == mseCommon.MseProviderName {
+		if pc.Switch {
+			req.Config[mseCommon.MseErdaSBACRouteSwitch] = true
+		} else {
+			req.Config[mseCommon.MseErdaSBACRouteSwitch] = false
+		}
 	}
 
 	return req


### PR DESCRIPTION
#### What this PR does / why we need it:
Gateway policy csrf and sbac added config for mse not allowed for kong.

#### Specified Reviewers:

/assign @dspo @luobily @sixther-dc 


#### ChangeLog

Bugfix： Fix the bug that gateway policy csrf and sbac added config for mse not allowed for kong（修复了为支持 MSE 网关策略而新增的配置项导致Kong网关校验策略配置失败的问题）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that gateway policy csrf and sbac added config for mse not allowed for kong        |
| 🇨🇳 中文    |       修复了为支持 MSE 网关策略而新增的配置项导致Kong网关校验策略配置失败的问题       |


#### Need cherry-pick to release versions?

/cherry-pick release/2.3

