### PR TITLE
fix: migration interrupted due to requests version

### DIFF
--- a/.erda/migrations/cmdb/requirements.txt
+++ b/.erda/migrations/cmdb/requirements.txt
@@ -1,4 +1,4 @@
 Django==3.2.23
 pytz==2021.1
 sqlparse==0.4.4
-requests==2.31.0
+requests==2.27.1


### PR DESCRIPTION
#### What this PR does / why we need it:

The common pip proxies, such as `Aliyun`, `Tsinghua`, and `CAS`, do not currently support the official version `2.31.0` of requests. 
This will cause the erda migration to fail. To fix this, you can downgrade the requests version to `2.27.1`. 
In the future, it is best to avoid frequent dependency upgrades to avoid this issue.

![image](https://github.com/iutx/erda/assets/31346321/2bc1f759-e1d5-4dda-bcde-424be1f4028e)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=556116&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix migration interrupted due to requests version            |
| 🇨🇳 中文    |      修复 requetes 版本问题导致 migration 中断        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
