### PR TITLE
chore: remove arch path in single image build

### DIFF
--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -51,7 +51,7 @@ setup_single_module_env() {
     elif [ -d "build/dockerfiles/${APP_NAME}" ];then
         DOCKERFILE="build/dockerfiles/${APP_NAME}/Dockerfile"
     fi
-    DOCKER_IMAGE="${ARCH}/${APP_NAME}:${IMAGE_TAG}"
+    DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG}"
 }
 
 # setup envionment variables for build all

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -34,7 +34,6 @@ cd $(git rev-parse --show-toplevel)
 ARCH="${ARCH:-$(go env GOARCH)}"
 VERSION="$(build/scripts/make-version.sh)"
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
-IMAGE_TAG_WITH_ARCH="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}-${ARCH}"
 DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
 BASE_DOCKER_IMAGE="registry.erda.cloud/erda/erda-base:20230811"
 DOCKERFILE=${DOCKERFILE_DEFAULT}
@@ -52,8 +51,8 @@ setup_single_module_env() {
     elif [ -d "build/dockerfiles/${APP_NAME}" ];then
         DOCKERFILE="build/dockerfiles/${APP_NAME}/Dockerfile"
     fi
-    DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG_WITH_ARCH}"
-    IMAGE_TAG="${IMAGE_TAG_WITH_ARCH}"
+    IMAGE_TAG="${IMAGE_TAG}-${ARCH}"
+    DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG}"
 }
 
 # setup envionment variables for build all

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -34,6 +34,7 @@ cd $(git rev-parse --show-toplevel)
 ARCH="${ARCH:-$(go env GOARCH)}"
 VERSION="$(build/scripts/make-version.sh)"
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
+IMAGE_TAG_WITH_ARCH="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}-${ARCH}"
 DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
 BASE_DOCKER_IMAGE="registry.erda.cloud/erda/erda-base:20230811"
 DOCKERFILE=${DOCKERFILE_DEFAULT}
@@ -51,7 +52,7 @@ setup_single_module_env() {
     elif [ -d "build/dockerfiles/${APP_NAME}" ];then
         DOCKERFILE="build/dockerfiles/${APP_NAME}/Dockerfile"
     fi
-    DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG}"
+    DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG_WITH_ARCH}"
 }
 
 # setup envionment variables for build all

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -53,6 +53,7 @@ setup_single_module_env() {
         DOCKERFILE="build/dockerfiles/${APP_NAME}/Dockerfile"
     fi
     DOCKER_IMAGE="${APP_NAME}:${IMAGE_TAG_WITH_ARCH}"
+    IMAGE_TAG="${IMAGE_TAG_WITH_ARCH}"
 }
 
 # setup envionment variables for build all


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove arch path in single image build.

Build a single-architecture image without the need for an additional layer of identification; this approach may be utilized in the development environment. For multi-architecture scenarios, utilize `buildx`.

<img width="1327" alt="image" src="https://github.com/erda-project/erda/assets/31346321/c23c8daa-e9b7-4f67-8c31-2b6dda467650">


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  remove arch path in single image build            |
| 🇨🇳 中文    |     单架构构建移除 arch 路径         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
