### PR TITLE
fix(openapi): skip validate csrf token for self-addr and same host-port

### DIFF
--- a/internal/core/openapi/openapi-ng/interceptors/csrf/csrf.go
+++ b/internal/core/openapi/openapi-ng/interceptors/csrf/csrf.go
@@ -135,18 +135,19 @@ func (p *provider) Interceptor(h http.HandlerFunc) http.HandlerFunc {
 				referer := r.Header.Get("Referer")
 				p.Log.Debugf("referer: %s", referer)
 				if referer == "" {
-					p.Log.Debugf("skip validate token for empty referer")
+					p.Log.Debug("skip validate token for empty referer")
 					validateToken = false
 				}
 				if r.Host == os.Getenv("SELF_ADDR") {
-					p.Log.Debugf("skip validate token for self-addr")
+					p.Log.Debug("skip validate token for self-addr")
 					validateToken = false
 				}
 				if ref, err := url.Parse(referer); err == nil {
 					refHostPort := getHostPort(ref.Host, ref.Scheme)
 					rHostPort := getHostPort(r.Host, r.URL.Scheme)
+					p.Log.Debugf("refHostPort: %s, rHostPort: %s", refHostPort, rHostPort)
 					if refHostPort == rHostPort {
-						p.Log.Debugf("skip validate token for same host-port: %s", refHostPort)
+						p.Log.Debug("skip validate token for same host-port")
 						validateToken = false
 					}
 				}

--- a/internal/core/openapi/openapi-ng/interceptors/csrf/csrf.go
+++ b/internal/core/openapi/openapi-ng/interceptors/csrf/csrf.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -125,24 +126,36 @@ func (p *provider) Interceptor(h http.HandlerFunc) http.HandlerFunc {
 			// Reuse token
 			token = k.Value
 		}
+		p.Log.Debugf("token from cookie: %s", token)
 		switch r.Method {
 		case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
 		default:
 			validateToken := true
 			if p.Cfg.AllowValidReferer {
 				referer := r.Header.Get("Referer")
+				p.Log.Debugf("referer: %s", referer)
 				if referer == "" {
+					p.Log.Debugf("skip validate token for empty referer")
+					validateToken = false
+				}
+				if r.Host == os.Getenv("SELF_ADDR") {
+					p.Log.Debugf("skip validate token for self-addr")
 					validateToken = false
 				}
 				if ref, err := url.Parse(referer); err == nil {
-					if ref.Host == r.Host {
+					refHostPort := getHostPort(ref.Host, ref.Scheme)
+					rHostPort := getHostPort(r.Host, r.URL.Scheme)
+					if refHostPort == rHostPort {
+						p.Log.Debugf("skip validate token for same host-port: %s", refHostPort)
 						validateToken = false
 					}
 				}
 			}
+			p.Log.Debugf("validateToken: %v", validateToken)
 			if validateToken {
 				// Validate token only for requests which are not defined as 'safe' by RFC7231
 				clientToken, err := p.extractor(r)
+				p.Log.Debugf("token from client: %s", clientToken)
 				if err != nil {
 					// Browsers block frontend JavaScript code from accessing the Set Cookie header,
 					// as required by the Fetch spec, which defines Set-Cookie as a forbidden response-header name
@@ -280,6 +293,18 @@ func firstNonEmpty(ss ...string) string {
 		}
 	}
 	return ""
+}
+
+func getHostPort(host, scheme string) string {
+	colon := strings.LastIndexByte(host, ':')
+	if colon != -1 {
+		return host
+	}
+	// plus port by scheme
+	if scheme == "https" {
+		return host + ":443"
+	}
+	return host + ":80"
 }
 
 func init() {

--- a/internal/core/openapi/openapi-ng/interceptors/csrf/csrf_test.go
+++ b/internal/core/openapi/openapi-ng/interceptors/csrf/csrf_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csrf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getHostPort(t *testing.T) {
+	assert.Equal(t, "localhost:8080", getHostPort("localhost:8080", ""))
+	assert.Equal(t, "localhost:8080", getHostPort("localhost:8080", "http"))
+	assert.Equal(t, "localhost:8080", getHostPort("localhost:8080", "https"))
+	assert.Equal(t, "localhost:443", getHostPort("localhost", "https"))
+	assert.Equal(t, "localhost:80", getHostPort("localhost", "http"))
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

skip validate csrf token for self-addr and same host-port.

See `url.URL.Host`:

```go
	Host        string    // host or host:port
```

so we need plus port for host before compare.


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   skip validate csrf token for self-addr and same host-port           |
| 🇨🇳 中文    |   csrf-token 跳过验证 self-addr 和相同的 host-port           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.4` when this PR is merged.
