### PR TITLE
fix(gittar): AI code-review restore diff-lines from old-diff-note in one discussion

### DIFF
--- a/internal/tools/gittar/models/note.go
+++ b/internal/tools/gittar/models/note.go
@@ -214,7 +214,9 @@ func (svc *Service) constructDiscussionNote(repo *gitmodule.Repository, user *Us
 	noteData := NoteData{
 		DiffLines:   relatedDiffLines,
 		OldLine:     req.OldLine,
+		OldLineTo:   req.OldLineTo,
 		NewLine:     req.NewLine,
+		NewLineTo:   req.NewLineTo,
 		OldPath:     req.OldPath,
 		NewPath:     req.NewPath,
 		OldCommitId: req.OldCommitId,


### PR DESCRIPTION
#### What this PR does / why we need it:

- fix: store oldLineTo/newLineTo to data
- feat: restore diff-lines from old-diff-note in one discussion


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=556935&iterationID=12783&tab=BUG&type=BUG)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  AI code-review restore diff-lines from old-diff-note in one discussion            |
| 🇨🇳 中文    |   AI 代码审查从同一个会话中恢复 diff-lines            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.4-beta.5` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
