### PR TITLE
fix(orchestrator): addon mysql missing cluster name label

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/mysql/mysql.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/mysql/mysql.go
@@ -203,6 +203,10 @@ func (my *MysqlOperator) Convert(sg *apistructs.ServiceGroup) interface{} {
 		obj.Spec.Labels["ADDON_ID"] = addonID
 	}
 
+	if clusterName, ok := mysql.Env[apistructs.DICE_CLUSTER_NAME.String()]; ok {
+		obj.Spec.Labels[apistructs.DICE_CLUSTER_NAME.String()] = clusterName
+	}
+
 	return obj
 }
 

--- a/internal/tools/orchestrator/services/addon/addon_status.go
+++ b/internal/tools/orchestrator/services/addon/addon_status.go
@@ -1304,8 +1304,9 @@ func (a *Addon) BuildMysqlOperatorServiceItem(params *apistructs.AddonHandlerCre
 		"ADDON_ID":      addonIns.ID,
 		"ADDON_NODE_ID": addonNodeId,
 
-		"MYSQL_VERSION":       operatorSpec.Version,
-		"MYSQL_ROOT_PASSWORD": password,
+		"MYSQL_VERSION":                       operatorSpec.Version,
+		"MYSQL_ROOT_PASSWORD":                 password,
+		apistructs.DICE_CLUSTER_NAME.String(): params.ClusterName,
 	}
 
 	// 保存mysql的master节点信息


### PR DESCRIPTION
#### What this PR does / why we need it:
fix addon mysql missing cluster name label

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=388558&iterationID=1737&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn @cxr29 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that addon mysql missing cluster name label （修复了mysql addon实例缺少集群标签的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that addon mysql missing cluster name label            |
| 🇨🇳 中文    |     修复了mysql addon实例缺少集群标签的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
