### PR TITLE
feat(dop): pipeline grpc client support set max send size bytes

### DIFF
--- a/internal/apps/dop/conf/conf.go
+++ b/internal/apps/dop/conf/conf.go
@@ -78,6 +78,8 @@ type Conf struct {
 	ExportIssueFileStoreDay     int    `env:"EXPORT_ISSUE_FILE_STORE_DAY" default:"7"`
 	UpdateGuideExpiryStatusCron string `env:"UPDATE_GUIDE_EXPIRY_STATUS_CRON" default:"0 0/5 * * * ?"`
 
+	PipelineGrpcClientMaxCallSendSizeBytes int `env:"PIPELINE_GRPC_CLIENT_MAX_SEND_SIZE_BYTES" default:"0"`
+
 	GittarPublicURL string `env:"GITTAR_PUBLIC_URL"`
 }
 
@@ -276,4 +278,10 @@ func UpdateGuideExpiryStatusCron() string {
 
 func GittarPublicURL() string {
 	return cfg.GittarPublicURL
+}
+
+// PipelineGrpcClientMaxCallSendSizeBytes The maximum amount of data that the grpc client can send to the pipeline server
+// see https://stackoverflow.com/questions/55362342/grpc-received-message-larger-than-max-8653851-vs-4194304
+func PipelineGrpcClientMaxCallSendSizeBytes() int {
+	return cfg.PipelineGrpcClientMaxCallSendSizeBytes
 }

--- a/internal/apps/dop/initialize.go
+++ b/internal/apps/dop/initialize.go
@@ -24,7 +24,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/schema"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	pipelinepb "github.com/erda-project/erda-proto-go/core/pipeline/pipeline/pb"
 
 	"github.com/erda-project/erda-infra/base/servicehub"
 	cronpb "github.com/erda-project/erda-proto-go/core/pipeline/cron/pb"
@@ -100,6 +103,10 @@ func (p *provider) Initialize(ctx servicehub.Context) error {
 	if conf.Debug() {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Infof("set log level: %s", logrus.DebugLevel)
+	}
+
+	if conf.PipelineGrpcClientMaxCallSendSizeBytes() > 0 {
+		p.PipelineSvc = ctx.Service("erda.core.pipeline.pipeline.PipelineService", grpc.MaxCallSendMsgSize(conf.PipelineGrpcClientMaxCallSendSizeBytes())).(pipelinepb.PipelineServiceServer)
 	}
 
 	// TODO invoke self use service


### PR DESCRIPTION
#### What this PR does / why we need it:
feat pipeline grpc client support set max send size bytes

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: feat pipeline grpc client support set max send size bytes （dop的pipeline grpc client支持设置最大传送值）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    feat pipeline grpc client support set max send size bytes          |
| 🇨🇳 中文    |      dop的pipeline grpc client支持设置最大传送值        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
