### PR TITLE
fix(collector): collector exporter compress panic due to index out of range

### DIFF
--- a/internal/tools/monitor/oap/collector/lib/compressor/writer.go
+++ b/internal/tools/monitor/oap/collector/lib/compressor/writer.go
@@ -19,9 +19,11 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"sync"
 )
 
 type gzipEncoder struct {
+	sync.Mutex
 	buf    *bytes.Buffer
 	writer *gzip.Writer
 }
@@ -39,7 +41,9 @@ func (ge *gzipEncoder) Compress(buf []byte) ([]byte, error) {
 	defer func() {
 		ge.buf.Reset()
 		ge.writer.Reset(ge.buf)
+		ge.Unlock()
 	}()
+	ge.Lock()
 	if _, err := ge.writer.Write(buf); err != nil {
 		return nil, fmt.Errorf("gizp write data: %w", err)
 	}

--- a/internal/tools/monitor/oap/collector/lib/compressor/writer_test.go
+++ b/internal/tools/monitor/oap/collector/lib/compressor/writer_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compressor
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/internal/tools/monitor/core/metric"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func RandStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func BenchmarkCompress(b *testing.B) {
+	encoder := NewGzipEncoder(3)
+	wait := sync.WaitGroup{}
+	for i := 0; i < b.N; i++ {
+		wait.Add(1)
+		go func(idx int) {
+			items := make([]*metric.Metric, 0, i)
+			for j := 0; j < idx; j++ {
+				items = append(items, &metric.Metric{
+					Name:      "test",
+					Timestamp: time.Now().UnixNano(),
+					Tags: map[string]string{
+						"tag1": RandStringRunes(rand.Intn(1000)),
+						"tag2": RandStringRunes(rand.Intn(1000)),
+					},
+					Fields: map[string]interface{}{
+						"field1": RandStringRunes(rand.Intn(1000)),
+						"field2": RandStringRunes(rand.Intn(1000)),
+					},
+				})
+			}
+			obj := map[string][]*metric.Metric{
+				"metrics": items,
+			}
+			buf, err := json.Marshal(&obj)
+			if err != nil {
+				b.Fatal(fmt.Errorf("serialize err: %w", err))
+			}
+			compressed, err := encoder.Compress(buf)
+			assert.NoError(b, err)
+			assert.NotEmpty(b, compressed)
+			wait.Done()
+		}(i)
+	}
+	wait.Wait()
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix collector exporter compress panic due to index out of range

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=540704&iterationID=-1&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that collector exporter compress panic due to index out of range （修复了collector的exporter由于数组越界造成panic的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that collector exporter compress panic due to index out of range           |
| 🇨🇳 中文    |    修复了collector的exporter由于数组越界造成panic的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
