### PR TITLE
fix: fix pipeline dbgc

### DIFF
--- a/api/proto/core/pipeline/pipeline/pipeline.proto
+++ b/api/proto/core/pipeline/pipeline/pipeline.proto
@@ -406,7 +406,12 @@ message PipelinePagingRequest {
   uint64 endIDLt = 40;
   PipelineDefinitionRequest pipelineDefinitionRequest = 41;
   string pipelineDefinition = 42;
-  bool IsNoSnapshotInDefinition = 43;
+  string definitionJoin = 43;
+  string sourceJoin = 44;
+  bool SourceNotJoin = 45;
+  bool AllowDefinitionIdIsNull = 46;
+  string joinCondition = 47
+//  bool IsNoSnapshotInDefinition = 43;
 }
 
 message PipelinePagingResponse {

--- a/api/proto/core/pipeline/pipeline/pipeline.proto
+++ b/api/proto/core/pipeline/pipeline/pipeline.proto
@@ -406,12 +406,6 @@ message PipelinePagingRequest {
   uint64 endIDLt = 40;
   PipelineDefinitionRequest pipelineDefinitionRequest = 41;
   string pipelineDefinition = 42;
-  string definitionJoin = 43;
-  string sourceJoin = 44;
-  bool SourceNotJoin = 45;
-  bool AllowDefinitionIdIsNull = 46;
-  string joinCondition = 47
-//  bool IsNoSnapshotInDefinition = 43;
 }
 
 message PipelinePagingResponse {
@@ -459,6 +453,12 @@ message PipelineDefinitionRequest {
   repeated string sourceRemotes = 3;
   string location = 4;
   string definitionID = 5;
+  string definitionJoinType = 6;
+  string sourceJoinType = 7;
+  bool sourceNotJoin = 8;
+  bool allowDefinitionIdIsNull = 9;
+  bool isNotSnapshotForDefinition = 10;
+  bool notNeedQueryDefinition = 11;
 }
 
 message PipelineTaskOperateRequest {

--- a/api/proto/core/pipeline/pipeline/pipeline.proto
+++ b/api/proto/core/pipeline/pipeline/pipeline.proto
@@ -406,6 +406,7 @@ message PipelinePagingRequest {
   uint64 endIDLt = 40;
   PipelineDefinitionRequest pipelineDefinitionRequest = 41;
   string pipelineDefinition = 42;
+  bool IsNoSnapshotInDefinition = 43;
 }
 
 message PipelinePagingResponse {

--- a/apistructs/pipeline.go
+++ b/apistructs/pipeline.go
@@ -443,6 +443,9 @@ func IsPipelineDefinitionReqEmpty(definition *pipelinepb.PipelineDefinitionReque
 	if definition.Location != "" {
 		return false
 	}
+	if definition.IsNotSnapshotForDefinition {
+		return false
+	}
 	return true
 }
 

--- a/internal/tools/pipeline/dbclient/op_pipeline.go
+++ b/internal/tools/pipeline/dbclient/op_pipeline.go
@@ -386,6 +386,11 @@ func (client *Client) PageListPipelines(req *pipelinepb.PipelinePagingRequest, o
 		}
 	}
 
+	if req.IsNoSnapshotInDefinition {
+		baseSQL.Join("LEFT", definitiondb.PipelineDefinition{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_definition_id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
+		baseSQL.Where(tableFieldName(definitiondb.PipelineDefinition{}.TableName(), "id") + " is null or " + fmt.Sprintf("%v.pipeline_id != %v.id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
+	}
+
 	if !req.AllSources && len(req.Source) > 0 {
 		baseSQL.In(tableFieldName((&spec.PipelineBase{}).TableName(), "pipeline_source"), req.Source)
 	}

--- a/internal/tools/pipeline/dbclient/op_pipeline.go
+++ b/internal/tools/pipeline/dbclient/op_pipeline.go
@@ -246,6 +246,19 @@ func (p *PageListPipelinesResult) GetMinPipelineID() uint64 {
 	return minID
 }
 
+func (p *PageListPipelinesResult) GetMaxPipelineID() uint64 {
+	if len(p.PagingPipelineIDs) == 0 {
+		return 0
+	}
+	maxID := p.PagingPipelineIDs[0]
+	for _, id := range p.PagingPipelineIDs {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	return maxID
+}
+
 func getLabels(source map[string]*structpb.Value) (map[string][]string, error) {
 	labels := make(map[string][]string)
 	for k, v := range source {
@@ -362,19 +375,39 @@ func (client *Client) PageListPipelines(req *pipelinepb.PipelinePagingRequest, o
 
 	if req.PipelineDefinitionRequest != nil {
 		var definitionReq = req.PipelineDefinitionRequest
-		needQueryDefinition = true
-		baseSQL.Where(tableFieldName((&spec.PipelineBase{}).TableName(), "pipeline_definition_id") + " is not null ")
-		baseSQL.Where(tableFieldName((&spec.PipelineBase{}).TableName(), "pipeline_definition_id") + " != '' ")
+		needQueryDefinition = !definitionReq.NotNeedQueryDefinition
+
+		if !definitionReq.AllowDefinitionIdIsNull {
+			baseSQL.Where(tableFieldName((&spec.PipelineBase{}).TableName(), "pipeline_definition_id") + " is not null ")
+			baseSQL.Where(tableFieldName((&spec.PipelineBase{}).TableName(), "pipeline_definition_id") + " != '' ")
+		}
+
 		if !apistructs.IsPipelineDefinitionReqEmpty(req.PipelineDefinitionRequest) {
-			baseSQL.Join("INNER", definitiondb.PipelineDefinition{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_definition_id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
-			baseSQL.Join("INNER", sourcedb.PipelineSource{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_source_id", sourcedb.PipelineSource{}.TableName(), definitiondb.PipelineDefinition{}.TableName()))
+			// default join type is inner
+			if definitionReq.DefinitionJoinType == "" {
+				definitionReq.DefinitionJoinType = "INNER"
+			}
+
+			baseSQL.Join(definitionReq.DefinitionJoinType, definitiondb.PipelineDefinition{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_definition_id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
+
+			if !definitionReq.SourceNotJoin {
+				if definitionReq.SourceJoinType == "" {
+					definitionReq.SourceJoinType = "INNER"
+				}
+				baseSQL.Join(definitionReq.SourceJoinType, sourcedb.PipelineSource{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_source_id", sourcedb.PipelineSource{}.TableName(), definitiondb.PipelineDefinition{}.TableName()))
+			}
+
+			if definitionReq.IsNotSnapshotForDefinition {
+				baseSQL.Where(tableFieldName(definitiondb.PipelineDefinition{}.TableName(), "id") + " is null or " + fmt.Sprintf("%v.pipeline_id != %v.id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
+			}
+
 			if len(definitionReq.Name) > 0 {
 				baseSQL.Where(fmt.Sprintf("%v.name like ?", definitiondb.PipelineDefinition{}.TableName()), "%"+definitionReq.Name+"%")
 			}
 			if definitionReq.Location != "" {
 				baseSQL.Where(fmt.Sprintf("%s.location = ?", definitiondb.PipelineDefinition{}.TableName()), definitionReq.Location)
 			}
-			if len(definitionReq.SourceRemotes) > 0 {
+			if len(definitionReq.SourceRemotes) > 0 && !definitionReq.SourceNotJoin {
 				baseSQL.In(tableFieldName(sourcedb.PipelineSource{}.TableName(), "remote"), definitionReq.SourceRemotes)
 			}
 			if len(definitionReq.Creators) > 0 {
@@ -384,11 +417,6 @@ func (client *Client) PageListPipelines(req *pipelinepb.PipelinePagingRequest, o
 				baseSQL.Where(fmt.Sprintf("%s.id = ?", definitiondb.PipelineDefinition{}.TableName()), definitionReq.DefinitionID)
 			}
 		}
-	}
-
-	if req.IsNoSnapshotInDefinition {
-		baseSQL.Join("LEFT", definitiondb.PipelineDefinition{}.TableName(), fmt.Sprintf("%v.id = %v.pipeline_definition_id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
-		baseSQL.Where(tableFieldName(definitiondb.PipelineDefinition{}.TableName(), "id") + " is null or " + fmt.Sprintf("%v.pipeline_id != %v.id", definitiondb.PipelineDefinition{}.TableName(), (&spec.PipelineBase{}).TableName()))
 	}
 
 	if !req.AllSources && len(req.Source) > 0 {

--- a/internal/tools/pipeline/dbclient/op_pipeline_definition.go
+++ b/internal/tools/pipeline/dbclient/op_pipeline_definition.go
@@ -56,6 +56,23 @@ func (client *Client) GetPipelineDefinitionByPipelineID(pipelineID uint64, ops .
 	return &pipelineDefinition, true, nil
 }
 
+func (client *Client) GetPipelineDefinitionByIDs(ids []string, ops ...SessionOption) ([]*db.PipelineDefinition, error) {
+	var pipelineDefinitions []*db.PipelineDefinition
+	if len(ids) <= 0 {
+		return pipelineDefinitions, nil
+	}
+	session := client.NewSession(ops...)
+	defer session.Close()
+
+	var err error
+	err = session.In("id", ids).Where("soft_deleted_at = 0").Find(&pipelineDefinitions)
+	if err != nil {
+		return nil, err
+	}
+
+	return pipelineDefinitions, nil
+}
+
 func (client *Client) UpdatePipelineDefinition(id string, pipelineDefinition *db.PipelineDefinition, ops ...SessionOption) error {
 	session := client.NewSession(ops...)
 	defer session.Close()

--- a/internal/tools/pipeline/providers/dbgc/dbgc_test.go
+++ b/internal/tools/pipeline/providers/dbgc/dbgc_test.go
@@ -115,7 +115,7 @@ func TestReconciler_doPipelineDatabaseGC(t *testing.T) {
 		gcNum++
 	}
 
-	monkey.PatchInstanceMethod(reflect.TypeOf(&r), "DoDBGC", func(r *provider, pipelineID uint64, gcOption apistructs.PipelineGCDBOption) error {
+	monkey.PatchInstanceMethod(reflect.TypeOf(&r), "DoDBGC", func(r *provider, pipeline *spec.Pipeline, gcOption apistructs.PipelineGCDBOption) error {
 		assert.True(t, gcNum < 4, "DoDBGC times >= 4")
 		addCountNum()
 		return nil
@@ -221,8 +221,8 @@ func TestReconciler_doPipelineDatabaseGC1(t *testing.T) {
 		})
 		defer patch.Unpatch()
 
-		patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(&r), "DoDBGC", func(r *provider, pipelineID uint64, gcOption apistructs.PipelineGCDBOption) error {
-			assert.Equal(t, pipelineID, uint64(1))
+		patch1 := monkey.PatchInstanceMethod(reflect.TypeOf(&r), "DoDBGC", func(r *provider, pipeline *spec.Pipeline, gcOption apistructs.PipelineGCDBOption) error {
+			assert.Equal(t, pipeline.PipelineID, uint64(1))
 			return fmt.Errorf("error")
 		})
 		defer patch1.Unpatch()

--- a/pkg/strutil/example_slice_test.go
+++ b/pkg/strutil/example_slice_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+func ExampleDistinctArrayInStructByFiled() {
+	type TestIntStruct struct {
+		Name  string
+		Field int
+	}
+
+	input := []TestIntStruct{
+		{Field: 1, Name: "1"},
+		{Field: 2, Name: "2"},
+		{Field: 3, Name: "3"},
+		{Field: 3, Name: "3"},
+	}
+
+	output := strutil.DistinctArrayInStructByFiled(input, func(t TestIntStruct) (string, bool) {
+		hash := sha256.Sum256([]byte(fmt.Sprintf("%s%d", t.Name, t.Field)))
+		return string(hash[:]), false
+	})
+
+	fmt.Println(output)
+
+	// Output: [{1 1} {2 2} {3 3}]
+}
+
+func ExampleDistinctArrayFiledInStruct() {
+	type TestIntStruct struct {
+		Name  string
+		Field int
+	}
+
+	input := []TestIntStruct{
+		{Field: 1, Name: "1"},
+		{Field: 2, Name: "2"},
+		{Field: 1, Name: "3"},
+	}
+
+	output := strutil.DistinctArrayFiledInStruct(input, func(t TestIntStruct) (int, bool) {
+		return t.Field, false
+	})
+
+	fmt.Println(output)
+
+	// Output: [1 2]
+}

--- a/pkg/strutil/slice.go
+++ b/pkg/strutil/slice.go
@@ -80,11 +80,70 @@ func DistinctArray[T comparable](arr []T) []T {
 // you should offer a function to get the field from the struct
 // besides, the function you can set a skip condition, if skip is true, it will ignore the elem
 // it returns the array of Type T(the same as the array offered)
-func DistinctArrayInStructByFiled[T any, C comparable](arr []T, fn func(T) (target C, skip bool)) []T {
+//
+// For Example:
+//
+// 1. use multiple fields for deduplication
+//
+//	type TestIntStruct struct {
+//		Name  string
+//		Field int
+//	}
+//
+//	testInt := []TestIntStruct{
+//		{Field: 1, Name: "1"},
+//		{Field: 2, Name: "2"},
+//		{Field: 1, Name: "3"},
+//		{Field: 1, Name: "3"},
+//	}
+//
+//	testIntResp := DistinctArrayInStructByFiled(testInt, func(t TestIntStruct) (string, bool) {
+//		hash := sha256.Sum256([]byte(fmt.Sprintf("%s%d", t.Name, t.Field)))
+//		return string(hash[:]), false
+//	})
+//
+// Result:
+//
+//	testIntResp = []TestIntStruct{
+//		{Field: 1, Name: "1"},
+//		{Field: 2, Name: "2"},
+//		{Field: 1, Name: "3"},
+//	}
+//
+// 2. use only one fields for deduplication and skip the field equals xxx
+//
+//	type TestStringStruct struct {
+//		Name  string
+//		Field string
+//	}
+//
+//	testString := []TestStringStruct{
+//		{Name: "1", Field: "123"},
+//		{Name: "2", Field: "234"},
+//		{Name: "#", Field: "#"},
+//		{Name: "#2", Field: "#"},
+//		{Name: "#3", Field: "#"},
+//		{Name: "123", Field: "123"},
+//	}
+//
+//	testStringResp := DistinctArrayInStructByFiled(testString, func(t TestStringStruct) (string, bool) {
+//		if t.Field == "123" {
+//			return t.Field, true
+//		}
+//		return t.Field, false
+//	})
+//
+// Result:
+//
+//	testStringResp := []TestStringStruct{
+//		{Name: "2", Field: "234"},
+//		{Name: "#", Field: "#"},
+//	}
+func DistinctArrayInStructByFiled[T any, C comparable](arr []T, getField func(T) (value C, skip bool)) []T {
 	dupMap := make(map[C]struct{})
 	unique := make([]T, 0)
 	for _, item := range arr {
-		value, skip := fn(item)
+		value, skip := getField(item)
 		if skip {
 			continue
 		}
@@ -100,6 +159,25 @@ func DistinctArrayInStructByFiled[T any, C comparable](arr []T, fn func(T) (targ
 // you should offer a function to get the field from the struct
 // besides, the function you can set a skip condition, if skip is true, it will ignore the elem
 // it returns the array of Type C(the field type)
+//
+// For Example：
+//
+//	type TestIntStruct struct {
+//		Name  string
+//		Field int
+//	}
+//	testInt := []TestIntStruct{
+//		{Field: 1, Name: "1"},
+//		{Field: 2, Name: "2"},
+//		{Field: 1, Name: "3"},
+//	}
+//	testIntResp := DistinctArrayFiledInStruct(testInt, func(t TestIntStruct) (int, bool) {
+//		return t.Field, false
+//	})
+//
+// Result：
+//
+//	testIntWant = []int{1, 2}
 func DistinctArrayFiledInStruct[T any, C comparable](arr []T, fn func(T) (target C, skip bool)) []C {
 	dupMap := make(map[C]struct{})
 	unique := make([]C, 0)

--- a/pkg/strutil/slice.go
+++ b/pkg/strutil/slice.go
@@ -60,3 +60,58 @@ func DedupAnySlice(s interface{}, uniq func(i int) interface{}) interface{} {
 	}
 	return out.Interface()
 }
+
+// DistinctArray is used to get unique elements from a slice with comparable type \
+func DistinctArray[T comparable](arr []T) []T {
+	dupMap := make(map[T]struct{})
+	unique := make([]T, 0)
+	for _, item := range arr {
+		// if not exist, add in the unique array
+		if _, ok := dupMap[item]; !ok {
+			dupMap[item] = struct{}{}
+			unique = append(unique, item)
+		}
+	}
+
+	return unique
+}
+
+// DistinctArrayInStructByFiled it is used to get unique elements from struct array filter by filed
+// you should offer a function to get the field from the struct
+// besides, the function you can set a skip condition, if skip is true, it will ignore the elem
+// it returns the array of Type T(the same as the array offered)
+func DistinctArrayInStructByFiled[T any, C comparable](arr []T, fn func(T) (target C, skip bool)) []T {
+	dupMap := make(map[C]struct{})
+	unique := make([]T, 0)
+	for _, item := range arr {
+		value, skip := fn(item)
+		if skip {
+			continue
+		}
+		if _, ok := dupMap[value]; !ok {
+			dupMap[value] = struct{}{}
+			unique = append(unique, item)
+		}
+	}
+	return unique
+}
+
+// DistinctArrayFiledInStruct it is used to get unique elements from struct
+// you should offer a function to get the field from the struct
+// besides, the function you can set a skip condition, if skip is true, it will ignore the elem
+// it returns the array of Type C(the field type)
+func DistinctArrayFiledInStruct[T any, C comparable](arr []T, fn func(T) (target C, skip bool)) []C {
+	dupMap := make(map[C]struct{})
+	unique := make([]C, 0)
+	for _, item := range arr {
+		value, skip := fn(item)
+		if skip {
+			continue
+		}
+		if _, ok := dupMap[value]; !ok {
+			dupMap[value] = struct{}{}
+			unique = append(unique, value)
+		}
+	}
+	return unique
+}

--- a/pkg/strutil/slice_test.go
+++ b/pkg/strutil/slice_test.go
@@ -97,3 +97,153 @@ func TestReverseString(t *testing.T) {
 		t.Error("error")
 	}
 }
+
+func TestDistinctArray(t *testing.T) {
+	var (
+		a      = []string{"1", "@", "#", "@", "3", "124", "@@", "#"}
+		a_want = []string{"1", "@", "#", "3", "124", "@@"}
+		b      = []int{1, 5, 2, 5, 5, 7}
+		b_want = []int{1, 5, 2, 7}
+	)
+
+	a = strutil.DistinctArray(a)
+	for i := 0; i < len(a); i++ {
+		if a[i] != a_want[i] {
+			t.Error("err in distinctArrayWithFilter in array 'a'")
+		}
+	}
+
+	b = strutil.DistinctArray(b)
+	for i := 0; i < len(b); i++ {
+		if b[i] != b_want[i] {
+			t.Error("err in distinctArrayWithFilter in array 'b'")
+		}
+	}
+
+}
+
+func TestDistinctArrayInStructByFiled(t *testing.T) {
+	type TestIntStruct struct {
+		Name  string
+		Field int
+	}
+
+	type TestStringStruct struct {
+		Name  string
+		Field string
+	}
+
+	testInt := []TestIntStruct{
+		{Field: 1, Name: "1"},
+		{Field: 2, Name: "2"},
+		{Field: 1, Name: "3"},
+	}
+	testIntWant := []TestIntStruct{
+		{Field: 1, Name: "1"},
+		{Field: 2, Name: "2"},
+	}
+
+	testString := []TestStringStruct{
+		{Name: "1", Field: "123"},
+		{Name: "2", Field: "234"},
+		{Name: "#", Field: "#"},
+		{Name: "#2", Field: "#"},
+		{Name: "#3", Field: "#"},
+		{Name: "123", Field: "123"},
+	}
+
+	testStringWant := []TestStringStruct{
+		{Name: "2", Field: "234"},
+		{Name: "#", Field: "#"},
+	}
+
+	testIntResp := strutil.DistinctArrayInStructByFiled(testInt, func(t TestIntStruct) (int, bool) {
+		return t.Field, false
+	})
+	if len(testIntResp) != len(testIntWant) {
+		t.Error("length is not equal")
+	}
+	for i := 0; i < len(testIntWant); i++ {
+		if testIntWant[i] != testIntResp[i] {
+			t.Error("err in test int")
+			return
+		}
+	}
+
+	testStringResp := strutil.DistinctArrayInStructByFiled(testString, func(t TestStringStruct) (string, bool) {
+		if t.Field == "123" {
+			return t.Field, true
+		}
+		return t.Field, false
+	})
+	if len(testStringResp) != len(testStringWant) {
+		t.Error("length is not equal")
+	}
+	for i := 0; i < len(testStringResp); i++ {
+		if testStringWant[i] != testStringResp[i] {
+			t.Error("err in test string")
+			return
+		}
+	}
+
+}
+
+func TestDistinctArrayFiledInStruct(t *testing.T) {
+	type TestIntStruct struct {
+		Name  string
+		Field int
+	}
+
+	type TestStringStruct struct {
+		Name  string
+		Field string
+	}
+
+	testInt := []TestIntStruct{
+		{Field: 1, Name: "1"},
+		{Field: 2, Name: "2"},
+		{Field: 1, Name: "3"},
+	}
+	testIntWant := []int{1, 2}
+
+	testString := []TestStringStruct{
+		{Name: "1", Field: "123"},
+		{Name: "2", Field: "234"},
+		{Name: "#", Field: "#"},
+		{Name: "#2", Field: "#"},
+		{Name: "#3", Field: "#"},
+		{Name: "123", Field: "123"},
+	}
+
+	testStringWant := []string{"123", "234"}
+
+	testIntResp := strutil.DistinctArrayFiledInStruct(testInt, func(t TestIntStruct) (int, bool) {
+		return t.Field, false
+	})
+	if len(testIntResp) != len(testIntWant) {
+		t.Error("length is not equal")
+	}
+	for i := 0; i < len(testIntWant); i++ {
+		if testIntWant[i] != testIntResp[i] {
+			t.Error("err in test int")
+			return
+		}
+	}
+
+	testStringResp := strutil.DistinctArrayFiledInStruct(testString, func(t TestStringStruct) (string, bool) {
+		if t.Field == "#" {
+			return t.Field, true
+		}
+		return t.Field, false
+	})
+	if len(testStringResp) != len(testStringWant) {
+		t.Error("length is not equal")
+	}
+	for i := 0; i < len(testStringResp); i++ {
+		if testStringWant[i] != testStringResp[i] {
+			t.Error("err in test string")
+			return
+		}
+	}
+
+}

--- a/pkg/strutil/slice_test.go
+++ b/pkg/strutil/slice_test.go
@@ -15,6 +15,8 @@
 package strutil_test
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	"github.com/erda-project/erda/pkg/strutil"
@@ -137,10 +139,12 @@ func TestDistinctArrayInStructByFiled(t *testing.T) {
 		{Field: 1, Name: "1"},
 		{Field: 2, Name: "2"},
 		{Field: 1, Name: "3"},
+		{Field: 1, Name: "3"},
 	}
 	testIntWant := []TestIntStruct{
 		{Field: 1, Name: "1"},
 		{Field: 2, Name: "2"},
+		{Field: 1, Name: "3"},
 	}
 
 	testString := []TestStringStruct{
@@ -157,8 +161,9 @@ func TestDistinctArrayInStructByFiled(t *testing.T) {
 		{Name: "#", Field: "#"},
 	}
 
-	testIntResp := strutil.DistinctArrayInStructByFiled(testInt, func(t TestIntStruct) (int, bool) {
-		return t.Field, false
+	testIntResp := strutil.DistinctArrayInStructByFiled(testInt, func(t TestIntStruct) (string, bool) {
+		hash := sha256.Sum256([]byte(fmt.Sprintf("%s%d", t.Name, t.Field)))
+		return string(hash[:]), false
 	})
 	if len(testIntResp) != len(testIntWant) {
 		t.Error("length is not equal")


### PR DESCRIPTION
#### What this PR does / why we need it:
The dbgc in the pipeline has two issues. 
- One is that some invalid data fails to parse, causing the gc process fail
- The other is that data bound to a definition is skipped in the GC process

This PR modified the logic of dbgc for pipeline records bound to a definition. Now, only the pipeline record associated with the last execution of the definition is retained, and all other records that meet the GC conditions will cleaned up.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=557257&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix pipeline dbgc             |
| 🇨🇳 中文    |  修复了流水线 dbgc 失效的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
