### PR TITLE
fix: optimal prompt

### DIFF
--- a/internal/pkg/ai-functions/functions/test-case/function.go
+++ b/internal/pkg/ai-functions/functions/test-case/function.go
@@ -640,7 +640,7 @@ func processSingleTestCase(ctx context.Context, factory functions.FunctionFactor
 		return errors.Wrap(err, "processSingleTestCase get requirement related tasks info failed")
 	}
 	for _, include := range issueRelations.IssueInclude {
-		if include.Type == apistructs.IssueTypeTask {
+		if include.Type == apistructs.IssueTypeTask && (include.TaskType == "dev" || include.TaskType == "开发") {
 			tasks = append(tasks, include.Title)
 		}
 	}

--- a/internal/pkg/ai-functions/functions/test-case/group.go
+++ b/internal/pkg/ai-functions/functions/test-case/group.go
@@ -98,7 +98,7 @@ func generateGroupsFromRequirement(ctx context.Context, wg *sync.WaitGroup, user
 		return errors.Wrap(err, "generateGroupsFromRequirement get requirement related tasks info failed")
 	}
 	for _, include := range issueRelations.IssueInclude {
-		if include.Type == apistructs.IssueTypeTask {
+		if include.Type == apistructs.IssueTypeTask && (include.TaskType == "dev" || include.TaskType == "开发") {
 			tasks = append(tasks, include.Title)
 		}
 	}

--- a/internal/pkg/ai-functions/provider.go
+++ b/internal/pkg/ai-functions/provider.go
@@ -19,8 +19,6 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/pkg/errors"
-
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/pkg/transport"
@@ -72,7 +70,7 @@ func (p *provider) Init(ctx servicehub.Context) (err error) {
 		p.Config.ModelIds["gpt-4"] = os.Getenv(handler.EnvAiProxyChatgpt4ModelId)
 	}
 	if p.Config.ModelIds["gpt-4"] == "" {
-		return errors.Errorf("env %s not set", handler.EnvAiProxyChatgpt4ModelId)
+		p.L.Warnf("env %s not set", handler.EnvAiProxyChatgpt4ModelId)
 	}
 
 	pb.RegisterAiFunctionImp(p.R, p.AIFunction())


### PR DESCRIPTION
#### What this PR does / why we need it:
Optimize prompt for task names only use  task with type dev 

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
Optimize task names in prompt only use  task with type dev （优化prompt 中任务名称列表，仅允许使用类型为开发的任务名称）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     Optimize task names in prompt only use  task with type dev  |
| 🇨🇳 中文    |     优化prompt 中任务名称列表，仅允许使用类型为开发的任务名称   |


#### Need cherry-pick to release versions?

cherry-pick release/2.4
