### PR TITLE
fix: hepa check nginx custom config err when kong version is 0.14.1

### DIFF
--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -1303,9 +1303,9 @@ func (impl GatewayApiPolicyServiceImpl) checkDuplicatedPolicyConfig(gatewayProvi
 
 	switch category {
 	case apipolicy.Policy_Engine_Custom:
-		// custom 策略需要跟其他所有策略校验冲突
+		// custom 策略需要跟其他所有策略校验冲突 (csrf 和 sbac 无需检查，因为没有配置会更新到 nginx conf)
 		categories = []string{apipolicy.Policy_Engine_Built_in, apipolicy.Policy_Engine_WAF, apipolicy.Policy_Engine_Service_Guard, apipolicy.Policy_Engine_CORS,
-			apipolicy.Policy_Engine_IP, apipolicy.Policy_Engine_Proxy, apipolicy.Policy_Engine_SBAC, apipolicy.Policy_Engine_CSRF}
+			apipolicy.Policy_Engine_IP, apipolicy.Policy_Engine_Proxy}
 	default:
 		categories = []string{apipolicy.Policy_Engine_Custom}
 	}


### PR DESCRIPTION
…ng  version is 0.14.1

#### What this PR does / why we need it:
hepa check nginx custom config confliction will case err when kong version is 0.14.1

#### Which issue(s) this PR fixes:
https://erda.cloud/erda/dop/projects/387/ticket?id=388014&iterationID=-1&type=TICKET

#### Specified Reviewers:

/assign @dspo @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

Bugfix： Fix the bug that hepa check nginx custom config err when kong version is 0.14.1 （修复了 kong 0.14.1 版本 nginx 自定义配置冲突校验 csrf 和 sbac 策略解析报错的问题）


| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that hepa check nginx custom config err when kong version is 0.14.1    |
| 🇨🇳 中文    |    修复了 kong 0.14.1 版本 nginx 自定义配置冲突校验 csrf 和 sbac 策略解析报错的问题    |


#### Need cherry-pick to release versions?

/cherry-pick release/2.3
