### PR TITLE
fix(parser): resolve panic when parsing invalid data in diceyml

### DIFF
--- a/pkg/parser/diceyml/diceyml.go
+++ b/pkg/parser/diceyml/diceyml.go
@@ -348,6 +348,9 @@ func polish(obj *Object) {
 }
 
 func validateE(obj *Object, raw []byte) error {
+	if len(raw) == 0 {
+		return invalidRawData
+	}
 	errs := validate(obj, raw)
 	if len(errs) > 0 {
 		es := []string{}

--- a/pkg/parser/diceyml/diceyml_test.go
+++ b/pkg/parser/diceyml/diceyml_test.go
@@ -1008,7 +1008,32 @@ func TestDiceYmlInsertJobImage(t *testing.T) {
 	err = d.InsertImage(map[string]string{"job1": "image1"}, nil)
 	assert.Nil(t, err, "%v", err)
 	fmt.Printf("%+v\n", d.Obj().Jobs["job1"]) // debug print
+}
 
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlData []byte
+		wantErr  bool
+	}{
+		{
+			name:     "Valid YAML",
+			yamlData: []byte(testyml),
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid YAML",
+			yamlData: []byte(""),
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := New(tt.yamlData, true); (err != nil) != tt.wantErr {
+				t.Fatalf("New with validate error: %+v, wantErr: %v", err, tt.wantErr)
+			}
+		})
+	}
 }
 
 //func TestDiceYmlMergeValues(t *testing.T) {

--- a/pkg/parser/diceyml/errors.go
+++ b/pkg/parser/diceyml/errors.go
@@ -15,6 +15,7 @@
 package diceyml
 
 var (
+	invalidRawData             = errortype("invalid raw data")
 	notfoundJob                = errortype("not found job in yaml")
 	notfoundService            = errortype("not found service in yaml")
 	invalidService             = errortype("invalid service defined in yaml")

--- a/pkg/parser/diceyml/fieldname_validate_visitor.go
+++ b/pkg/parser/diceyml/fieldname_validate_visitor.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,6 +37,11 @@ func NewFieldnameValidateVisitor(raw []byte) (DiceYmlVisitor, error) {
 	if err := yaml.Unmarshal(raw, &rawmap); err != nil {
 		return nil, err
 	}
+
+	if rawmap == nil {
+		return nil, errors.New("unmarshalled map is nil")
+	}
+
 	tp := reflect.TypeOf(rawmap)
 	if tp.Kind() != reflect.Map || tp.Key().Kind() != reflect.Interface || tp.Elem().Kind() != reflect.Interface {
 		return nil, fmt.Errorf("not a map[interface{}]interface{} type")

--- a/pkg/parser/diceyml/fieldname_validate_visitor_test.go
+++ b/pkg/parser/diceyml/fieldname_validate_visitor_test.go
@@ -69,8 +69,32 @@ addons:
 `
 
 func TestFieldnameValidate(t *testing.T) {
-	d, err := New([]byte(fieldname_validate_yml), false)
-	assert.Nil(t, err)
-	es := FieldnameValidate(d.Obj(), []byte(fieldname_validate_yml))
-	assert.Equal(t, 4, len(es))
+	tests := []struct {
+		name           string
+		yamlData       []byte
+		expectErrCount int
+	}{
+		{
+			name:           "Valid YAML",
+			yamlData:       []byte(fieldname_validate_yml),
+			expectErrCount: 4,
+		},
+		{
+			name:           "Invalid YAML",
+			yamlData:       []byte(""),
+			expectErrCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := New(tt.yamlData, false)
+			assert.NoError(t, err)
+
+			es := FieldnameValidate(d.Obj(), tt.yamlData)
+			if len(es) != tt.expectErrCount {
+				t.Fatalf("expect %d errors, but got %d errors", tt.expectErrCount, len(es))
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
1. fix resolve panic when parsing invalid data in diceyml.
2. add friendly tips when provided invalid data.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/ticket?id=559389&iterationID=-1&type=TICKET)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix resolve panic when parsing invalid data in diceyml             |
| 🇨🇳 中文    |    修复错误数据解析 diceyml 导致的 panic 问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
