### PR TITLE
fix(pipeline): fix action i18n issue

### DIFF
--- a/apistructs/extension_test.go
+++ b/apistructs/extension_test.go
@@ -49,7 +49,7 @@ func TestConvertToDetail(t *testing.T) {
 			Desc:        "代码仓库克隆",
 		},
 	}
-	actionDetail := s.ConvertToDetail()
+	actionDetail := s.ConvertToDetail("zh-CN")
 	assert.Equal(t, "git-checkout", actionDetail.Name)
 	assert.Equal(t, "1.0", actionDetail.Version)
 	assert.Equal(t, "git-checkout", actionDetail.DisplayName)

--- a/apistructs/extention.go
+++ b/apistructs/extention.go
@@ -328,25 +328,25 @@ type ActionSpec struct {
 	Executor          *ActionExecutor     `json:"executor" yaml:"executor"`
 }
 
-func (s *ActionSpec) ConvertToDetail() PipelineTaskActionDetail {
+func (s *ActionSpec) ConvertToDetail(lang string) PipelineTaskActionDetail {
 	return PipelineTaskActionDetail{
 		Name:        s.Name,
 		Version:     s.Version,
 		Type:        s.Type,
 		LogoUrl:     s.LogoUrl,
-		DisplayName: s.GetLocaleDisplayName(i18n.GetGoroutineBindLang()),
-		Description: s.GetLocaleDesc(i18n.GetGoroutineBindLang()),
+		DisplayName: s.GetLocaleDisplayName(lang),
+		Description: s.GetLocaleDesc(lang),
 	}
 }
 
-func (s *ActionSpec) Convert2PBDetail() *basepb.PipelineTaskActionDetail {
+func (s *ActionSpec) Convert2PBDetail(lang string) *basepb.PipelineTaskActionDetail {
 	return &basepb.PipelineTaskActionDetail{
 		Name:        s.Name,
 		Version:     s.Version,
 		Type:        s.Type,
 		LogoUrl:     s.LogoUrl,
-		DisplayName: s.GetLocaleDisplayName(i18n.GetGoroutineBindLang()),
-		Description: s.GetLocaleDesc(i18n.GetGoroutineBindLang()),
+		DisplayName: s.GetLocaleDisplayName(lang),
+		Description: s.GetLocaleDesc(lang),
 	}
 }
 

--- a/cmd/erda-server/conf/i18n/issue-manage.yaml
+++ b/cmd/erda-server/conf/i18n/issue-manage.yaml
@@ -12,7 +12,7 @@ en:
   childrenInProgress: "reason: included task has started"
   mrCreated: "reason: task/bug is related by MR"
   iterationChanged: "reason: iteration is changed"
-  planFinishedAtChanged: "resaon: plan finished at is changed"
+  planFinishedAtChanged: "reason: plan finished at is changed"
   childrenPlanUpdated: "reason: plan time of included task is changed"
   parentLabelsChanged: "reason: labels of the requirement are changed"
   parentIterationChanged: "reason: iteration of the requirement is changed"

--- a/cmd/erda-server/conf/i18n/msp-i18n.yaml
+++ b/cmd/erda-server/conf/i18n/msp-i18n.yaml
@@ -63,7 +63,7 @@ en:
   traceServices: Service
   traceDistribution: Tracing time distribution
   cpuUsage: Container CPU
-  memoryUsage: Container 内存
+  memoryUsage: Container Memory
   diskioUsage: Disk IO
   networkUsage: Container Network
   nodejs_memory_heap: Heap Memory

--- a/internal/tools/pipeline/providers/graph/graph.service.go
+++ b/internal/tools/pipeline/providers/graph/graph.service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/bundle"
 	"github.com/erda-project/erda/internal/tools/pipeline/services/apierrors"
+	"github.com/erda-project/erda/pkg/common/apis"
 	"github.com/erda-project/erda/pkg/i18n"
 	"github.com/erda-project/erda/pkg/parser/pipelineyml"
 	"github.com/erda-project/erda/pkg/strutil"
@@ -49,13 +50,17 @@ func (s *graphService) PipelineYmlGraph(ctx context.Context, req *pb.PipelineYml
 			Data: graph,
 		}, nil
 	}
-	if err := s.loadGraphActionNameAndLogo(graph); err != nil {
+	lang := apis.GetLang(ctx)
+	if lang == "" {
+		lang = i18n.ZH
+	}
+	if err := s.loadGraphActionNameAndLogo(graph, lang); err != nil {
 		return nil, apierrors.ErrParsePipelineYml.InternalError(err)
 	}
 	return &pb.PipelineYmlGraphResponse{Data: graph}, nil
 }
 
-func (s *graphService) loadGraphActionNameAndLogo(graph *basepb.PipelineYml) error {
+func (s *graphService) loadGraphActionNameAndLogo(graph *basepb.PipelineYml, lang string) error {
 	stages := graph.Stages
 	var graphStages [][]*basepb.PipelineYmlAction
 	stageBytes, err := stages.MarshalJSON()
@@ -111,9 +116,9 @@ func (s *graphService) loadGraphActionNameAndLogo(graph *basepb.PipelineYml) err
 				continue
 			}
 
-			action.DisplayName = actionSpec.GetLocaleDisplayName(i18n.GetGoroutineBindLang())
+			action.DisplayName = actionSpec.GetLocaleDisplayName(lang)
 			action.LogoUrl = actionSpec.LogoUrl
-			action.Description = actionSpec.GetLocaleDesc(i18n.GetGoroutineBindLang())
+			action.Description = actionSpec.GetLocaleDesc(lang)
 			actionValue, err := convertAction2Value(action)
 			if err != nil {
 				return err

--- a/internal/tools/pipeline/providers/graph/graph.service_test.go
+++ b/internal/tools/pipeline/providers/graph/graph.service_test.go
@@ -104,7 +104,7 @@ locale:
 	s := &graphService{
 		bdl: bdl,
 	}
-	err = s.loadGraphActionNameAndLogo(yml)
+	err = s.loadGraphActionNameAndLogo(yml, "zh-CN")
 	assert.NoError(t, err)
 	ymlbyte, err := yml.MarshalJSON()
 	assert.NoError(t, err)

--- a/internal/tools/pipeline/providers/pipeline/interface.go
+++ b/internal/tools/pipeline/providers/pipeline/interface.go
@@ -27,7 +27,7 @@ import (
 type Interface interface {
 	pb.PipelineServiceServer
 
-	Detail(pipelineID uint64) (*pb.PipelineDetailDTO, error)
+	Detail(ctx context.Context, pipelineID uint64) (*pb.PipelineDetailDTO, error)
 	List(req *pb.PipelinePagingRequest) (*pb.PipelineListResponseData, error)
 	PreCheck(p *spec.Pipeline, stages []spec.PipelineStage, userID string, autoRun bool) error
 	DealPipelineCallbackOfAction(data []byte) (err error)

--- a/internal/tools/pipeline/providers/pipeline/provider.go
+++ b/internal/tools/pipeline/providers/pipeline/provider.go
@@ -16,14 +16,11 @@ package pipeline
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/pkg/transport"
-	transhttp "github.com/erda-project/erda-infra/pkg/transport/http"
-	"github.com/erda-project/erda-infra/pkg/transport/http/encoding"
 	"github.com/erda-project/erda-infra/providers/mysqlxorm"
 	cronpb "github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
 	"github.com/erda-project/erda-proto-go/core/pipeline/pipeline/pb"
@@ -42,7 +39,6 @@ import (
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/secret"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/user"
 	"github.com/erda-project/erda/pkg/common/apis"
-	"github.com/erda-project/erda/pkg/i18n"
 )
 
 type config struct {
@@ -100,20 +96,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		cancel:       p.Cancel,
 	}
 	if p.Register != nil {
-		pb.RegisterPipelineServiceImp(p.Register, p.pipelineService, apis.Options(),
-			transport.WithHTTPOptions(
-				transhttp.WithDecoder(func(r *http.Request, data interface{}) error {
-					lang := r.URL.Query().Get("lang")
-					if lang != "" {
-						r.Header.Set("lang", lang)
-					}
-					locale := i18n.GetLocaleNameByRequest(r)
-					if locale != "" {
-						i18n.SetGoroutineBindLang(locale)
-					}
-					return encoding.DecodeRequest(r, data)
-				}),
-			))
+		pb.RegisterPipelineServiceImp(p.Register, p.pipelineService, apis.Options())
 	}
 	return nil
 }

--- a/internal/tools/pipeline/providers/pipeline/task_view.go
+++ b/internal/tools/pipeline/providers/pipeline/task_view.go
@@ -23,7 +23,7 @@ import (
 
 func (s *pipelineService) PipelineTaskView(ctx context.Context, req *pb.PipelineTaskViewRequest) (*pb.PipelineTaskViewResponse, error) {
 	if req.PipelineID != 0 {
-		detail, err := s.Detail(req.PipelineID)
+		detail, err := s.Detail(ctx, req.PipelineID)
 		if err != nil {
 			return nil, apierrors.ErrTaskView.InternalError(err)
 		}
@@ -49,7 +49,7 @@ func (s *pipelineService) PipelineTaskView(ctx context.Context, req *pb.Pipeline
 		return nil, apierrors.ErrTaskView.NotFound()
 	}
 
-	detail, err := s.Detail(pageResult.Pipelines[0].ID)
+	detail, err := s.Detail(ctx, pageResult.Pipelines[0].ID)
 	if err != nil {
 		return nil, apierrors.ErrTaskView.InternalError(err)
 	}

--- a/internal/tools/pipeline/providers/task/task.service.go
+++ b/internal/tools/pipeline/providers/task/task.service.go
@@ -46,7 +46,7 @@ type taskService struct {
 }
 
 func (s *taskService) PipelineTaskDetail(ctx context.Context, req *pb.PipelineTaskDetailRequest) (*pb.PipelineTaskDetailResponse, error) {
-	p, err := s.pipelineSvc.Detail(req.PipelineID)
+	p, err := s.pipelineSvc.Detail(ctx, req.PipelineID)
 	if err != nil {
 		return nil, apierrors.ErrGetPipelineTaskDetail.InternalError(err)
 	}
@@ -67,7 +67,7 @@ func (s *taskService) PipelineTaskDetail(ctx context.Context, req *pb.PipelineTa
 }
 
 func (s *taskService) PipelineTaskGetBootstrapInfo(ctx context.Context, req *pb.PipelineTaskGetBootstrapInfoRequest) (*pb.PipelineTaskGetBootstrapInfoResponse, error) {
-	p, err := s.pipelineSvc.Detail(req.PipelineID)
+	p, err := s.pipelineSvc.Detail(ctx, req.PipelineID)
 	if err != nil {
 		return nil, apierrors.ErrGetTaskBootstrapInfo.InternalError(err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
update get language method in `pipeline` and `graph` providers
use `apis.GetLang()` to instaed `i18n.GetGoroutineByLang()` if the ctx has the `lang` value.
because the goroutine will get the repeated goroutineID, then use `goroutine_context.GetContext()` will get the ctx from previous goroutine with the same goroutineID if we have not cleared the ctx while the goroutine ends

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=549197&iterationID=12783&type=BUG)

#### Specified Reviewers:

/assign @sfwn @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix action i18 issue            |
| 🇨🇳 中文    |   修复了action国际化不稳定的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
