### PR TITLE
feat: set ErrorStyle=information for cell DropList to avoid warning opening by Microsoft-Excel

### DIFF
--- a/pkg/excel/multi_sheet.go
+++ b/pkg/excel/multi_sheet.go
@@ -36,6 +36,7 @@ func NewSheetHandlerForDropList(startRow, startCol, endRow, endCol int, dropList
 		if err := dv.SetDropList(dropList); err != nil {
 			return fmt.Errorf("failed to set drop list, err: %v", err)
 		}
+		dv.SetError(xlsx.StyleInformation, nil, nil)
 		sheet.AddDataValidation(dv)
 		return nil
 	}
@@ -63,18 +64,6 @@ func NewSheetHandlerForTip(startRow, startCol, endRow, endCol int, title, msg st
 	return func(sheet *xlsx.Sheet) error {
 		dv := xlsx.NewDataValidation(startRow, startCol, endRow, endCol, true)
 		dv.SetInput(&title, &msg)
-		sheet.AddDataValidation(dv)
-		return nil
-	}
-}
-
-// NewSheetHandlerForError
-// TODO although the code seems right, it not works now
-func NewSheetHandlerForError(startRow, startCol, endRow, endCol int, err error) SheetHandler {
-	return func(sheet *xlsx.Sheet) error {
-		dv := xlsx.NewDataValidation(startRow, startCol, endRow, endCol, true)
-		title := err.Error()
-		dv.SetError(xlsx.StyleStop, &title, &title)
 		sheet.AddDataValidation(dv)
 		return nil
 	}
@@ -145,12 +134,3 @@ func WriteFile(w io.Writer, f *File, filename string) error {
 
 	return nil
 }
-
-//func AddSheetByColumn(f *XlsxFile, columns map[]string, sheetName string) error {
-//	sheet, err := f.File.AddSheet(sheetName)
-//	if err != nil {
-//		return fmt.Errorf("failed to add sheet, sheetName: %s, err: %v", sheetName, err)
-//	}
-//	fulfillColumnDataIntoSheet(sheet, columns)
-//	return nil
-//}

--- a/pkg/excel/multi_sheet_test.go
+++ b/pkg/excel/multi_sheet_test.go
@@ -15,6 +15,7 @@
 package excel
 
 import (
+	"os"
 	"testing"
 	"unicode/utf8"
 
@@ -62,4 +63,21 @@ func Test_ensureDropList1(t *testing.T) {
 	dropList = []string{"a", "b", "c"} // 1(a)+2(")=3
 	ensureDropList(&dropList, 0)
 	assert.Equal(t, 0, len(dropList))
+}
+
+func TestExcelDataValidationError(t *testing.T) {
+	f := NewFile()
+	row1 := []Cell{NewTitleCell("status")}
+	row2 := []Cell{NewCell("")}
+	data := [][]Cell{row1, row2}
+	err := AddSheetByCell(f, data, "test", NewSheetHandlerForDropList(1, 0, 1, 0, []string{"", "init", "ing", "done"}))
+	outputF, err := os.Create("./test_with_error_style.xlsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(outputF.Name())
+	err = WriteFile(outputF, f, "test_with_error_style.xlsx")
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

set ErrorStyle=information for cell DropList to avoid warning opening by Microsoft-Excel

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   set ErrorStyle=information for cell DropList to avoid warning opening by Microsoft-Excel           |
| 🇨🇳 中文    |    将单元格DropList的错误样式设置为信息，以避免在Microsoft Excel中打开时出现警告。          |
