### PR TITLE
fix(orchestrator): redis addon deployed by operator missing exporter

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/elasticsearch/elasticsearch.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/elasticsearch/elasticsearch.go
@@ -378,7 +378,7 @@ func (eo *ElasticsearchOperator) NodeSetsConvert(sg *apistructs.ServiceGroup, sc
 						},
 					}, {
 						Name:    "es-exporter",
-						Image:   "quay.io/prometheuscommunity/elasticsearch-exporter:v1.5.0",
+						Image:   esExporterImage,
 						Command: []string{"/bin/elasticsearch_exporter", esUri},
 						Ports: []corev1.ContainerPort{
 							{

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis.go
@@ -33,6 +33,10 @@ import (
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
+var (
+	redisExporterImage = "registry.erda.cloud/retag/redis-exporter:v1.45.0"
+)
+
 type RedisOperator struct {
 	k8s         addon.K8SUtil
 	deployment  addon.DeploymentUtil
@@ -386,6 +390,10 @@ func (ro *RedisOperator) convertRedis(svc apistructs.Service, affinity *corev1.A
 			"memory": resource.MustParse(
 				fmt.Sprintf("%dMi", int(svc.Resources.Mem))),
 		},
+	}
+	settings.Exporter = RedisExporter{
+		Enabled: true,
+		Image:   redisExporterImage,
 	}
 	settings.Image = svc.Image
 	settings.CustomConfig = []string{

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/redis/redis_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/erda-project/erda/apistructs"
+)
+
+func Test_convertRedis(t *testing.T) {
+	svc := apistructs.Service{
+		Env: map[string]string{
+			"DICE_ORG_ID": "1",
+		},
+		Image: "redis:6.2.10",
+		Resources: apistructs.Resources{
+			Cpu:    0.1,
+			Mem:    1024,
+			MaxCPU: 0.1,
+			MaxMem: 1024,
+		},
+	}
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{},
+	}
+	ro := &RedisOperator{
+		overcommit: &mockOverCommitUtil{},
+	}
+	redis := ro.convertRedis(svc, affinity)
+	assert.Equal(t, redisExporterImage, redis.Exporter.Image)
+	assert.Equal(t, "ignore-warnings ARM64-COW-BUG", redis.CustomConfig[0])
+}
+
+type mockOverCommitUtil struct{}
+
+func (m *mockOverCommitUtil) CPUOvercommit(limit float64) float64 {
+	return limit
+}
+
+func (m *mockOverCommitUtil) MemoryOvercommit(limit int) int {
+	return limit
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix redis addon deployed by operator missing exporter

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=438836&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that redis addon deployed by operator missing exporter（修复了redis通过operator部署后没有exporter的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that redis addon deployed by operator missing exporter            |
| 🇨🇳 中文    |     修复了redis通过operator部署后没有exporter的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
