### PR TITLE
perf(orchestrator): optimize the sql statement to get the last api id

### DIFF
--- a/internal/tools/orchestrator/hepa/repository/service/gateway_upstream_api_service.go
+++ b/internal/tools/orchestrator/hepa/repository/service/gateway_upstream_api_service.go
@@ -61,7 +61,7 @@ func (impl *GatewayUpstreamApiServiceImpl) updateFields(update *orm.GatewayUpstr
 func (impl *GatewayUpstreamApiServiceImpl) GetLastApiId(cond *orm.GatewayUpstreamApi) string {
 	var descList []orm.GatewayUpstreamApi
 	err := orm.Desc(impl.engine, "register_id").And("upstream_id = ? and api_name = ? and api_id != ''",
-		cond.UpstreamId, cond.ApiName).Find(&descList)
+		cond.UpstreamId, cond.ApiName).Limit(1).Find(&descList)
 	if err != nil {
 		log.Errorf("error happend:%+v", errors.WithStack(err))
 		return ""


### PR DESCRIPTION
#### What this PR does / why we need it:
optimize the sql statement to get the last api id

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=558817&iterationID=12783&tab=TASK&type=TASK)


#### Specified Reviewers:

/assign @sfwn @wangzhuzhen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: optimize the sql statement to get the last api id（优化了hepa获取last apiid的sql语句）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | optimize the sql statement to get the last api id             |
| 🇨🇳 中文    |   优化了hepa获取last apiid的sql语句           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
