### PR TITLE
fix: log-analytics interface not exist

### DIFF
--- a/internal/apps/msp/menu/menu.service.go
+++ b/internal/apps/msp/menu/menu.service.go
@@ -220,7 +220,7 @@ func (s *menuService) GetMenu(ctx context.Context, req *pb.GetMenuRequest) (*pb.
 	// setup logKey for service monitor
 	for _, item := range items {
 		for _, child := range item.Children {
-			if child.EnName == "Service" {
+			if child.EnName == "Service" && len(logKey) > 0 {
 				child.Params["logKey"] = logKey
 				break
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix log-analytics interface not exist

the front end will judge whether the logKey is 'undefined', so the value cannot be set to empty


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that log-analytics interface not exist（修复了日志分析页面显示不存在的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that log-analytics interface not exist           |
| 🇨🇳 中文    |      修复了日志分析页面显示不存在的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
