### PR TITLE
fix: add logs in definition-cleanup

### DIFF
--- a/internal/tools/pipeline/providers/dbgc/definition_cleanup/definition_cleanup.go
+++ b/internal/tools/pipeline/providers/dbgc/definition_cleanup/definition_cleanup.go
@@ -93,6 +93,7 @@ func (p *provider) cronCleanup(ctx context.Context) {
 }
 
 func (p *provider) doCleanupRepeatRecords(ctx context.Context, uniqueSourceGroupList []sourcedb.PipelineSourceUniqueGroupWithCount) {
+	p.Log.Info("[Start Cleanup]")
 	for index, group := range uniqueSourceGroupList {
 		// if the uniqueSourceGroup.count is not equal 1, it means it has the repeat records, need merge and cleanup
 		// otherwise, skip the clean logic
@@ -317,6 +318,14 @@ func (p *provider) MergeCronByDefinitionIds(ctx context.Context, definitionIds [
 	cronList, err = p.cronDbClient.BatchGetPipelineCronByDefinitionID(definitionIds, ops...)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// due to the cron is directly deleted, this prints out all the fields of all the cron found in the search
+	if len(cronList) > 0 {
+		p.Log.Infof("[Batch Get Cron By Definition ID %d] (length : %d): \n", latestExecDefinition.ID, len(cronList))
+		for _, c := range cronList {
+			p.Log.Infof("cron is: %+v，enable: %t", c, *c.Enable)
+		}
 	}
 
 	if p.Cfg.DryRun {

--- a/internal/tools/pipeline/providers/dbgc/definition_cleanup/definition_cleanup_test.go
+++ b/internal/tools/pipeline/providers/dbgc/definition_cleanup/definition_cleanup_test.go
@@ -126,6 +126,7 @@ func newProvider(t *testing.T, dbSourceName string, ctrl *gomock.Controller) *pr
 
 	logger := mocklogger.NewMockLogger(ctrl)
 	logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Return().AnyTimes()
+	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).Return().AnyTimes()
 	p := &provider{
 		MySQL: sqlite3Db,
 		Cfg:   &config{DryRun: false},


### PR DESCRIPTION
#### What this PR does / why we need it:
Since cron records are directly deleted, we should output the records to be deleted. If necessary, they can be used for recovery.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn

#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  add the logs output for cron records in definition-cleanup            |
| 🇨🇳 中文    |   新增definition-cleanup模块清理cron记录时的cron字段日志打印          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
