### PR TITLE
fix(monitor): set time column as first order express

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
@@ -781,7 +781,7 @@ func TestOrderBy(t *testing.T) {
 		{
 			name: "group. axis",
 			sql:  "select avg(load1::field),avg(load5::field),avg(load15::field),service_id::tag from table GROUP BY service_id::tag,time()",
-			want: `SELECT AVG(if(indexOf(number_field_keys,'load15') == 0,null,number_field_values[indexOf(number_field_keys,'load15')])) AS "f401d9b077f06a6e", AVG(if(indexOf(number_field_keys,'load1') == 0,null,number_field_values[indexOf(number_field_keys,'load1')])) AS "719d37bba7262d89", AVG(if(indexOf(number_field_keys,'load5') == 0,null,number_field_values[indexOf(number_field_keys,'load5')])) AS "2756505adaab8174", toNullable(tag_values[indexOf(tag_keys,'service_id')]) AS "service_id::tag", MIN("timestamp") AS "bucket_timestamp" FROM "table" GROUP BY "service_id::tag", intDiv(toRelativeSecondNum(timestamp), 60) ORDER BY "service_id::tag" ASC, "bucket_timestamp" ASC`,
+			want: `SELECT AVG(if(indexOf(number_field_keys,'load15') == 0,null,number_field_values[indexOf(number_field_keys,'load15')])) AS "f401d9b077f06a6e", AVG(if(indexOf(number_field_keys,'load1') == 0,null,number_field_values[indexOf(number_field_keys,'load1')])) AS "719d37bba7262d89", AVG(if(indexOf(number_field_keys,'load5') == 0,null,number_field_values[indexOf(number_field_keys,'load5')])) AS "2756505adaab8174", toNullable(tag_values[indexOf(tag_keys,'service_id')]) AS "service_id::tag", MIN("timestamp") AS "bucket_timestamp" FROM "table" GROUP BY "service_id::tag", intDiv(toRelativeSecondNum(timestamp), 60) ORDER BY "bucket_timestamp" ASC, "service_id::tag" ASC`,
 		},
 		{
 			name: "avg column",
@@ -806,7 +806,7 @@ func TestOrderBy(t *testing.T) {
 		{
 			name: "test",
 			sql:  "SELECT key::tag,max(value) as max_value FROM jvm_gc GROUP BY time(),key::tag",
-			want: "SELECT MAX(value) AS \"max_value\", key AS \"key::tag\", addSeconds(toDateTime('1970-01-01 00:00:00'),intDiv(toRelativeSecondNum(timestamp), 60) * 60) AS \"bucket_timestamp\" FROM \"table\" GROUP BY \"key::tag\", intDiv(toRelativeSecondNum(timestamp), 60) ORDER BY \"key::tag\" ASC, \"bucket_timestamp\" ASC",
+			want: "SELECT MAX(value) AS \"max_value\", key AS \"key::tag\", addSeconds(toDateTime('1970-01-01 00:00:00'),intDiv(toRelativeSecondNum(timestamp), 60) * 60) AS \"bucket_timestamp\" FROM \"table\" GROUP BY \"key::tag\", intDiv(toRelativeSecondNum(timestamp), 60) ORDER BY \"bucket_timestamp\" ASC, \"key::tag\" ASC",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it:
 set time column as first order express

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that set time column as first order express （修复了由于时间没有优先排序导致图表断续的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that set time column as first order express             |
| 🇨🇳 中文    |      修复了由于时间没有优先排序导致图表断续的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
