### PR TITLE
fix(heap): acl rule leak

### DIFF
--- a/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
@@ -2587,7 +2587,19 @@ func (impl GatewayOpenapiServiceImpl) UpdatePackageApi(packageId, apiId string, 
 			if err != nil {
 				return
 			}
+			// 可能在更新路由操作之前，已经手动调整过路由授权，因此需要恢复手动创建的调用方授权
+			err = (*impl.consumerBiz).TouchPackageApiAclRules(packageId, apiId)
+			if err != nil {
+				return
+			}
+
 		} else if updateDao.AclType == gw.ACL_OFF {
+			// 可能在更新路由操作之前，已经手动调整过路由授权，因此先要清理掉，然后再创建
+			err = impl.deleteApiPassAuthRules(apiId)
+			if err != nil {
+				return
+			}
+
 			err = impl.createApiPassAuthRules(pack, apiId)
 			if err != nil {
 				return

--- a/internal/tools/orchestrator/hepa/services/openapi_consumer/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_consumer/impl/impl.go
@@ -1382,7 +1382,7 @@ func (impl GatewayOpenapiConsumerServiceImpl) UpdatePackageApiAcls(packageId, pa
 			}
 		}
 	}
-	err = impl.touchPackageApiAclRules(packageId, packageApiId)
+	err = impl.TouchPackageApiAclRules(packageId, packageApiId)
 	if err != nil {
 		return
 	}
@@ -1390,7 +1390,7 @@ func (impl GatewayOpenapiConsumerServiceImpl) UpdatePackageApiAcls(packageId, pa
 	return
 }
 
-func (impl GatewayOpenapiConsumerServiceImpl) touchPackageApiAclRules(packageId, packageApiId string) error {
+func (impl GatewayOpenapiConsumerServiceImpl) TouchPackageApiAclRules(packageId, packageApiId string) error {
 	pack, err := impl.packageDb.Get(packageId)
 	if err != nil {
 		return err

--- a/internal/tools/orchestrator/hepa/services/openapi_consumer/interface.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_consumer/interface.go
@@ -45,4 +45,5 @@ type GatewayOpenapiConsumerService interface {
 	UpdatePackageAcls(string, *dto.PackageAclsDto) (bool, error)
 	GetPackageApiAcls(string, string) ([]dto.PackageAclInfoDto, error)
 	UpdatePackageApiAcls(string, string, *dto.PackageAclsDto) (bool, error)
+	TouchPackageApiAclRules(packageId, packageApiId string) error
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the bug that when enable skip authorization, meanwhile reset callers. Then 2 acl rules left, leaked.

refers：https://erda.cloud/erda/dop/projects/387/ticket?id=552453&iterationID=-1&type=TICKET

#### Specified Reviewers:

/assign @luobily 


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that when enable skip authorization, meanwhile reset callers. Then 2 acl rules left, leaked.   |
| 🇨🇳 中文    |   设置路由跳过鉴权的期间同时重新对调用方授权，两个接口的操作导致 acl rule 泄漏   |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4
