### PR TITLE
fix: executor goroutine pool empty when update

### DIFF
--- a/internal/core/messenger/eventbox/dispatcher/filters/webhookfilter.go
+++ b/internal/core/messenger/eventbox/dispatcher/filters/webhookfilter.go
@@ -60,12 +60,17 @@ func (w *WebhookFilter) Filter(m *types.Message) *errors.DispatchError {
 	internalHs := w.impl.SearchHooks(apistructs.HookLocation{
 		Org: "-1",
 	}, eventLabel.Event)
-	hs := w.impl.SearchHooks(apistructs.HookLocation{
-		Org:         eventLabel.OrgID,
-		Project:     eventLabel.ProjectID,
-		Application: eventLabel.ApplicationID,
-		Env:         []string{eventLabel.Env},
-	}, eventLabel.Event)
+
+	var hs []apistructs.Hook
+	if eventLabel.OrgID != "-1" {
+		hs = w.impl.SearchHooks(apistructs.HookLocation{
+			Org:         eventLabel.OrgID,
+			Project:     eventLabel.ProjectID,
+			Application: eventLabel.ApplicationID,
+			Env:         []string{eventLabel.Env},
+		}, eventLabel.Event)
+	}
+
 	if len(hs)+len(internalHs) == 0 {
 		logrus.Warnf("no webhook care event: %v", eventLabel)
 		return derr

--- a/internal/tools/orchestrator/scheduler/executor/executor.go
+++ b/internal/tools/orchestrator/scheduler/executor/executor.go
@@ -182,18 +182,19 @@ func deleteOneExecutor(m *Manager, config *executorconfig.ExecutorConfig) {
 		p.Stop()
 	}
 
-	executortypes.UnRegisterEvChan(executortypes.Name(config.Name))
+	executortypes.UnRegisterEvChan(name)
 	events.GetEventManager().UnRegisterEventCallback(config.Name)
 
-	if executor, ok := m.executors[executortypes.Name(config.Name)]; ok {
+	if executor, ok := m.executors[name]; ok {
 		executor.CleanUpBeforeDelete()
 	}
 
 	// Delete the creation function corresponding to the executor
-	delete(m.executors, executortypes.Name(config.Name))
+	delete(m.executors, name)
 	// Delete the configuration of the executor
-	delete(m.executorConfigs, executortypes.Name(config.Name))
-	//
+	delete(m.executorConfigs, name)
+	// Delete the pools
+	delete(m.pools, name)
 	//delete(m.executorStopCh, executortypes.Name(config.Name))
 	// Delete the map corresponding to the relationship between executor name and cluster name in conf
 	conf.GetConfStore().ExecutorStore.Delete(config.Name)

--- a/internal/tools/orchestrator/scheduler/executor/executortypes/types.go
+++ b/internal/tools/orchestrator/scheduler/executor/executortypes/types.go
@@ -127,7 +127,7 @@ func Register(kind Kind, create CreateFn) error {
 
 // Get a GetEventChanFn according to an executor's name
 func RegisterEvChan(name Name, get GetEventChanFn, cb EventCbFn) error {
-	logrus.Debugf("in RegisterEvChan going to register executor: %s", name)
+	logrus.Infof("in RegisterEvChan going to register executor: %s", name)
 	if _, ok := EvFuncMap[name]; ok {
 		return errors.Errorf("duplicate to register executor's event channel: %s", name)
 	}
@@ -137,7 +137,7 @@ func RegisterEvChan(name Name, get GetEventChanFn, cb EventCbFn) error {
 }
 
 func UnRegisterEvChan(name Name) {
-	logrus.Debugf("in UnRegisterEvChan going to unregister executor: %s", name)
+	logrus.Infof("in UnRegisterEvChan going to unregister executor: %s", name)
 	delete(EvFuncMap, name)
 	delete(EvCbMap, name)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
fix executor goroutine pool empty when update

1. eventbox repeated callback invocation.
2. executor update failed when goroutine already stoped.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix update executor goroutine pool empty              |
| 🇨🇳 中文    |   修复更新 executor gotouine pool 为空问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
