### PR TITLE
feat: change default org audit retention days to 30

### DIFF
--- a/internal/core/legacy/conf/conf.go
+++ b/internal/core/legacy/conf/conf.go
@@ -71,10 +71,11 @@ type Conf struct {
 	// --- 文件管理 end ---
 
 	// audit
-	AuditCleanCron           string `env:"AUDIT_CLEAN_CRON" default:"0 0 3 * * ?"`     // audit soft delete cron
-	AuditArchiveCron         string `env:"AUDIT_ARCHIVE_CRON" default:"0 0 4 * * ?"`   // audit archive cron
-	SysAuditCleanInterval    int    `env:"SYS_AUDIT_CLEAN_INTERVAL" default:"-7"`      // sys audit clean interval
-	OrgAuditMaxRetentionDays uint64 `env:"ORG_AUDIT_MAX_RETENTION_DAYS" default:"180"` // org level audit max retention days
+	AuditCleanCron               string `env:"AUDIT_CLEAN_CRON" default:"0 0 3 * * ?"`        // audit soft delete cron
+	AuditArchiveCron             string `env:"AUDIT_ARCHIVE_CRON" default:"0 0 4 * * ?"`      // audit archive cron
+	SysAuditCleanInterval        int    `env:"SYS_AUDIT_CLEAN_INTERVAL" default:"-7"`         // sys audit clean interval
+	OrgAuditMaxRetentionDays     uint64 `env:"ORG_AUDIT_MAX_RETENTION_DAYS" default:"180"`    // org level audit max retention days
+	OrgAuditDefaultRetentionDays uint64 `env:"ORG_AUDIT_DEFAULT_RETENTION_DAYS" default:"30"` // org level audit default retention days
 
 	// erda-configs
 	ErdaConfigsBasePath string `env:"ERDA_CONFIGS_BASE_PATH" default:"common-conf/erda-configs"`
@@ -375,6 +376,10 @@ func CreateOrgEnabled() bool {
 
 func OrgAuditMaxRetentionDays() uint64 {
 	return cfg.OrgAuditMaxRetentionDays
+}
+
+func OrgAuditDefaultRetentionDays() uint64 {
+	return cfg.OrgAuditDefaultRetentionDays
 }
 
 func SubscribeLimitNum() uint64 {

--- a/internal/core/legacy/dao/audit.go
+++ b/internal/core/legacy/dao/audit.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jinzhu/gorm"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/core/legacy/conf"
 	"github.com/erda-project/erda/internal/core/legacy/model"
 )
 
@@ -133,7 +134,7 @@ func (client *DBClient) InitOrgAuditInterval(orgIDs []uint64) error {
 
 	for _, v := range orgs {
 		config := &v.Config
-		config.AuditInterval = -7
+		config.AuditInterval = int64(-conf.OrgAuditDefaultRetentionDays())
 		cfg, err := json.Marshal(config)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### What this PR does / why we need it:
change default org audit retention days to 30

#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Optimize change default org audit retention days to 30（将企业审计日志默认保留时间调整为30天）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Optimize change default org audit retention days to 30         |
| 🇨🇳 中文    |     将企业审计日志默认保留时间调整为30天         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
