### PR TITLE
feat(hepa): support custom unity package domain by env

### DIFF
--- a/internal/tools/orchestrator/hepa/services/global/impl/impl_test.go
+++ b/internal/tools/orchestrator/hepa/services/global/impl/impl_test.go
@@ -16,9 +16,12 @@ package impl
 
 import (
 	"context"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/kong"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/repository/service"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/endpoint_api"
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/services/global"
@@ -77,6 +80,55 @@ func TestGatewayGlobalServiceImpl_Clone(t *testing.T) {
 			}
 			if got := impl.Clone(tt.args.ctx); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Clone() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_generateEndpoints(t *testing.T) {
+	type args struct {
+		endpoint       string
+		env            string
+		subDomainSplit string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 string
+	}{
+		{
+			name: "Test_01",
+			args: args{
+				endpoint:       "abc.test.com",
+				env:            "dev",
+				subDomainSplit: "-",
+			},
+			want:  "dev-abc.test.com",
+			want1: "dev." + kong.InnerHost,
+		},
+		{
+			name: "Test_02",
+			args: args{
+				endpoint:       "abc.test.com",
+				env:            "dev",
+				subDomainSplit: "-",
+			},
+			want:  "abc.test.com",
+			want1: "dev." + kong.InnerHost,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "Test_02" {
+				os.Setenv(EnvUnityPackageDomainPrefix+strings.ToUpper(tt.args.env), tt.args.endpoint)
+			}
+			got, got1 := generateEndpoints(tt.args.endpoint, tt.args.env, tt.args.subDomainSplit)
+			if got != tt.want {
+				t.Errorf("generateEndpoints() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("generateEndpoints() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
Support custom unity package domain by hepa env. Let cluster wild domain name as "*.terminus.io", For example, If you set env DICE_UNITY_DOMAIN_DEV="abc.terminus.com" for hepa, After a new project create and deploy with gateway addon, you will get a custom unity package domain  "abc.terminus.com", not legacy unity package domain  "dev-geateway.terminus.io" for dev workspace.

envs name as follow:
DICE_UNITY_DOMAIN_PROD 
DICE_UNITY_DOMAIN_STAGING 
DICE_UNITY_DOMAIN_TEST  
DICE_UNITY_DOMAIN_DEV


#### Which issue(s) this PR fixes:
- [【api网关】【来自答疑】支持unit流量入口自定域名](https://erda.cloud/erda/dop/projects/387/issues/all?id=316041&iterationID=-1&type=REQUIREMENT)



#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
Feature: Support custom unity package domain by hepa env （实现通过 hepa 组件的环境变量自定义Unity 流量入口域名）
| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      Support custom unity package domain by hepa env         |
| 🇨🇳 中文    |   实现通过 hepa 组件的环境变量自定义Unity 流量入口域名    |


#### Need cherry-pick to release versions?
/cherry-pick release/2.4

