### PR TITLE
fix(hepa): nginx custom validating support set more add_header

### DIFF
--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -57,7 +57,7 @@ const (
 
 var azMutex []*sync.Mutex
 
-// Nginx 配置 llocations 部分，more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return 等允许多次设置
+// Nginx 配置 llocations 部分，more_set_headers、proxy_set_header、set、limit_req、limit_conn、error_page、deny、allow、return、add_header 等允许多次设置
 var skipKeys = map[string]bool{
 	"more_set_headers": true,
 	"proxy_set_header": true,
@@ -68,6 +68,7 @@ var skipKeys = map[string]bool{
 	"deny":             true,
 	"allow":            true,
 	"return":           true,
+	"add_header":       true,
 }
 
 func init() {


### PR DESCRIPTION
#### What this PR does / why we need it:
nginx custom validating support set more add_header




#### Specified Reviewers:

/assign @dspo @luobily @sfwn 


#### ChangeLog
Bugfix： Fix the bug that nginx custom validating not support set more add_header  （修复了 nginx 自定义配置不支持设置多个 add_header 的错误）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that nginx custom validating not support set more add_header      |
| 🇨🇳 中文    |     修复了 nginx 自定义配置不支持设置多个 add_header 的错误       |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4
