### PR TITLE
fix(gittar): skip find diff section if all line numbers is 0 (e.g. MR_FILE type ai code-review)

### DIFF
--- a/internal/tools/gittar/models/note.go
+++ b/internal/tools/gittar/models/note.go
@@ -359,6 +359,10 @@ func (svc *Service) createAISession(note Note, user *User) (string, error) {
 // oldLineNo: -1, newLineNo: 12, type: "add"
 func findDiffSectionInOneFile(req NoteRequest, diffFile *gitmodule.DiffFile) (*gitmodule.DiffSection, []*gitmodule.DiffLine, error) {
 	// check line numbers
+	// 0. 如果均为 0，说明不需要 find section (例如 MR_FILE 类型的 AI 评审，只是需要 req 里的 oldPath/newPath)
+	if req.OldLine == 0 && req.NewLine == 0 && req.OldLineTo == 0 && req.NewLineTo == 0 {
+		return nil, nil, nil
+	}
 	// 1. 兼容老数据：如果 oldLineTo 或 newLineTo 有一个为 0，则必须同时为 0
 	if (req.OldLineTo == 0 || req.NewLineTo == 0) && req.OldLineTo|req.NewLineTo != 0 {
 		return nil, nil, fmt.Errorf("invalid line numbers: oldLineTo and newLineTo must be 0 at the same time")

--- a/internal/tools/gittar/models/note_test.go
+++ b/internal/tools/gittar/models/note_test.go
@@ -95,42 +95,56 @@ func Test_findDiffSectionInOneFile(t *testing.T) {
 		name            string
 		args            args
 		wantErr         bool
+		wantSection     bool
 		wantDiffLineLen int
 	}{
+		{
+			name:            "MR_FILE type aiCodeReview",
+			args:            args{req: NoteRequest{OldLine: 0, NewLine: 0, OldLineTo: 0, NewLineTo: 0}},
+			wantErr:         false,
+			wantSection:     false,
+			wantDiffLineLen: 0,
+		},
 		{
 			name:            "invalid: oldLineTo and newLineTo must be 0 at the same time",
 			args:            args{req: NoteRequest{OldLineTo: 0, NewLineTo: 1}},
 			wantErr:         true,
+			wantSection:     false,
 			wantDiffLineLen: 0,
 		},
 		{
 			name:            "invalid: oldLineTo < oldLine, when oldLineTo != -1",
 			args:            args{req: NoteRequest{OldLine: 4, OldLineTo: 3, NewLine: 4, NewLineTo: -1}},
 			wantErr:         true,
+			wantSection:     false,
 			wantDiffLineLen: 0,
 		},
 		{
 			name:            "valid: oldLine == newLine == -1, means section",
 			args:            args{req: NoteRequest{OldLine: -1, NewLine: -1}},
 			wantErr:         false,
+			wantSection:     false,
 			wantDiffLineLen: 1,
 		},
 		{
 			name:            "valid: oldLine=1, newLineNo=1, oldLineTo=-1, newLineTo=12",
 			args:            args{req: NoteRequest{OldLine: 1, NewLine: 1, OldLineTo: -1, NewLineTo: 12}},
 			wantErr:         false,
+			wantSection:     true,
 			wantDiffLineLen: validLineCount,
 		},
 		{
 			name:            "valid: oldLine=-1, newLineNo=4, oldLineTo=4, newLineTo=10",
 			args:            args{req: NoteRequest{OldLine: -1, NewLine: 4, OldLineTo: 4, NewLineTo: 10}},
 			wantErr:         false,
+			wantSection:     true,
 			wantDiffLineLen: 7 + RelatedDiffLinesCountBefore,
 		},
 		{
 			name:            "valid: oneline, oldLine=3, newLineNo=9, oldLineTo=3, newLineTo=9",
 			args:            args{req: NoteRequest{OldLine: 3, NewLine: 9, OldLineTo: 3, NewLineTo: 9}},
 			wantErr:         false,
+			wantSection:     true,
 			wantDiffLineLen: 1 + RelatedDiffLinesCountBefore,
 		},
 	}
@@ -145,8 +159,10 @@ func Test_findDiffSectionInOneFile(t *testing.T) {
 				if len(findDiffLines) != tt.wantDiffLineLen {
 					t.Errorf("findDiffSectionInOneFile() gotDiffLineLen = %v, want %v", len(findDiffLines), tt.wantDiffLineLen)
 				}
-				if !reflect.DeepEqual(findSection, diffFile.Sections[0]) {
-					t.Errorf("findDiffSectionInOneFile() gotSection = %v, want %v", findSection, diffFile.Sections[0])
+				if tt.wantSection {
+					if !reflect.DeepEqual(findSection, diffFile.Sections[0]) {
+						t.Errorf("findDiffSectionInOneFile() gotSection = %v, want %v", findSection, diffFile.Sections[0])
+					}
 				}
 			}
 		})


### PR DESCRIPTION
#### What this PR does / why we need it:

gittar skip find diff section if all line numbers is 0 (e.g. MR_FILE type ai code-review)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  gittar skip find diff section if all line numbers is 0 (e.g. MR_FILE type ai code-review)           |
| 🇨🇳 中文    |    当所有 line numbers 均为 0 时，gittar 不再查找 diff section (例如 MR_FILE 类型的 AI 代码审查)         |

