### PR TITLE
fix(gittar): add content truncated flag to file code-review prompt

### DIFF
--- a/internal/tools/gittar/ai/cr/impl/cr_mr_file/file.go
+++ b/internal/tools/gittar/ai/cr/impl/cr_mr_file/file.go
@@ -132,11 +132,13 @@ func (r *OneChangedFile) constructAIRequest(i18n i18n.Translator, lang i18n.Lang
 		FileName     string
 		FileContent  string
 		UserLang     string
+		Truncated    bool
 	}
 	tmplArgs.CodeLanguage = r.CodeLanguage
 	tmplArgs.FileName = r.FileName
 	tmplArgs.FileContent = r.FileContent
 	tmplArgs.UserLang = i18nutil.GetUserLang(lang)
+	tmplArgs.Truncated = r.Truncated
 
 	for i := range req.Messages {
 		t, _ := template.New("").Parse(req.Messages[i].Content)

--- a/internal/tools/gittar/ai/cr/impl/cr_mr_file/prompt.yaml
+++ b/internal/tools/gittar/ai/cr/impl/cr_mr_file/prompt.yaml
@@ -5,7 +5,7 @@ messages:
   - role: system
     content: |
       You are an expert Software Engineer.
-      Below is a file, please help me do a brief code review on it (don't print file name and file content in your review).
+      Below is a file (content truncated: {{.Truncated}}), please help me do a brief code review on it (don't print file name and file content in your review).
       Please summarize the code and identify potential problems (at most 5). Start with the most important findings.
 
       File `{{.FileName}}`:


### PR DESCRIPTION
#### What this PR does / why we need it:

add content truncated flag to file code-review prompt


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=563983&iterationID=12783&type=BUG)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |     add content truncated flag to file code-review prompt         |
| 🇨🇳 中文    |    将内容截断标志添加到文件代码审查提示中          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/2.4-beta.5` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
