### PR TITLE
feat(gittar): ai-mr-cr source add `___${cluster_name}` suffix

### DIFF
--- a/internal/tools/gittar/conf/conf.go
+++ b/internal/tools/gittar/conf/conf.go
@@ -15,9 +15,11 @@
 package conf
 
 import (
+	"os"
 	"strings"
 	"time"
 
+	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/pkg/discover"
 	"github.com/erda-project/erda/pkg/envconf"
 )
@@ -211,4 +213,8 @@ func DiceProtocol() string {
 
 func RefreshPersonalContributorDuration() time.Duration {
 	return cfg.RefreshPersonalContributorDuration
+}
+
+func DiceCluster() string {
+	return os.Getenv(apistructs.DICE_CLUSTER_NAME.String())
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

ai-mr-cr source add `___${cluster_name}` suffix, to distinguish invoker cluster.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=562371&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    ai-mr-cr source add `___${cluster_name}` suffix, to distinguish invoker cluster.          |
| 🇨🇳 中文    |    ai 代码审查 source 添加 `___$cluster_name}` 后缀，用来区分调用者集群          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.4-beta.5` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
