### PR TITLE
fix: hepa check nginx custom config error when set return

### DIFF
--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -1403,10 +1403,10 @@ func getNginxConfFromPolicyConfig(p apipolicy.PolicyConfig) (map[string]string, 
 
 			key := strings.ReplaceAll(keys[l-1], "-", "_")
 			if _, ok := ret[key]; ok {
-				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return 等允许多次设置
 				if key != "more_set_headers" && key != "proxy_set_header" &&
 					key != "set" && key != "limit_req" && key != "limit_conn" &&
-					key != "error_page" && key != "deny" && key != "allow" {
+					key != "error_page" && key != "deny" && key != "allow" && key != "return" {
 					return ret, errors.Errorf("Annotation nginx conf %s duplicated", key)
 				}
 			}
@@ -1431,10 +1431,10 @@ func getNginxConfFromPolicyConfig(p apipolicy.PolicyConfig) (map[string]string, 
 			logrus.Infof("p.IngressController.ConfigOption[%s]=%v \n", k, p.IngressController.ConfigOption[k])
 			key := strings.ReplaceAll(k, "-", "_")
 			if _, ok := ret[key]; ok {
-				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return 等允许多次设置
 				if key != "more_set_headers" && key != "proxy_set_header" &&
 					key != "set" && key != "limit_req" && key != "limit_conn" &&
-					key != "error_page" && key != "deny" && key != "allow" {
+					key != "error_page" && key != "deny" && key != "allow" && key != "return" {
 					return ret, errors.Errorf("ConfigOption nginx conf %s duplicated", key)
 				}
 			}
@@ -1485,10 +1485,10 @@ func extractConfigFromString(kind, src string, ret map[string]string) error {
 			if len(kv) >= 2 {
 				key := strings.ReplaceAll(kv[0], "-", "_")
 				if _, ok := ret[key]; ok {
-					// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow 等允许多次设置
+					// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return 等允许多次设置
 					if key != "more_set_headers" && key != "proxy_set_header" &&
 						key != "set" && key != "limit_req" && key != "limit_conn" &&
-						key != "error_page" && key != "deny" && key != "allow" {
+						key != "error_page" && key != "deny" && key != "allow" && key != "return" {
 						return errors.Errorf("%s nginx conf %s duplicated", kind, key)
 					}
 				}


### PR DESCRIPTION
#### What this PR does / why we need it:
 Hepa check nginx custom config error when set return, because cors policy have set return 200 default when it enabled。


#### Specified Reviewers:

/assign @dspo @luobily 


#### ChangeLog

Bugfix： Fix the bug that hepa check nginx custom config error when set return（修复了 hepa 检查 nginx 自定义配置 return 语句与 cors 策略默认配置冲突的错误）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that hepa check nginx custom config error when set return   |
| 🇨🇳 中文    |   修复了 hepa 检查 nginx 自定义配置 return 语句与 cors 策略默认配置冲突的错误  |


#### Need cherry-pick to release versions?
/cherry-pick release/2.4-beta.1
