### PR TITLE
fix(orchestrator): redis-operator deploy failure due to arm64-cow-bug

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis.go
@@ -388,6 +388,9 @@ func (ro *RedisOperator) convertRedis(svc apistructs.Service, affinity *corev1.A
 		},
 	}
 	settings.Image = svc.Image
+	settings.CustomConfig = []string{
+		"ignore-warnings ARM64-COW-BUG",
+	}
 	return settings
 }
 
@@ -414,6 +417,7 @@ func convertSentinel(svc apistructs.Service, affinity *corev1.Affinity) Sentinel
 		fmt.Sprintf("auth-pass %s", svc.Env["requirepass"]),
 		"down-after-milliseconds 12000",
 		"failover-timeout 12000",
+		"ignore-warnings ARM64-COW-BUG",
 	}
 	settings.Image = svc.Image
 	return settings


### PR DESCRIPTION
#### What this PR does / why we need it:
fix redis-operator deploy failure due to arm64-cow-bug

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that redis-operator deploy failure due to arm64-cow-bug （修复了中间件redis在arm环境部署失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that redis-operator deploy failure due to arm64-cow-bug           |
| 🇨🇳 中文    |    修复了中间件redis在arm环境部署失败的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
