### PR TITLE
feat(ai-proxy): auto del accept-encoding for bailian lllm

### DIFF
--- a/internal/apps/ai-proxy/filters/bailian-director/filter.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/filter.go
@@ -85,6 +85,7 @@ func (f *BailianDirector) OnRequest(ctx context.Context, w http.ResponseWriter, 
 		r.Header.Set(httputil.HeaderKeyContentType, string(httputil.ApplicationJsonUTF8))
 		r.Header.Set(httputil.HeaderKeyAuthorization, vars.ConcatBearer(token))
 		r.Header.Set(httputil.HeaderKeyAccept, string(httputil.ApplicationJsonUTF8))
+		r.Header.Del(httputil.HeaderKeyAcceptEncoding) // remove gzip. Actual test: gzip is not ok; deflate is ok; br is ok
 	})
 
 	// parse original request body

--- a/pkg/http/httputil/mediatype.go
+++ b/pkg/http/httputil/mediatype.go
@@ -31,4 +31,5 @@ var (
 	HeaderKeyAccessControlAllowOrigin = textproto.CanonicalMIMEHeaderKey("Access-Control-Allow-Origin")
 	HeaderKeyAuthorization            = textproto.CanonicalMIMEHeaderKey("Authorization")
 	HeaderKeyAccept                   = textproto.CanonicalMIMEHeaderKey("Accept")
+	HeaderKeyAcceptEncoding           = textproto.CanonicalMIMEHeaderKey("Accept-Encoding")
 )


### PR DESCRIPTION
#### What this PR does / why we need it:

Auto del accept-encoding for bailian lllm.

Test result:
- gzip is not ok
- deflate is ok
- br is ok


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    auto del accept-encoding for bailian lllm          |
| 🇨🇳 中文    |   百炼大模型自动删除 accept-encoding header           |
