### PR TITLE
fix: remove nginx validation for main/http/server

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/custom/policy.go
@@ -28,7 +28,8 @@ type Policy struct {
 }
 
 // 如下参数在 nginx-template 中有全局设置，因此不能在 cunstom 中再次设置
-var UNSETABLE_KEYS = map[string]string{"client_max_body_size": "100m",
+var UNSETABLE_KEYS = map[string]string{
+	"client_max_body_size":  "100m",
 	"proxy_connect_timeout": "5s",
 	"proxy_buffer_size":     "256k",
 	"proxy_buffers":         "4 256k",

--- a/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/ip/policy.go
@@ -73,9 +73,6 @@ func (policy Policy) ParseConfig(dto apipolicy.PolicyDto, ctx map[string]interfa
 	}
 
 	if !policyDto.Switch {
-		if gatewayProvider == mseCommon.MseProviderName {
-
-		}
 		switch gatewayProvider {
 		case mseCommon.MseProviderName:
 			switch policyDto.IpSource {

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -1440,47 +1440,6 @@ func getNginxConfFromPolicyConfig(p apipolicy.PolicyConfig) (map[string]string, 
 		}
 	}
 
-	if p.IngressController != nil {
-		for k, v := range p.IngressController.ConfigOption {
-			logrus.Infof("p.IngressController.ConfigOption[%s]=%v \n", k, p.IngressController.ConfigOption[k])
-			key := strings.ReplaceAll(k, "-", "_")
-			if _, ok := ret[key]; ok {
-				// more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return 等允许多次设置
-				if !skipKeys[key] {
-					return ret, errors.Errorf("ConfigOption nginx conf %s duplicated", key)
-				}
-			}
-			if v == nil {
-				ret[key] = ""
-			} else {
-				ret[key] = *v
-			}
-		}
-
-		if p.IngressController.MainSnippet != nil {
-			src := *(p.IngressController.MainSnippet)
-			err := extractConfigFromString("p.IngressController.MainSnippet", src, ret)
-			if err != nil {
-				return ret, err
-			}
-		}
-
-		if p.IngressController.HttpSnippet != nil {
-			src := *(p.IngressController.HttpSnippet)
-			err := extractConfigFromString("p.IngressController.HttpSnippet", src, ret)
-			if err != nil {
-				return ret, err
-			}
-		}
-
-		if p.IngressController.ServerSnippet != nil {
-			src := *(p.IngressController.ServerSnippet)
-			err := extractConfigFromString("p.IngressController.ServerSnippet", src, ret)
-			if err != nil {
-				return ret, err
-			}
-		}
-	}
 	return ret, nil
 }
 

--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl_test.go
@@ -123,7 +123,7 @@ location @LIMIT-xxxxxx {
 					IngressController: pc2,
 				},
 			},
-			want:    "proxy_next_upstream=error timeout http_429 non_idempotent",
+			want:    "",
 			wantErr: false,
 		},
 		{
@@ -138,7 +138,7 @@ location @LIMIT-xxxxxx {
 					IngressController: pc3,
 				},
 			},
-			want:    "proxy_next_upstream=error timeout http_581 non_idempotent",
+			want:    "",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove nginx validation for main/http/server configurations

#### Specified Reviewers:

/assign @dspo @luobily @sfwn 


#### ChangeLog
Feature: Optimize to remove  nginx validation for main/http/server configurations in hepa （优化了hepa 中 nginx 自定义配置校验，移除对 main/http/server 对应配置的校验，只保留对 location 的校验）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Optimize to remove  nginx validation for main/http/server configurations in hepa   |
| 🇨🇳 中文    |   优化了hepa 中 nginx 自定义配置校验，移除对 main/http/server 对应配置的校验，只保留对 location 的校验   |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4
