### PR TITLE
fix: Ignore pipeline source creation logic if the source already exists when creating a pipeline

### DIFF
--- a/api/proto/dop/projectpipeline/projectpipeline.proto
+++ b/api/proto/dop/projectpipeline/projectpipeline.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package erda.dop.projectpipeline;
 
 import "common/openapi.proto";
+import "core/pipeline/source/source.proto";
 import "github.com/envoyproxy/protoc-gen-validate/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
@@ -217,6 +218,7 @@ message CreateProjectPipelineSourcePreCheckRequest {
 message CreateProjectPipelineSourcePreCheckResponse {
     bool pass = 1;
     string message = 2;
+    erda.core.pipeline.source.PipelineSource source = 3;
 }
 
 message CreateProjectPipelineNamePreCheckRequest {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix: Ignore pipeline source creation logic if the source already exists when creating a pipeline

Due to the previous issue of duplicate source creation, it is possible for a YAML file to have multiple sources. 
Therefore, validation is required to ensure data integrity. 
In the future, data cleanup will be necessary to solve this issue.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=557235&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @sfwn


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix: Ignore pipeline source creation logic if the source already exists when creating a pipeline             |
| 🇨🇳 中文    |   修复了创建流水线时，由于之前存在重复source，导致报错：`source it not unique`           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
