### PR TITLE
fix(monitor): domain overview chart timestamp error

### DIFF
--- a/cmd/monitor/monitor/conf/chartview/frontend/domain_overview.json
+++ b/cmd/monitor/monitor/conf/chartview/frontend/domain_overview.json
@@ -264,8 +264,7 @@
               "ta_timing"
             ],
             "groupby": [
-              "time()",
-              "host::tag"
+              "time()"
             ],
             "orderby": [],
             "select": [
@@ -390,8 +389,7 @@
               "ta_timing"
             ],
             "groupby": [
-              "time()",
-              "host::tag"
+              "time()"
             ],
             "orderby": [],
             "select": [


### PR DESCRIPTION
#### What this PR does / why we need it:
fix domain overview chart timestamp error

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=472697&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that domain overview chart timestamp error （修复了访问域名大盘时间轴乱序的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that domain overview chart timestamp error             |
| 🇨🇳 中文    |    修复了访问域名大盘时间轴乱序的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
