### PR TITLE
fix: collector-agent docker_container_summary modifier processor get container id error

### DIFF
--- a/cmd/monitor/collector/bootstrap-agent.yaml
+++ b/cmd/monitor/collector/bootstrap-agent.yaml
@@ -174,9 +174,12 @@ erda.oap.collector.processor.modifier@docker_container_summary:
     - action: rename
       key: fields.container_network_transmit_errors_total
       value: fields.tx_errors
-    - action: rename
-      key: tags.name
-      value: tags.container_id
+    - action: regex
+      key: tags.id
+      value: '\/kubepods.*?(?P<container_id>\w{64})' #  have kubepods and match 64-character
+      # containerd arm: /system.slice/containerd.service/kubepods-burstable-pod29c95a11_3435_474a_be34_226976d3035f.slice:cri-containerd:01c5cfd0633692a2a14bfa656e947cd4c23e5d17492382f354f262c72f27802d
+      # /kubepods/burstable/podc15fa300-e090-4b5d-a850-eb65900a8dac/0fa5d0a7434e23d87f13617f2ab16186530c32ef877724842f96bbe8d4ba8935
+      # /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod314d3a36_aea1_4a0b_9a62_7254ed0f187e.slice/docker-37975252123ac98398aeb6fdc9feb3b35eaaf35e7536430ad2cb8a8c67303ee1.scope
     - action: rename
       key: fields.container_resources_memory_request
       value: fields.mem_request

--- a/internal/tools/monitor/oap/collector/lib/util_test.go
+++ b/internal/tools/monitor/oap/collector/lib/util_test.go
@@ -77,11 +77,29 @@ func TestRegexGroupMap(t *testing.T) {
 	}{
 		{
 			args: args{
-				pattern: regexp.MustCompile("^/kubepods/\\w+/[\\w|\\-]+/(?P<container_id>\\w+)"),
+				pattern: regexp.MustCompile("/kubepods.*?(?P<container_id>\\w{64})"),
 				s:       "/kubepods/burstable/pod164ec226-8106-4904-9bcb-0218a9b2b793/8367a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec",
 			},
 			want: map[string]string{
 				"container_id": "8367a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec",
+			},
+		},
+		{
+			args: args{
+				pattern: regexp.MustCompile("/kubepods.*?(?P<container_id>\\w{64})"),
+				s:       "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1a12223c_7554_4ced_b17c_168b016f218e.slice/cri-containerd-03e25d833346fe6f59608fdbbc5a7776680788609c2daf34e29f9be95ffbda24.scope",
+			},
+			want: map[string]string{
+				"container_id": "03e25d833346fe6f59608fdbbc5a7776680788609c2daf34e29f9be95ffbda24",
+			},
+		},
+		{
+			args: args{
+				pattern: regexp.MustCompile("/kubepods.*?(?P<container_id>\\w{64})"),
+				s:       "/system.slice/containerd.service/kubepods-burstable-pod29c95a11_3435_474a_be34_226976d3035f.slice:cri-containerd:01c5cfd0633692a2a14bfa656e947cd4c23e5d17492382f354f262c72f27802d",
+			},
+			want: map[string]string{
+				"container_id": "01c5cfd0633692a2a14bfa656e947cd4c23e5d17492382f354f262c72f27802d",
 			},
 		},
 		{


### PR DESCRIPTION
#### What this PR does / why we need it:
pr: #5631 

Name may not necessarily represent the container ID in some distributions.
e.g.
<img width="1403" alt="image" src="https://github.com/erda-project/erda/assets/31346321/9e8e38ab-128d-4e37-a9a5-49d9670bf266">

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix collector-agent docker_container_summary modifier processor get container id error           |
| 🇨🇳 中文    |     修复 collector-agent    docker_container_summary modifier processor  获取容器 id 失败问题    |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
