### PR TITLE
feat: make project delivery management report basic provider

### DIFF
--- a/apistructs/issue.go
+++ b/apistructs/issue.go
@@ -1159,8 +1159,9 @@ type IssueTestCaseRelationsListRequest struct {
 
 // IssueManHourSumRequest 事件下所有的任务总和请求
 type IssuesStageRequest struct {
-	StatisticRange string `json:"statisticRange"` //事件类型 项目/迭代
-	RangeID        int64  `json:"rangeId"`        //项目id/迭代id
+	StatisticRange string  `json:"statisticRange"` //事件类型 项目/迭代
+	RangeID        int64   `json:"rangeId"`        //项目id/迭代id
+	StateIDS       []int64 `json:"stateIds"`       // state id list
 }
 
 // IssueManHourSumResponse 事件下所有的任务总和响应
@@ -1172,7 +1173,8 @@ type IssueManHourSumResponse struct {
 	ImplementManHour int64 `json:"implementManHour"`
 	DeployManHour    int64 `json:"deployManHour"`
 	OperatorManHour  int64 `json:"operatorManHour"`
-	SumManHour       int64 `json:"sumManHour"`
+	SumElapsedTime   int64 `json:"sumElapsedTime"`
+	SumEstimateTime  int64 `json:"sumEstimateTime"`
 }
 
 // IssueBugPercentageResponse 缺陷率响应

--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -23,6 +23,9 @@ health:
 component-protocol:
 openapi-component-protocol:
 
+prometheus:
+  router_label_enable: false
+
 i18n:
   common: # core-services
     - conf/i18n/cs-i18n.yml # core-services
@@ -279,7 +282,7 @@ uc-adaptor:
 dop: { }
 erda.core.dop.taskerror: { }
 erda.dop.qa.unittest: { }
-project-report: { }
+project-management-report: { }
 erda.dop.search: { }
 # pipeline cms
 grpc-client@erda.core.pipeline.cms:

--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -279,6 +279,7 @@ uc-adaptor:
 dop: { }
 erda.core.dop.taskerror: { }
 erda.dop.qa.unittest: { }
+project-report: { }
 erda.dop.search: { }
 # pipeline cms
 grpc-client@erda.core.pipeline.cms:
@@ -393,6 +394,8 @@ logs-index-query:
     file: conf/msp/logs/default_field_settings.yml
 etcd-election@msp:
   root_path: "/msp-election"
+etcd-election@project-management-report:
+  root_path: "/project-management-report-election"
 cassandra:
   _enable: ${CASSANDRA_ENABLE:false}
   host: "${CASSANDRA_ADDR:localhost:9042}"

--- a/cmd/erda-server/main.go
+++ b/cmd/erda-server/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/erda-project/erda/internal/apps/gallery"
 
 	// pkg
+	_ "github.com/erda-project/erda-infra/providers/prometheus"
 	_ "github.com/erda-project/erda/internal/pkg/audit"
 	_ "github.com/erda-project/erda/internal/pkg/dingtalktest"
 	_ "github.com/erda-project/erda/internal/pkg/profileagent"

--- a/cmd/erda-server/main.go
+++ b/cmd/erda-server/main.go
@@ -142,6 +142,7 @@ import (
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/issue/sync"
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/pipelinetemplate"
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/project/home"
+	_ "github.com/erda-project/erda/internal/apps/dop/providers/project_report"
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/projectpipeline"
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/publishitem"
 	_ "github.com/erda-project/erda/internal/apps/dop/providers/queue"

--- a/cmd/monitor/collector/bootstrap.yaml
+++ b/cmd/monitor/collector/bootstrap.yaml
@@ -69,7 +69,7 @@ erda.oap.collector.receiver.dummy:
 erda.oap.collector.receiver.prometheus-remote-write@prometheus:
 
 erda.oap.collector.receiver.prometheus-remote-write@external_metrics:
-  remote_write_url: "${EXTERNAL_METRIC_REMOTE_WRITE_URL:/api/v1/external-remote-write}"
+  remote_write_url: "${EXTERNAL_METRIC_REMOTE_WRITE_URL:/api/v1/external-prometheus-remote-write}"
 
 erda.oap.collector.receiver.jaeger:
 

--- a/cmd/monitor/collector/bootstrap.yaml
+++ b/cmd/monitor/collector/bootstrap.yaml
@@ -69,7 +69,7 @@ erda.oap.collector.receiver.dummy:
 erda.oap.collector.receiver.prometheus-remote-write@prometheus:
 
 erda.oap.collector.receiver.prometheus-remote-write@external_metrics:
-  remote_write_url: "${EXTERNAL_METRIC_REMOTE_WRITE_URL:/api/v1/external-prometheus-remote-write}"
+  remote_write_url: "${EXTERNAL_METRIC_REMOTE_WRITE_URL:/api/v1/external-remote-write}"
 
 erda.oap.collector.receiver.jaeger:
 

--- a/internal/apps/dop/providers/issue/dao/issue_relation.go
+++ b/internal/apps/dop/providers/issue/dao/issue_relation.go
@@ -15,6 +15,8 @@
 package dao
 
 import (
+	"fmt"
+
 	"github.com/jinzhu/gorm"
 
 	"github.com/erda-project/erda/apistructs"
@@ -158,4 +160,24 @@ func (client *DBClient) IssueChildrenCount(issueIDs []uint64, relationType []str
 
 func (client *DBClient) BatchCreateIssueRelations(issueRels []IssueRelation) error {
 	return client.BulkInsert(issueRels)
+}
+
+// GetRequirementInclusionTaskNum get the number of requirements associated with the task in this iteration
+func (client *DBClient) GetRequirementInclusionTaskNum(iterationID uint64) (uint64, error) {
+	var count uint64
+	if err := client.Table("dice_issue_relation").Select("distinct(issue_id)").Where(fmt.Sprintf("issue_id in (select id from dice_issues where iteration_id='%d' and type='REQUIREMENT') and type='inclusion'", iterationID)).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// GetTaskConnRequirementNum get the number of tasks associated with the requirement in this iteration
+func (client *DBClient) GetTaskConnRequirementNum(iterationID uint64) (uint64, error) {
+	var count uint64
+	if err := client.Table("dice_issue_relation").Select("distinct(related_issue)").Where(fmt.Sprintf("related_issue in (select id from dice_issues where iteration_id='%d' and type='TASK') and type='inclusion'", iterationID)).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }

--- a/internal/apps/dop/providers/project_report/cache.go
+++ b/internal/apps/dop/providers/project_report/cache.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"strconv"
+
+	"github.com/patrickmn/go-cache"
+
+	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
+	"github.com/erda-project/erda/internal/core/legacy/model"
+)
+
+type orgCache struct {
+	*cache.Cache
+}
+
+func (o *orgCache) Get(key uint64) *orgpb.Org {
+	org, ok := o.Cache.Get(strconv.FormatUint(key, 10))
+	if !ok {
+		return nil
+	}
+	return org.(*orgpb.Org)
+}
+
+func (o *orgCache) Set(key uint64, orgDto *orgpb.Org) {
+	o.Cache.Set(strconv.FormatUint(key, 10), orgDto, cache.NoExpiration)
+}
+
+type projectCache struct {
+	*cache.Cache
+}
+
+func (p *projectCache) Get(key int64) *model.Project {
+	projectDto, ok := p.Cache.Get(strconv.FormatInt(key, 10))
+	if !ok {
+		return nil
+	}
+	return projectDto.(*model.Project)
+}
+
+func (p *projectCache) Set(key int64, projectDto *model.Project) {
+	p.Cache.Set(strconv.FormatInt(key, 10), projectDto, cache.NoExpiration)
+}
+
+type iterationCache struct {
+	*cache.Cache
+}
+
+func (i *iterationCache) Get(key uint64) *IterationInfo {
+	iter, ok := i.Cache.Get(strconv.FormatUint(key, 10))
+	if !ok {
+		return nil
+	}
+	return iter.(*IterationInfo)
+}
+
+func (i *iterationCache) Set(key uint64, iter *IterationInfo) {
+	i.Cache.Set(strconv.FormatUint(key, 10), iter, cache.NoExpiration)
+}
+
+func (i *iterationCache) Iterate(fn func(k string, v interface{}) error) {
+	for k, v := range i.Cache.Items() {
+		if err := fn(k, v.Object); err != nil {
+			return
+		}
+	}
+}

--- a/internal/apps/dop/providers/project_report/calculate.go
+++ b/internal/apps/dop/providers/project_report/calculate.go
@@ -16,115 +16,280 @@ package project_report
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"time"
 
 	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
-	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
+	issuepb "github.com/erda-project/erda-proto-go/dop/issue/core/pb"
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/internal/pkg/metrics/report"
-	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rutil"
 )
 
-func (p *provider) doReportMetricTask(ctx context.Context) {
-	rutil.ContinueWorking(ctx, p.Log, func(ctx context.Context) rutil.WaitDuration {
-		// analyzed snippet and non-snippet pipeline database gc
-		p.DoReportMetricForAllProjects(ctx)
-
-		return rutil.ContinueWorkingWithDefaultInterval
-	}, rutil.WithContinueWorkingDefaultRetryInterval(p.Cfg.ProjectReportMetricDuration))
-}
-
-func (p *provider) DoReportMetricForAllProjects(ctx context.Context) {
-	_, orgs, err := p.Org.ListOrgs(ctx, []int64{}, &orgpb.ListOrgRequest{
+func (p *provider) refreshBasicIterations() error {
+	_, orgs, err := p.Org.ListOrgs(context.Background(), []int64{}, &orgpb.ListOrgRequest{
 		PageNo:   1,
 		PageSize: 9999,
 	}, true)
 	if err != nil {
 		p.Log.Errorf("failed to get all orgs, err: %v", err)
-		return
+		return err
 	}
-	allOrgs := make(map[uint64]*orgpb.Org)
-	for _, org := range orgs {
-		allOrgs[org.ID] = org
+	for i := range orgs {
+		p.orgSet.Set(orgs[i].ID, orgs[i])
 	}
-	projects, err := p.bdl.GetAllProjects()
+
+	projects, err := p.projDB.GetAllProjects()
 	if err != nil {
 		p.Log.Errorf("failed to get all projects, err: %v", err)
-		return
+		return err
 	}
-	for _, projectDto := range projects {
-		orgDto, ok := allOrgs[projectDto.OrgID]
-		if !ok {
+	for i := range projects {
+		p.projectSet.Set(projects[i].ID, &projects[i])
+	}
+	iterations, _, err := p.iterationDB.PagingIterations(apistructs.IterationPagingRequest{
+		PageNo:   1,
+		PageSize: 99999,
+	})
+	if err != nil {
+		p.Log.Errorf("failed to get all iterations, err: %v", err)
+		return err
+	}
+
+	for i := range iterations {
+		projectDto := p.projectSet.Get(int64(iterations[i].ProjectID))
+		if projectDto == nil {
+			p.Log.Errorf("failed to find project for iteration, iterationID: %d, projectID: %d",
+				iterations[i].ID, iterations[i].ProjectID)
+			continue
+		}
+		orgDto := p.orgSet.Get(uint64(projectDto.OrgID))
+		if orgDto == nil {
 			p.Log.Errorf("failed to find org for project: %s, projectID: %d, orgID: %d",
 				projectDto.Name, projectDto.ID, projectDto.OrgID)
 			continue
 		}
-		numberFields, err := p.CalculateProjectMetrics(projectDto.ID)
-		if err != nil {
-			p.Log.Errorf("failed to calculate project metrics for project: %s, projectID: %d, err: %v",
-				projectDto.Name, projectDto.ID, err)
-			continue
+		labels, _ := p.getIterationLabelDetails(iterations[i].ID)
+		if iter := p.iterationSet.Get(iterations[i].ID); iter != nil {
+			iter.Iteration = &iterations[i]
+			iter.Labels = labels
+		} else {
+			p.iterationSet.Set(iterations[i].ID, &IterationInfo{
+				Iteration:  &iterations[i],
+				ProjectDto: projectDto,
+				OrgDto:     orgDto,
+				Labels:     labels,
+			})
 		}
-		_, _, metricLabels := generateProjectMetricLabels(&projectDto, orgDto)
-		if err := p.ReportClient.Send([]*report.Metric{{
-			Name:      metricGroupName,
-			Timestamp: time.Now().UnixNano(),
-			Tags:      metricLabels,
-			Fields:    numberFields,
-		}}); err != nil {
-			p.Log.Errorf("failed to push project project metrics, projectID: %d, err: %v", projectDto.ID, err)
-			continue
-		}
-		p.Log.Infof("success to push project metrics, projectName: %s, projectID: %d", projectDto.Name, projectDto.ID)
 	}
+
+	return nil
 }
 
-func (p *provider) CalculateProjectMetrics(projectID uint64) (map[string]interface{}, error) {
-	fields := make(map[string]interface{})
+func (p *provider) getIterationLabelDetails(iterationID uint64) ([]string, []apistructs.ProjectLabel) {
+	lrs, _ := p.iterationDB.GetLabelRelationsByRef(apistructs.LabelTypeIteration, strconv.FormatUint(iterationID, 10))
+	labelIDs := make([]uint64, 0, len(lrs))
+	for _, v := range lrs {
+		labelIDs = append(labelIDs, v.LabelID)
+	}
+	var labelNames []string
+	var labels []apistructs.ProjectLabel
+	labels, _ = p.bdl.ListLabelByIDs(labelIDs)
+	labelNames = make([]string, 0, len(labels))
+	for _, v := range labels {
+		labelNames = append(labelNames, v.Name)
+	}
+	return labelNames, labels
+}
 
-	requirementTotal, err := p.getRequirementTotalNum(projectID)
+func (p *provider) metricFieldsEtcdKey(iterID uint64) string {
+	return p.Cfg.IterationMetricEtcdPrefixKey + strconv.FormatUint(iterID, 10)
+}
+
+func (p *provider) checkIterationNumberFields() {
+	p.iterationSet.Iterate(func(key string, value interface{}) error {
+		iter := value.(*IterationInfo)
+		if iter.IterationMetricFields == nil || !iter.IterationMetricFields.IsValid() {
+			fields, err := p.getIterationFields(iter)
+			if err != nil {
+				p.Log.Errorf("failed to generate iteration fields, iterationID: %d, err: %v", iter.Iteration.ID, err)
+				return nil
+			}
+			iter.IterationMetricFields = fields
+		}
+		return nil
+	})
+}
+
+func (p *provider) getIterationFields(iter *IterationInfo) (*IterationMetricFields, error) {
+	if iter.IterationMetricFields != nil && iter.IterationMetricFields.IsValid() {
+		return iter.IterationMetricFields, nil
+	}
+
+	fields := &IterationMetricFields{}
+	if err := p.Js.Get(context.Background(), p.metricFieldsEtcdKey(iter.Iteration.ID), fields); err == nil && fields.IsValid() {
+		return fields, nil
+	}
+
+	if !p.Election.IsLeader() {
+		return nil, nil
+	}
+
+	fields, err := p.calIterationFields(iter)
 	if err != nil {
 		return nil, err
 	}
-	fields[TotalRequirementNum] = requirementTotal
+	p.Js.Put(context.Background(), p.metricFieldsEtcdKey(iter.Iteration.ID), fields)
+	return fields, nil
+}
 
-	taskTotal, err := p.getTaskTotalNum(projectID)
+func (p *provider) calIterationFields(iter *IterationInfo) (*IterationMetricFields, error) {
+	fields := &IterationMetricFields{
+		CalculatedAt: time.Now(),
+	}
+	var doneReqStateIDS []int64
+	doneReqStates, err := p.issueDB.GetIssuesStatesByTypes(&apistructs.IssueStatesRequest{
+		ProjectID: iter.Iteration.ProjectID,
+		IssueType: []apistructs.IssueType{apistructs.IssueTypeRequirement},
+		StateBelongs: []apistructs.IssueStateBelong{
+			apistructs.IssueStateBelongDone,
+			apistructs.IssueStateBelongClosed,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
-	fields[TotalTaskNum] = taskTotal
+	for i := range doneReqStates {
+		doneReqStateIDS = append(doneReqStateIDS, int64(doneReqStates[i].ID))
+	}
+
+	var doneTaskStateIDS []int64
+	doneTaskStates, err := p.issueDB.GetIssuesStatesByTypes(&apistructs.IssueStatesRequest{
+		ProjectID: iter.Iteration.ProjectID,
+		IssueType: []apistructs.IssueType{apistructs.IssueTypeTask},
+		StateBelongs: []apistructs.IssueStateBelong{
+			apistructs.IssueStateBelongDone,
+			apistructs.IssueStateBelongClosed,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range doneTaskStates {
+		doneTaskStateIDS = append(doneTaskStateIDS, int64(doneTaskStates[i].ID))
+	}
+
+	var doneBugStateIDS []int64
+	doneBugStates, err := p.issueDB.GetIssuesStatesByTypes(&apistructs.IssueStatesRequest{
+		ProjectID: iter.Iteration.ProjectID,
+		IssueType: []apistructs.IssueType{apistructs.IssueTypeBug},
+		StateBelongs: []apistructs.IssueStateBelong{
+			apistructs.IssueStateBelongClosed,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range doneBugStates {
+		doneBugStateIDS = append(doneBugStateIDS, int64(doneBugStates[i].ID))
+	}
+
+	iterationSummary := p.issueDB.GetIssueSummary(int64(iter.Iteration.ID), doneTaskStateIDS, doneBugStateIDS, doneReqStateIDS)
+
+	fields.TaskTotal = uint64(iterationSummary.Task.UnDone + iterationSummary.Task.Done)
+	fields.RequirementTotal = uint64(iterationSummary.Requirement.UnDone + iterationSummary.Requirement.Done)
+	requirementInclusionTaskNum, err := p.issueDB.GetRequirementInclusionTaskNum(iter.Iteration.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	totalTaskEstimateTime, err := p.issueDB.GetTaskIssueManHourSum(
+		apistructs.IssuesStageRequest{
+			StatisticRange: "iteration",
+			RangeID:        int64(iter.Iteration.ID),
+		})
+	if err != nil {
+		return nil, err
+	}
+	fields.TaskEstimatedMinute = uint64(totalTaskEstimateTime.SumEstimateTime)
+
+	if fields.RequirementTotal > 0 {
+		fields.RequirementCompleteSchedule = float64(iterationSummary.Requirement.Done) / float64(fields.RequirementTotal)
+		fields.RequirementAssociatedPercent = float64(requirementInclusionTaskNum) / float64(fields.RequirementTotal)
+	}
+	taskBeInclusionReqNum, err := p.issueDB.GetTaskConnRequirementNum(iter.Iteration.ID)
+	if err != nil {
+		return nil, err
+	}
+	haveUndoneTaskAssigneeNum, err := p.issueDB.GetHaveUndoneTaskAssigneeNum(iter.Iteration.ID, doneTaskStateIDS)
+	if err != nil {
+		return nil, err
+	}
+	fields.IterationAssigneeNum = haveUndoneTaskAssigneeNum
+	if fields.TaskTotal > 0 {
+		fields.TaskCompleteSchedule = float64(iterationSummary.Task.Done) / float64(fields.TaskTotal)
+		fields.TaskAssociatedPercent = float64(taskBeInclusionReqNum) / float64(fields.TaskTotal)
+	}
+
+	fields.BugTotal = uint64(iterationSummary.Bug.UnDone + iterationSummary.Bug.Done)
+	seriousBugNum, err := p.issueDB.GetSeriousBugNum(iter.Iteration.ID)
+	if err != nil {
+		return nil, err
+	}
+	demandDesignBugNum, err := p.issueDB.GetDemandDesignBugNum(iter.Iteration.ID)
+	if err != nil {
+		return nil, err
+	}
+	_, reopenBugNum, err := p.issueDB.PagingIssues(issuepb.PagingIssueRequest{
+		ProjectID:    iter.Iteration.ProjectID,
+		IterationID:  int64(iter.Iteration.ID),
+		Type:         []string{apistructs.IssueTypeBug.String()},
+		StateBelongs: []string{string(apistructs.IssueStateBelongReopen)},
+	}, true)
+	if fields.BugTotal > 0 {
+		fields.BugCompleteSchedule = float64(iterationSummary.Bug.Done) / float64(fields.BugTotal)
+		fields.SeriousBugPercent = float64(seriousBugNum) / float64(fields.BugTotal)
+		fields.DemandDesignBugPercent = float64(demandDesignBugNum) / float64(fields.BugTotal)
+		fields.ReopenBugPercent = float64(reopenBugNum) / float64(fields.BugTotal)
+	}
+
+	doneTaskElapsedMinute, err := p.issueDB.GetTaskIssueManHourSum(
+		apistructs.IssuesStageRequest{
+			StatisticRange: "iteration",
+			RangeID:        int64(iter.Iteration.ID),
+			StateIDS:       doneTaskStateIDS,
+		})
+	if err != nil {
+		return nil, err
+	}
+	fields.TaskElapsedMinute = uint64(doneTaskElapsedMinute.SumElapsedTime)
 
 	return fields, nil
 }
 
-// getRequirementTotalNum get requirement issue total num for all states of the project
-func (p *provider) getRequirementTotalNum(projectID uint64) (uint64, error) {
-	_, requirementTotal, err := p.IssueSvc.Paging(pb.PagingIssueRequest{
-		ProjectID: projectID,
-		Type: []string{
-			apistructs.IssueTypeRequirement.String(),
-		},
-		External: true,
-	})
-	if err != nil {
-		return 0, err
+func (p *provider) iterationLabelsFunc(iter *IterationInfo) map[string]string {
+	labels := map[string]string{
+		labelIterationID:    strconv.FormatUint(iter.Iteration.ID, 10),
+		labelProjectID:      strconv.FormatUint(iter.Iteration.ProjectID, 10),
+		labelIterationTitle: iter.Iteration.Title,
 	}
-
-	return requirementTotal, nil
-}
-
-// getTaskTotalNum task type issue total num for all states of the project
-func (p *provider) getTaskTotalNum(projectID uint64) (uint64, error) {
-	_, taskTotal, err := p.IssueSvc.Paging(pb.PagingIssueRequest{
-		ProjectID: projectID,
-		Type: []string{
-			apistructs.IssueTypeTask.String(),
-		},
-		External: true,
-	})
-	if err != nil {
-		return 0, err
+	for i := range iter.Labels {
+		label := iter.Labels[i]
+		splitLabel := strings.Split(label, ":")
+		if len(splitLabel) != 2 {
+			continue
+		}
+		labels[splitLabel[0]] = splitLabel[1]
 	}
-
-	return taskTotal, nil
+	projectDto := p.projectSet.Get(int64(iter.Iteration.ProjectID))
+	if projectDto == nil {
+		return labels
+	}
+	labels[labelProjectName] = projectDto.Name
+	labels[labelOrgID] = strconv.FormatInt(projectDto.OrgID, 10)
+	orgDto := p.orgSet.Get(uint64(projectDto.OrgID))
+	if orgDto == nil {
+		return labels
+	}
+	labels[labelOrgName] = orgDto.Name
+	return labels
 }

--- a/internal/apps/dop/providers/project_report/calculate.go
+++ b/internal/apps/dop/providers/project_report/calculate.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"context"
+	"time"
+
+	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
+	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/internal/pkg/metrics/report"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rutil"
+)
+
+func (p *provider) doReportMetricTask(ctx context.Context) {
+	rutil.ContinueWorking(ctx, p.Log, func(ctx context.Context) rutil.WaitDuration {
+		// analyzed snippet and non-snippet pipeline database gc
+		p.DoReportMetricForAllProjects(ctx)
+
+		return rutil.ContinueWorkingWithDefaultInterval
+	}, rutil.WithContinueWorkingDefaultRetryInterval(p.Cfg.ProjectReportMetricDuration))
+}
+
+func (p *provider) DoReportMetricForAllProjects(ctx context.Context) {
+	_, orgs, err := p.Org.ListOrgs(ctx, []int64{}, &orgpb.ListOrgRequest{
+		PageNo:   1,
+		PageSize: 9999,
+	}, true)
+	if err != nil {
+		p.Log.Errorf("failed to get all orgs, err: %v", err)
+		return
+	}
+	allOrgs := make(map[uint64]*orgpb.Org)
+	for _, org := range orgs {
+		allOrgs[org.ID] = org
+	}
+	projects, err := p.bdl.GetAllProjects()
+	if err != nil {
+		p.Log.Errorf("failed to get all projects, err: %v", err)
+		return
+	}
+	for _, projectDto := range projects {
+		orgDto, ok := allOrgs[projectDto.OrgID]
+		if !ok {
+			p.Log.Errorf("failed to find org for project: %s, projectID: %d, orgID: %d",
+				projectDto.Name, projectDto.ID, projectDto.OrgID)
+			continue
+		}
+		numberFields, err := p.CalculateProjectMetrics(projectDto.ID)
+		if err != nil {
+			p.Log.Errorf("failed to calculate project metrics for project: %s, projectID: %d, err: %v",
+				projectDto.Name, projectDto.ID, err)
+			continue
+		}
+		_, _, metricLabels := generateProjectMetricLabels(&projectDto, orgDto)
+		if err := p.ReportClient.Send([]*report.Metric{{
+			Name:      metricGroupName,
+			Timestamp: time.Now().UnixNano(),
+			Tags:      metricLabels,
+			Fields:    numberFields,
+		}}); err != nil {
+			p.Log.Errorf("failed to push project project metrics, projectID: %d, err: %v", projectDto.ID, err)
+			continue
+		}
+		p.Log.Infof("success to push project metrics, projectName: %s, projectID: %d", projectDto.Name, projectDto.ID)
+	}
+}
+
+func (p *provider) CalculateProjectMetrics(projectID uint64) (map[string]interface{}, error) {
+	fields := make(map[string]interface{})
+
+	requirementTotal, err := p.getRequirementTotalNum(projectID)
+	if err != nil {
+		return nil, err
+	}
+	fields[TotalRequirementNum] = requirementTotal
+
+	taskTotal, err := p.getTaskTotalNum(projectID)
+	if err != nil {
+		return nil, err
+	}
+	fields[TotalTaskNum] = taskTotal
+
+	return fields, nil
+}
+
+// getRequirementTotalNum get requirement issue total num for all states of the project
+func (p *provider) getRequirementTotalNum(projectID uint64) (uint64, error) {
+	_, requirementTotal, err := p.IssueSvc.Paging(pb.PagingIssueRequest{
+		ProjectID: projectID,
+		Type: []string{
+			apistructs.IssueTypeRequirement.String(),
+		},
+		External: true,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return requirementTotal, nil
+}
+
+// getTaskTotalNum task type issue total num for all states of the project
+func (p *provider) getTaskTotalNum(projectID uint64) (uint64, error) {
+	_, taskTotal, err := p.IssueSvc.Paging(pb.PagingIssueRequest{
+		ProjectID: projectID,
+		Type: []string{
+			apistructs.IssueTypeTask.String(),
+		},
+		External: true,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return taskTotal, nil
+}

--- a/internal/apps/dop/providers/project_report/calculate_test.go
+++ b/internal/apps/dop/providers/project_report/calculate_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
+	"github.com/erda-project/erda/pkg/mock"
+)
+
+func Test_getRequirementTotalNum(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	issueService := mock.NewMockIssueQuery(ctrl)
+	issueService.EXPECT().Paging(gomock.Any()).AnyTimes().Return([]*pb.Issue{{Id: 1}}, uint64(1), nil)
+	p := &provider{
+		IssueSvc: issueService,
+	}
+	total, err := p.getRequirementTotalNum(1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), total)
+}
+
+func Test_getTaskTotalNum(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	issueService := mock.NewMockIssueQuery(ctrl)
+	issueService.EXPECT().Paging(gomock.Any()).AnyTimes().Return([]*pb.Issue{{Id: 1}}, uint64(1), nil)
+	p := &provider{
+		IssueSvc: issueService,
+	}
+	total, err := p.getTaskTotalNum(1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), total)
+}

--- a/internal/apps/dop/providers/project_report/metrics.go
+++ b/internal/apps/dop/providers/project_report/metrics.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"sort"
+	"strconv"
+
+	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
+	"github.com/erda-project/erda/apistructs"
+)
+
+const (
+	metricGroupName = "project_delivery_report"
+)
+
+const (
+	labelOrgName = "org_name"
+
+	labelMeta          = "_meta"
+	labelMetricScope   = "_metric_scope"
+	labelMetricScopeID = "_metric_scope_id"
+)
+
+var (
+	// TotalRequirementNum requirement type issue total num for all statuses under the project
+	TotalRequirementNum = "total_requirement_num"
+	// TotalTaskNum task type issue total num for all statuses under the project
+	TotalTaskNum = "total_task_num"
+)
+
+func generateProjectMetricLabels(projectDto *apistructs.ProjectDTO, orgDto *orgpb.Org) ([]string, []string, map[string]string) {
+
+	metricLabelMap := map[string]string{
+		labelMeta:          "true",
+		labelMetricScope:   "org",
+		labelMetricScopeID: orgDto.Name,
+		labelOrgName:       orgDto.Name,
+		// tenant
+		apistructs.LabelOrgID:       strconv.FormatUint(projectDto.OrgID, 10),
+		apistructs.LabelOrgName:     orgDto.Name,
+		apistructs.LabelProjectID:   strconv.FormatUint(projectDto.ID, 10),
+		apistructs.LabelProjectName: projectDto.Name,
+	}
+
+	var metricsKeys []string
+	for k := range metricLabelMap {
+		metricsKeys = append(metricsKeys, k)
+	}
+	// the order of metricsKeys is guaranteed to be consistent,
+	// so that prometheus will not report an error
+	sort.Strings(metricsKeys)
+
+	var metricsValues []string
+	for _, k := range metricsKeys {
+		metricsValues = append(metricsValues, metricLabelMap[k])
+	}
+
+	return metricsKeys, metricsValues, metricLabelMap
+}

--- a/internal/apps/dop/providers/project_report/metrics.go
+++ b/internal/apps/dop/providers/project_report/metrics.go
@@ -15,58 +15,333 @@
 package project_report
 
 import (
-	"sort"
+	"regexp"
 	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
 	"github.com/erda-project/erda/apistructs"
+	iterationdb "github.com/erda-project/erda/internal/apps/dop/dao"
+	"github.com/erda-project/erda/internal/core/legacy/model"
 )
 
 const (
-	metricGroupName = "project_delivery_report"
+	metricGroupName = "project_management_report"
 )
 
 const (
-	labelOrgName = "org_name"
+	labelOrgName     = "org_name"
+	labelProjectName = "project_name"
 
-	labelMeta          = "_meta"
-	labelMetricScope   = "_metric_scope"
-	labelMetricScopeID = "_metric_scope_id"
+	labelMeta           = "_meta"
+	labelMetricScope    = "_metric_scope"
+	labelMetricScopeID  = "_metric_scope_id"
+	labelIterationID    = "iteration_id"
+	labelProjectID      = "project_id"
+	labelOrgID          = "org_id"
+	labelIterationTitle = "iteration_title"
 )
+
+type IterationInfo struct {
+	Iteration  *iterationdb.Iteration
+	OrgDto     *orgpb.Org
+	ProjectDto *model.Project
+	Labels     []string
+
+	IterationMetricFields *IterationMetricFields
+}
+
+type IterationMetricFields struct {
+	IterationID  uint64
+	CalculatedAt time.Time
+
+	// task-related metrics
+	TaskTotal             uint64
+	TaskEstimatedMinute   uint64
+	TaskElapsedMinute     uint64
+	TaskCompleteSchedule  float64
+	TaskAssociatedPercent float64
+
+	// requirement-related metrics
+	RequirementTotal             uint64
+	RequirementCompleteSchedule  float64
+	RequirementAssociatedPercent float64
+
+	// bug-related metrics
+	BugTotal               uint64
+	SeriousBugPercent      float64
+	DemandDesignBugPercent float64
+	ReopenBugPercent       float64
+	BugCompleteSchedule    float64
+
+	// iteration-related metrics
+	IterationAssigneeNum uint64
+}
+
+// IsValid returns true if the IterationMetricFields is valid.
+// we need to ensure that IterationMetricFields is the data of the day to avoid double calculation
+func (i *IterationMetricFields) IsValid() bool {
+	return i.CalculatedAt.Day() == time.Now().Day()
+}
 
 var (
-	// TotalRequirementNum requirement type issue total num for all statuses under the project
-	TotalRequirementNum = "total_requirement_num"
-	// TotalTaskNum task type issue total num for all statuses under the project
-	TotalTaskNum = "total_task_num"
+	allIterationMetrics = []iterationMetric{
+		{
+			name:      "iteration_task_total",
+			help:      "Cumulative task type issue iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = float64(iterationInfo.IterationMetricFields.TaskTotal)
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_requirement_total",
+			help:      "Cumulative requirement type issue iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = float64(iterationInfo.IterationMetricFields.RequirementTotal)
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_bug_total",
+			help:      "Cumulative bug type issue iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = float64(iterationInfo.IterationMetricFields.BugTotal)
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_task_estimated_minute",
+			help:      "Cumulative estimated minute of task type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value uint64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.TaskEstimatedMinute
+				}
+				return metricValues{
+					{
+						value:     float64(value),
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_task_elapsed_minute",
+			help:      "Cumulative elapsed minute of task type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value uint64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.TaskElapsedMinute
+				}
+				return metricValues{
+					{
+						value:     float64(value),
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_task_complete_schedule",
+			help:      "Cumulative complete schedule of task type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.TaskCompleteSchedule
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_task_associated_percent",
+			help:      "Accumulate the proportion of the number of requirements associated with the current task",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.TaskAssociatedPercent
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_requirement_complete_schedule",
+			help:      "Cumulative complete schedule of requirement type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.RequirementCompleteSchedule
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_requirement_associated_percent",
+			help:      "Accumulate the proportion of the number of requirements associated with the task",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.RequirementAssociatedPercent
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_serious_bug_percent",
+			help:      "Cumulative fatal/serious bug percent of bug type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.SeriousBugPercent
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_demand_design_bug_percent",
+			help:      "Cumulative demand/design bug percent of bug type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.DemandDesignBugPercent
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_reopen_bug_percent",
+			help:      "Cumulative reopen bug percent of bug type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.ReopenBugPercent
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_bug_complete_schedule",
+			help:      "Cumulative complete schedule of bug type issue in iteration.",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value float64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.BugCompleteSchedule
+				}
+				return metricValues{
+					{
+						value:     value,
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+		{
+			name:      "iteration_assignee_total",
+			help:      "The number of people who still have unfinished tasks in the project as of now",
+			valueType: prometheus.CounterValue,
+			getValues: func(iterationInfo *IterationInfo) metricValues {
+				var value uint64
+				if iterationInfo.IterationMetricFields != nil {
+					value = iterationInfo.IterationMetricFields.IterationAssigneeNum
+				}
+				return metricValues{
+					{
+						value:     float64(value),
+						timestamp: time.Now(),
+					},
+				}
+			},
+		},
+	}
 )
 
-func generateProjectMetricLabels(projectDto *apistructs.ProjectDTO, orgDto *orgpb.Org) ([]string, []string, map[string]string) {
+var invalidNameCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
-	metricLabelMap := map[string]string{
-		labelMeta:          "true",
-		labelMetricScope:   "org",
-		labelMetricScopeID: orgDto.Name,
-		labelOrgName:       orgDto.Name,
-		// tenant
-		apistructs.LabelOrgID:       strconv.FormatUint(projectDto.OrgID, 10),
-		apistructs.LabelOrgName:     orgDto.Name,
-		apistructs.LabelProjectID:   strconv.FormatUint(projectDto.ID, 10),
-		apistructs.LabelProjectName: projectDto.Name,
+// sanitizeLabelName replaces anything that doesn't match
+// client_label.LabelNameRE with an underscore.
+func sanitizeLabelName(name string) string {
+	return invalidNameCharRE.ReplaceAllString(name, "_")
+}
+
+func DefaultIterationLabels(iteration *apistructs.Iteration) map[string]string {
+	set := map[string]string{
+		labelIterationID:    strconv.FormatInt(iteration.ID, 10),
+		labelProjectID:      strconv.FormatUint(iteration.ProjectID, 10),
+		labelIterationTitle: iteration.Title,
 	}
-
-	var metricsKeys []string
-	for k := range metricLabelMap {
-		metricsKeys = append(metricsKeys, k)
-	}
-	// the order of metricsKeys is guaranteed to be consistent,
-	// so that prometheus will not report an error
-	sort.Strings(metricsKeys)
-
-	var metricsValues []string
-	for _, k := range metricsKeys {
-		metricsValues = append(metricsValues, metricLabelMap[k])
-	}
-
-	return metricsKeys, metricsValues, metricLabelMap
+	return set
 }

--- a/internal/apps/dop/providers/project_report/metrics_test.go
+++ b/internal/apps/dop/providers/project_report/metrics_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda-proto-go/core/org/pb"
+	"github.com/erda-project/erda/apistructs"
+)
+
+func Test_generateProjectMetricLabels(t *testing.T) {
+	projectDto := &apistructs.ProjectDTO{
+		ID:          1,
+		Name:        "project1",
+		OrgID:       1,
+		DisplayName: "project1",
+	}
+	orgDto := &pb.Org{
+		ID:          1,
+		Name:        "org1",
+		DisplayName: "org1",
+	}
+	keys, values, labels := generateProjectMetricLabels(projectDto, orgDto)
+	assert.Equal(t, 8, len(keys))
+	assert.Equal(t, 8, len(values))
+	assert.Equal(t, "org1", labels[labelOrgName])
+}

--- a/internal/apps/dop/providers/project_report/metrics_test.go
+++ b/internal/apps/dop/providers/project_report/metrics_test.go
@@ -16,27 +16,19 @@ package project_report
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/erda-project/erda-proto-go/core/org/pb"
-	"github.com/erda-project/erda/apistructs"
 )
 
-func Test_generateProjectMetricLabels(t *testing.T) {
-	projectDto := &apistructs.ProjectDTO{
-		ID:          1,
-		Name:        "project1",
-		OrgID:       1,
-		DisplayName: "project1",
+func TestIsValid(t *testing.T) {
+	validFields := &IterationMetricFields{
+		CalculatedAt: time.Now(),
 	}
-	orgDto := &pb.Org{
-		ID:          1,
-		Name:        "org1",
-		DisplayName: "org1",
+	assert.Equal(t, true, validFields.IsValid())
+
+	invalidFields := &IterationMetricFields{
+		CalculatedAt: time.Now().Add(-25 * time.Hour),
 	}
-	keys, values, labels := generateProjectMetricLabels(projectDto, orgDto)
-	assert.Equal(t, 8, len(keys))
-	assert.Equal(t, 8, len(values))
-	assert.Equal(t, "org1", labels[labelOrgName])
+	assert.Equal(t, false, invalidFields.IsValid())
 }

--- a/internal/apps/dop/providers/project_report/metrics_test.go
+++ b/internal/apps/dop/providers/project_report/metrics_test.go
@@ -32,3 +32,8 @@ func TestIsValid(t *testing.T) {
 	}
 	assert.Equal(t, false, invalidFields.IsValid())
 }
+
+func Test_sanitizeLabelName(t *testing.T) {
+	label := "erda-project-id"
+	assert.Equal(t, "erda_project_id", sanitizeLabelName(label))
+}

--- a/internal/apps/dop/providers/project_report/prometheus.go
+++ b/internal/apps/dop/providers/project_report/prometheus.go
@@ -105,10 +105,10 @@ func (c *PrometheusCollector) collectIterationInfo(ch chan<- prometheus.Metric) 
 
 		for _, im := range c.iterationMetrics {
 			desc := im.desc(labels)
-			for _, metricValue := range im.getValues(iter) {
+			for _, metricVal := range im.getValues(iter) {
 				ch <- prometheus.NewMetricWithTimestamp(
-					metricValue.timestamp,
-					prometheus.MustNewConstMetric(desc, im.valueType, float64(metricValue.value), append(values, metricValue.labels...)...),
+					metricVal.timestamp,
+					prometheus.MustNewConstMetric(desc, im.valueType, metricVal.value, append(values, metricVal.labels...)...),
 				)
 			}
 		}

--- a/internal/apps/dop/providers/project_report/prometheus_test.go
+++ b/internal/apps/dop/providers/project_report/prometheus_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"testing"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/erda-project/erda/internal/apps/dop/dao"
+	"github.com/erda-project/erda/pkg/database/dbengine"
+)
+
+type mockInfoProvider struct{}
+
+func (m *mockInfoProvider) GetRequestedIterationsInfo() (map[uint64]*IterationInfo, error) {
+	return map[uint64]*IterationInfo{
+		1: {
+			Iteration: &dao.Iteration{
+				BaseModel: dbengine.BaseModel{
+					ID: 1,
+				},
+				ProjectID: 1,
+			},
+			IterationMetricFields: &IterationMetricFields{
+				RequirementTotal:            2,
+				RequirementDoneTotal:        1,
+				RequirementCompleteSchedule: 0.5,
+			},
+		},
+	}, nil
+}
+
+func Test_collectIterationInfo(t *testing.T) {
+	p := &provider{
+		orgSet:       &orgCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+		projectSet:   &projectCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+		iterationSet: &iterationCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+	}
+	collector := &PrometheusCollector{
+		infoProvider:        &mockInfoProvider{},
+		iterationLabelsFunc: p.iterationLabelsFunc,
+		iterationMetrics:    allIterationMetrics,
+		errors: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "iteration",
+			Name:      "scrape_error",
+			Help:      "1 if there was an error while getting iteration metrics, 0 otherwise",
+		}),
+	}
+	ch := make(chan prometheus.Metric, 100)
+	defer close(ch)
+	go func() {
+		for m := range ch {
+			t.Log(m.Desc().String())
+		}
+	}()
+	collector.collectIterationInfo(ch)
+	time.Sleep(time.Second)
+}
+
+func TestDescribe(t *testing.T) {
+	p := &provider{
+		orgSet:       &orgCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+		projectSet:   &projectCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+		iterationSet: &iterationCache{cache.New(cache.NoExpiration, cache.NoExpiration)},
+	}
+	collector := &PrometheusCollector{
+		infoProvider:        &mockInfoProvider{},
+		iterationLabelsFunc: p.iterationLabelsFunc,
+		iterationMetrics:    allIterationMetrics,
+		errors: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "iteration",
+			Name:      "scrape_error",
+			Help:      "1 if there was an error while getting iteration metrics, 0 otherwise",
+		}),
+	}
+	ch := make(chan *prometheus.Desc, 100)
+	defer close(ch)
+	go func() {
+		for m := range ch {
+			t.Log(m.String())
+		}
+	}()
+	collector.Describe(ch)
+	time.Sleep(time.Second)
+}

--- a/internal/apps/dop/providers/project_report/provider.go
+++ b/internal/apps/dop/providers/project_report/provider.go
@@ -16,49 +16,136 @@ package project_report
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"time"
+
+	"github.com/patrickmn/go-cache"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
 	election "github.com/erda-project/erda-infra/providers/etcd-election"
 	"github.com/erda-project/erda/bundle"
+	iterationdb "github.com/erda-project/erda/internal/apps/dop/dao"
 	"github.com/erda-project/erda/internal/apps/dop/providers/issue/core/query"
+	issuedb "github.com/erda-project/erda/internal/apps/dop/providers/issue/dao"
+	"github.com/erda-project/erda/internal/core/legacy/dao"
 	"github.com/erda-project/erda/internal/core/org"
-	"github.com/erda-project/erda/internal/pkg/metrics/report"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rutil"
+	"github.com/erda-project/erda/pkg/database/dbengine"
+	"github.com/erda-project/erda/pkg/jsonstore"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 type config struct {
-	ProjectReportMetricDuration time.Duration `file:"project_report_metric_duration" env:"PROJECT_REPORT_METRIC_DURATION" default:"2h"`
+	RefreshBasicInfoDuration        time.Duration `file:"refresh_basic_info_duration" env:"REFRESH_BASIC_INFO_DURATION" default:"1h"`
+	RefreshCheckNumberFiledDuration time.Duration `file:"refresh_check_number_filed_duration" env:"REFRESH_CHECK_NUMBER_FILED_DURATION" default:"20m"`
+	IterationMetricEtcdPrefixKey    string        `file:"iteration_metric_etcd_prefix_key" env:"ITERATION_METRIC_ETCD_PREFIX_KEY" default:"/devops/metrics/iteration/"`
 }
 
 // +provider
 type provider struct {
-	Cfg *config
-	Log logs.Logger
-	bdl *bundle.Bundle
+	Cfg         *config
+	Log         logs.Logger
+	bdl         *bundle.Bundle
+	projDB      *dao.DBClient
+	issueDB     *issuedb.DBClient
+	iterationDB *iterationdb.DBClient
 
-	ReportClient report.MetricReport `autowired:"metric-report-client"`
-	Org          org.Interface
-	IssueSvc     query.Interface
-	Election     election.Interface `autowired:"etcd-election@project-management-report"`
+	Org      org.Interface
+	IssueSvc query.Interface
+	Election election.Interface `autowired:"etcd-election@project-management-report"`
+	Js       jsonstore.JsonStore
+
+	orgSet       *orgCache
+	projectSet   *projectCache
+	iterationSet *iterationCache
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
 	p.bdl = bundle.New(bundle.WithErdaServer())
+	js, err := jsonstore.New()
+	if err != nil {
+		return fmt.Errorf("failed to init jsonstore, err: %v", err)
+	}
+	p.Js = js
+	db, err := dao.NewDBClient()
+	if err != nil {
+		return err
+	}
+	p.projDB = db
+	p.issueDB = &issuedb.DBClient{
+		DBEngine: &dbengine.DBEngine{
+			DB: db.DB,
+		},
+	}
+	p.iterationDB = &iterationdb.DBClient{
+		DBEngine: &dbengine.DBEngine{
+			DB: db.DB,
+		},
+	}
+
+	prometheus.MustRegister(&PrometheusCollector{
+		infoProvider:        p,
+		iterationLabelsFunc: p.iterationLabelsFunc,
+		errors: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "iteration",
+			Name:      "scrape_error",
+			Help:      "1 if there was an error while getting iteration metrics, 0 otherwise",
+		}),
+		iterationMetrics: allIterationMetrics,
+	})
+	p.orgSet = &orgCache{cache.New(cache.NoExpiration, cache.NoExpiration)}
+	p.projectSet = &projectCache{cache.New(cache.NoExpiration, cache.NoExpiration)}
+	p.iterationSet = &iterationCache{cache.New(cache.NoExpiration, cache.NoExpiration)}
 	return nil
 }
 
 func (p *provider) Run(ctx context.Context) error {
-	p.Election.OnLeader(p.doReportMetricTask)
+	p.Start(ctx)
 	return nil
 }
 
+func (p *provider) Start(ctx context.Context) {
+	go func() {
+		rutil.ContinueWorking(ctx, p.Log, func(ctx context.Context) rutil.WaitDuration {
+			if err := p.refreshBasicIterations(); err != nil {
+				p.Log.Errorf("failed to refresh basic iterations, err: %v", err)
+				return rutil.ContinueWorkingWithCustomInterval(time.Minute)
+			}
+
+			return rutil.ContinueWorkingWithDefaultInterval
+		}, rutil.WithContinueWorkingDefaultRetryInterval(p.Cfg.RefreshBasicInfoDuration))
+	}()
+	go func() {
+		<-time.NewTimer(time.Duration(rand.Intn(10)) * time.Minute).C
+		rutil.ContinueWorking(ctx, p.Log, func(ctx context.Context) rutil.WaitDuration {
+			p.checkIterationNumberFields()
+
+			return rutil.ContinueWorkingWithDefaultInterval
+		}, rutil.WithContinueWorkingDefaultRetryInterval(p.Cfg.RefreshCheckNumberFiledDuration))
+	}()
+}
+
+func (p *provider) GetRequestedIterationsInfo() (map[uint64]*IterationInfo, error) {
+	result := make(map[uint64]*IterationInfo)
+	p.iterationSet.Iterate(func(key string, value interface{}) error {
+		iterationInfo := value.(*IterationInfo)
+		result[iterationInfo.Iteration.ID] = iterationInfo
+		return nil
+	})
+	return result, nil
+}
+
 func init() {
-	servicehub.Register("project-report", &servicehub.Spec{
-		Services:     []string{"project-report"},
-		Dependencies: []string{"metric-report-client"},
-		Description:  "project delivery management report",
-		ConfigFunc:   func() interface{} { return &config{} },
-		Creator:      func() servicehub.Provider { return &provider{} },
+	servicehub.Register("project-management-report", &servicehub.Spec{
+		Services:    []string{"project-management-report"},
+		Description: "project delivery management report",
+		ConfigFunc:  func() interface{} { return &config{} },
+		Creator:     func() servicehub.Provider { return &provider{} },
 	})
 }

--- a/internal/apps/dop/providers/project_report/provider.go
+++ b/internal/apps/dop/providers/project_report/provider.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_report
+
+import (
+	"context"
+	"time"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-infra/base/servicehub"
+	election "github.com/erda-project/erda-infra/providers/etcd-election"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/internal/apps/dop/providers/issue/core/query"
+	"github.com/erda-project/erda/internal/core/org"
+	"github.com/erda-project/erda/internal/pkg/metrics/report"
+)
+
+type config struct {
+	ProjectReportMetricDuration time.Duration `file:"project_report_metric_duration" env:"PROJECT_REPORT_METRIC_DURATION" default:"2h"`
+}
+
+// +provider
+type provider struct {
+	Cfg *config
+	Log logs.Logger
+	bdl *bundle.Bundle
+
+	ReportClient report.MetricReport `autowired:"metric-report-client"`
+	Org          org.Interface
+	IssueSvc     query.Interface
+	Election     election.Interface `autowired:"etcd-election@project-management-report"`
+}
+
+func (p *provider) Init(ctx servicehub.Context) error {
+	p.bdl = bundle.New(bundle.WithErdaServer())
+	return nil
+}
+
+func (p *provider) Run(ctx context.Context) error {
+	p.Election.OnLeader(p.doReportMetricTask)
+	return nil
+}
+
+func init() {
+	servicehub.Register("project-report", &servicehub.Spec{
+		Services:     []string{"project-report"},
+		Dependencies: []string{"metric-report-client"},
+		Description:  "project delivery management report",
+		ConfigFunc:   func() interface{} { return &config{} },
+		Creator:      func() servicehub.Provider { return &provider{} },
+	})
+}

--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/external_metric/external_metrics.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/external_metric/external_metrics.go
@@ -27,6 +27,8 @@ import (
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda/internal/tools/monitor/core/metric"
+	"github.com/erda-project/erda/internal/tools/monitor/core/settings/retention-strategy"
+	tablepkg "github.com/erda-project/erda/internal/tools/monitor/core/storekit/clickhouse/table"
 	"github.com/erda-project/erda/internal/tools/monitor/core/storekit/clickhouse/table/creator"
 	"github.com/erda-project/erda/internal/tools/monitor/core/storekit/clickhouse/table/loader"
 	"github.com/erda-project/erda/internal/tools/monitor/oap/collector/core/model/odata"
@@ -36,17 +38,19 @@ import (
 )
 
 const (
-	chTableCreator = "clickhouse.table.creator@external_metric"
-	chTableLoader  = "clickhouse.table.loader@external_metric"
+	chTableCreator   = "clickhouse.table.creator@external_metric"
+	chTableLoader    = "clickhouse.table.loader@external_metric"
+	chTableRetention = "storage-retention-strategy@external_metric"
 )
 
 type Builder struct {
-	logger  logs.Logger
-	client  clickhouse.Conn
-	Creator creator.Interface
-	Loader  loader.Interface
-	cfg     *builder.BuilderConfig
-	batchC  chan []*metric.Metric
+	logger    logs.Logger
+	client    clickhouse.Conn
+	Creator   creator.Interface
+	Loader    loader.Interface
+	Retention retention.Interface
+	cfg       *builder.BuilderConfig
+	batchC    chan []*metric.Metric
 }
 
 func (bu *Builder) BuildBatch(ctx context.Context, sourceBatch interface{}) ([]driver.Batch, error) {
@@ -78,6 +82,12 @@ func NewBuilder(ctx servicehub.Context, logger logs.Logger, cfg *builder.Builder
 		return nil, fmt.Errorf("service %q must existed", chTableCreator)
 	} else {
 		bu.Creator = svc
+	}
+
+	if svc, ok := ctx.Service(chTableRetention).(retention.Interface); !ok {
+		return nil, fmt.Errorf("service %q must existed", chTableRetention)
+	} else {
+		bu.Retention = svc
 	}
 
 	if svc, ok := ctx.Service(chTableLoader).(loader.Interface); !ok {
@@ -185,11 +195,17 @@ func (bu *Builder) buildBatches(ctx context.Context, items []*metric.Metric) ([]
 }
 
 func (bu *Builder) getOrCreateTenantTable(ctx context.Context, data *metric.Metric) (string, error) {
+	key := bu.Retention.GetConfigKey(data.Name, data.Tags)
+	ttl := bu.Retention.GetTTL(key)
 	var (
 		wait  <-chan error
 		table string
 	)
-	wait, table = bu.Creator.Ensure(ctx, data.Tags[lib.OrgNameKey], "", int64(time.Hour))
+	if len(key) > 0 {
+		wait, table = bu.Creator.Ensure(ctx, data.Tags[lib.OrgNameKey], key, tablepkg.FormatTTLToDays(ttl))
+	} else {
+		wait, table = bu.Creator.Ensure(ctx, data.Tags[lib.OrgNameKey], "", tablepkg.FormatTTLToDays(ttl))
+	}
 	if wait != nil {
 		select {
 		case <-wait: // ignore


### PR DESCRIPTION
#### What this PR does / why we need it:
project delivery management report basic provider
make prometheus collector for iteration
at present, the provider only collector iteration basic metrics for project

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=453638&iterationID=1841&type=TASK)


#### Specified Reviewers:

/assign @sfwn 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support make project delivery management report basic provider（实现项目交付报表基础指标采集的provider）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Support make project delivery management report basic provider           |
| 🇨🇳 中文    |    实现项目交付报表基础指标采集的provider          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
