### PR TITLE
fix(hepa): hepa `EOF` due to client not found

### DIFF
--- a/internal/tools/orchestrator/hepa/services/org_client/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/org_client/impl/impl.go
@@ -164,6 +164,10 @@ func (impl GatewayOrgClientServiceImpl) GetCredentials(id string) (res dto.Clien
 	if err != nil {
 		return
 	}
+	if dao == nil {
+		err = errors.New("client not found")
+		return
+	}
 	res = dto.ClientInfoDto{
 		ClientId:     dao.Id,
 		ClientSecret: dao.ClientSecret,


### PR DESCRIPTION
#### What this PR does / why we need it:
fix hepa `EOF` due to client not found

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=558468&iterationID=12783&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn @wangzhuzhen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that hepa `EOF` due to client not found （修复了不存在的client导致hepa EOF的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that hepa `EOF` due to client not found          |
| 🇨🇳 中文    |    修复了不存在的client导致hepa EOF的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
