### PR TITLE
fix: deploy MSE gateway no need deploy pgsql

### DIFF
--- a/internal/apps/msp/resource/deploy/coordinator/coordinator_test.go
+++ b/internal/apps/msp/resource/deploy/coordinator/coordinator_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/internal/apps/msp/resource/deploy/handlers"
+)
+
+func Test_isNeedDeployGatewayDependedAddon(t *testing.T) {
+	type args struct {
+		resourceSpecType string
+		resourceSpecName string
+		clusterConfig    map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test_01",
+			args: args{
+				resourceSpecType: "addon",
+				resourceSpecName: "api-gateway",
+				clusterConfig: map[string]string{
+					handlers.GatewayProviderVendorKey: "MSE",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Test_02",
+			args: args{
+				resourceSpecType: "addon",
+				resourceSpecName: "api-gateway",
+				clusterConfig: map[string]string{
+					handlers.GatewayProviderVendorKey: "",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNeedDeployGatewayDependedAddon(tt.args.resourceSpecType, tt.args.resourceSpecName, tt.args.clusterConfig); got != tt.want {
+				t.Errorf("isNeedDeployGatewayDependedAddon() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
If Erda deploy on Aliyun ACK,  api-gateway addon will use Aliyun MSE Gateway, so no need to deploy  Erda Kong api-gateway depended postgresql addon

#### Which issue(s) this PR fixes:



#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
Bugfix： Fix the bug that  no need to deploy  Erda Kong api-gateway depended postgresql addon when use Aliyun MSE Gateway（修复了 Erda 平台使用阿里云 MSE 网关的情况下，依然部署了 Kong 网关底层依赖的 postgresql addon 的问题 ）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       Bugfix： Fix the bug that  no need to deploy  Erda Kong api-gateway depended postgresql addon when use Aliyun MSE Gateway      |
| 🇨🇳 中文    |        修复了 Erda 平台使用阿里云 MSE 网关的情况下，依然部署了 Kong 网关底层依赖的 postgresql addon 的问题     |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4
