### PR TITLE
fix: remove log-service startTime for msp restart

### DIFF
--- a/internal/apps/msp/apm/log-service/query/log.service.download.go
+++ b/internal/apps/msp/apm/log-service/query/log.service.download.go
@@ -94,16 +94,10 @@ func (p *provider) DownloadLogsFromMonitor(r *http.Request, w http.ResponseWrite
 	if len(expr) > 0 {
 		expr = fmt.Sprintf("(%s) AND", expr)
 	}
-	if start > p.logService.startTime {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			ToESQueryString())
-	} else if logKeys.Contains(logServiceKey) {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			Where(func(k LogKeyType, v StringList) bool { return k == logServiceKey }).
-			ToESQueryString())
-	} else {
+	if logKeys.IsEmpty() {
 		return nil
 	}
+	expr = fmt.Sprintf("%s (%s)", expr, logKeys.ToESQueryString())
 
 	maxReturn := params.MaxReturn
 	isDescendingOrder := !StringList(params.Sort).All(func(item string) bool { return strings.HasSuffix(item, " asc") })
@@ -158,7 +152,7 @@ func (p *provider) DownloadLogsFromMonitor(r *http.Request, w http.ResponseWrite
 }
 
 func (p *provider) DownloadLogsFromLoghub(r *http.Request, w http.ResponseWriter, params *LogDownloadRequest) error {
-	if p.Cfg.QueryLogESEnabled && params.Start*int64(time.Millisecond) > p.logService.startTime {
+	if p.Cfg.QueryLogESEnabled {
 		return nil
 	}
 

--- a/internal/apps/msp/apm/log-service/query/log.service.go
+++ b/internal/apps/msp/apm/log-service/query/log.service.go
@@ -35,7 +35,6 @@ type logService struct {
 	p               *provider
 	logDeploymentDB *db.LogDeploymentDB
 	logInstanceDB   *db.LogInstanceDB
-	startTime       int64
 }
 
 func (s *logService) HistogramAggregation(ctx context.Context, req *pb.HistogramAggregationRequest) (*pb.HistogramAggregationResponse, error) {

--- a/internal/apps/msp/apm/log-service/query/log.service.histogram.go
+++ b/internal/apps/msp/apm/log-service/query/log.service.histogram.go
@@ -46,16 +46,10 @@ func (s *logService) HistogramAggregationFromMonitor(ctx context.Context, req *p
 	if len(expr) > 0 {
 		expr = fmt.Sprintf("(%s) AND", expr)
 	}
-	if start > s.startTime {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			ToESQueryString())
-	} else if logKeys.Contains(logServiceKey) {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			Where(func(k LogKeyType, v StringList) bool { return k == logServiceKey }).
-			ToESQueryString())
-	} else {
+	if logKeys.IsEmpty() {
 		return nil, nil
 	}
+	expr = fmt.Sprintf("%s (%s)", expr, logKeys.ToESQueryString())
 
 	if req.TraceID != "" {
 		expr = fmt.Sprintf("%s AND trace_id:%s", expr, req.TraceID)
@@ -137,7 +131,7 @@ func (s *logService) HistogramAggregationFromMonitor(ctx context.Context, req *p
 }
 
 func (s *logService) HistogramAggregationFromLoghub(ctx context.Context, req *pb.HistogramAggregationRequest) (*pb.HistogramAggregationResponse, error) {
-	if s.p.Cfg.QueryLogESEnabled && req.Start*int64(time.Millisecond) > s.startTime {
+	if s.p.Cfg.QueryLogESEnabled {
 		return nil, nil
 	}
 

--- a/internal/apps/msp/apm/log-service/query/log.service.terms.go
+++ b/internal/apps/msp/apm/log-service/query/log.service.terms.go
@@ -44,16 +44,10 @@ func (s *logService) TermsAggregationFromMonitor(ctx context.Context, req *pb.Bu
 	if len(expr) > 0 {
 		expr = fmt.Sprintf("(%s) AND", expr)
 	}
-	if start > s.startTime {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			ToESQueryString())
-	} else if logKeys.Contains(logServiceKey) {
-		expr = fmt.Sprintf("%s (%s)", expr, logKeys.
-			Where(func(k LogKeyType, v StringList) bool { return k == logServiceKey }).
-			ToESQueryString())
-	} else {
+	if logKeys.IsEmpty() {
 		return nil, nil
 	}
+	expr = fmt.Sprintf("%s (%s)", expr, logKeys.ToESQueryString())
 
 	missing, _ := structpb.NewValue("null")
 	options := &monitorpb.TermsAggOptions{
@@ -116,7 +110,7 @@ func (s *logService) TermsAggregationFromMonitor(ctx context.Context, req *pb.Bu
 }
 
 func (s *logService) TermsAggregationFromLoghub(ctx context.Context, req *pb.BucketAggregationRequest) (*pb.BucketAggregationResponse, error) {
-	if s.p.Cfg.QueryLogESEnabled && req.Start*int64(time.Millisecond) > s.startTime {
+	if s.p.Cfg.QueryLogESEnabled {
 		return nil, nil
 	}
 

--- a/internal/apps/msp/apm/log-service/query/provider.go
+++ b/internal/apps/msp/apm/log-service/query/provider.go
@@ -16,7 +16,6 @@ package log_service
 
 import (
 	"io/ioutil"
-	"time"
 
 	"github.com/jinzhu/gorm"
 	"gopkg.in/yaml.v3"
@@ -81,7 +80,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		p.Cfg.IndexFieldSettings.DefaultSettings = defaultSettings
 	}
 
-	p.logService = &logService{p, &db.LogDeploymentDB{DB: p.DB}, &db.LogInstanceDB{DB: p.DB}, time.Now().UnixNano()}
+	p.logService = &logService{p, &db.LogDeploymentDB{DB: p.DB}, &db.LogInstanceDB{DB: p.DB}}
 	if p.Register != nil {
 		pb.RegisterLogServiceImp(p.Register, p.logService, apis.Options())
 	}

--- a/internal/apps/msp/apm/log-service/query/utils.go
+++ b/internal/apps/msp/apm/log-service/query/utils.go
@@ -77,6 +77,10 @@ func (g LogKeyGroup) Contains(keyType LogKeyType) bool {
 	return ok
 }
 
+func (g LogKeyGroup) IsEmpty() bool {
+	return g == nil || len(g) == 0
+}
+
 func (g LogKeyGroup) Where(filter func(k LogKeyType, v StringList) bool) LogKeyGroup {
 	result := LogKeyGroup{}
 	for keyType, list := range g {

--- a/internal/apps/msp/apm/log-service/query/utils_test.go
+++ b/internal/apps/msp/apm/log-service/query/utils_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_service
+
+import (
+	"testing"
+)
+
+func TestLogKeyGroup_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		g    LogKeyGroup
+		want bool
+	}{
+		{
+			name: "nil",
+			g:    nil,
+			want: true,
+		},
+		{
+			name: "empty",
+			g:    LogKeyGroup{},
+			want: true,
+		},
+		{
+			name: "not empty",
+			g: LogKeyGroup{
+				logServiceKey: StringList{"1"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.g.IsEmpty(); got != tt.want {
+				t.Errorf("IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

log-service's `startTime` field is set to `time.Now().Nano()`.
So, if msp(erda-server) restart, for example, when you query log about 5 mins ago, log-query-request's `timeStart` field is older than log-service's `startTime`, so we lose some important tags for query, so returned nothing.
And when msp is lived more than 5 mins, the same log-query request will return truly data.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=456067&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @chengjoey @tomatopunk 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  remove log-service startTime for msp restart            |
| 🇨🇳 中文    |   log-service 删除 startTime 参数           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
