### PR TITLE
fix: failed to render project namespace on cmp

### DIFF
--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
@@ -185,7 +185,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 			Label: name,
 			Value: name,
 		}
-		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
+		if suf, ok := hasSuffix(name); ok && cputil2.IsProjectNamespace(name) {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
 				continue

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-events-list/filter/render.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,15 +27,13 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/apps/cmp"
 	cputil2 "github.com/erda-project/erda/internal/apps/cmp/component-protocol/cputil"
 	"github.com/erda-project/erda/internal/apps/cmp/component-protocol/types"
-	"github.com/erda-project/erda/pkg/http/httpclient"
-
-	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"
 )
 
 func init() {
@@ -196,7 +193,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 			id := splits[1]
 			num, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				logrus.Errorf("failed to parse project id %s from namespace %s, %v", id, name, err)
+				logrus.Warnf("failed to parse project id %s from namespace %s, %v", id, name, err)
 				continue
 			}
 
@@ -297,23 +294,6 @@ func (f *ComponentFilter) Transfer(component *cptype.Component) {
 		"filter__urlQuery": f.State.FilterURLQuery,
 	}
 	component.Operations = f.Operations
-}
-
-func (f *ComponentFilter) getDisplayName(name string) (string, error) {
-	splits := strings.Split(name, "-")
-	if len(splits) != 3 {
-		return "", errors.New("invalid name")
-	}
-	id := splits[1]
-	num, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		return "", err
-	}
-	project, err := f.bdl.GetProjectWithSetter(uint64(num), httpclient.SetParams(url.Values{"withQuota": {"true"}}))
-	if err != nil {
-		return "", err
-	}
-	return project.DisplayName, nil
 }
 
 func hasSuffix(name string) (string, bool) {

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFilter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFilter/render.go
@@ -153,7 +153,7 @@ func (f *ComponentAddPodFilter) SetComponentValue(ctx context.Context) error {
 			Label: name,
 			Value: name,
 		}
-		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
+		if suf, ok := hasSuffix(name); ok && cputil2.IsProjectNamespace(name) {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
 				continue

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFilter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/addPodFilter/render.go
@@ -161,7 +161,7 @@ func (f *ComponentAddPodFilter) SetComponentValue(ctx context.Context) error {
 			id := splits[1]
 			num, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				logrus.Errorf("failed to parse project id %s from namespace %s, %v", id, name, err)
+				logrus.Warnf("failed to parse project id %s from namespace %s, %v", id, name, err)
 				continue
 			}
 

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
@@ -177,7 +177,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 			Label: name,
 			Value: name,
 		}
-		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
+		if suf, ok := hasSuffix(name); ok && cputil2.IsProjectNamespace(name) {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
 				continue

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"
@@ -179,12 +180,14 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
-				return errors.New("invalid name")
+				continue
 			}
+
 			id := splits[1]
 			num, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				return errors.Errorf("failed to parse project id %s, %v", id, err)
+				logrus.Warnf("failed to parse project id %s from namespace %s, %v", id, name, err)
+				continue
 			}
 
 			displayName, ok := projectID2displayName[uint64(num)]

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render_test.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-pods/filter/render_test.go
@@ -15,11 +15,21 @@
 package filter
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"testing"
 
+	"bou.ke/monkey"
+	"github.com/rancher/apiserver/pkg/types"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+	"github.com/erda-project/erda-infra/providers/component-protocol/protobuf/proto-go/cp/pb"
+	i18n2 "github.com/erda-project/erda-infra/providers/i18n"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/internal/apps/cmp"
 	"github.com/erda-project/erda/internal/apps/cmp/component-protocol/cputil"
 )
 
@@ -204,4 +214,61 @@ func TestHasSuffix(t *testing.T) {
 	if ok {
 		t.Error("test failed, expected to not have suffix, actual do")
 	}
+}
+
+// Mocking the GetAllNamespacesFromCache function
+func mockGetAllNamespacesFromCache(context.Context, cmp.SteveServer, string, string, string) ([]string, error) {
+	return []string{
+		"project-test", "project-dev", "project-x-prod",
+		"project-1-dev", "project-1-test", "project-1-staging", "project-2-prod",
+		"group-addon-kafka--va2f089955c034f91831fad04a87db39c",
+		"pipeline-1044864799342689",
+		"erda-system", "kube-system", "default",
+	}, nil
+}
+
+// Mocking the GetAllProjectsDisplayNameFromCache function
+func mockGetAllProjectsDisplayNameFromCache(bdl *bundle.Bundle, orgID string) (map[uint64]string, error) {
+	return map[uint64]string{
+		1: "Project 1",
+		2: "Project 2",
+	}, nil
+}
+
+type mockSteveServer struct {
+	cmp.SteveServer
+}
+
+func (s *mockSteveServer) ListSteveResource(context.Context, *apistructs.SteveRequest) ([]types.APIObject, error) {
+	return []types.APIObject{}, nil
+}
+
+func TestSetComponentValue(t *testing.T) {
+	filter := &ComponentFilter{
+		sdk: &cptype.SDK{
+			Lang: make([]*i18n2.LanguageCode, 0),
+			Tran: &i18n2.NopTranslator{},
+			Identity: &pb.IdentityInfo{
+				UserID: "fake-user-id",
+				OrgID:  "fake-org-id",
+			},
+			InParams: map[string]interface{}{
+				"clusterName": "local-cluster",
+			},
+		},
+		server: &mockSteveServer{},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, cptype.GlobalInnerKeyCtxSDK, filter.sdk)
+
+	monkey.Patch(cputil.GetAllNamespacesFromCache, mockGetAllNamespacesFromCache)
+	monkey.Patch(cputil.GetAllProjectsDisplayNameFromCache, mockGetAllProjectsDisplayNameFromCache)
+	defer monkey.UnpatchAll()
+
+	// Call the function to test
+	err := filter.SetComponentValue(ctx)
+
+	// Assertions
+	assert.NoError(t, err)
 }

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/addWorkloadFilter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/addWorkloadFilter/render.go
@@ -161,7 +161,7 @@ func (f *ComponentAddWorkloadFilter) SetComponentValue(ctx context.Context) erro
 			id := splits[1]
 			num, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				logrus.Errorf("failed to parse project id %s from namespace %s, %v", id, name, err)
+				logrus.Warnf("failed to parse project id %s from namespace %s, %v", id, name, err)
 				continue
 			}
 

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/addWorkloadFilter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/addWorkloadFilter/render.go
@@ -153,7 +153,7 @@ func (f *ComponentAddWorkloadFilter) SetComponentValue(ctx context.Context) erro
 			Label: name,
 			Value: name,
 		}
-		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
+		if suf, ok := hasSuffix(name); ok && cputil2.IsProjectNamespace(name) {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
 				continue

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
@@ -174,7 +174,7 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 			Label: name,
 			Value: name,
 		}
-		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
+		if suf, ok := hasSuffix(name); ok && cputil2.IsProjectNamespace(name) {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
 				continue

--- a/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
+++ b/internal/apps/cmp/component-protocol/components/cmp-dashboard-workloads-list/filter/render.go
@@ -19,12 +19,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/component-protocol/cpregister/base"
@@ -34,7 +34,6 @@ import (
 	"github.com/erda-project/erda/internal/apps/cmp"
 	cputil2 "github.com/erda-project/erda/internal/apps/cmp/component-protocol/cputil"
 	"github.com/erda-project/erda/internal/apps/cmp/component-protocol/types"
-	"github.com/erda-project/erda/pkg/http/httpclient"
 )
 
 func init() {
@@ -178,12 +177,13 @@ func (f *ComponentFilter) SetComponentValue(ctx context.Context) error {
 		if suf, ok := hasSuffix(name); ok && strings.HasPrefix(name, "project-") {
 			splits := strings.Split(name, "-")
 			if len(splits) != 3 {
-				return errors.New("invalid name")
+				continue
 			}
 			id := splits[1]
 			num, err := strconv.ParseInt(id, 10, 64)
 			if err != nil {
-				return errors.Errorf("failed to parse project id %s, %v", id, err)
+				logrus.Warnf("failed to parse project id %s from namespace %s, %v", id, name, err)
+				continue
 			}
 
 			displayName, ok := projectID2displayName[uint64(num)]
@@ -349,21 +349,4 @@ func hasSuffix(name string) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func (f *ComponentFilter) getDisplayName(name string) (string, error) {
-	splits := strings.Split(name, "-")
-	if len(splits) != 3 {
-		return "", errors.New("invalid name")
-	}
-	id := splits[1]
-	num, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		return "", err
-	}
-	project, err := f.bdl.GetProjectWithSetter(uint64(num), httpclient.SetParams(url.Values{"withQuota": {"true"}}))
-	if err != nil {
-		return "", err
-	}
-	return project.DisplayName, nil
 }

--- a/internal/apps/cmp/component-protocol/cputil/util.go
+++ b/internal/apps/cmp/component-protocol/cputil/util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,10 @@ import (
 	"github.com/erda-project/erda/internal/core/org"
 	"github.com/erda-project/erda/pkg/k8sclient"
 	"github.com/erda-project/erda/pkg/k8sclient/scheme"
+)
+
+var (
+	projectNamespacePattern = regexp.MustCompile(`^project-\d+-(dev|test|staging|prod)$`)
 )
 
 // ParseWorkloadStatus get status for workloads from .metadata.fields
@@ -500,4 +505,8 @@ func CheckPermission(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func IsProjectNamespace(namespace string) bool {
+	return projectNamespacePattern.MatchString(namespace)
 }

--- a/internal/apps/cmp/component-protocol/cputil/util_test.go
+++ b/internal/apps/cmp/component-protocol/cputil/util_test.go
@@ -21,6 +21,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/rancher/wrangler/pkg/data"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	cppb "github.com/erda-project/erda-infra/providers/component-protocol/protobuf/proto-go/cp/pb"
@@ -428,5 +429,30 @@ func TestCheckPermission(t *testing.T) {
 				t.Log(err)
 			}
 		})
+	}
+}
+
+func TestIsProjectNamespace(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		// Test cases with valid project namespaces
+		{input: "project-123-dev", expected: true},
+		{input: "project-456-test", expected: true},
+		{input: "project-789-staging", expected: true},
+		{input: "project-1000-prod", expected: true},
+
+		// Test cases with invalid project namespaces
+		{input: "project-xyz-dev", expected: false},
+		{input: "project-123-production", expected: false},
+		{input: "invalid-format", expected: false},
+		{input: "project-123-unknown", expected: false},
+		{input: "", expected: false},
+	}
+
+	for _, tc := range testCases {
+		actual := IsProjectNamespace(tc.input)
+		assert.Equal(t, tc.expected, actual, "Input: %s", tc.input)
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
1. failed to render project namespace on cmp
2. cleanup unuse code
<img width="1361" alt="image" src="https://github.com/erda-project/erda/assets/31346321/e0a39db4-fe79-4da0-aa0b-ffb21bf51fa1">

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | failed to render project namespace on cmp             |
| 🇨🇳 中文    |  cmp 渲染项目级 namespace 失败             |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
