### PR TITLE
fix(monitor): failed to parse log ttl duration

### DIFF
--- a/internal/tools/monitor/core/settings/monitor.go
+++ b/internal/tools/monitor/core/settings/monitor.go
@@ -63,12 +63,11 @@ func (s *settingsService) monitorConfigMap(ns string) *configDefine {
 	}
 	ttl = os.Getenv("LOG_TTL")
 	if len(ttl) > 0 {
-		sed, err := strconv.ParseInt(ttl, 10, 64)
+		duration, err := time.ParseDuration(ttl)
 		if err != nil {
 			s.p.Log.Errorf("fail to parse log ttl: %s", err)
 		} else {
-			const daySec = float64(24 * 60 * 60)
-			log.TTL = int64(math.Ceil(float64(sed) / daySec))
+			log.TTL = int64(math.Ceil(duration.Hours() / 24))
 		}
 	}
 	cd := &configDefine{


### PR DESCRIPTION
#### What this PR does / why we need it:
fix failed to parse log ttl duration

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=569014&iterationID=12783&tab=ALL&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that failed to parse log ttl duration （修复了monitor解析log_ttl环境变量失败）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that failed to parse log ttl duration           |
| 🇨🇳 中文    |      修复了monitor解析log_ttl环境变量失败        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
