### PR TITLE
fix: ai function validate Params

### DIFF
--- a/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase.go
+++ b/internal/pkg/ai-functions/handler/handler_ai_function_create_testcase.go
@@ -164,7 +164,7 @@ func validateParamsForCreateTestcase(req aitestcase.FunctionParams) error {
 		if tp.IssueID <= 0 {
 			return errors.Errorf("AI function functionParams requirements[%d].issueID for %s invalid", idx, aitestcase.Name)
 		}
-		if tp.Prompt == "" {
+		if tp.Prompt == "" && len(tp.Req.StepAndResults) == 0 {
 			return errors.Errorf("AI function functionParams requirements[%d].prompt for %s invalid", idx, aitestcase.Name)
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
When call testcase create with  testCaseCreateReq, no need set prompt parameter.


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
Bugfix： Fix the bug that  no need validate prompt parameter for ruquirement with testCaseCreateReq parameter （修复了 应用修改完成的测试用例时，无需提供 prompt 的校验逻辑）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Fix the bug that  no need validate prompt parameter for ruquirement with testCaseCreateReq parameter         |
| 🇨🇳 中文    |        修复了 应用修改完成的测试用例时，无需提供 prompt 的校验逻辑      |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4