### PR TITLE
fix: use `container_spec_memory_limit_bytes` as container memory limit metric source

### DIFF
--- a/internal/apps/msp/apm/service/components/resources-container-monitor/container/provider.go
+++ b/internal/apps/msp/apm/service/components/resources-container-monitor/container/provider.go
@@ -92,7 +92,7 @@ func (p *provider) getCpuLineGraph(ctx context.Context, startTime, endTime int64
 }
 
 func (p *provider) getMemoryLineGraph(ctx context.Context, startTime, endTime int64, instanceId string) ([]*model.LineGraphMetaData, error) {
-	statement := fmt.Sprintf("SELECT round_float(avg(mem_limit::field), 2),round_float(avg(mem_usage::field), 2) " +
+	statement := fmt.Sprintf("SELECT round_float(avg(container_spec_memory_limit_bytes::field), 2),round_float(avg(mem_usage::field), 2) " +
 		"FROM docker_container_summary " +
 		"WHERE pod_uid::tag=$pod_uid " +
 		"GROUP BY time()")


### PR DESCRIPTION
#### What this PR does / why we need it:
use `container_spec_memory_limit_bytes` as container memory limit metric source

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=568840&iterationID=12783&tab=ALL&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that contianer memory limit metirc incorrect（修复了容器监控的内存限制变为主机内存的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that contianer memory limit metirc incorrect           |
| 🇨🇳 中文    |      修复了容器监控的内存限制变为主机内存的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
