### PR TITLE
fix: constant appending of errors causing oom

### DIFF
--- a/internal/tools/pipeline/pkg/taskerror/ordered_test.go
+++ b/internal/tools/pipeline/pkg/taskerror/ordered_test.go
@@ -98,3 +98,83 @@ func TestOrderedResponses_ConvertErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeOrderError(t *testing.T) {
+	now := time.Now()
+	testcase := []struct {
+		name        string
+		ordered     []*Error
+		newOrderErr []*Error
+		want        []*Error
+	}{
+		{
+			name: "ordered is less 10",
+			ordered: []*Error{
+				{Code: "1", Msg: "This is error msg", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "2", Msg: "This is error msg 2", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "3", Msg: "This is error msg 3", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "4", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 3}},
+				{Code: "5", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 4}},
+			},
+			newOrderErr: []*Error{
+				{Code: "6", Msg: "", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "7", Msg: "This is error msg 7", Ctx: ErrorContext{StartTime: now.Add(-1 * time.Hour), EndTime: now.Add(-1 * time.Hour), Count: 1}},
+				{Code: "8", Msg: "This is error msg 7", Ctx: ErrorContext{StartTime: now.Add(1 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 1}},
+				{Code: "9", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+			},
+			want: []*Error{
+				{Code: "1", Msg: "This is error msg", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "2", Msg: "This is error msg 2", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "3", Msg: "This is error msg 3", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "4", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 3}},
+				{Code: "5", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 4}},
+				{Code: "6", Msg: "", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "7", Msg: "This is error msg 7", Ctx: ErrorContext{StartTime: now.Add(-1 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 2}},
+				{Code: "9", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+			},
+		},
+		{
+			name: "ordered is more than 10",
+			ordered: []*Error{
+				{Code: "1", Msg: "This is error msg", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "2", Msg: "This is error msg 2", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "3", Msg: "This is error msg 3", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "4", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 3}},
+				{Code: "5", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 4}},
+				{Code: "6", Msg: "This is error msg 6", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "7", Msg: "This is error msg 7", Ctx: ErrorContext{StartTime: now.Add(-1 * time.Hour), EndTime: now.Add(-1 * time.Hour), Count: 1}},
+				{Code: "8", Msg: "This is error msg 8", Ctx: ErrorContext{StartTime: now.Add(1 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 1}},
+				{Code: "9", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 2}},
+				{Code: "10", Msg: "This is error msg 10", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "11", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+			},
+			newOrderErr: []*Error{
+				{Code: "12", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now.Add(-2 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 1}},
+				{Code: "13", Msg: "This is Error msg 7", Ctx: ErrorContext{StartTime: now.Add(-1 * time.Hour), EndTime: now.Add(-1 * time.Hour), Count: 1}},
+				{Code: "14", Msg: "this is error msg 7", Ctx: ErrorContext{StartTime: now.Add(1 * time.Hour), EndTime: now, Count: 1}},
+				{Code: "15", Msg: "This is error msg 15", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+			},
+			want: []*Error{
+				{Code: "1", Msg: "This is error msg", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "2", Msg: "This is error msg 2", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "3", Msg: "This is error msg 3", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "4", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 3}},
+				{Code: "5", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 4}},
+				{Code: "6", Msg: "This is error msg 6", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "7", Msg: "This is error msg 7", Ctx: ErrorContext{StartTime: now.Add(-1 * time.Hour), EndTime: now, Count: 3}},
+				{Code: "8", Msg: "This is error msg 8", Ctx: ErrorContext{StartTime: now.Add(1 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 1}},
+				{Code: "9", Msg: "This is error msg 4", Ctx: ErrorContext{StartTime: now.Add(-2 * time.Hour), EndTime: now.Add(1 * time.Hour), Count: 3}},
+				{Code: "10", Msg: "This is error msg 10", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "11", Msg: "This is error msg 5", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+				{Code: "15", Msg: "This is error msg 15", Ctx: ErrorContext{StartTime: now, EndTime: now, Count: 1}},
+			},
+		},
+	}
+
+	for _, test := range testcase {
+		t.Run(test.name, func(t *testing.T) {
+			ordered := MergeOrderError(test.ordered, test.newOrderErr)
+			assert.Equal(t, test.want, ordered)
+		})
+	}
+}

--- a/internal/tools/pipeline/providers/reconciler/provider.go
+++ b/internal/tools/pipeline/providers/reconciler/provider.go
@@ -61,6 +61,8 @@ type provider struct {
 
 type config struct {
 	RetryInterval time.Duration `file:"retry_interval" default:"5s"`
+
+	TaskErrAppendMaxLimit int `file:"task_err_append_max_limit" env:"TASK_ERR_APPEND_MAX_LIMIT" default:"20"`
 }
 
 func (r *provider) Init(ctx servicehub.Context) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
task reconciler reties and appends errors continuously, leading to memory growth if the error not resolved(will cause oom).
existing mechanism of merging errors is to compare with the last err, but fails with cycling difference err will ignore this mechanism, so it needs adjustment

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=550206&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn 

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix constant appending of errors when task reconciler causing oom          |
| 🇨🇳 中文    |    修复了task调度时错误不断追加导致OOM的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
