### PR TITLE
refactor(ai-proxy): routes & config & initial-filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,3 @@ api/proto-go
 *.xlsx
 /cmd/ai-proxy/conf/erda-platforms.yml
 /cmd/ai-proxy/conf/providers.yml
-/cmd/ai-proxy/conf/routes.yml

--- a/cmd/ai-proxy/bootstrap.yml
+++ b/cmd/ai-proxy/bootstrap.yml
@@ -5,9 +5,9 @@ grpc-server@ai:
   addr: ":8082"
 
 erda.app.ai-proxy:
-  routesRef: conf/routes.yml
-  logLevel: ${LOG_LEVEL:debug}
-  openOnErda: ${OPEN_ON_ERDA:true} # 是否将 API 通过 Erda Openapi 暴露出来
+  routes_ref: conf/routes.yml
+  log_level: ${LOG_LEVEL:info}
+  open_on_erda: ${OPEN_ON_ERDA:true} # 是否将 API 通过 Erda Openapi 暴露出来
 
 gorm.v2:
   debug: ${MYSQL_DEBUG:false}
@@ -19,4 +19,4 @@ erda.app.ai-proxy.metrics:
 grpc-client@erda.core.openapi.dynamic_register:
   addr: ${ERDA_SERVER_GRPC_ADDR:erda-server:8096}
   block: false
-erda.core.openapi.dynamic_register-client: {}
+erda.core.openapi.dynamic_register-client: { }

--- a/cmd/ai-proxy/conf/routes.yml
+++ b/cmd/ai-proxy/conf/routes.yml
@@ -5,6 +5,7 @@ routes:
     method: POST
     router: null
     filters:
+      - name: initial
       - name: log-http
       - name: rate-limit
       - name: body-size-limit

--- a/cmd/ai-proxy/conf/routes.yml
+++ b/cmd/ai-proxy/conf/routes.yml
@@ -29,7 +29,7 @@ routes:
             - RewriteScheme
             - RewriteHost
             - AddModelInRequestBody
-      - name: audit
       - name: message-context
         config:
-          sysMsg: "background: Your name is Erda Assistant. You are trained by Erda. If I ask you 'who are you' please answer 'I'm Erda Assistant and trained by Erda'. You prefer to answer in Chinese."
+          sysMsg: "background: Your name is Erda AI Assistant. You are trained by Erda."
+      - name: audit

--- a/cmd/ai-proxy/conf/routes.yml
+++ b/cmd/ai-proxy/conf/routes.yml
@@ -1,0 +1,34 @@
+# see: internal/pkg/ai-proxy/route/route.go#Routes
+
+routes:
+  - path: /v1/chat/completions
+    method: POST
+    router: null
+    filters:
+      - name: log-http
+      - name: rate-limit
+      - name: body-size-limit
+        config:
+          maxSize: 102400
+          message: { "messages": [ { "role": "ai-proxy", "content": "问题超长啦, 请重置会话", "name": "ai-proxy" } ] }
+      - name: context
+      - name: azure-director
+        config:
+          directors:
+            - TransAuthorization
+            - SetModelAPIVersionIfNotSpecified
+            - DefaultQueries("api-version=2023-07-01-preview")
+            - RewriteScheme
+            - RewriteHost
+            - RewritePath("/openai/deployments/${ provider.metadata.deployment_id }/chat/completions")
+      - name: openai-director
+        config:
+          directors:
+            - TransAuthorization
+            - RewriteScheme
+            - RewriteHost
+            - AddModelInRequestBody
+      - name: audit
+      - name: message-context
+        config:
+          sysMsg: "background: Your name is Erda Assistant. You are trained by Erda. If I ask you 'who are you' please answer 'I'm Erda Assistant and trained by Erda'. You prefer to answer in Chinese."

--- a/internal/apps/ai-proxy/common/ctxhelper/config.go
+++ b/internal/apps/ai-proxy/common/ctxhelper/config.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctxhelper
+
+import (
+	"context"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/config"
+)
+
+func GetConfig(ctx context.Context) (*config.Config, bool) {
+	v, ok := ctx.Value(CtxKeyOfConfig{}).(*config.Config)
+	return v, ok
+}

--- a/internal/apps/ai-proxy/common/ctxhelper/ctx.go
+++ b/internal/apps/ai-proxy/common/ctxhelper/ctx.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctxhelper
+
+type (
+	CtxKeyOfConfig struct{ CtxKeyOfConfig any }
+)

--- a/internal/apps/ai-proxy/common/ctxhelper/logger.go
+++ b/internal/apps/ai-proxy/common/ctxhelper/logger.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctxhelper
+
+import (
+	"context"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+func GetLogger(ctx context.Context) logs.Logger {
+	return ctx.Value(reverseproxy.LoggerCtxKey{}).(logs.Logger)
+}

--- a/internal/apps/ai-proxy/config/config.go
+++ b/internal/apps/ai-proxy/config/config.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+
+	"github.com/erda-project/erda/internal/pkg/ai-proxy/route"
+)
+
+type Config struct {
+	LogLevelStr string       `file:"log_level" default:"info" env:"LOG_LEVEL"`
+	LogLevel    logrus.Level `json:"-" yaml:"-"`
+
+	SelfURL    string `file:"self_url" env:"SELF_URL" required:"true"`
+	OpenOnErda bool   `file:"open_on_erda" default:"false" env:"OPEN_ON_ERDA"`
+
+	Exporter configPromExporter
+
+	RoutesRef string       `file:"routes_ref"`
+	Routes    route.Routes `json:"-" yaml:"-"`
+}
+
+type configPromExporter struct {
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Subsystem string `json:"subsystem" yaml:"subsystem"`
+	Name      string `json:"name" yaml:"name"`
+}
+
+// DoPost do some post process after config loaded
+func (cfg *Config) DoPost() error {
+	// parse routes ref
+	if err := parseFileConfig(cfg.RoutesRef, "routes", &cfg.Routes); err != nil {
+		return fmt.Errorf("failed to parse routes ref: %v", err)
+	}
+	if err := cfg.Routes.Validate(); err != nil {
+		return fmt.Errorf("failed to validate routes: %v", err)
+	}
+
+	// parse log level
+	level, err := logrus.ParseLevel(cfg.LogLevelStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse log level, level: %s, err: %v", cfg.LogLevel, err)
+	}
+	logrus.SetLevel(level)
+	cfg.LogLevel = level
+
+	return nil
+}
+
+func parseFileConfig(refPath, key string, target interface{}) error {
+	data, err := os.ReadFile(refPath)
+	if err != nil {
+		return err
+	}
+	var m = make(map[string]json.RawMessage)
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	data, ok := m[key]
+	if !ok {
+		return nil
+	}
+	return yaml.Unmarshal(data, target)
+}

--- a/internal/apps/ai-proxy/dependent_filters.go
+++ b/internal/apps/ai-proxy/dependent_filters.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/body-size-limit"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/erda-auth"
+	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/initial"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/log-http"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/message-context"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/openai-director"

--- a/internal/apps/ai-proxy/filters/initial/filter.go
+++ b/internal/apps/ai-proxy/filters/initial/filter.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package initial
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+const (
+	Name = "initial"
+)
+
+var (
+	_ reverseproxy.RequestFilter  = (*Initial)(nil)
+	_ reverseproxy.ResponseFilter = (*Initial)(nil)
+)
+
+func init() {
+	reverseproxy.RegisterFilterCreator(Name, New)
+}
+
+type Initial struct {
+	*reverseproxy.DefaultResponseFilter
+}
+
+// Enable is always true for initial filter
+func (f *Initial) Enable(ctx context.Context, req *http.Request) bool {
+	return true
+}
+
+func New(_ json.RawMessage) (reverseproxy.Filter, error) {
+	return &Initial{DefaultResponseFilter: reverseproxy.NewDefaultResponseFilter()}, nil
+}
+
+func (f *Initial) OnRequest(ctx context.Context, w http.ResponseWriter, infor reverseproxy.HttpInfor) (signal reverseproxy.Signal, err error) {
+	return reverseproxy.Continue, nil
+}
+
+func (f *Initial) OnResponseChunk(ctx context.Context, infor reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) (signal reverseproxy.Signal, err error) {
+	return f.DefaultResponseFilter.OnResponseChunk(ctx, infor, w, chunk)
+}
+
+func (f *Initial) OnResponseEOF(ctx context.Context, infor reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) error {
+	return f.DefaultResponseFilter.OnResponseEOF(ctx, infor, w, chunk)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

- commit reoutes.yaml
- add initial filter to split default OnResponseXXX actions from log-http filter
- refactor config; put config into ctx

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   refactor ai-proxy: routes & config & initial-filter           |
| 🇨🇳 中文    |   重构 ai-proxy: 路由 & 配置 & 用于初始化的 Filter           |
