### PR TITLE
fix: hepa get policy return

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/built-in/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/built-in/policy.go
@@ -38,7 +38,7 @@ func (policy Policy) NeedSerialUpdate() bool {
 	return true
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	return nil
 }
 

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/built-in/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/built-in/policy_test.go
@@ -12,46 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverguard
+package builtin
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
-	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
-
-func Test_setMSEIngressAnnotation(t *testing.T) {
-	type args struct {
-		policyDto          *PolicyDto
-		ingressAnnotations *apipolicy.IngressAnnotation
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Test_01",
-			args: args{
-				policyDto: &PolicyDto{
-					BaseDto:        apipolicy.BaseDto{},
-					MaxTps:         0,
-					Busrt:          2,
-					ExtraLatency:   0,
-					RefuseCode:     0,
-					RefuseResponse: "",
-				},
-				ingressAnnotations: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
-		})
-	}
-}
 
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
 	type fields struct {
@@ -71,18 +39,14 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 			name: "Test_01",
 			fields: fields{
 				BasePolicy: apipolicy.BasePolicy{
-					PolicyName: apipolicy.Policy_Engine_Service_Guard,
+					PolicyName: apipolicy.Policy_Category_BuiltIn,
 				},
 			},
 			args: args{
-				gatewayProvider: mseCommon.MseProviderName,
+				gatewayProvider: "",
 				ctx:             nil,
 			},
-			want: &PolicyDto{
-				ExtraLatency:   500,
-				RefuseCode:     503,
-				RefuseResponse: "local_rate_limited",
-			},
+			want: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy.go
@@ -30,7 +30,7 @@ type Policy struct {
 	apipolicy.BasePolicy
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	dto := &PolicyDto{
 		Methods:     "GET, PUT, POST, DELETE, PATCH, OPTIONS",
 		Headers:     "$http_access_control_request_headers",
@@ -38,6 +38,12 @@ func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.P
 		Credentials: true,
 		MaxAge:      86400,
 	}
+
+	if gatewayProvider == mseCommon.MseProviderName {
+		dto.Headers = ""
+		dto.Origin = ""
+	}
+
 	dto.Switch = false
 	return dto
 }

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/cors/policy_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
 	annotationscommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common"
+	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
 
 func TestPolicy_setIngressAnnotations(t *testing.T) {
@@ -107,6 +108,52 @@ func TestPolicy_setIngressAnnotations(t *testing.T) {
 			}
 			if got := policy.setIngressAnnotations(tt.args.gatewayProvider, tt.args.policyDto, tt.args.locationSnippet); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("setIngressAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicy_CreateDefaultConfig(t *testing.T) {
+	type fields struct {
+		BasePolicy apipolicy.BasePolicy
+	}
+	type args struct {
+		gatewayProvider string
+		ctx             map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   apipolicy.PolicyDto
+	}{
+		{
+			name: "Test_01",
+			fields: fields{
+				BasePolicy: apipolicy.BasePolicy{
+					PolicyName: apipolicy.Policy_Engine_CORS,
+				},
+			},
+			args: args{
+				gatewayProvider: mseCommon.MseProviderName,
+				ctx:             nil,
+			},
+			want: &PolicyDto{
+				Methods:     "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+				Headers:     "",
+				Origin:      "",
+				Credentials: true,
+				MaxAge:      86400,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := Policy{
+				BasePolicy: tt.fields.BasePolicy,
+			}
+			if got := policy.CreateDefaultConfig(tt.args.gatewayProvider, tt.args.ctx); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateDefaultConfig() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy.go
@@ -46,7 +46,7 @@ type Policy struct {
 	apipolicy.BasePolicy
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	value, ok := ctx[apipolicy.CTX_SERVICE_INFO]
 	if !ok {
 		logrus.Errorf("get identify failed:%+v", ctx)

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/csrf/policy_test.go
@@ -12,46 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverguard
+package csrf
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
-	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
-
-func Test_setMSEIngressAnnotation(t *testing.T) {
-	type args struct {
-		policyDto          *PolicyDto
-		ingressAnnotations *apipolicy.IngressAnnotation
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Test_01",
-			args: args{
-				policyDto: &PolicyDto{
-					BaseDto:        apipolicy.BaseDto{},
-					MaxTps:         0,
-					Busrt:          2,
-					ExtraLatency:   0,
-					RefuseCode:     0,
-					RefuseResponse: "",
-				},
-				ingressAnnotations: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
-		})
-	}
-}
 
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
 	type fields struct {
@@ -61,6 +30,12 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 		gatewayProvider string
 		ctx             map[string]interface{}
 	}
+	ctx := make(map[string]interface{})
+	ctx[apipolicy.CTX_SERVICE_INFO] = apipolicy.ServiceInfo{
+		ProjectName: "test",
+		Env:         "PROD",
+	}
+	tokenName := "x-test-prod-csrf-token"
 	tests := []struct {
 		name   string
 		fields fields
@@ -71,17 +46,22 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 			name: "Test_01",
 			fields: fields{
 				BasePolicy: apipolicy.BasePolicy{
-					PolicyName: apipolicy.Policy_Engine_Service_Guard,
+					PolicyName: apipolicy.Policy_Engine_CSRF,
 				},
 			},
 			args: args{
-				gatewayProvider: mseCommon.MseProviderName,
-				ctx:             nil,
+				gatewayProvider: "",
+				ctx:             ctx,
 			},
 			want: &PolicyDto{
-				ExtraLatency:   500,
-				RefuseCode:     503,
-				RefuseResponse: "local_rate_limited",
+				ExcludedMethod: []string{http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace},
+				TokenName:      tokenName,
+				CookieSecure:   false,
+				ValidTTL:       1800,
+				RefreshTTL:     10,
+				ErrStatus:      403,
+				ErrMsg:         `{"message":"This form has expired. Please refresh and try again."}`,
+				Switch:         false,
 			},
 		},
 	}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
@@ -38,7 +38,7 @@ var UNSETABLE_KEYS = map[string]string{"client_max_body_size": "100m",
 	"port_in_redirect":      "off",
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	dto := &PolicyDto{}
 	dto.Switch = false
 	return dto

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy_test.go
@@ -12,46 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverguard
+package custom
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
-	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
-
-func Test_setMSEIngressAnnotation(t *testing.T) {
-	type args struct {
-		policyDto          *PolicyDto
-		ingressAnnotations *apipolicy.IngressAnnotation
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Test_01",
-			args: args{
-				policyDto: &PolicyDto{
-					BaseDto:        apipolicy.BaseDto{},
-					MaxTps:         0,
-					Busrt:          2,
-					ExtraLatency:   0,
-					RefuseCode:     0,
-					RefuseResponse: "",
-				},
-				ingressAnnotations: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
-		})
-	}
-}
 
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
 	type fields struct {
@@ -68,20 +36,20 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 		want   apipolicy.PolicyDto
 	}{
 		{
-			name: "Test_01",
 			fields: fields{
 				BasePolicy: apipolicy.BasePolicy{
-					PolicyName: apipolicy.Policy_Engine_Service_Guard,
+					PolicyName: apipolicy.Policy_Engine_Custom,
 				},
 			},
 			args: args{
-				gatewayProvider: mseCommon.MseProviderName,
+				gatewayProvider: "",
 				ctx:             nil,
 			},
 			want: &PolicyDto{
-				ExtraLatency:   500,
-				RefuseCode:     503,
-				RefuseResponse: "local_rate_limited",
+				BaseDto: apipolicy.BaseDto{
+					Switch: false,
+					Global: false,
+				},
 			},
 		},
 	}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
@@ -38,7 +38,7 @@ type Policy struct {
 	apipolicy.BasePolicy
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	dto := &PolicyDto{
 		IpSource:  REMOTE_IP,
 		IpAclType: ACL_BLACK,

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy_test.go
@@ -81,3 +81,50 @@ func TestPolicy_buildMSEPluginReq(t *testing.T) {
 		})
 	}
 }
+
+func TestPolicy_CreateDefaultConfig(t *testing.T) {
+	type fields struct {
+		BasePolicy apipolicy.BasePolicy
+	}
+	type args struct {
+		gatewayProvider string
+		ctx             map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   apipolicy.PolicyDto
+	}{
+		{
+			name: "Test_01",
+			fields: fields{
+				BasePolicy: apipolicy.BasePolicy{
+					PolicyName: apipolicy.Policy_Engine_IP,
+				},
+			},
+			args: args{
+				gatewayProvider: "",
+				ctx:             nil,
+			},
+			want: &PolicyDto{
+				IpSource:  REMOTE_IP,
+				IpAclType: ACL_BLACK,
+				BaseDto: apipolicy.BaseDto{
+					Switch: false,
+					Global: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := Policy{
+				BasePolicy: tt.fields.BasePolicy,
+			}
+			if got := policy.CreateDefaultConfig(tt.args.gatewayProvider, tt.args.ctx); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateDefaultConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy.go
@@ -33,7 +33,7 @@ type Policy struct {
 	apipolicy.BasePolicy
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	dto := &PolicyDto{
 		ReqBuffer:         true,
 		RespBuffer:        true,

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy_test.go
@@ -12,46 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverguard
+package proxy
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
-	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
-
-func Test_setMSEIngressAnnotation(t *testing.T) {
-	type args struct {
-		policyDto          *PolicyDto
-		ingressAnnotations *apipolicy.IngressAnnotation
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Test_01",
-			args: args{
-				policyDto: &PolicyDto{
-					BaseDto:        apipolicy.BaseDto{},
-					MaxTps:         0,
-					Busrt:          2,
-					ExtraLatency:   0,
-					RefuseCode:     0,
-					RefuseResponse: "",
-				},
-				ingressAnnotations: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
-		})
-	}
-}
 
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
 	type fields struct {
@@ -71,17 +39,23 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 			name: "Test_01",
 			fields: fields{
 				BasePolicy: apipolicy.BasePolicy{
-					PolicyName: apipolicy.Policy_Engine_Service_Guard,
+					PolicyName: apipolicy.Policy_Engine_Proxy,
 				},
 			},
 			args: args{
-				gatewayProvider: mseCommon.MseProviderName,
+				gatewayProvider: "",
 				ctx:             nil,
 			},
 			want: &PolicyDto{
-				ExtraLatency:   500,
-				RefuseCode:     503,
-				RefuseResponse: "local_rate_limited",
+				ReqBuffer:         true,
+				RespBuffer:        true,
+				ClientReqLimit:    100,
+				ClientReqTimeout:  60,
+				ClientRespTimeout: 60,
+				ProxyReqTimeout:   60,
+				ProxyRespTimeout:  60,
+				HostPassthrough:   false,
+				SSLRedirect:       true,
 			},
 		},
 	}

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy.go
@@ -39,7 +39,7 @@ type Policy struct {
 	apipolicy.BasePolicy
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	return new(PolicyDto)
 }
 

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/sbac/policy_test.go
@@ -23,7 +23,7 @@ import (
 
 // need not do unit test
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
-	new(sbac.Policy).CreateDefaultConfig(make(map[string]interface{}))
+	new(sbac.Policy).CreateDefaultConfig("", make(map[string]interface{}))
 }
 
 func TestPolicy_UnmarshalConfig(t *testing.T) {

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/server-guard/policy.go
@@ -37,11 +37,15 @@ func (policy Policy) NeedSerialUpdate() bool {
 	return true
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	dto := &PolicyDto{
 		ExtraLatency:   500,
 		RefuseCode:     429,
 		RefuseResponse: "System is busy, please try it later.",
+	}
+	if gatewayProvider == mseCommon.MseProviderName {
+		dto.RefuseCode = 503
+		dto.RefuseResponse = "local_rate_limited"
 	}
 	dto.Switch = false
 	return dto

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy.go
@@ -32,7 +32,7 @@ func (policy Policy) NeedSerialUpdate() bool {
 	return true
 }
 
-func (policy Policy) CreateDefaultConfig(ctx map[string]interface{}) apipolicy.PolicyDto {
+func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]interface{}) apipolicy.PolicyDto {
 	return &PolicyDto{
 		WafEnable:   WAF_SWITCH_WATCH,
 		RemoveRules: "",

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy_test.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/waf/policy_test.go
@@ -12,46 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverguard
+package waf
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
-	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
 )
-
-func Test_setMSEIngressAnnotation(t *testing.T) {
-	type args struct {
-		policyDto          *PolicyDto
-		ingressAnnotations *apipolicy.IngressAnnotation
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "Test_01",
-			args: args{
-				policyDto: &PolicyDto{
-					BaseDto:        apipolicy.BaseDto{},
-					MaxTps:         0,
-					Busrt:          2,
-					ExtraLatency:   0,
-					RefuseCode:     0,
-					RefuseResponse: "",
-				},
-				ingressAnnotations: nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setMSEIngressAnnotation(tt.args.policyDto, tt.args.ingressAnnotations)
-		})
-	}
-}
 
 func TestPolicy_CreateDefaultConfig(t *testing.T) {
 	type fields struct {
@@ -71,17 +39,16 @@ func TestPolicy_CreateDefaultConfig(t *testing.T) {
 			name: "Test_01",
 			fields: fields{
 				BasePolicy: apipolicy.BasePolicy{
-					PolicyName: apipolicy.Policy_Engine_Service_Guard,
+					PolicyName: apipolicy.Policy_Engine_WAF,
 				},
 			},
 			args: args{
-				gatewayProvider: mseCommon.MseProviderName,
+				gatewayProvider: "",
 				ctx:             nil,
 			},
 			want: &PolicyDto{
-				ExtraLatency:   500,
-				RefuseCode:     503,
-				RefuseResponse: "local_rate_limited",
+				WafEnable:   WAF_SWITCH_WATCH,
+				RemoveRules: "",
 			},
 		},
 	}

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/mse_adapter_test.go
@@ -181,7 +181,6 @@ func TestMseAdapterImpl_GetVersion(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name:    "Test_01",
 			fields:  fields{ProviderName: "MSE"},
@@ -908,7 +907,6 @@ func TestMseAdapterImpl_PutPlugin(t *testing.T) {
 		want    *PluginRespDto
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name:    "Test_01",
 			fields:  fields{ProviderName: "MSE"},
@@ -950,7 +948,6 @@ func TestMseAdapterImpl_UpdatePlugin(t *testing.T) {
 		want    *PluginRespDto
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name:   "Test_01",
 			fields: fields{ProviderName: "MSE"},

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/plugins/mse_key_auth_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/plugins/mse_key_auth_test.go
@@ -33,7 +33,6 @@ func Test_mergeKeyAuthConfig(t *testing.T) {
 		want    dto.MsePluginConfig
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "Test_01",
 			args: args{

--- a/internal/tools/orchestrator/hepa/gateway-providers/mse/plugins/mse_para_sign_auth_test.go
+++ b/internal/tools/orchestrator/hepa/gateway-providers/mse/plugins/mse_para_sign_auth_test.go
@@ -33,7 +33,6 @@ func Test_mergeParaSignAuthConfig(t *testing.T) {
 		want    dto.MsePluginConfig
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "Test_01",
 			args: args{

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -199,7 +199,7 @@ func (impl GatewayApiPolicyServiceImpl) GetPolicyConfig(category, packageId, pac
 	ctx[apipolicy.CTX_SERVICE_INFO] = serviceInfo
 	if packageApiId == "" {
 		var dto interface{}
-		dto, err = policyEngine.GetConfig(category, packageId, nil, ctx)
+		dto, err = policyEngine.GetConfig(gatewayProvider, category, packageId, nil, ctx)
 		if err != nil {
 			return
 		}
@@ -222,7 +222,7 @@ func (impl GatewayApiPolicyServiceImpl) GetPolicyConfig(category, packageId, pac
 		}
 	}
 	var dto interface{}
-	dto, err = policyEngine.GetConfig(category, packageId, zone, ctx)
+	dto, err = policyEngine.GetConfig(gatewayProvider, category, packageId, zone, ctx)
 	if err != nil {
 		return
 	}

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
@@ -210,7 +210,6 @@ func Test_validateCustomNginxConf(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "Test_01",
 			args: args{

--- a/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
@@ -3174,7 +3174,7 @@ func (impl GatewayOpenapiServiceImpl) CreateTenantPackage(tenantId string, gatew
 			if err != nil {
 				goto clear_route
 			}
-			corsConfig = policyEngine.CreateDefaultConfig(nil)
+			corsConfig = policyEngine.CreateDefaultConfig(gatewayProvider, nil)
 			corsConfig.SetEnable(true)
 			configByte, err = json.Marshal(corsConfig)
 			if err != nil {
@@ -3390,7 +3390,7 @@ func (impl GatewayOpenapiServiceImpl) createOrGetTenantHubPackage(ctx context.Co
 		if err != nil {
 			goto clear_route
 		}
-		corsConfig = policyEngine.CreateDefaultConfig(nil)
+		corsConfig = policyEngine.CreateDefaultConfig(gatewayProvider, nil)
 		corsConfig.SetEnable(true)
 		configByte, err = json.Marshal(corsConfig)
 		if err != nil {
@@ -3610,7 +3610,22 @@ func (impl GatewayOpenapiServiceImpl) clearRoutePolicy(category, packageId, pack
 	if err != nil {
 		return err
 	}
-	config := engine.CreateDefaultConfig(map[string]interface{}{})
+	pack, err := impl.packageDb.Get(packageId)
+	if err != nil {
+		return err
+	}
+	if pack == nil {
+		return errors.New("endpoint not found")
+	}
+
+	gatewayProvider, err := impl.GetGatewayProvider(pack.DiceClusterName)
+	if err != nil {
+		errMsg := errors.Errorf("get gateway provider failed for cluster %s: %v\n", pack.DiceClusterName, err)
+		logrus.Error(errMsg)
+		return errMsg
+	}
+
+	config := engine.CreateDefaultConfig(gatewayProvider, map[string]interface{}{})
 	configByte, err := json.Marshal(config)
 	if err != nil {
 		return errors.Errorf("mashal failed, config:%v, err:%v",


### PR DESCRIPTION
#### What this PR does / why we need it:
Adapting for Erda API Gateway web call GetPolicy() get default config for policy,  different gateway  provider (mse or kong) need return different config for default。 

#### Which issue(s) this PR fixes:



#### Specified Reviewers:

/assign @dspo @luobily @sixther-dc 


#### ChangeLog
Bugfix： Fix the bug that different gateway  provider (mse or kong) need return different config for default （修复了前端页面适配网关类型获取不同网关对应的网关策略的默认设置）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that different gateway  provider (mse or kong) need return different config for default   |
| 🇨🇳 中文    |   修复了前端页面适配网关类型获取不同网关对应的网关策略的默认设置  |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
