### PR TITLE
feat(ai-function): create testset if not set testSetID

### DIFF
--- a/bundle/testset.go
+++ b/bundle/testset.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle/apierrors"
+	"github.com/erda-project/erda/pkg/http/httputil"
+)
+
+func (b *Bundle) CreateTestSet(req apistructs.TestSetCreateRequest) (*apistructs.TestSet, error) {
+	host, err := b.urls.ErdaServer()
+	if err != nil {
+		return &apistructs.TestSet{}, err
+	}
+
+	var data apistructs.TestSetCreateResponse
+	r, err := b.hc.Post(host).Path("/api/testsets").
+		Header(httputil.InternalHeader, "AI").
+		Header(httputil.UserHeader, req.IdentityInfo.UserID).
+		JSONBody(&req).Do().JSON(&data)
+
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !r.IsOK() {
+		return nil, toAPIError(r.StatusCode(), apistructs.ErrorResponse{Msg: "CreateTestSet failed"})
+	}
+	return data.Data, nil
+}
+
+func (b *Bundle) GetTestSets(req apistructs.TestSetListRequest) ([]apistructs.TestSet, error) {
+	host, err := b.urls.ErdaServer()
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	params.Set("recycled", "false")
+	params.Set("parentID", fmt.Sprintf("%d", *req.ParentID))
+	params.Set("projectID", fmt.Sprintf("%d", *req.ProjectID))
+
+	var data apistructs.TestSetListResponse
+	r, err := b.hc.Get(host).Path("/api/testsets").
+		Params(params).
+		Header(httputil.InternalHeader, "AI").
+		JSONBody(&req).Do().JSON(&data)
+
+	if err != nil {
+		return nil, apierrors.ErrInvoke.InternalError(err)
+	}
+	if !r.IsOK() {
+		return nil, toAPIError(r.StatusCode(), apistructs.ErrorResponse{Msg: "GetTestSets failed"})
+	}
+
+	return data.Data, nil
+}

--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -619,4 +619,4 @@ grpc-client@erda.core.monitor.settings:
 erda.core.monitor.settings-client:
 service-profile-overview:
 erda.app.ai-function:
-  openaiAddr: ${OPENAI_ADDR:http://ai-proxy:8081}
+  openaiAddr: ${AI_PROXY_ADDR:http://ai-proxy:8081}

--- a/internal/pkg/ai-functions/functions/test-case/function.go
+++ b/internal/pkg/ai-functions/functions/test-case/function.go
@@ -56,20 +56,22 @@ type FunctionParams struct {
 	Requirements []TestCaseParam `json:"requirements,omitempty"`
 }
 type TestCaseParam struct {
-	IssueID uint64 `json:"issueID,omitempty"`
-	Prompt  string `json:"prompt,omitempty"`
+	IssueID uint64                           `json:"issueID,omitempty"`
+	Prompt  string                           `json:"prompt,omitempty"`
+	Req     apistructs.TestCaseCreateRequest `json:"testCaseCreateReq,omitempty"`
 }
 
 // TestCaseFunctionInput 用于为单个需求生成测试用例的输入
 type TestCaseFunctionInput struct {
-	TestSetID uint64
-	IssueID   uint64
-	Prompt    string
+	TestSetParentID uint64
+	TestSetID       uint64
+	IssueID         uint64
+	Prompt          string
 }
 
 // TestCaseMeta 用于关联生成的测试用例与对应的需求
 type TestCaseMeta struct {
-	Req             apistructs.TestCaseCreateRequest `json:"testCaseCreateReq,omitempty"` // 当前项目 ID，用于权限校验
+	Req             apistructs.TestCaseCreateRequest `json:"testCaseCreateReq,omitempty"` // 当前项目 ID 对应的创建测试用例请求
 	RequirementName string                           `json:"requirementName"`             // 需求对应的 issue 的 Title
 	RequirementID   uint64                           `json:"requirementID"`               // 需求对应的 issueID
 	TestCaseID      uint64                           `json:"testcaseID,omitempty"`        // 创建测试用例成功返回的测试用例 ID

--- a/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase.go
+++ b/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase.go
@@ -24,11 +24,15 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/erda-project/erda-proto-go/apps/aifunction/pb"
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/pkg/ai-functions/functions"
 	aitestcase "github.com/erda-project/erda/internal/pkg/ai-functions/functions/test-case"
 	aiHandlerUtils "github.com/erda-project/erda/internal/pkg/ai-functions/handler/utils"
 	"github.com/erda-project/erda/pkg/http/httpserver"
 )
+
+const AIGeneratedTestSeName = "AI_Generated"
 
 func (h *AIFunction) createTestCaseForRequirementIDAndTestID(ctx context.Context, factory functions.FunctionFactory, req *pb.ApplyRequest, openaiURL *url.URL) (any, error) {
 	results := make([]any, 0)
@@ -46,6 +50,46 @@ func (h *AIFunction) createTestCaseForRequirementIDAndTestID(ctx context.Context
 
 	if err := validateParamsForCreateTestcase(functionParams); err != nil {
 		return nil, errors.Wrapf(err, "validateParamsForCreateTestcase faild")
+	}
+
+	// 用户未指定测试集可能需要创建测试集
+	if functionParams.TestSetID == 0 {
+		bdl := bundle.New(bundle.WithErdaServer())
+		var parentTestSetId uint64 = 0
+		projectId := req.GetBackground().GetProjectID()
+		userId := req.GetBackground().GetUserID()
+
+		testSets, err := bdl.GetTestSets(apistructs.TestSetListRequest{
+			ParentID:  &parentTestSetId,
+			ProjectID: &projectId,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "get  testSets by project failed")
+		}
+
+		needCreate := true
+		for _, testSet := range testSets {
+			if testSet.ParentID == 0 && testSet.Name == AIGeneratedTestSeName {
+				functionParams.TestSetID = testSet.ID
+				needCreate = false
+				break
+			}
+		}
+
+		if needCreate {
+			testSet, err := bdl.CreateTestSet(apistructs.TestSetCreateRequest{
+				ProjectID: &projectId,
+				ParentID:  &parentTestSetId,
+				Name:      AIGeneratedTestSeName,
+				IdentityInfo: apistructs.IdentityInfo{
+					UserID: userId,
+				},
+			})
+			if err != nil {
+				return nil, errors.Wrap(err, "create TestSet failed")
+			}
+			functionParams.TestSetID = testSet.ID
+		}
 	}
 
 	for _, tp := range functionParams.Requirements {
@@ -72,19 +116,43 @@ func processSingleTestCase(ctx context.Context, factory functions.FunctionFactor
 		IssueID:   tp.IssueID,
 		Prompt:    tp.Prompt,
 	}
+	if len(tp.Req.StepAndResults) > 0 {
+		// 表示是修改后批量应用应用生成的测试用例，直接调用创建接口，无需再次生成
+		bdl := bundle.New(bundle.WithErdaServer())
+		// 根据 issueID 获取对应的需求 Title
+		issue, err := bdl.GetIssue(tp.IssueID)
+		if err != nil {
+			return errors.Wrap(err, "get requirement info failed when create testcase")
+		}
 
-	result, err := aiHandlerUtils.GetChatMessageFunctionCallArguments(ctx, factory, req, openaiURL, tp.Prompt, callbackInput)
-	if err != nil {
-		return err
+		aiCreateTestCaseResponse, err := bdl.CreateTestCase(tp.Req)
+		if err != nil {
+			err = errors.Errorf("create testcase with req %+v failed: %v", tp.Req, err)
+			return errors.Wrap(err, "bundle CreateTestCase failed for ")
+		}
+
+		*results = append(*results, aitestcase.TestCaseMeta{
+			Req:             tp.Req,
+			RequirementName: issue.Title,
+			RequirementID:   tp.IssueID,
+			TestCaseID:      aiCreateTestCaseResponse.TestCaseID,
+		})
+	} else {
+		// 表示需要生成
+		result, err := aiHandlerUtils.GetChatMessageFunctionCallArguments(ctx, factory, req, openaiURL, tp.Prompt, callbackInput)
+		if err != nil {
+			return err
+		}
+
+		*results = append(*results, result)
 	}
 
-	*results = append(*results, result)
 	return nil
 }
 
 // validateParamsForCreateTestcase 校验创建测试用例对应的参数配置
 func validateParamsForCreateTestcase(req aitestcase.FunctionParams) error {
-	if req.TestSetID <= 0 {
+	if req.TestSetID < 0 {
 		return errors.Errorf("AI function functionParams testSetID for %s invalid", aitestcase.Name)
 	}
 

--- a/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase_test.go
+++ b/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-proto-go/apps/aifunction/pb"
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/pkg/ai-functions/functions"
 	aitestcase "github.com/erda-project/erda/internal/pkg/ai-functions/functions/test-case"
 	"github.com/erda-project/erda/internal/pkg/ai-functions/sdk"
@@ -81,6 +82,7 @@ func TestAIFunction_createTestCaseForRequirementIDAndTestID(t *testing.T) {
 		},
 		NeedAdjust: false,
 	}
+
 	factory, _ := functions.Retrieve(req.GetFunctionName())
 	results := []apistructs.TestCaseStepAndResult{
 		{
@@ -100,6 +102,47 @@ func TestAIFunction_createTestCaseForRequirementIDAndTestID(t *testing.T) {
 			Step:   "用户点击注册",
 		},
 	}
+
+	params1 := params
+	params1.TestSetID = 0
+	reuirements1 := make([]aitestcase.TestCaseParam, 0)
+	reuirements1 = append(reuirements1, aitestcase.TestCaseParam{
+		IssueID: 30001127564,
+		Prompt:  "用户登录",
+		Req: apistructs.TestCaseCreateRequest{
+			ProjectID:      4717,
+			TestSetID:      24227,
+			Name:           "用户登录",
+			PreCondition:   "用户打开登录页面",
+			StepAndResults: results,
+			APIs:           nil,
+			Desc:           "Powered by AI.\n\n对应需求:\n用户登录",
+			Priority:       "P2",
+			LabelIDs:       nil,
+			IdentityInfo: apistructs.IdentityInfo{
+				UserID: "1003933",
+			},
+		},
+	})
+
+	params1.Requirements = reuirements1
+	jsonData, _ = json.Marshal(params1)
+	value1 := structpb.Value{}
+	jsonpb.UnmarshalString(string(jsonData), &value1)
+
+	req1 := &pb.ApplyRequest{
+		FunctionName:   aitestcase.Name,
+		FunctionParams: &value1,
+		Background: &pb.Background{
+			UserID:      "1003933",
+			OrgID:       633,
+			OrgName:     "erda-development",
+			ProjectID:   4717,
+			ProjectName: "testhpa",
+		},
+		NeedAdjust: false,
+	}
+
 	testCaseReq := apistructs.TestCaseCreateRequest{
 		ProjectID:      4717,
 		TestSetID:      24227,
@@ -107,15 +150,20 @@ func TestAIFunction_createTestCaseForRequirementIDAndTestID(t *testing.T) {
 		PreCondition:   "用户打开登录页面",
 		StepAndResults: results,
 		APIs:           nil,
-		Desc:           "Powered by AI.\n\n对应需求:\n用户登录",
+		Desc:           fmt.Sprintf("Powered by AI.\n\n对应需求:\n%s", "用户登录"),
 		Priority:       "P2",
 		LabelIDs:       nil,
 		IdentityInfo: apistructs.IdentityInfo{
 			UserID: "1003933",
 		},
 	}
+
+	var requirementId int64
+	requirementId = 30001127564
 	issue := &apistructs.Issue{
-		RequirementID:    nil,
+		ID: requirementId,
+		//RequirementID:    nil,
+		RequirementID:    &requirementId,
 		RequirementTitle: "",
 		Type:             apistructs.IssueTypeRequirement,
 		Title:            "用户登录",
@@ -171,6 +219,21 @@ func TestAIFunction_createTestCaseForRequirementIDAndTestID(t *testing.T) {
 			want:    wantData,
 			wantErr: false,
 		},
+		{
+			name: "Test_02",
+			fields: fields{
+				Log:       nil,
+				OpenaiURL: url,
+			},
+			args: args{
+				ctx:       nil,
+				factory:   factory,
+				req:       req1,
+				openaiURL: url,
+			},
+			want:    wantData,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -203,6 +266,61 @@ func TestAIFunction_createTestCaseForRequirementIDAndTestID(t *testing.T) {
 					RequirementName: issue.Title,
 					RequirementID:   uint64(issue.ID),
 					TestCaseID:      testcaseId,
+				}, nil
+			})
+
+			bdl := bundle.New(bundle.WithErdaServer())
+			monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetTestSets", func(_ *bundle.Bundle,
+				req apistructs.TestSetListRequest) ([]apistructs.TestSet, error) {
+
+				if tt.name == "Test_02" {
+					return []apistructs.TestSet{}, nil
+				}
+
+				return []apistructs.TestSet{
+					{
+						ID:        10001,
+						Name:      AIGeneratedTestSeName,
+						ProjectID: 4717,
+						ParentID:  0,
+						Recycled:  false,
+						Directory: "/" + AIGeneratedTestSeName,
+						Order:     0,
+					},
+				}, nil
+			})
+
+			monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "CreateTestSet", func(_ *bundle.Bundle,
+				req apistructs.TestSetCreateRequest) (*apistructs.TestSet, error) {
+				return &apistructs.TestSet{
+					ID:        24227,
+					Name:      "",
+					ProjectID: 0,
+					ParentID:  0,
+					Recycled:  false,
+					Directory: "",
+					Order:     0,
+					CreatorID: "",
+					UpdaterID: "",
+				}, nil
+			})
+
+			monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "GetIssue", func(_ *bundle.Bundle,
+				id uint64) (*apistructs.Issue, error) {
+				return &apistructs.Issue{
+					RequirementID:    nil,
+					RequirementTitle: "",
+					Type:             apistructs.IssueTypeRequirement,
+					Title:            "用户登录",
+					Content:          "",
+					Priority:         apistructs.IssuePriorityNormal,
+				}, nil
+			})
+
+			monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "CreateTestCase", func(_ *bundle.Bundle,
+				req apistructs.TestCaseCreateRequest) (apistructs.AICreateTestCaseResponse, error) {
+				return apistructs.AICreateTestCaseResponse{
+					TestCaseID: testcaseId,
 				}, nil
 			})
 


### PR DESCRIPTION
#### What this PR does / why we need it:
AI function create  testcase will create testset if not set testSetID


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
Feature: Support ai function create testset if not set testSetID（支持AI function 在测试集 ID 未指定的情况下创建测试集.）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Support ai function create testset if not set testSetID          |
| 🇨🇳 中文    |       支持AI function 在测试集 ID 未指定的情况下创建测试集.       |


#### Need cherry-pick to release versions?
/cherry-pick release/2.4