### PR TITLE
fix: convert ProjectIDs type to []string

### DIFF
--- a/internal/apps/dop/providers/efficiency_measure/contributor_query.go
+++ b/internal/apps/dop/providers/efficiency_measure/contributor_query.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 type PersonalContributorRow struct {
@@ -158,7 +159,7 @@ func (p *provider) makeContributorBasicSql(req *apistructs.PersonalContributionR
 			Group("repoID").
 			Group("timestamp")
 		if len(req.ProjectIDs) > 0 {
-			tx = tx.Where("tag_values[indexOf(tag_keys,'org_id')] in (?)", req.ProjectIDs)
+			tx = tx.Where("tag_values[indexOf(tag_keys,'project_id')] in (?)", strutil.ToStrSlice(req.ProjectIDs))
 		}
 		return tx.Find(&[]PersonalContributorRow{})
 	})

--- a/internal/apps/dop/providers/efficiency_measure/efficiency_query.go
+++ b/internal/apps/dop/providers/efficiency_measure/efficiency_query.go
@@ -26,6 +26,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 type PersonalEfficiencyRow struct {
@@ -198,7 +199,7 @@ func (p *provider) makeEfficiencyBasicSql(req *apistructs.PersonalEfficiencyRequ
 			tx = tx.Where("tag_values[indexOf(tag_keys,'user_id')] = '?'", req.UserID)
 		}
 		if len(req.ProjectIDs) > 0 {
-			tx = tx.Where("tag_values[indexOf(tag_keys,'project_id')] in (?)", req.ProjectIDs)
+			tx = tx.Where("tag_values[indexOf(tag_keys,'project_id')] in (?)", strutil.ToStrSlice(req.ProjectIDs))
 		}
 		for _, query := range req.LabelQuerys {
 			if query.Operation == "like" {
@@ -298,7 +299,6 @@ func (p *provider) makeEfficiencyBasicSql(req *apistructs.PersonalEfficiencyRequ
     last_value(projectDisplayName) as projectDisplayName,
     sum(lastRequirementTotal) as requirementTotal,
     if(requirementTotal - sum(firstRequirementTotal) > 0, requirementTotal - sum(firstRequirementTotal), 0) as rangeRequirementTotal,
-    sum(lastRequirementTotal) as requirementTotal,
     sum(workingRequirementTotal) as workingRequirementTotal,
     if(workingRequirementTotal - sum(firstWorkingRequirementTotal) > 0, workingRequirementTotal - sum(firstWorkingRequirementTotal), 0) as rangeWorkingRequirementTotal,
     sum(pendingRequirementTotal) as pendingRequirementTotal,

--- a/internal/apps/dop/providers/efficiency_measure/func_points_trend.go
+++ b/internal/apps/dop/providers/efficiency_measure/func_points_trend.go
@@ -27,6 +27,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 type FuncPointTrendRow struct {
@@ -111,7 +112,7 @@ func (p *provider) makeFuncPointTrendSql(req *apistructs.FuncPointTrendRequest) 
 			Group("projectID").
 			Group("timestamp")
 		if len(req.ProjectIDs) > 0 {
-			tx = tx.Where("tag_values[indexOf(tag_keys,'user_id')] in (?)", req.ProjectIDs)
+			tx = tx.Where("tag_values[indexOf(tag_keys,'project_id')] in (?)", strutil.ToStrSlice(req.ProjectIDs))
 		}
 		return tx.Find(&[]FuncPointTrendRow{})
 	})

--- a/internal/apps/dop/providers/project_report/query.go
+++ b/internal/apps/dop/providers/project_report/query.go
@@ -29,6 +29,7 @@ import (
 	"github.com/erda-project/erda/internal/apps/dop/bdl"
 	"github.com/erda-project/erda/internal/pkg/user"
 	"github.com/erda-project/erda/pkg/http/httpserver"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 type ProjectReportRow struct {
@@ -494,18 +495,10 @@ func (p *provider) checkPermission(req *apistructs.ProjectReportRequest, identit
 func genLastValueWhereSql(req *apistructs.ProjectReportRequest) string {
 	var projectIDSql, iterationIDSql, labelQuerySql string
 	if len(req.ProjectIDs) > 0 {
-		var projectIDs []string
-		for _, id := range req.ProjectIDs {
-			projectIDs = append(projectIDs, fmt.Sprintf("'%d'", id))
-		}
-		projectIDSql = fmt.Sprintf("AND tag_values[indexOf(tag_keys,'project_id')] IN (%s)", strings.Join(projectIDs, ","))
+		projectIDSql = fmt.Sprintf("AND tag_values[indexOf(tag_keys,'project_id')] IN (%s)", strings.Join(strutil.ToStrSlice(req.ProjectIDs, true), ","))
 	}
 	if len(req.IterationIDs) > 0 {
-		var iterationIDs []string
-		for _, id := range req.IterationIDs {
-			iterationIDs = append(iterationIDs, fmt.Sprintf("'%d'", id))
-		}
-		iterationIDSql = fmt.Sprintf("AND tag_values[indexOf(tag_keys,'iteration_id')] IN (%s)", strings.Join(iterationIDs, ","))
+		iterationIDSql = fmt.Sprintf("AND tag_values[indexOf(tag_keys,'iteration_id')] IN (%s)", strings.Join(strutil.ToStrSlice(req.IterationIDs, true), ","))
 	}
 	for _, query := range req.LabelQuerys {
 		if query.Key == labelProjectName {

--- a/pkg/strutil/convert.go
+++ b/pkg/strutil/convert.go
@@ -15,6 +15,7 @@
 package strutil
 
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -23,4 +24,24 @@ func NoCopyBytesToString(b []byte) string {
 }
 func NoCopyStringToBytes(s string) []byte {
 	return *(*[]byte)(unsafe.Pointer(&s))
+}
+
+func ToStrSlice[T uint64 | uint | int64 | int](input []T, withQuote ...bool) []string {
+	result := make([]string, len(input))
+	var quote bool
+	if len(withQuote) > 0 && withQuote[0] {
+		quote = true
+	}
+
+	for i, val := range input {
+		var str string
+		if quote {
+			str = fmt.Sprintf("'%v'", val)
+		} else {
+			str = fmt.Sprintf("%v", val)
+		}
+		result[i] = str
+	}
+
+	return result
 }

--- a/pkg/strutil/convert_test.go
+++ b/pkg/strutil/convert_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToStrSlice(t *testing.T) {
+	testCases := []struct {
+		input     interface{}
+		withQuote bool
+		expected  []string
+	}{
+		{
+			input:     []int{1, 2, 3, 4, 5},
+			withQuote: true,
+			expected:  []string{"'1'", "'2'", "'3'", "'4'", "'5'"},
+		},
+		{
+			input:    []int64{10, 20, 30, 40, 50},
+			expected: []string{"10", "20", "30", "40", "50"},
+		},
+		{
+			input:     []uint{100, 200, 300, 400, 500},
+			withQuote: true,
+			expected:  []string{"'100'", "'200'", "'300'", "'400'", "'500'"},
+		},
+		{
+			input:    []uint64{1000, 2000, 3000, 4000, 5000},
+			expected: []string{"1000", "2000", "3000", "4000", "5000"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		var result []string
+		switch input := testCase.input.(type) {
+		case []int:
+			result = ToStrSlice(input, testCase.withQuote)
+		case []int64:
+			result = ToStrSlice(input, testCase.withQuote)
+		case []uint:
+			result = ToStrSlice(input, testCase.withQuote)
+		case []uint64:
+			result = ToStrSlice(input, testCase.withQuote)
+		default:
+			t.Errorf("Unsupported input type: %T", testCase.input)
+			continue
+		}
+
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Input: %v, withQuote: %v\nExpected: %v\nGot: %v", testCase.input, testCase.withQuote, testCase.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix(performance_measure.go):convert ProjectIDs type to []string]

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @chengjoey @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
fix(performance_measure.go):convert ProjectIDs type to []string] （转换 ProjectIDs 为 []string，类型转换）

-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     fix(performance_measure.go):convert ProjectIDs type to []string]         |
| 🇨🇳 中文    |        转换 ProjectIDs 为 []string，类型转换     |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
