### PR TITLE
fix(monitor): frontend chart overview wrong timestamp order

### DIFF
--- a/cmd/monitor/monitor/conf/chartview/frontend/ajax_overview.json
+++ b/cmd/monitor/monitor/conf/chartview/frontend/ajax_overview.json
@@ -89,8 +89,7 @@
               "ta_req"
             ],
             "groupby": [
-              "time()",
-              "req_path::tag"
+              "time()"
             ],
             "orderby": [],
             "select": [
@@ -215,8 +214,7 @@
               "ta_req"
             ],
             "groupby": [
-              "time()",
-              "req_path::tag"
+              "time()"
             ],
             "orderby": [],
             "select": [

--- a/cmd/monitor/monitor/conf/chartview/frontend/page_overview.json
+++ b/cmd/monitor/monitor/conf/chartview/frontend/page_overview.json
@@ -251,8 +251,7 @@
               "ta_timing"
             ],
             "groupby": [
-              "time()",
-              "doc_path::tag"
+              "time()"
             ],
             "select": [
               {
@@ -369,8 +368,7 @@
               "ta_timing"
             ],
             "groupby": [
-              "time()",
-              "doc_path::tag"
+              "time()"
             ],
             "select": [
               {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix fronted chart overview wrong timestamp order


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=467820&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that fronted chart overview wrong timestamp order （修复了前端监控图表时间轴时间顺序出错的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that fronted chart overview wrong timestamp order             |
| 🇨🇳 中文    |   修复了前端监控图表时间轴时间顺序出错的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
