### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/internal/apps/cmp/steve/proxy/proxy_store.go
+++ b/internal/apps/cmp/steve/proxy/proxy_store.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 
@@ -434,7 +433,7 @@ func (s *Store) Update(apiOp *types.APIRequest, schema *types.APISchema, params 
 	}
 
 	if apiOp.Method == http.MethodPatch {
-		bytes, err := ioutil.ReadAll(io.LimitReader(apiOp.Request.Body, 2<<20))
+		bytes, err := io.ReadAll(io.LimitReader(apiOp.Request.Body, 2<<20))
 		if err != nil {
 			return types.APIObject{}, err
 		}

--- a/internal/apps/dop/services/signauth/sign_auth.go
+++ b/internal/apps/dop/services/signauth/sign_auth.go
@@ -101,7 +101,7 @@ type urlEncodedSigner struct {
 }
 
 func (a *urlEncodedSigner) Sign() (string, error) {
-	bodyData, err := iol.ReadAll(a.r.Body)
+	bodyData, err := io.ReadAll(a.r.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/apps/dop/services/signauth/sign_auth.go
+++ b/internal/apps/dop/services/signauth/sign_auth.go
@@ -24,7 +24,7 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -101,7 +101,7 @@ type urlEncodedSigner struct {
 }
 
 func (a *urlEncodedSigner) Sign() (string, error) {
-	bodyData, err := ioutil.ReadAll(a.r.Body)
+	bodyData, err := iol.ReadAll(a.r.Body)
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +116,7 @@ func (a *urlEncodedSigner) Sign() (string, error) {
 	// 更新请求
 	values.Set("sign", sign)
 	bodyS := values.Encode()
-	a.r.Body = ioutil.NopCloser(bytes.NewBufferString(bodyS))
+	a.r.Body = io.NopCloser(bytes.NewBufferString(bodyS))
 	a.r.ContentLength = int64(len(bodyS))
 
 	return sign, nil
@@ -134,7 +134,7 @@ func (a *jsonSigner) Sign() (string, error) {
 
 	var dataS = "{}"
 	if a.r.Body != nil {
-		data, err := ioutil.ReadAll(a.r.Body)
+		data, err := io.ReadAll(a.r.Body)
 		if err != nil {
 			return "", err
 		}
@@ -152,7 +152,7 @@ func (a *jsonSigner) Sign() (string, error) {
 		"sign":   sign,
 	}
 	marshal, _ := json.Marshal(m)
-	a.r.Body = ioutil.NopCloser(bytes.NewBuffer(marshal))
+	a.r.Body = io.NopCloser(bytes.NewBuffer(marshal))
 	a.r.ContentLength = int64(len(marshal))
 
 	return sign, nil

--- a/internal/apps/msp/apm/browser/ipdb/ipdb.go
+++ b/internal/apps/msp/apm/browser/ipdb/ipdb.go
@@ -19,7 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 )
 
@@ -30,7 +30,7 @@ var (
 
 // NewLocator .
 func NewLocator(dataFile string) (loc *Locator, err error) {
-	data, err := ioutil.ReadFile(dataFile)
+	data, err := io.ReadFile(dataFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apps/msp/apm/browser/ipdb/ipdb.go
+++ b/internal/apps/msp/apm/browser/ipdb/ipdb.go
@@ -19,8 +19,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
 	"net"
+	"os"
 )
 
 var (

--- a/internal/apps/msp/apm/browser/ipdb/ipdb.go
+++ b/internal/apps/msp/apm/browser/ipdb/ipdb.go
@@ -19,7 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
+	"os"
 	"net"
 )
 
@@ -30,7 +30,7 @@ var (
 
 // NewLocator .
 func NewLocator(dataFile string) (loc *Locator, err error) {
-	data, err := io.ReadFile(dataFile)
+	data, err := os.ReadFile(dataFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/openapi/legacy/component-protocol/generate/gen_auto_register.go
+++ b/internal/core/openapi/legacy/component-protocol/generate/gen_auto_register.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -24,7 +23,7 @@ import (
 //go:generate go run gen_auto_register.go
 func main() {
 	var buf strings.Builder
-	fs, err := ioutil.ReadDir("../scenarios")
+	fs, err := os.ReadDir("../scenarios")
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +31,7 @@ func main() {
 	for _, f := range fs {
 		if f.IsDir() {
 			scenarioName := f.Name()
-			cs, err := ioutil.ReadDir("../scenarios/" + scenarioName + "/components")
+			cs, err := os.ReadDir("../scenarios/" + scenarioName + "/components")
 			if err != nil {
 				panic(err)
 			}
@@ -85,7 +84,7 @@ func main() {
 	buf.WriteString("\tvar protocols = map[string]string{\n")
 	for s := range comps {
 		buf.WriteString(fmt.Sprintf("\t\t\"%s\": `\n", s))
-		pData, err := ioutil.ReadFile("../scenarios/" + s + "/protocol.yml")
+		pData, err := os.ReadFile("../scenarios/" + s + "/protocol.yml")
 		if err != nil {
 			panic(err)
 		}

--- a/internal/pkg/dcos/dcos.go
+++ b/internal/pkg/dcos/dcos.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -40,7 +40,7 @@ func GetVersion(masterIP string) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -66,7 +66,7 @@ func GetApps(masterIP string) ([]map[string]interface{}, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func GetApp(masterIP, id string) (map[string]interface{}, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func PutApp(masterIP string, m map[string]interface{}) (string, error) {
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		return "", fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err = ioutil.ReadAll(res.Body)
+	b, err = io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -168,7 +168,7 @@ func RestartApp(masterIP, id string) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -203,7 +203,7 @@ func DeleteApp(masterIP, id string) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("malformed status code: %d", res.StatusCode)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/metrics/query/query.go
+++ b/internal/pkg/metrics/query/query.go
@@ -16,7 +16,7 @@ package query
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -81,7 +81,7 @@ func (client *queryClient) doAction(req *MetricQueryRequest, resp *MetricQueryRe
 }
 
 func marshalResponse(response *http.Response, resp *MetricQueryResponse) error {
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/cluster-agent/pkg/leaderelection/leaderelection.go
+++ b/internal/tools/cluster-agent/pkg/leaderelection/leaderelection.go
@@ -17,7 +17,6 @@ package leaderelection
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -131,7 +130,7 @@ func getNamespace() (string, error) {
 		return ns, nil
 	}
 
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns, nil
 		}

--- a/internal/tools/gittar/pkg/gc/gc.go
+++ b/internal/tools/gittar/pkg/gc/gc.go
@@ -16,7 +16,7 @@ package gc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -59,7 +59,7 @@ func ScheduledExecuteClean() {
 func repositoryClean() {
 	logrus.Infof("gc: start gc")
 	defer logrus.Infof("gc: end gc")
-	projectFileInfos, err := ioutil.ReadDir(repositoryRootAddr)
+	projectFileInfos, err := os.ReadDir(repositoryRootAddr)
 	if err != nil {
 		logrus.Errorf("gc: read dir %s error: %v", repositoryRootAddr, err)
 		return
@@ -71,7 +71,7 @@ func repositoryClean() {
 			continue
 		}
 		var projectPath = repositoryRootAddr + "/" + projectFileInfo.Name()
-		applicationFileInfos, err := ioutil.ReadDir(projectPath)
+		applicationFileInfos, err := os.ReadDir(projectPath)
 		if err != nil {
 			logrus.Errorf("gc: read dir %s error: %v", projectPath, err)
 			continue

--- a/internal/tools/gittar/pkg/util/http_test.go
+++ b/internal/tools/gittar/pkg/util/http_test.go
@@ -17,7 +17,6 @@ package util
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -31,6 +30,6 @@ func TestHandleRequest(t *testing.T) {
 	}
 	req.Header.Set("base64-encoded-request-body", "true")
 	HandleRequest(req)
-	b, _ := ioutil.ReadAll(req.Body)
+	b, _ := io.ReadAll(req.Body)
 	assert.Equal(t, "hello erda", string(b))
 }

--- a/internal/tools/monitor/common/ext.go
+++ b/internal/tools/monitor/common/ext.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/erda-project/erda-infra/providers/httpserver"
 	api "github.com/erda-project/erda/pkg/common/httpapi"
@@ -52,7 +51,7 @@ func (r *ExtResponse) ReadCloser(ctx httpserver.Context) io.ReadCloser {
 		})
 		r.status = api.InternalError.Status()
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(byts))
+	return io.NopCloser(bytes.NewBuffer(byts))
 }
 
 func (r *ExtResponse) Response(ctx httpserver.Context) httpserver.Response {

--- a/internal/tools/monitor/core/agent-injector/admission_review.go
+++ b/internal/tools/monitor/core/agent-injector/admission_review.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"strings"
@@ -120,7 +119,7 @@ func (p *provider) readAdmissionReview(rw http.ResponseWriter, r *http.Request) 
 	// read body
 	var body []byte
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			p.writeError(rw, http.StatusBadRequest, fmt.Sprintf("failed to read body: %s", err))
 			return nil

--- a/internal/tools/monitor/core/metric/query/chartmeta/files.go
+++ b/internal/tools/monitor/core/metric/query/chartmeta/files.go
@@ -17,7 +17,6 @@ package chartmeta
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,7 +139,7 @@ func readFile(file string, out interface{}) error {
 		if err != nil {
 			continue
 		}
-		byts, err := ioutil.ReadFile(file)
+		byts, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/monitor/core/storekit/clickhouse/table/creator/creator.go
+++ b/internal/tools/monitor/core/storekit/clickhouse/table/creator/creator.go
@@ -17,7 +17,7 @@ package creator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -111,7 +111,7 @@ func (p *provider) createTable(ctx context.Context, tableName, aliasTableName st
 		table.DatabaseNameKey, p.Cfg.Database,
 		table.TtlDaysNameKey, strconv.FormatInt(ttlDays, 10))
 
-	data, err := ioutil.ReadFile(p.Cfg.DDLTemplate)
+	data, err := os.ReadFile(p.Cfg.DDLTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %s", p.Cfg.DDLTemplate)
 	}

--- a/internal/tools/monitor/core/storekit/clickhouse/table/initializer/init.go
+++ b/internal/tools/monitor/core/storekit/clickhouse/table/initializer/init.go
@@ -17,7 +17,7 @@ package initializer
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -103,7 +103,7 @@ func (p *provider) extractTenantAndKey(table string, meta *loader.TableMeta, tab
 
 func (p *provider) executeDDLs(ddlFiles []ddlFile, replacer *strings.Replacer) error {
 	for _, file := range ddlFiles {
-		data, err := ioutil.ReadFile(file.Path)
+		data, err := os.ReadFile(file.Path)
 		if err != nil {
 			return fmt.Errorf("failed to read file: %s", file.Path)
 		}

--- a/internal/tools/monitor/core/storekit/elasticsearch/index/cleaner/provider.go
+++ b/internal/tools/monitor/core/storekit/elasticsearch/index/cleaner/provider.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -137,7 +137,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 
 	// rollover body for disk clean
 	if len(p.Cfg.DiskClean.RolloverBodyFile) > 0 {
-		body, err := ioutil.ReadFile(p.Cfg.DiskClean.RolloverBodyFile)
+		body, err := os.ReadFile(p.Cfg.DiskClean.RolloverBodyFile)
 		if err != nil {
 			return fmt.Errorf("failed to load rollover body file for disk clean: %s", err)
 		}

--- a/internal/tools/monitor/core/storekit/elasticsearch/index/initializer/init.go
+++ b/internal/tools/monitor/core/storekit/elasticsearch/index/initializer/init.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/olivere/elastic"
@@ -41,7 +41,7 @@ func (p *provider) initTemplates(ctx context.Context, client *elastic.Client, te
 		if len(t.Path) <= 0 {
 			return fmt.Errorf("template(%d).Path is unspecified", i)
 		}
-		template, err := ioutil.ReadFile(t.Path)
+		template, err := os.ReadFile(t.Path)
 		if err != nil {
 			return fmt.Errorf("failed to load template{%d, %q, %q}: %s", i, t.Name, t.Path, err)
 		}

--- a/internal/tools/monitor/core/storekit/elasticsearch/index/rollover/provider.go
+++ b/internal/tools/monitor/core/storekit/elasticsearch/index/rollover/provider.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -127,7 +127,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 }
 
 func (p *provider) loadRolloverBody() error {
-	body, err := ioutil.ReadFile(p.Cfg.BodyFile)
+	body, err := os.ReadFile(p.Cfg.BodyFile)
 	if err != nil {
 		return fmt.Errorf("failed to load rollover body file: %s", err)
 	}

--- a/internal/tools/monitor/extensions/loghub/index/manager/index_rollover.go
+++ b/internal/tools/monitor/extensions/loghub/index/manager/index_rollover.go
@@ -17,7 +17,7 @@ package manager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	cfgpkg "github.com/recallsong/go-utils/config"
 )
@@ -26,7 +26,7 @@ func (p *provider) loadRolloverBody() error {
 	if len(p.C.RolloverBodyFile) <= 0 {
 		return nil
 	}
-	body, err := ioutil.ReadFile(p.C.RolloverBodyFile)
+	body, err := os.ReadFile(p.C.RolloverBodyFile)
 	if err != nil {
 		return fmt.Errorf("fail to load index rollover file: %s", err)
 	}

--- a/internal/tools/monitor/extensions/loghub/index/manager/index_template.go
+++ b/internal/tools/monitor/extensions/loghub/index/manager/index_template.go
@@ -17,7 +17,7 @@ package manager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/olivere/elastic"
@@ -28,7 +28,7 @@ func (p *provider) setupIndexTemplate(client *elastic.Client) error {
 	if len(p.C.IndexTemplateName) <= 0 || len(p.C.IndexTemplateFile) <= 0 {
 		return nil
 	}
-	template, err := ioutil.ReadFile(p.C.IndexTemplateFile)
+	template, err := os.ReadFile(p.C.IndexTemplateFile)
 	if err != nil {
 		return fmt.Errorf("fail to load index template: %s", err)
 	}

--- a/internal/tools/orchestrator/hepa/common/wrapper/http_wrapper.go
+++ b/internal/tools/orchestrator/hepa/common/wrapper/http_wrapper.go
@@ -17,7 +17,7 @@ package wrapper
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -71,7 +71,7 @@ func DoRequest(client *http.Client, method, url string, body []byte, timeout int
 		return respBody, nil, errors.Wrap(err, "http client send request failed")
 	}
 	succ = true
-	respBody, err = ioutil.ReadAll(resp.Body)
+	respBody, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "read form response body failed")
 	}

--- a/internal/tools/pipeline/actionagent/agenttool/mv_test.go
+++ b/internal/tools/pipeline/actionagent/agenttool/mv_test.go
@@ -15,7 +15,6 @@
 package agenttool
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,10 +24,10 @@ import (
 func TestMv(t *testing.T) {
 	tmpDir := "/tmp"
 	tmpPrefix := "tmp"
-	sourceDir, err := ioutil.TempDir(tmpDir, tmpPrefix)
+	sourceDir, err := os.MkdirTemp(tmpDir, tmpPrefix)
 	assert.NoError(t, err)
 	defer os.RemoveAll(sourceDir)
-	destDir, err := ioutil.TempDir(tmpDir, tmpPrefix)
+	destDir, err := os.MkdirTemp(tmpDir, tmpPrefix)
 	assert.NoError(t, err)
 	defer os.RemoveAll(destDir)
 	err = Mv(sourceDir, destDir)

--- a/internal/tools/pipeline/actionagent/filewatch/watch.go
+++ b/internal/tools/pipeline/actionagent/filewatch/watch.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -89,11 +88,11 @@ func New(ctx context.Context) (*Watcher, error) {
 				// 全量处理
 				fullHandler, ok := w.fullFileHandlerMap[event.Name]
 				if ok {
-					content, err := ioutil.ReadFile(event.Name)
+					content, err := os.ReadFile(event.Name)
 					if err != nil {
 						continue
 					}
-					if err := fullHandler(ioutil.NopCloser(bytes.NewBuffer(content))); err != nil {
+					if err := fullHandler(io.NopCloser(bytes.NewBuffer(content))); err != nil {
 						logger.Printf("failed to handle file: %s, err: %v\n", event.Name, err)
 						continue
 					}

--- a/pkg/cloudstorage/minioclient/minioclient.go
+++ b/pkg/cloudstorage/minioclient/minioclient.go
@@ -16,7 +16,7 @@ package minioclient
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -80,7 +80,7 @@ func (c *MinioClient) DownloadFile(bucketName, objectName string) ([]byte, error
 		}
 	}()
 
-	data, err := ioutil.ReadAll(obj)
+	data, err := io.ReadAll(obj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudstorage/ossclient/ossclient.go
+++ b/pkg/cloudstorage/ossclient/ossclient.go
@@ -16,7 +16,6 @@ package ossclient
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
@@ -79,7 +78,7 @@ func (c *OssClient) DownloadFile(bucketName, objectName string) ([]byte, error) 
 	}
 
 	var data []byte
-	if data, err = ioutil.ReadAll(reader); err != nil {
+	if data, err = io.ReadAll(reader); err != nil {
 		return nil, err
 	}
 

--- a/pkg/common/httpapi/model.go
+++ b/pkg/common/httpapi/model.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -49,7 +48,7 @@ func (r *baseResponse) ReadCloser(httpserver.Context) io.ReadCloser {
 		})
 		r.status = InternalError.status
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(byts))
+	return io.NopCloser(bytes.NewBuffer(byts))
 }
 
 func setContentType(ctx httpserver.Context) {

--- a/pkg/database/sqllint/config.go
+++ b/pkg/database/sqllint/config.go
@@ -16,7 +16,7 @@ package sqllint
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -129,7 +129,7 @@ func LoadConfig(data []byte) (map[string]Config, error) {
 }
 
 func LoadConfigFromLocal(filename string) (map[string]Config, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to ReadFile: %s", filename)
 	}

--- a/pkg/database/sqlparser/migrator/script.go
+++ b/pkg/database/sqlparser/migrator/script.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -59,7 +59,7 @@ type Script struct {
 
 // NewScript read the local file, parse data as SQL AST nodes, and mark script IsBase or not
 func NewScript(workdir, pathFromRepoRoot string) (*Script, error) {
-	data, err := ioutil.ReadFile(filepath.Join(workdir, pathFromRepoRoot))
+	data, err := os.ReadFile(filepath.Join(workdir, pathFromRepoRoot))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to ReadFile")
 	}

--- a/pkg/database/sqlparser/migrator/scripts.go
+++ b/pkg/database/sqlparser/migrator/scripts.go
@@ -17,7 +17,6 @@ package migrator
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,7 +71,7 @@ func NewScripts(parameters ScriptsParameters) (*Scripts, error) {
 		services     = make(map[string]*Module, 0)
 	)
 	dirname := filepath.Join(parameters.Workdir(), parameters.MigrationDir())
-	modulesInfos, err := ioutil.ReadDir(dirname)
+	modulesInfos, err := os.ReadDir(dirname)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to ReadDir %s", dirname)
 	}
@@ -99,7 +98,7 @@ func NewScripts(parameters ScriptsParameters) (*Scripts, error) {
 		modulesNames = append(modulesNames, moduleInfo.Name())
 
 		dirname := filepath.Join(parameters.Workdir(), parameters.MigrationDir(), moduleInfo.Name())
-		serviceDirInfos, err := ioutil.ReadDir(dirname)
+		serviceDirInfos, err := os.ReadDir(dirname)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to ReadDir %s", dirname)
 		}
@@ -111,7 +110,7 @@ func NewScripts(parameters ScriptsParameters) (*Scripts, error) {
 
 			// read requirements.txt
 			if strings.EqualFold(fileInfo.Name(), pygrator.RequirementsFilename) {
-				module.PythonRequirementsText, err = ioutil.ReadFile(filepath.Join(parameters.Workdir(), parameters.MigrationDir(), moduleInfo.Name(), fileInfo.Name()))
+				module.PythonRequirementsText, err = os.ReadFile(filepath.Join(parameters.Workdir(), parameters.MigrationDir(), moduleInfo.Name(), fileInfo.Name()))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/encoding/jsonpath/jackson.go
+++ b/pkg/encoding/jsonpath/jackson.go
@@ -16,7 +16,6 @@ package jsonpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -28,7 +27,7 @@ const JacksonExpressPrefix = "$."
 
 // use jackson-path command to parse json
 func Jackson(jsonInput, filter string) (interface{}, error) {
-	f, err := ioutil.TempFile("", "input")
+	f, err := os.CreateTemp("", "input")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/encoding/jsonpath/jq.go
+++ b/pkg/encoding/jsonpath/jq.go
@@ -17,14 +17,13 @@ package jsonpath
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 )
 
 func JQ(jsonInput, filter string) (interface{}, error) {
-	f, err := ioutil.TempFile("", "input")
+	f, err := os.CreateTemp("", "input")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,7 +17,6 @@ package helm
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -332,7 +331,7 @@ func (c *Client) AddOrUpdateRepo(repoEntry *repo.Entry) error {
 		}()
 	}
 
-	rfContent, err := ioutil.ReadFile(rfPath)
+	rfContent, err := os.ReadFile(rfPath)
 	if err != nil {
 		return fmt.Errorf("repo file read error, path: %s, error: %v", rfPath, err)
 	}

--- a/pkg/http/httpclient/request.go
+++ b/pkg/http/httpclient/request.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -135,7 +134,7 @@ func dupRequest(req *http.Request) (*http.Request, *http.Request, error) {
 	var bodybuf []byte
 	if req.Body != nil {
 		var err error
-		bodybuf, err = ioutil.ReadAll(req.Body)
+		bodybuf, err = io.ReadAll(req.Body)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -212,7 +211,7 @@ func (r AfterDo) JSON(o interface{}) (*Response, error) {
 
 	// check content-type before decode body
 	contentType := resp.Header.Get("Content-Type")
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +274,7 @@ func (r AfterDo) DiscardBody() (*Response, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	return &Response{
 		internal: resp,
 	}, nil

--- a/pkg/http/httpclient/request_test.go
+++ b/pkg/http/httpclient/request_test.go
@@ -16,7 +16,7 @@ package httpclient
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -177,7 +177,7 @@ func TestWriteBody(t *testing.T) {
 	if err := writeBody(w, &resp); err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(w)
+	data, err := io.ReadAll(w)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/http/httpclient/trace.go
+++ b/pkg/http/httpclient/trace.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -42,12 +41,12 @@ func (t *DefaultTracer) TraceRequest(req *http.Request) {
 }
 
 func (t *DefaultTracer) TraceResponse(r *http.Response) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		io.WriteString(t.w, fmt.Sprintf("TraceResponse: read response body fail: %v", err))
 		return
 	}
 	r.Body.Close()
 	io.WriteString(t.w, fmt.Sprintf("ResponseBody: %s\n", string(body)))
-	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+	r.Body = io.NopCloser(bytes.NewReader(body))
 }

--- a/pkg/i18n/locale_loader.go
+++ b/pkg/i18n/locale_loader.go
@@ -16,7 +16,7 @@ package i18n
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -50,7 +50,7 @@ func (loader *LocaleResourceLoader) addResource(locale string, keys map[string]s
 
 func (loader *LocaleResourceLoader) LoadFile(fileList ...string) error {
 	for _, filePath := range fileList {
-		resourceBytes, err := ioutil.ReadFile(filePath)
+		resourceBytes, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func (loader *LocaleResourceLoader) LoadFile(fileList ...string) error {
 }
 
 func (loader *LocaleResourceLoader) LoadDir(dir string) error {
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/httpstream/spdy/roundtripper.go
+++ b/pkg/k8s/httpstream/spdy/roundtripper.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -308,7 +307,7 @@ func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connec
 	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
 		defer resp.Body.Close()
 		responseError := ""
-		responseErrorBytes, err := ioutil.ReadAll(resp.Body)
+		responseErrorBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			responseError = "unable to read error from server response"
 		} else {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -16,13 +16,12 @@ package license
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestParseLicense(t *testing.T) {
-	bytes, err := ioutil.ReadFile("license.json")
+	bytes, err := os.ReadFile("license.json")
 	if err != nil {
 		panic(err)
 	}
@@ -30,7 +29,7 @@ func TestParseLicense(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	ioutil.WriteFile("license_key.txt", []byte(licenseKey), os.ModePerm)
+	os.WriteFile("license_key.txt", []byte(licenseKey), os.ModePerm)
 	println(licenseKey)
 	license, err := ParseLicense(licenseKey)
 	if err != nil {

--- a/pkg/swagger/oas3/expand_schema_test.go
+++ b/pkg/swagger/oas3/expand_schema_test.go
@@ -15,7 +15,7 @@
 package oas3_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/erda-project/erda/pkg/swagger/oas3"
@@ -23,7 +23,7 @@ import (
 
 func TestExpandSchemaRef2(t *testing.T) {
 	filename := "./testdata/dop-all.yaml"
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("failed to ReadFile: %v", err)
 	}

--- a/pkg/swagger/oas3/expand_test.go
+++ b/pkg/swagger/oas3/expand_test.go
@@ -16,14 +16,14 @@ package oas3_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/erda-project/erda/pkg/swagger/oas3"
 )
 
 func TestToYaml(t *testing.T) {
-	data, err := ioutil.ReadFile("./testdata/gaia-oas3.json")
+	data, err := os.ReadFile("./testdata/gaia-oas3.json")
 	if err != nil {
 		t.Error(err)
 	}
@@ -113,7 +113,7 @@ func TestToYaml(t *testing.T) {
 
 // go test -v -run TestExpandAllOf
 func TestExpandAllOf(t *testing.T) {
-	data, err := ioutil.ReadFile("./testdata/allof-oas3.json")
+	data, err := os.ReadFile("./testdata/allof-oas3.json")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/swagger/oasconv/oasconv_test.go
+++ b/pkg/swagger/oasconv/oasconv_test.go
@@ -15,7 +15,7 @@
 package oasconv_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ func TestOAS2ConvTo3(t *testing.T) {
 }
 
 func testOas2ConvertTo3WithBasePath(t *testing.T) {
-	data, err := ioutil.ReadFile(oas2WithBasePath)
+	data, err := os.ReadFile(oas2WithBasePath)
 	if err != nil {
 		t.Fatalf("failed to ReadFile, filename: %s, err: %v", oas2WithBasePath, err)
 	}

--- a/tools/cli/utils/dicedir.go
+++ b/tools/cli/utils/dicedir.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -215,7 +214,7 @@ func mkProjErdaDirPath(path string) string {
 
 func ListDir(dir string) ([]string, error) {
 	var files []string
-	fileInfos, err := ioutil.ReadDir(dir)
+	fileInfos, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cli/utils/format.go
+++ b/tools/cli/utils/format.go
@@ -16,7 +16,7 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -81,7 +81,7 @@ func ReadYml(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s", path)
 	}
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s", path)
 	}

--- a/tools/cli/utils/workspace.go
+++ b/tools/cli/utils/workspace.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -70,7 +69,7 @@ func IsWorkspaceDirty(dir string) (bool, error) {
 
 func GetWorkspacePipelines(dir string) ([]string, error) {
 	var ymls []string
-	fs, err := ioutil.ReadDir(dir)
+	fs, err := os.ReadDir(dir)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/tools/gotools/go-copyright/main.go
+++ b/tools/gotools/go-copyright/main.go
@@ -20,7 +20,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -93,7 +92,7 @@ func checkCopyright() ([]string, error) {
 }
 
 func checkFile(filename string) (bool, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return false, err
 	}
@@ -140,7 +139,7 @@ func isGenerated(fset *token.FileSet, file *ast.File) bool {
 
 func loadIgnoreFiles() []string {
 	const cfgfile = ".licenserc.json"
-	byts, err := ioutil.ReadFile(cfgfile)
+	byts, err := os.ReadFile(cfgfile)
 	if err != nil {
 		return nil
 	}

--- a/tools/gotools/go-imports-order/main.go
+++ b/tools/gotools/go-imports-order/main.go
@@ -19,7 +19,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -73,7 +72,7 @@ func checkAllFiles() ([]string, error) {
 }
 
 func checkFile(filename string) (bool, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return false, err
 	}

--- a/tools/gotools/go-test-sum/cover/profile.go
+++ b/tools/gotools/go-test-sum/cover/profile.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -162,5 +161,5 @@ func Write(filename string, mode string, profiles []*Profile) error {
 			buf.WriteString(fmt.Sprintf("%s:%d.%d,%d.%d %d %d\n", p.FileName, b.StartLine, b.StartCol, b.EndLine, b.EndCol, b.NumStmt, b.Count))
 		}
 	}
-	return ioutil.WriteFile(filename, buf.Bytes(), os.ModePerm)
+	return os.WriteFile(filename, buf.Bytes(), os.ModePerm)
 }

--- a/tools/gotools/go-test-sum/main.go
+++ b/tools/gotools/go-test-sum/main.go
@@ -23,7 +23,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -162,7 +161,7 @@ func testAllPackages(base string) error {
 		buf := make([]byte, 8)
 		hash := md5.New()
 		for _, file := range info.files {
-			byts, err := ioutil.ReadFile(file.path)
+			byts, err := os.ReadFile(file.path)
 			if err != nil {
 				return err
 			}
@@ -299,7 +298,7 @@ type testSumItem struct {
 }
 
 func readTestSum() map[string]*testSumItem {
-	byts, err := ioutil.ReadFile(testSumFilename)
+	byts, err := os.ReadFile(testSumFilename)
 	if err != nil {
 		return nil
 	}
@@ -342,7 +341,7 @@ func writeTestSum(testSum map[string]*testSumItem) error {
 		sum := testSum[key]
 		buf.WriteString(fmt.Sprintf("%s %s %s\n", sum.pkg, sum.hash, sum.testTime.Format(time.RFC3339Nano)))
 	}
-	return ioutil.WriteFile(testSumFilename, buf.Bytes(), os.ModePerm)
+	return os.WriteFile(testSumFilename, buf.Bytes(), os.ModePerm)
 }
 
 func readBasePath() (string, error) {
@@ -350,7 +349,7 @@ func readBasePath() (string, error) {
 }
 
 func readBasePathFromDir(dir string) (string, error) {
-	mod, err := ioutil.ReadFile(filepath.Join(dir, "go.mod"))
+	mod, err := os.ReadFile(filepath.Join(dir, "go.mod"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     remove refs to deprecated io/ioutil         |
| 🇨🇳 中文    |      删除对已弃用的 io/ioutil 的引用        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
