### PR TITLE
feat(ai-proxy): bailian qwenv1 support both stream&non-stream request

### DIFF
--- a/internal/apps/ai-proxy/common/ctxhelper/stream.go
+++ b/internal/apps/ai-proxy/common/ctxhelper/stream.go
@@ -12,24 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vars
+package ctxhelper
 
 import (
-	"strings"
+	"context"
+	"sync"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
+	"github.com/erda-project/erda/pkg/reverseproxy"
 )
 
-func ConcatBearer(v string) string {
-	return "Bearer " + v
+func GetIsStream(ctx context.Context) (bool, bool) {
+	value, ok := ctx.Value(reverseproxy.CtxKeyMap{}).(*sync.Map).Load(vars.MapKeyIsStream{})
+	if !ok || value == nil {
+		return false, false
+	}
+	isStream, ok := value.(bool)
+	if !ok {
+		return false, false
+	}
+	return isStream, true
 }
 
-func TrimBearer(v string) string {
-	return strings.TrimPrefix(v, "Bearer ")
-}
-
-func ConcatChunkDataPrefix(v []byte) []byte {
-	return []byte("data: " + string(v) + "\n\n")
-}
-
-func TrimChunkDataPrefix(v []byte) []byte {
-	return []byte(strings.TrimPrefix(strings.TrimSuffix(string(v), "\n\n"), "data: "))
+func PutIsStream(ctx context.Context, isStream bool) {
+	m := ctx.Value(reverseproxy.CtxKeyMap{}).(*sync.Map)
+	m.Store(vars.MapKeyIsStream{}, isStream)
 }

--- a/internal/apps/ai-proxy/filters/bailian-director/filter.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/filter.go
@@ -160,7 +160,7 @@ func transferHistoryMessages(g message.Group) []*ChatQaMessage {
 
 var botOKMsg = openai.ChatCompletionMessage{
 	Role:    openai.ChatMessageRoleAssistant,
-	Content: "OK",
+	Content: "Got it",
 }
 
 func autoFillQaPair(msgs message.Messages) []*ChatQaMessage {

--- a/internal/apps/ai-proxy/filters/bailian-director/filter.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/filter.go
@@ -47,6 +47,9 @@ func init() {
 
 type BailianDirector struct {
 	*reverseproxy.DefaultResponseFilter
+
+	lastCompletionDataLineIndex int
+	lastCompletionDataLineText  string
 }
 
 func New(config json.RawMessage) (reverseproxy.Filter, error) {
@@ -106,7 +109,7 @@ func (f *BailianDirector) OnRequest(ctx context.Context, w http.ResponseWriter, 
 		AppId:   &modelMeta.Secret.AppId,
 		Prompt:  &prompt,
 		History: historyMsgs,
-		Stream:  false, // stream=true has bug in bailian
+		Stream:  openaiReq.Stream,
 	}
 	b, err := json.Marshal(&bailianReq)
 	if err != nil {

--- a/internal/apps/ai-proxy/filters/bailian-director/resp.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/resp.go
@@ -48,7 +48,6 @@ func (f *BailianDirector) OnResponseChunk(ctx context.Context, infor reverseprox
 // data: {"Data":{"Debug":{},"DocReferences":[],"ResponseId":"ba91dde7238
 // ```
 // the last line may be incomplete.
-
 func (f *BailianDirector) handleResponseStreamChunk(ctx context.Context, w reverseproxy.Writer, bailianChunk []byte) (reverseproxy.Signal, error) {
 	f.DefaultResponseFilter.Buffer.Write(bailianChunk)
 	signal, lastCompleteDeltaResp := f.getDeltaTextFromStreamChunk(f.DefaultResponseFilter.Buffer.Bytes())
@@ -69,7 +68,6 @@ func (f *BailianDirector) handleResponseStreamChunk(ctx context.Context, w rever
 	if _, err := w.Write(b); err != nil {
 		return reverseproxy.Intercept, fmt.Errorf("failed to write openai response, err: %v", err)
 	}
-	// adjust header content-length
 	return reverseproxy.Continue, nil
 }
 

--- a/internal/apps/ai-proxy/filters/bailian-director/resp.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/resp.go
@@ -18,44 +18,151 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/sashabaranov/go-openai"
 
 	modelpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model/pb"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
 	"github.com/erda-project/erda/pkg/reverseproxy"
+	"github.com/erda-project/erda/pkg/strutil"
 )
 
 func (f *BailianDirector) OnResponseChunk(ctx context.Context, infor reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) (signal reverseproxy.Signal, err error) {
-	f.DefaultResponseFilter.Buffer.Write(chunk)
-	return reverseproxy.Continue, nil
+	isStream, _ := ctxhelper.GetIsStream(ctx)
+	if !isStream {
+		f.DefaultResponseFilter.Buffer.Write(chunk)
+		return reverseproxy.Continue, nil
+	}
+	// handle chunk
+	return f.handleResponseStreamChunk(ctx, w, chunk)
 }
 
-func (f *BailianDirector) OnResponseEOF(ctx context.Context, _ reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) (err error) {
-	// convert bailian response to openai response
-	var bailianResp CompletionResponse
-	if err := json.Unmarshal(f.DefaultResponseFilter.Buffer.Bytes(), &bailianResp); err != nil {
-		return fmt.Errorf("failed to unmarshal bailian response, err: %v", err)
+// chunk format:
+// ```plain text
+// data: {"Data":{"Debug":{},"DocReferences":[],"ResponseId":"ba91dde7238a401383dff1fda7c950e6","Text":"hello","Thoughts":[]},"RequestId":"db1190f8ff344bdca363f05420fa6b58","Success":true}
+//
+// data: {"Data":{"Debug":{},"DocReferences":[],"ResponseId":"ba91dde7238a401383dff1fda7c950e6","Text":"hello world","Thoughts":[]},"RequestId":"db1190f8ff344bdca363f05420fa6b58","Success":true}
+//
+// data: {"Data":{"Debug":{},"DocReferences":[],"ResponseId":"ba91dde7238
+// ```
+// the last line may be incomplete.
+
+func (f *BailianDirector) handleResponseStreamChunk(ctx context.Context, w reverseproxy.Writer, bailianChunk []byte) (reverseproxy.Signal, error) {
+	f.DefaultResponseFilter.Buffer.Write(bailianChunk)
+	signal, lastCompleteDeltaResp := f.getDeltaTextFromStreamChunk(f.DefaultResponseFilter.Buffer.Bytes())
+	if signal == reverseproxy.Intercept || lastCompleteDeltaResp == nil {
+		return signal, nil
 	}
+	// convert bailian response to openai response
 	model, _ := ctxhelper.GetModel(ctx)
-	openaiResp, err := convertToOpenaiResponse(model, bailianResp)
+	openaiResp, err := convertToOpenaiStreamChunk(model, *lastCompleteDeltaResp)
 	if err != nil {
-		return fmt.Errorf("failed to convert bailian response to openai response, err: %v", err)
+		return reverseproxy.Intercept, fmt.Errorf("failed to convert bailian response to openai response, err: %v", err)
 	}
 	b, err := json.Marshal(openaiResp)
 	if err != nil {
-		return fmt.Errorf("failed to marshal openai response, err: %v", err)
+		return reverseproxy.Intercept, fmt.Errorf("failed to marshal openai response, err: %v", err)
 	}
+	b = vars.ConcatChunkDataPrefix(b)
 	if _, err := w.Write(b); err != nil {
+		return reverseproxy.Intercept, fmt.Errorf("failed to write openai response, err: %v", err)
+	}
+	// adjust header content-length
+	return reverseproxy.Continue, nil
+}
+
+func (f *BailianDirector) getDeltaTextFromStreamChunk(allChunks []byte) (reverseproxy.Signal, *CompletionResponse) {
+	allLines := string(allChunks)
+	allDataLines := strutil.Split(allLines, "\n", true)
+	// try to get the last complete data line
+	var lastCompleteDataLine CompletionResponse
+	var lastCompleteDataLineText string
+	for i := len(allDataLines) - 1; i >= 0; i-- {
+		if i < f.lastCompletionDataLineIndex {
+			break
+		}
+		if err := json.Unmarshal(vars.TrimChunkDataPrefix([]byte(allDataLines[i])), &lastCompleteDataLine); err == nil {
+			f.lastCompletionDataLineIndex = i
+			if lastCompleteDataLine.Success == false {
+				return reverseproxy.Intercept, nil
+			}
+			if lastCompleteDataLine.Data == nil {
+				continue
+			}
+			if lastCompleteDataLine.Data.Text == nil || *lastCompleteDataLine.Data.Text == "" {
+				continue
+			}
+			lastCompleteDataLineText = *lastCompleteDataLine.Data.Text
+			break
+		}
+	}
+	if lastCompleteDataLineText == "" {
+		return reverseproxy.Continue, nil
+	}
+	// 因为 qwenv1 目前 stream 不是真 chunk，每个 data line 的 text 都是在之前的基础上进行 append，所以需要主动计算增量值，模拟真 chunk 形式返回
+	delta := strings.TrimPrefix(lastCompleteDataLineText, f.lastCompletionDataLineText)
+	if delta == "" {
+		return reverseproxy.Continue, nil
+	}
+	f.lastCompletionDataLineText = lastCompleteDataLineText
+	lastCompleteDataLine.Data.Text = &delta
+	return reverseproxy.Continue, &lastCompleteDataLine
+}
+
+func (f *BailianDirector) OnResponseEOF(ctx context.Context, _ reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) (err error) {
+	// only stream style need append [DONE] chunk
+	isStream, _ := ctxhelper.GetIsStream(ctx)
+	if !isStream {
+		// convert all at once
+		model, _ := ctxhelper.GetModel(ctx)
+		var bailianResp CompletionResponse
+		if err := json.Unmarshal(f.DefaultResponseFilter.Buffer.Bytes(), &bailianResp); err != nil {
+			return fmt.Errorf("failed to unmarshal bailian response, err: %v", err)
+		}
+		openaiResp, err := convertToOpenaiResponse(model, bailianResp)
+		if err != nil {
+			return fmt.Errorf("failed to convert bailian response to openai response, err: %v", err)
+		}
+		b, err := json.Marshal(openaiResp)
+		if err != nil {
+			return fmt.Errorf("failed to marshal openai response, err: %v", err)
+		}
+		return f.DefaultResponseFilter.OnResponseEOF(ctx, nil, w, b)
+	}
+	// append [DONE] chunk
+	doneChunk := vars.ConcatChunkDataPrefix([]byte("[DONE]"))
+	if _, err := w.Write(doneChunk); err != nil {
 		return fmt.Errorf("failed to write openai response, err: %v", err)
 	}
-	return err
+	return nil
+}
+
+func convertToOpenaiStreamChunk(model *modelpb.Model, bailianResponse CompletionResponse) (*openai.ChatCompletionStreamResponse, error) {
+	openaiResp := &openai.ChatCompletionStreamResponse{
+		ID:     *bailianResponse.Data.ResponseId,
+		Object: "chat.completion.chunk",
+		Model:  model.Name,
+		Choices: []openai.ChatCompletionStreamChoice{
+			{
+				Index: 0,
+				Delta: openai.ChatCompletionStreamChoiceDelta{
+					Role:    openai.ChatMessageRoleAssistant,
+					Content: *bailianResponse.Data.Text,
+				},
+				FinishReason: openai.FinishReasonNull,
+			},
+		},
+	}
+	return openaiResp, nil
 }
 
 func convertToOpenaiResponse(model *modelpb.Model, bailianResponse CompletionResponse) (*openai.CompletionResponse, error) {
 	openaiResp := &openai.CompletionResponse{
-		ID:    *bailianResponse.Data.ResponseId,
-		Model: model.Name,
+		ID:     *bailianResponse.Data.ResponseId,
+		Object: "chat.completion",
+		Model:  model.Name,
 		Choices: []openai.CompletionChoice{
 			{
 				Text:         *bailianResponse.Data.Text,

--- a/internal/apps/ai-proxy/filters/message-context/filter.go
+++ b/internal/apps/ai-proxy/filters/message-context/filter.go
@@ -167,6 +167,7 @@ func (c *SessionContext) OnRequest(ctx context.Context, _ http.ResponseWriter, i
 	}
 	ctxhelper.PutMessageGroup(ctx, messageGroup)
 	ctxhelper.PutUserPrompt(ctx, requestedMessages[len(requestedMessages)-1].Content)
+	ctxhelper.PutIsStream(ctx, chatCompletionRequest.Stream)
 
 	return reverseproxy.Continue, nil
 }

--- a/internal/apps/ai-proxy/vars/consts.go
+++ b/internal/apps/ai-proxy/vars/consts.go
@@ -58,4 +58,5 @@ type (
 	MapKeyClientToken    struct{ MapKeyClientToken any }
 	MapKeyMessageGroup   struct{ MapKeyMessageGroup any }
 	MapKeyUserPrompt     struct{ MapKeyUserPrompt any }
+	MapKeyIsStream       struct{ MapKeyIsStream any }
 )


### PR DESCRIPTION
#### What this PR does / why we need it:

bailian qwenv1 support both stream&non-stream request


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/terminus/dop/projects/1265/issues/all?id=532809&iterationID=13370&type=TASK)


#### Specified Reviewers:

/assign @wangzhuzhen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   bailian qwenv1 support both stream&non-stream request           |
| 🇨🇳 中文    |  阿里云百炼通义千问模型支持流式和非流式请求            |
