### PR TITLE
fix(orchestrator): edas list application multi response error

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/edas/app.client.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/edas/app.client.go
@@ -48,17 +48,14 @@ func (c *wrapEDAS) GetAppID(appName string) (string, error) {
 
 	l.Info("request id: ", resp.RequestId)
 
-	switch len(resp.ApplicationList.Application) {
-	case 0:
-		return "", ErrApplicationNotFound
-	case 1:
-		app := resp.ApplicationList.Application[0]
-
-		l.Infof("successfully to get app id: %s, name: %s", app.AppId, appName)
-		return app.AppId, nil
-	default:
-		return "", errors.Errorf("application %s get multi response", appName)
+	for _, app := range resp.ApplicationList.Application {
+		if app.Name == appName {
+			l.Infof("successfully to get app id: %s, name: %s", app.AppId, appName)
+			return app.AppId, nil
+		}
 	}
+
+	return "", ErrApplicationNotFound
 }
 
 // deleteAppByID delete application by app id


### PR DESCRIPTION
#### What this PR does / why we need it:
The EDAS list application utilizes the fuzzy matching technique, which distinguishes it from the anticipated approach.
Currently EDAS does not support getting by the get `application name`.

e.g. `go-demo` will get multi response.

![image](https://github.com/erda-project/erda/assets/31346321/f855c779-8964-448e-8885-fab282a7317e)


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix edas list application multi response error              |
| 🇨🇳 中文    |     修复 edas 获取应用多返回错误        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
