### PR TITLE
fix(monitor): transaction table sort by avgDuration failed

### DIFF
--- a/internal/apps/msp/apm/service/view/table/transaction.go
+++ b/internal/apps/msp/apm/service/view/table/transaction.go
@@ -38,9 +38,8 @@ var (
 )
 
 var TransactionTableSortFieldSqlMap = map[string]string{
-	columnReqCount.Key:    "sum(elapsed_count::field)",
-	columnErrorCount.Key:  "sum(if(eq(error::tag, 'true'),elapsed_count::field,0))",
-	columnAvgDuration.Key: "sum(elapsed_sum::field)/sum(elapsed_count::field)",
+	columnReqCount.Key:   "sum(elapsed_count::field)",
+	columnErrorCount.Key: "sum(if(eq(error::tag, 'true'),elapsed_count::field,0))",
 }
 
 type TransactionTableRow struct {


### PR DESCRIPTION
#### What this PR does / why we need it:
fix transaction table sort by avgDuration failed

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=557586&iterationID=12783&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that transaction table sort by avgDuration failed（修复了http调用查询相应时间表失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that transaction table sort by avgDuration failed           |
| 🇨🇳 中文    |   修复了http调用查询相应时间表失败的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
