### PR TITLE
fix(orchestrator): only redis versions greater than 6.0 are deployed using the operator

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_deploy.go
+++ b/internal/tools/orchestrator/services/addon/addon_deploy.go
@@ -548,7 +548,7 @@ func (a *Addon) BuildAddonRequestGroup(params *apistructs.AddonHandlerCreateItem
 		}
 		buildErr = a.BuildCanalServiceItem(useOperator, params, addonIns, addonSpec, addonDice)
 	case apistructs.AddonRedis:
-		if capacity.RedisOperator && params.Plan == apistructs.AddonProfessional {
+		if capacity.RedisOperator && params.Plan == apistructs.AddonProfessional && version.Compare(addonSpec.Version, "6.2.10", ">=") {
 			_, addonOperatorDice, err := a.GetAddonExtention(&apistructs.AddonHandlerCreateItem{
 				AddonName: apistructs.AddonRedis + "-operator",
 				Plan:      apistructs.AddonBasic,

--- a/internal/tools/orchestrator/services/addon/addon_deploy_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_deploy_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
+	"github.com/mcuadros/go-version"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/erda-project/erda/apistructs"
@@ -234,4 +235,15 @@ func TestBuildMysqlOperatorServiceItem(t *testing.T) {
 	if err != nil {
 		t.Log(err)
 	}
+}
+
+func TestRedisVersionCompare(t *testing.T) {
+	lowRedisVersion := "3.2.12"
+	assert.Equal(t, false, version.Compare(lowRedisVersion, "6.2.10", ">="))
+
+	supportedVersion := "6.2.10"
+	assert.Equal(t, true, version.Compare(supportedVersion, "6.2.10", ">="))
+
+	highVersion := "6.3"
+	assert.Equal(t, true, version.Compare(highVersion, "6.2.10", ">="))
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
only redis versions greater than 6.0 are deployed using the operator

[reference](https://github.com/spotahome/redis-operator/blob/632aa3da88ee2a28ccb9fc4f571ddcb556dbd713/README.md?plain=1#L11)

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that only redis versions greater than 6.0 are deployed using the operator（修复了redis低于6.0版本使用operator发布失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that only redis versions greater than 6.0 are deployed using the operator          |
| 🇨🇳 中文    |    修复了redis低于6.0版本使用operator发布失败的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
