### PR TITLE
fix(hepa): add api failed due to lost consumerId

### DIFF
--- a/internal/tools/orchestrator/hepa/providers/micro_api/service.go
+++ b/internal/tools/orchestrator/hepa/providers/micro_api/service.go
@@ -71,8 +71,11 @@ func (s *apiService) GetApis(ctx context.Context, req *pb.GetApisRequest) (resp 
 func (s *apiService) CreateApi(ctx context.Context, req *pb.CreateApiRequest) (resp *pb.CreateApiResponse, err error) {
 	service := micro_api.Service.Clone(ctx)
 	reqDto := &dto.ApiReqDto{
-		ApiDto:          dto.MakeApiDto(req.ApiRequest),
-		ApiReqOptionDto: &dto.ApiReqOptionDto{},
+		ApiDto: dto.MakeApiDto(req.ApiRequest),
+		ApiReqOptionDto: &dto.ApiReqOptionDto{
+			Policies:   req.ApiRequest.Policies,
+			ConsumerId: req.ApiRequest.ConsumerId,
+		},
 	}
 	apiId, err := service.CreateApi(ctx, reqDto)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
POST /api/gateway/api  to add api will fail due ignore parameter consumerId

#### Which issue(s) this PR fixes:

- [【0124答疑】中海油微服务API添加异常](https://erda.cloud/erda/dop/projects/387/ticket?id=565857&iterationID=-1&type=TICKET)



#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
Bugfix： Fix the bug that POST /api/gateway/api to add api will fail due ignore parameter consumerId in hepa（修复了 微服务API管理页面手动 添加服务API 失败报错 参数不能为空的问题（因 consumerId 参数在处理过程中被忽略））


| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Fix the bug that POST /api/gateway/api to add api will fail due ignore parameter consumerId in hepa        |
| 🇨🇳 中文    |     修复了 微服务API管理页面手动 添加服务API 失败报错 参数不能为空的问题（因 consumerId 参数在处理过程中被忽略）    |


#### Need cherry-pick to release versions?
/cherry-pick release/2.4
