### PR TITLE
fix: gc deprecated release

### DIFF
--- a/internal/apps/dop/dicehub/release/cron.go
+++ b/internal/apps/dop/dicehub/release/cron.go
@@ -56,7 +56,7 @@ func (p *provider) ImageGCCron(client *v3.Client) {
 				logrus.Infof("key: %s already exists in etcd, don't run during this turn", key)
 				continue
 			}
-			if err := p.releaseService.RemoveDeprecatedsReleases(now); err != nil {
+			if err := p.releaseService.RemoveDeprecatedsReleases(next); err != nil {
 				logrus.Warnf("remove deprecated release error: %v", err)
 			}
 			if _, err := client.Delete(context.Background(), key); err != nil {

--- a/internal/apps/dop/dicehub/release/release.service.go
+++ b/internal/apps/dop/dicehub/release/release.service.go
@@ -1057,7 +1057,7 @@ func (s *ReleaseService) GetLatestReleasesByProjectAndVersion(projectID int64, v
 
 // RemoveDeprecatedsReleases Recycling expired release
 func (s *ReleaseService) RemoveDeprecatedsReleases(now time.Time) error {
-	d, err := time.ParseDuration(strutil.Concat("-", s.Config.MaxTimeReserved, "h")) // one month before, eg: -720h
+	d, err := time.ParseDuration(strutil.Concat("-", s.Config.MaxTimeReserved, "h"))
 	if err != nil {
 		return err
 	}
@@ -1068,7 +1068,8 @@ func (s *ReleaseService) RemoveDeprecatedsReleases(now time.Time) error {
 		return err
 	}
 
-	logrus.Infof("get unrefered release before %v, count: %d", d.String(), len(releases))
+	logrus.Infof("get unrefered release before %s (%s ago), count: %d",
+		before.String(), d.String(), len(releases))
 
 	for i := range releases {
 		release := releases[i]

--- a/internal/apps/dop/dicehub/release/release.service.go
+++ b/internal/apps/dop/dicehub/release/release.service.go
@@ -1068,8 +1068,8 @@ func (s *ReleaseService) RemoveDeprecatedsReleases(now time.Time) error {
 		return err
 	}
 
-	logrus.Infof("get unrefered release before %s (%s ago), count: %d",
-		before.String(), d.String(), len(releases))
+	logrus.Infof("found %d releases that had no references before %s",
+		len(releases), before.Format("2006-01-02 15:04:05"))
 
 	for i := range releases {
 		release := releases[i]

--- a/internal/apps/dop/dicehub/release/release_test.go
+++ b/internal/apps/dop/dicehub/release/release_test.go
@@ -205,8 +205,8 @@ services:
       replicas: 1
     image: test.image.com/nginx:testTag
     resources:
-      cpu: 0.1
-      mem: 128
+      cpu: ${cpu:0.1}
+      mem: ${mem:128}
 version: "2.0"
 `,
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix gc deprecated release.

1. The actual execution will be outside of `72h+24h` if the configuration is `72h`.
2. Use diceyml parser instead of yaml parser.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=557339&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix gc deprecated release        |
| 🇨🇳 中文    |   修复清理过期制品错误          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
