### PR TITLE
fix(dop): first requirement model add TaskOnly&BugOnly fields to ensure excel title order correct

### DIFF
--- a/internal/apps/dop/providers/issue/core/query/issueexcel/model_sample.go
+++ b/internal/apps/dop/providers/issue/core/query/issueexcel/model_sample.go
@@ -64,6 +64,18 @@ func (data DataForFulfill) GenerateSampleIssueSheetModels() []IssueSheetModel {
 			InclusionIssueIDs: []int64{2, -(3 + uuidPartsMustLength)},
 			CustomFields:      formatIssueCustomFields(&pb.Issue{Id: int64(requirementCommon.ID)}, pb.PropertyIssueTypeEnum_REQUIREMENT, data),
 		},
+		// Assign to `TaskOnly` and `BugOnly` fields to avoid uuid order mismatch error.
+		// Requirement is the first model, so just do for requirement only.
+		TaskOnly: IssueSheetModelTaskOnly{
+			TaskType:     "",
+			CustomFields: formatIssueCustomFields(&pb.Issue{Id: int64(requirementCommon.ID)}, pb.PropertyIssueTypeEnum_TASK, data),
+		},
+		BugOnly: IssueSheetModelBugOnly{
+			OwnerName:    "",
+			Source:       "",
+			ReopenCount:  0,
+			CustomFields: formatIssueCustomFields(&pb.Issue{Id: int64(requirementCommon.ID)}, pb.PropertyIssueTypeEnum_BUG, data),
+		},
 	}
 	// task
 	taskCommon := common


### PR DESCRIPTION
#### What this PR does / why we need it:

first requirement demo model add TaskOnly&BugOnly fields to ensure excel title order correct


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=502836&iterationID=12560&type=BUG)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   first requirement demo model add TaskOnly&BugOnly fields to ensure excel title order correct           |
| 🇨🇳 中文    |   第一个需求 Demo 模型添加 TaskOnly&BugOnly 字段，保证导出的 Excel 标题顺序正确           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
