### PR TITLE
feat(collector): retag component_name from label dice/component

### DIFF
--- a/cmd/monitor/collector/bootstrap-agent.yaml
+++ b/cmd/monitor/collector/bootstrap-agent.yaml
@@ -195,6 +195,12 @@ erda.oap.collector.processor.modifier@docker_container_summary:
     - action: rename
       key: tags.terminus_define_tag
       value: tags.job_id
+    - action: copy
+      key: tags.pod_labels_dice_component
+      value: tags.component_name
+      condition:
+        op: key_exist
+        key: tags.pod_labels_dice_component
     # --- instance_type logic block ---
     - action: set
       key: tags.instance_type

--- a/cmd/monitor/collector/bootstrap.yaml
+++ b/cmd/monitor/collector/bootstrap.yaml
@@ -230,6 +230,12 @@ erda.oap.collector.processor.modifier@docker_container_summary:
     - action: rename
       key: tags.terminus_define_tag
       value: tags.job_id
+    - action: copy
+      key: tags.pod_labels_dice_component
+      value: tags.component_name
+      condition:
+        op: key_exist
+        key: tags.pod_labels_dice_component
     # --- instance_type logic block ---
     - action: set
       key: tags.instance_type


### PR DESCRIPTION
#### What this PR does / why we need it:
retag component_name from label dice/component
<img width="1350" alt="image" src="https://github.com/erda-project/erda/assets/31346321/9721db7f-2784-4c2b-97e6-e78405eb8f99">


avg component from metrics 
```shell
SELECT toNullable(tag_values[indexOf(tag_keys,'component_name')]) AS "component_name::tag" FROM "monitor"."metrics_all" WHERE (("timestamp" >= fromUnixTimestamp64Nano(cast(1699340010037000000,'Int64'))) AND ("timestamp" < fromUnixTimestamp64Nano(cast(1699350810037000000,'Int64'))) AND (org_name = 'erda-demo') AND ("org_name" IN ('erda-demo', 'erda', '')) AND ("tenant_id" = 'erda-demo') AND ("metric_group" IN ('docker_container_summary'))) GROUP BY "component_name::tag" ORDER BY "component_name::tag" ASC
```

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sixther-dc @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add component name from label  (dice/component)          |
| 🇨🇳 中文    |   添加组件名（数据来源 dice/component）           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
