### PR TITLE
fix(monitor): container `mem_limit` value same with machine mem

### DIFF
--- a/cmd/monitor/monitor/conf/chartview/runtime/runtime-container-detail.json
+++ b/cmd/monitor/monitor/conf/chartview/runtime/runtime-container-detail.json
@@ -55,7 +55,7 @@
             "alias": "Mem Limit",
             "key": "valueNLlik561",
             "type": "expr",
-            "expr": "max(mem_limit::field)",
+            "expr": "min(mem_limit::field)",
             "unit": {
               "type": "CAPACITY",
               "unit": "B"
@@ -79,7 +79,7 @@
             "expr": "max(mem_usage::field)"
           }, {
             "alias": "valueNLlik561",
-            "expr": "max(mem_limit::field)"
+            "expr": "min(mem_limit::field)"
           }],
           "where": ["pod_uid::tag='{{podUid}}'"]
         },


### PR DESCRIPTION
#### What this PR does / why we need it:
fix container `mem_limit` value same with machine mem

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=548259&iterationID=12783&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that container `mem_limit` value same with machine mem（修复了容器监控的内存限制由于pause容器的原因与机器内存一致的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that container `mem_limit` value same with machine mem            |
| 🇨🇳 中文    |     修复了容器监控的内存限制由于pause容器的原因与机器内存一致的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
