### PR TITLE
fix(orchestrator): addon cache custom addon without default version

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addon
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+)
+
+func Test_GetDefault(t *testing.T) {
+	defer monkey.UnpatchAll()
+
+	InitCache(DefaultTtl, DefaultSize)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(cache.bdl), "QueryExtensionVersions", func(_ *bundle.Bundle,
+		req apistructs.ExtensionVersionQueryRequest) ([]apistructs.ExtensionVersion, error) {
+		switch req.Name {
+		case "mysql":
+			return []apistructs.ExtensionVersion{
+				{Name: "mysql", Version: "8.0.0", IsDefault: true},
+				{Name: "mysql", Version: "5.7.2"},
+			}, nil
+		case "canal":
+			return []apistructs.ExtensionVersion{
+				{Name: "canal", Version: "1.1.5"},
+				{Name: "canal", Version: "1.1.6"},
+			}, nil
+		case "custom":
+			return []apistructs.ExtensionVersion{
+				{Name: "custom", Version: "1.0.0"},
+			}, nil
+		default:
+			return []apistructs.ExtensionVersion{}, errors.New("not found")
+		}
+	})
+
+	type args struct {
+		name string
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectVersion string
+		expectEmpty   bool
+	}{
+		{
+			name: "multi version, get default version",
+			args: args{
+				name: "mysql",
+			},
+			expectVersion: "8.0.0",
+		},
+		{
+			name: "one version, get default version",
+			args: args{
+				name: "custom",
+			},
+			expectVersion: "1.0.0",
+		},
+		{
+			name: "get non default version",
+			args: args{
+				name: "canal",
+			},
+			expectEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cacheMap, err := GetCache().Get(tt.args.name)
+			assert.NoError(t, err, "Expected no error, but got ", err)
+
+			versionMap := cacheMap.(*VersionMap)
+			defaultVersion, ok := versionMap.GetDefault()
+			assert.Equal(t, !ok, tt.expectEmpty,
+				fmt.Sprintf("Expected %v, but got %v", tt.expectEmpty, ok))
+			assert.Equal(t, tt.expectVersion, defaultVersion.Version,
+				fmt.Sprintf("Expected %s, but got %s", tt.expectVersion, defaultVersion.Version))
+		})
+	}
+}

--- a/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
@@ -87,6 +87,8 @@ func Test_GetDefault(t *testing.T) {
 		},
 	}
 
+	defer GetCache().Purge()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cacheMap, err := GetCache().Get(tt.args.name)

--- a/internal/tools/orchestrator/services/addon/addon_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_test.go
@@ -1239,6 +1239,8 @@ func TestAddon2(t *testing.T) {
 }
 
 func TestGetAddonExtention(t *testing.T) {
+	defer monkey.UnpatchAll()
+
 	bdl := &bundle.Bundle{}
 	clusterSvc := &cluster.ClusterService{}
 	a := New(WithBundle(bdl), WithClusterSvc(clusterSvc))


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix o11 addon cache without default version
There's only one version, set it as the default version.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=562503&iterationID=12783&type=BUG)


#### Specified Reviewers:

/assign @sfwn @CeerDecy 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix o11 addon cache custom addon without default version            |
| 🇨🇳 中文    |    修复 o11 自定义 addon 缓存没有默认版本          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
