### PR TITLE
fix(monitor): let the logic of max func be consistent with min, if not existing it is null

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions.go
@@ -45,7 +45,7 @@ var CkAggFunctions = map[string]*SQlAggFuncDefine{
 					return goqu.MAX(lit).As(id), nil
 				}
 
-				f, _ := p.ckGetKey(field, influxql.AnyField)
+				f := p.ckColumnByOnlyExistingColumn(field)
 				return goqu.MAX(goqu.L(f)).As(id), nil
 			},
 			func(ctx *Context, id, field string, call *influxql.Call, v interface{}) (interface{}, bool) {

--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions_test.go
@@ -72,7 +72,7 @@ func TestAggregationFunction(t *testing.T) {
 					},
 				},
 			},
-			want: "SELECT MAX(number_field_values[indexOf(number_field_keys,'com_delete')]) AS \"1af26e55a4a29af8\" FROM \"table\"",
+			want: "SELECT MAX(if(indexOf(number_field_keys,'com_delete') == 0,null,number_field_values[indexOf(number_field_keys,'com_delete')])) AS \"1af26e55a4a29af8\" FROM \"table\"",
 		},
 		{
 			name:     "test min",

--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/parse_clickhouse_test.go
@@ -472,7 +472,7 @@ func TestSelect(t *testing.T) {
 		{
 			name: "select max",
 			sql:  "select max(column) from table",
-			want: "SELECT MAX(number_field_values[indexOf(number_field_keys,'column')]) AS \"322cc30ad1d92b84\" FROM \"table\"",
+			want: "SELECT MAX(if(indexOf(number_field_keys,'column') == 0,null,number_field_values[indexOf(number_field_keys,'column')])) AS \"322cc30ad1d92b84\" FROM \"table\"",
 		},
 		{
 			name: "select min",
@@ -566,7 +566,7 @@ func TestGroupBy(t *testing.T) {
 		{
 			name: "time(),max(column)",
 			sql:  "select max(column) from table group by time()",
-			want: "SELECT MAX(number_field_values[indexOf(number_field_keys,'column')]) AS \"322cc30ad1d92b84\", MIN(\"timestamp\") AS \"bucket_timestamp\" FROM \"table\" GROUP BY intDiv(toRelativeSecondNum(timestamp), 60)",
+			want: "SELECT MAX(if(indexOf(tag_keys,'column') == 0,null,tag_values[indexOf(tag_keys,'column')])) AS \"322cc30ad1d92b84\", MIN(\"timestamp\") AS \"bucket_timestamp\" FROM \"table\" GROUP BY intDiv(toRelativeSecondNum(timestamp), 60)",
 		},
 		{
 			name: "group_not_select_column",
@@ -591,12 +591,12 @@ func TestGroupBy(t *testing.T) {
 		{
 			name: "no group",
 			sql:  "select max(http_status_code::tag) from table",
-			want: "SELECT MAX(tag_values[indexOf(tag_keys,'http_status_code')]) AS \"61421335fd474c8e\" FROM \"table\"",
+			want: "SELECT MAX(if(indexOf(tag_keys,'http_status_code') == 0,null,tag_values[indexOf(tag_keys,'http_status_code')])) AS \"61421335fd474c8e\" FROM \"table\"",
 		},
 		{
 			name: "group tostring function",
 			sql:  "select max(http_status_code::tag),tostring(timestamp) from table group by tostring(timestamp)",
-			want: "SELECT MAX(tag_values[indexOf(tag_keys,'http_status_code')]) AS \"61421335fd474c8e\", toNullable(timestamp) AS \"timestamp\" FROM \"table\" GROUP BY \"timestamp\", '', tostring(timestamp)",
+			want: "SELECT MAX(if(indexOf(tag_keys,'http_status_code') == 0,null,tag_values[indexOf(tag_keys,'http_status_code')])) AS \"61421335fd474c8e\", toNullable(timestamp) AS \"timestamp\" FROM \"table\" GROUP BY \"timestamp\", '', tostring(timestamp)",
 		},
 		{
 			name: "group sub function",


### PR DESCRIPTION
#### What this PR does / why we need it:
 let the logic of max func be consistent with min, if not existing it is null

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=568386&iterationID=12783&tab=ALL&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that  let the logic of max func be consistent with min, if not existing it is null （修复了ck函数解析时max聚合函数的逻辑与min不一致的问题)

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that  let the logic of max func be consistent with min, if not existing it is null             |
| 🇨🇳 中文    |   修复了ck函数解析时max聚合函数的逻辑与min不一致的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
