### PR TITLE
fix(pipeline): failed to clean build cache images due to bundle initialization

### DIFF
--- a/internal/tools/pipeline/providers/build/provider.go
+++ b/internal/tools/pipeline/providers/build/provider.go
@@ -49,6 +49,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	if p.Register != nil {
 		pb.RegisterBuildServiceImp(p.Register, p.buildService, apis.Options())
 	}
+	p.bdl = bundle.New(bundle.WithCMP())
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
fix failed to clean build cache images due to bundle initialization

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that failed to clean build cache images due to bundle initialization（修复了缓存镜像gc失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that failed to clean build cache images due to bundle initialization           |
| 🇨🇳 中文    |      修复了缓存镜像gc失败的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
