### PR TITLE
fix(orchestrator): deployment order custom addon name precheck

### DIFF
--- a/internal/tools/orchestrator/services/deployment_order/deployment_order_render.go
+++ b/internal/tools/orchestrator/services/deployment_order/deployment_order_render.go
@@ -214,7 +214,7 @@ func (d *DeploymentOrder) staticPreCheck(langCodes infrai18n.LanguageCodes, user
 	}
 
 	for _, v := range customAddons {
-		customAddonsMap[v.Name] = 0
+		customAddonsMap[strings.ToUpper(v.Name)] = 0
 	}
 
 	// check addon
@@ -249,7 +249,7 @@ func (d *DeploymentOrder) staticPreCheck(langCodes infrai18n.LanguageCodes, user
 		}
 
 		if extension.Category == apistructs.AddonCustomCategory {
-			_, ok := customAddonsMap[instanceName]
+			_, ok := customAddonsMap[strings.ToUpper(instanceName)]
 			if !ok {
 				failReasons = append(failReasons, i18n.LangCodesSprintf(langCodes, I18nCustomAddonNotReady, instanceName))
 				continue

--- a/internal/tools/orchestrator/services/deployment_order/deployment_order_render_test.go
+++ b/internal/tools/orchestrator/services/deployment_order/deployment_order_render_test.go
@@ -68,7 +68,16 @@ func TestPreCheck(t *testing.T) {
 
 	monkey.PatchInstanceMethod(reflect.TypeOf(order.db), "ListCustomInstancesByProjectAndEnv",
 		func(*dbclient.DBClient, uint64, string) ([]dbclient.AddonInstance, error) {
-			return []dbclient.AddonInstance{}, nil
+			return []dbclient.AddonInstance{
+				{
+					ID:        "ub2c26cbe2458417bab70c80f702dc62c",
+					Name:      "custom",
+					AddonName: "custom",
+					Category:  apistructs.AddonCustomCategory,
+					Workspace: string(apistructs.WorkspaceDev),
+					ProjectID: "1",
+				},
+			}, nil
 		},
 	)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Souce: Erda addon where query conditions are case-insensitive.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=506036&iterationID=-1&type=TASK)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix deployment order custom addon name precheck             |
| 🇨🇳 中文    |   修复部署单自定义 addon 准备就绪名称检查           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
