### PR TITLE
fix(orchestrator): init-container download file failed due to openapi url

### DIFF
--- a/internal/tools/orchestrator/conf/conf.go
+++ b/internal/tools/orchestrator/conf/conf.go
@@ -49,6 +49,7 @@ type Conf struct {
 	TokenClientSecret          string `env:"TOKEN_CLIENT_SECRET" default:"devops/orchestrator"`
 	InspectServiceGroupTimeout int    `env:"INSPECT_SERVICEGROUP_TIMEOUT" default:"60"`
 	CollectorPublicURL         string `env:"COLLECTOR_PUBLIC_URL"`
+	OpenAPIPublicURL           string `env:"OPENAPI_PUBLIC_URL"`
 
 	// Conf for scheduler
 	DefaultRuntimeExecutor string `env:"DEFAULT_RUNTIME_EXECUTOR" default:"MARATHON"`
@@ -211,4 +212,8 @@ func ErdaNamespace() string {
 
 func CollectorPublicURL() string {
 	return cfg.CollectorPublicURL
+}
+
+func OpenAPIPublicURL() string {
+	return cfg.OpenAPIPublicURL
 }

--- a/internal/tools/orchestrator/services/deployment/deployment_context.go
+++ b/internal/tools/orchestrator/services/deployment/deployment_context.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -1716,14 +1715,13 @@ func (fsm *DeployFSMContext) convertService(serviceName string, service *diceyml
 			return nil, nil, err
 		}
 		// TODO: diceyml add dependon: openapi
-		openapiPublicAddr := os.Getenv("OPENAPI_PUBLIC_ADDR")
 		if service.Init == nil {
 			service.Init = map[string]diceyml.InitContainer{}
 		}
 		service.Init["internal-init-data"] = diceyml.InitContainer{
 			Image:      conf.InitContainerImage(),
 			SharedDirs: []diceyml.SharedDir{{Main: "/init-data", SideCar: "/data"}},
-			Cmd:        buildCurlDownloadFileCmd(groupFileconfigs, openapiPublicAddr, fsm.Runtime.FileToken, "/data"),
+			Cmd:        buildCurlDownloadFileCmd(groupFileconfigs, conf.OpenAPIPublicURL(), fsm.Runtime.FileToken, "/data"),
 		}
 	}
 	return usedAddonInsMap, usedAddonTenantMap, nil
@@ -1850,14 +1848,13 @@ func (fsm *DeployFSMContext) convertJob(jobName string, job *diceyml.Job,
 			}
 		}
 		// TODO: diceyml add dependon: openapi
-		openapiPublicAddr := os.Getenv("OPENAPI_PUBLIC_ADDR")
 		if job.Init == nil {
 			job.Init = map[string]diceyml.InitContainer{}
 		}
 		job.Init["internal-init-data"] = diceyml.InitContainer{
 			Image:      conf.InitContainerImage(),
 			SharedDirs: []diceyml.SharedDir{{Main: "/init-data", SideCar: "/data"}},
-			Cmd:        buildCurlDownloadFileCmd(groupFileconfigs, openapiPublicAddr, fsm.Runtime.FileToken, "/data"),
+			Cmd:        buildCurlDownloadFileCmd(groupFileconfigs, conf.OpenAPIPublicURL(), fsm.Runtime.FileToken, "/data"),
 		}
 	}
 	return usedAddonInsMap, usedAddonTenantMap, nil


### PR DESCRIPTION
#### What this PR does / why we need it:
fix init-container download file failed due to openapi url

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=452723&iterationID=-1&type=TICKET)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that init-container download file failed due to openapi url （修复了init-container下载配置失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that init-container download file failed due to openapi url            |
| 🇨🇳 中文    |   修复了init-container下载配置失败的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
