### PR TITLE
fix: adjust ai-proxy source and email plaintext

### DIFF
--- a/internal/pkg/ai-functions/sdk/api.go
+++ b/internal/pkg/ai-functions/sdk/api.go
@@ -15,6 +15,7 @@
 package sdk
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"strings"
@@ -22,6 +23,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/pkg/common/apis"
 	"github.com/erda-project/erda/pkg/strutil"
 )
 
@@ -51,4 +55,20 @@ func VerifyArguments(parameters, data json.RawMessage) (err error) {
 		ss = append(ss, item.String())
 	}
 	return errors.New(strings.Join(ss, "; "))
+}
+
+func GetUserInfo(ctx context.Context) (apistructs.UserInfo, error) {
+	bdl := bundle.New(bundle.WithErdaServer())
+	uerList, err := bdl.ListUsers(apistructs.UserListRequest{
+		UserIDs:   []string{apis.GetUserID(ctx)},
+		Plaintext: true,
+	})
+	if err != nil {
+		return apistructs.UserInfo{}, err
+	}
+	if len(uerList.Users) == 0 {
+		return apistructs.UserInfo{}, errors.Errorf("no user with id %s", apis.GetUserID(ctx))
+	}
+
+	return uerList.Users[0], nil
 }

--- a/internal/pkg/ai-functions/sdk/api_test.go
+++ b/internal/pkg/ai-functions/sdk/api_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+)
+
+func TestGetUserInfo(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	userinfo := apistructs.UserInfo{
+		ID:          "10000",
+		Name:        "test",
+		Nick:        "test",
+		Avatar:      "",
+		Phone:       "11111111111",
+		Email:       "111222@333.com",
+		Token:       "",
+		LastLoginAt: "",
+		PwdExpireAt: "",
+		Source:      "",
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    apistructs.UserInfo
+		wantErr bool
+	}{
+		{
+			name: "Test",
+			args: args{
+				ctx: context.WithValue(context.Background(), "user-id", "10000"),
+			},
+			want:    userinfo,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bdl := bundle.New(bundle.WithErdaServer())
+			monkey.PatchInstanceMethod(reflect.TypeOf(bdl), "ListUsers", func(_ *bundle.Bundle,
+				req apistructs.UserListRequest) (*apistructs.UserListResponseData, error) {
+				return &apistructs.UserListResponseData{
+					Users: []apistructs.UserInfo{userinfo},
+				}, nil
+			})
+
+			got, err := GetUserInfo(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetUserInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetUserInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adjust ai-proxy source and email plaintext

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
Bugfix： Fix the bug that define ai-proxy source and get email plaintext （修复了对接 ai-proxy 的 source 调整以及 email 脱敏）

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        Fix the bug that define ai-proxy source and get email plaintext       |
| 🇨🇳 中文    |      修复了对接 ai-proxy 的 source 调整以及 email 脱敏     |


#### Need cherry-pick to release versions?

/cherry-pick release/2.4
