### PR TITLE
refactor: change the use of Transfer to cputil.ObjJSONTransfe

### DIFF
--- a/internal/apps/dop/component-protocol/components/issue-manage/batchOperationTipModal/model.go
+++ b/internal/apps/dop/component-protocol/components/issue-manage/batchOperationTipModal/model.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
 	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
-
 	"github.com/erda-project/erda/bundle"
 )
 

--- a/internal/apps/dop/component-protocol/components/issue-manage/batchOperationTipModal/render_test.go
+++ b/internal/apps/dop/component-protocol/components/issue-manage/batchOperationTipModal/render_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/erda-project/erda-infra/providers/component-protocol/cptype"
+	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	"github.com/erda-project/erda-infra/providers/i18n"
 )
 
@@ -32,39 +33,28 @@ func (t NopTranslator) Sprintf(lang i18n.LanguageCodes, key string, args ...inte
 	return fmt.Sprintf(key, args...)
 }
 
-func TestTransfer(t *testing.T) {
-	type TestData struct {
-		Name string
-		Age  int
+func TestObjJSONTransfer(t *testing.T) {
+	bot := struct {
+		Operations []string
+	}{
+		Operations: []string{"op1", "op2", "op3"},
 	}
 
-	// 准备测试数据
-	a := TestData{Name: "John", Age: 30}
-	var b TestData
+	c := struct {
+		Operations []string
+	}{}
 
-	// 调用被测试的方法
-	err := Transfer(a, &b)
+	cputil.ObjJSONTransfer(bot.Operations, &c.Operations)
 
-	// 检查返回的错误
-	if err != nil {
-		t.Errorf("Transfer() returned an error: %v", err)
+	expected := []string{"op1", "op2", "op3"}
+	if len(c.Operations) != len(expected) {
+		t.Errorf("Expected %d operations, but got %d", len(expected), len(c.Operations))
 	}
 
-	// 检查b是否与a相等
-	if b != a {
-		t.Errorf("Transfer() did not transfer data correctly. Expected: %v, Got: %v", a, b)
-	}
-
-	// 测试传递nil值的情况
-	err = Transfer(nil, &b)
-	if err == nil {
-		t.Error("Transfer() should return an error when passing nil value")
-	}
-
-	// 测试传递非指针类型的情况
-	err = Transfer(a, b)
-	if err == nil {
-		t.Error("Transfer() should return an error when passing non-pointer value")
+	for i := 0; i < len(expected); i++ {
+		if c.Operations[i] != expected[i] {
+			t.Errorf("Expected operation %s, but got %s", expected[i], c.Operations[i])
+		}
 	}
 }
 

--- a/internal/apps/dop/component-protocol/components/issue-manage/issueTable/render.go
+++ b/internal/apps/dop/component-protocol/components/issue-manage/issueTable/render.go
@@ -34,7 +34,6 @@ import (
 	commonpb "github.com/erda-project/erda-proto-go/common/pb"
 	userpb "github.com/erda-project/erda-proto-go/core/user/pb"
 	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
-
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/apps/dop/bdl"
 	"github.com/erda-project/erda/internal/apps/dop/component-protocol/components/common"


### PR DESCRIPTION
#### What this PR does / why we need it:

refactor: change the use of Transfer to cputil.ObjJSONTransfe

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @chengjoey @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
refactor: change the use of Transfer to cputil.ObjJSONTransfe （将使用Transfer 改为使用 cputil.ObjJSONTransfe）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      refactor: change the use of Transfer to cputil.ObjJSONTransfe        |
| 🇨🇳 中文    |       将使用Transfer 改为使用 cputil.ObjJSONTransfe       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
