### PR TITLE
fix(monitor): closing lastResp in defer causes `fetch` func to be executed limit(pageSize) times

### DIFF
--- a/internal/tools/monitor/core/log/query/log.query.service.go
+++ b/internal/tools/monitor/core/log/query/log.query.service.go
@@ -348,7 +348,11 @@ func (s *logQueryService) queryRealLogItems(ctx context.Context, req Request, fn
 	if err != nil {
 		return nil, true, errors.NewInternalServerError(err)
 	}
-	defer it.Close()
+	defer func() {
+		if err := it.Close(); err != nil {
+			fmt.Printf("close iterator error: %v\n", err)
+		}
+	}()
 
 	if _, ok := it.(storekit.EmptyIterator); ok {
 		return nil, false, nil

--- a/internal/tools/monitor/core/log/storage/clickhouse/iterator.go
+++ b/internal/tools/monitor/core/log/storage/clickhouse/iterator.go
@@ -274,12 +274,6 @@ func (it *clickhouseIterator) fetch(dir iteratorDir) {
 		reverse = true
 	}
 	it.buffer = nil
-	defer func() {
-		if it.lastResp != nil {
-			it.lastResp.Close()
-			it.lastResp = nil
-		}
-	}()
 	for it.err == nil && len(it.buffer) == 0 {
 		fetchingRemote := false
 		if it.lastResp == nil {
@@ -344,6 +338,7 @@ func (it *clickhouseIterator) fetch(dir iteratorDir) {
 			if fetchingRemote {
 				it.err = io.EOF
 			}
+			it.lastResp = nil
 			return
 		}
 	}

--- a/internal/tools/monitor/core/log/storage/clickhouse/iterator.go
+++ b/internal/tools/monitor/core/log/storage/clickhouse/iterator.go
@@ -338,6 +338,9 @@ func (it *clickhouseIterator) fetch(dir iteratorDir) {
 			if fetchingRemote {
 				it.err = io.EOF
 			}
+			if err := it.lastResp.Close(); err != nil {
+				fmt.Printf("clickhouse iterator close lastResp error: %s\n", err.Error())
+			}
 			it.lastResp = nil
 			return
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:

Closing lastResp in defer causes `fetch` func to be executed limit(pageSize) times.
`it.Close()` will be executed outside `fetch` func where the iterator created.

**Updated:**
`it.Close()` can only close lastResp, but will leak lastLastResp, so we should close inside `fetch` func.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  closing lastResp in defer causes `fetch` func to be executed limit(pageSize) times            |
| 🇨🇳 中文    |   在 defer 中关闭 lastResp 会导致 `fetch` 函数被执行 limit(pageSize) 次           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
