### PR TITLE
fix(ai-proxy): stt audit empty responseBody

### DIFF
--- a/internal/apps/ai-proxy/filters/audit-before-llm-director/resp.go
+++ b/internal/apps/ai-proxy/filters/audit-before-llm-director/resp.go
@@ -51,11 +51,10 @@ func (f *Filter) OnResponseEOFImmutable(ctx context.Context, infor reverseproxy.
 		}
 	case modelpb.ModelType_audio:
 		var openaiAudioResp openai.AudioResponse
-		respBufferStr := respBuffer.String()
-		if err := json.NewDecoder(respBuffer).Decode(&openaiAudioResp); err == nil {
+		if err := json.Unmarshal([]byte(respBuffer.String()), &openaiAudioResp); err == nil {
 			completion = openaiAudioResp.Text
 		} else {
-			completion = respBufferStr
+			completion = respBuffer.String()
 		}
 	}
 

--- a/pkg/reverseproxy/reverseproxy.go
+++ b/pkg/reverseproxy/reverseproxy.go
@@ -298,7 +298,10 @@ func (p *ReverseProxy) serveHTTP(rw http.ResponseWriter, req *http.Request) {
 			}
 			signal, err := filter.OnRequest(ctx, rw, infor)
 			if err != nil {
-				http.Error(rw, fmt.Sprintf(`{"success": false, "message": %s, "error": %s}`, strconv.Quote(http.StatusText(http.StatusBadRequest)), strconv.Quote(err.Error())), http.StatusBadRequest)
+				// set content-type to application/json
+				rw.Header().Set("Content-Type", "application/json")
+				rw.WriteHeader(http.StatusBadRequest)
+				rw.Write([]byte(fmt.Sprintf(`{"success": false, "message": %s, "error": %s}`, strconv.Quote(http.StatusText(http.StatusBadRequest)), strconv.Quote(err.Error()))))
 				return
 			}
 			if signal != Continue {


### PR DESCRIPTION
#### What this PR does / why we need it:

- fix stt audit empty responseBody
- set content-type to application/json when filter error


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix ai-proxy stt audit empty responseBody           |
| 🇨🇳 中文    |    修复 ai-proxy STT 审计 responseBody 为空的问题          |
