### PR TITLE
feat(dop): window.open do not have header, so use query param to get lang

### DIFF
--- a/internal/apps/dop/providers/issue/core/provider.go
+++ b/internal/apps/dop/providers/issue/core/provider.go
@@ -31,6 +31,7 @@ import (
 	transhttp "github.com/erda-project/erda-infra/pkg/transport/http"
 	"github.com/erda-project/erda-infra/pkg/transport/http/encoding"
 	"github.com/erda-project/erda-infra/pkg/transport/interceptor"
+	"github.com/erda-project/erda-infra/providers/i18n"
 	commonpb "github.com/erda-project/erda-proto-go/common/pb"
 	userpb "github.com/erda-project/erda-proto-go/core/user/pb"
 	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
@@ -138,7 +139,8 @@ func (p *provider) Init(ctx servicehub.Context) error {
 						// all type return same sample
 						req.Type = nil
 						// locale
-						lang := apis.HTTPLanguage(r)
+						// window.open do not have header, so use query param
+						lang, _ := i18n.ParseLanguageCode(urlQuery.Get("Lang"))
 						if lang.Len() > 0 {
 							req.Locale = lang[0].String()
 						}


### PR DESCRIPTION
#### What this PR does / why we need it:

window.open do not have header, so use query param to get lang

related ui pr: https://github.com/erda-project/erda-ui/pull/3928


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   window.open do not have header, so use query param to get lang           |
| 🇨🇳 中文    |   window.open 没有 header，因此使用查询参数来获取 lang          |
