### PR TITLE
fix: o11 addon cache without default version

### DIFF
--- a/internal/tools/orchestrator/services/addon/addon_extension_cache.go
+++ b/internal/tools/orchestrator/services/addon/addon_extension_cache.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addon
+
+import (
+	"sync"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/sirupsen/logrus"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+	"github.com/erda-project/erda/pkg/http/httpclient"
+)
+
+const (
+	DefaultTtl  = 10 * time.Minute
+	DefaultSize = 500
+)
+
+const (
+	defaultVersionKey = "default"
+)
+
+type Cache struct {
+	gcache.Cache
+	bdl *bundle.Bundle
+}
+
+// VersionMap Version of the corresponding addon
+type VersionMap map[string]apistructs.ExtensionVersion
+
+func (v *VersionMap) GetDefault() (apistructs.ExtensionVersion, bool) {
+	res, ok := (*v)[defaultVersionKey]
+	return res, ok
+}
+
+var (
+	cache *Cache
+	mutex = &sync.Mutex{}
+)
+
+// GetCache Get the Cache in unary mode, if the Cache is not initialized, then use the default configuration to initialize it.
+func GetCache() *Cache {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if cache == nil {
+		logrus.Infof("Addon cache is not initialized and will be initialized using the default configuration")
+		InitCache(DefaultTtl, DefaultSize)
+	}
+	return cache
+}
+
+// InitCache Initialize the Cache
+func InitCache(ttl time.Duration, size int) {
+	// init Bundle
+	bundleOpts := []bundle.Option{
+		bundle.WithHTTPClient(
+			httpclient.New(
+				httpclient.WithTimeout(time.Second, time.Second*60),
+			)),
+		bundle.WithErdaServer(),
+	}
+	bdl := bundle.New(bundleOpts...)
+
+	var addonCache = &Cache{
+		bdl: bdl,
+	}
+
+	addonCache.initCache(ttl, size)
+
+	cache = addonCache
+}
+
+// InitCache Initialize the gcache.Cache
+func (a *Cache) initCache(ttl time.Duration, size int) {
+	a.Cache = gcache.New(size).LRU().Expiration(ttl).LoaderFunc(func(key interface{}) (interface{}, error) {
+		addonName := key.(string)
+		addons, err := a.bdl.QueryExtensionVersions(apistructs.ExtensionVersionQueryRequest{Name: addonName, All: true})
+		if err != nil {
+			logrus.Errorf("failed to query addon: %v", addonName)
+			return nil, err
+		}
+
+		versions := make(VersionMap)
+		switch len(addons) {
+		case 1:
+			// There's only one version, set it as the default version.
+			addon := addons[0]
+			versions[addon.Version] = addon
+			versions[defaultVersionKey] = addon
+		default:
+			for _, addon := range addons {
+				versions[addon.Version] = addon
+				if addon.IsDefault {
+					versions[defaultVersionKey] = addon
+				}
+			}
+		}
+		return &versions, nil
+	}).Build()
+}

--- a/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_extension_cache_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addon
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/bundle"
+)
+
+func Test_GetDefault(t *testing.T) {
+	defer monkey.UnpatchAll()
+
+	InitCache(DefaultTtl, DefaultSize)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(cache.bdl), "QueryExtensionVersions", func(_ *bundle.Bundle,
+		req apistructs.ExtensionVersionQueryRequest) ([]apistructs.ExtensionVersion, error) {
+		switch req.Name {
+		case "mysql":
+			return []apistructs.ExtensionVersion{
+				{Name: "mysql", Version: "8.0.0", IsDefault: true},
+				{Name: "mysql", Version: "5.7.2"},
+			}, nil
+		case "canal":
+			return []apistructs.ExtensionVersion{
+				{Name: "canal", Version: "1.1.5"},
+				{Name: "canal", Version: "1.1.6"},
+			}, nil
+		case "custom":
+			return []apistructs.ExtensionVersion{
+				{Name: "custom", Version: "1.0.0"},
+			}, nil
+		default:
+			return []apistructs.ExtensionVersion{}, errors.New("not found")
+		}
+	})
+
+	type args struct {
+		name string
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectVersion string
+		expectEmpty   bool
+	}{
+		{
+			name: "multi version, get default version",
+			args: args{
+				name: "mysql",
+			},
+			expectVersion: "8.0.0",
+		},
+		{
+			name: "one version, get default version",
+			args: args{
+				name: "custom",
+			},
+			expectVersion: "1.0.0",
+		},
+		{
+			name: "get non default version",
+			args: args{
+				name: "canal",
+			},
+			expectEmpty: true,
+		},
+	}
+
+	defer GetCache().Purge()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cacheMap, err := GetCache().Get(tt.args.name)
+			assert.NoError(t, err, "Expected no error, but got ", err)
+
+			versionMap := cacheMap.(*VersionMap)
+			defaultVersion, ok := versionMap.GetDefault()
+			assert.Equal(t, !ok, tt.expectEmpty,
+				fmt.Sprintf("Expected %v, but got %v", tt.expectEmpty, ok))
+			assert.Equal(t, tt.expectVersion, defaultVersion.Version,
+				fmt.Sprintf("Expected %s, but got %s", tt.expectVersion, defaultVersion.Version))
+		})
+	}
+}

--- a/internal/tools/orchestrator/services/addon/addon_test.go
+++ b/internal/tools/orchestrator/services/addon/addon_test.go
@@ -1222,6 +1222,8 @@ func TestAddon2(t *testing.T) {
 }
 
 func TestGetAddonExtention(t *testing.T) {
+	defer monkey.UnpatchAll()
+
 	bdl := &bundle.Bundle{}
 	clusterSvc := &cluster.ClusterService{}
 	a := New(WithBundle(bdl), WithClusterSvc(clusterSvc))


### PR DESCRIPTION
#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |              |
| 🇨🇳 中文    |              |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
