### PR TITLE
fix(msp): failed to get notify detail due to msp_env scope type

### DIFF
--- a/apistructs/notify_group.go
+++ b/apistructs/notify_group.go
@@ -18,6 +18,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -132,6 +133,18 @@ type NotifyGroupDetail struct {
 	DingdingList           []Target       `json:"dingdingList"`
 	DingdingWorkNoticeList []Target       `json:"dingdingWorknoticeList"`
 	WebHookList            []string       `json:"webhookList"`
+	Label                  string         `json:"-"`
+}
+
+func (n *NotifyGroupDetail) GetScopeDetail() (scopeID, scopeType string) {
+	label := make(map[string]string)
+	err := json.Unmarshal([]byte(n.Label), &label)
+	if err != nil {
+		return
+	}
+	scopeID = label[MSPMemberScopeId]
+	scopeType = label[MSPMemberScope]
+	return
 }
 
 // CreateNotifyGroupRequest 创建通知组请求

--- a/apistructs/notify_group_test.go
+++ b/apistructs/notify_group_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apistructs
+
+import "testing"
+
+func TestGetScopeDetail(t *testing.T) {
+	testCases := []struct {
+		name          string
+		label         string
+		wantScopeID   string
+		wantScopeType string
+	}{
+		{
+			name:          "empty label",
+			label:         "",
+			wantScopeID:   "",
+			wantScopeType: "",
+		},
+		{
+			name:          "project scope",
+			label:         "{\"member_scopeID\":\"1\",\"member_scopeType\":\"project\"}",
+			wantScopeID:   "1",
+			wantScopeType: "project",
+		},
+		{
+			name:          "wrong label",
+			label:         "member_scopeID: 1",
+			wantScopeType: "",
+			wantScopeID:   "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &NotifyGroupDetail{
+				Label: tc.label,
+			}
+			scopeID, scopeType := n.GetScopeDetail()
+			if scopeID != tc.wantScopeID {
+				t.Errorf("want scopeID: %s, but got: %s", tc.wantScopeID, scopeID)
+			}
+			if scopeType != tc.wantScopeType {
+				t.Errorf("want scopeType: %s, but got: %s", tc.wantScopeType, scopeType)
+			}
+		})
+	}
+}

--- a/internal/core/legacy/services/notify/notify_group.go
+++ b/internal/core/legacy/services/notify/notify_group.go
@@ -214,6 +214,7 @@ func (o *NotifyGroup) GetDetail(id int64, orgID int64) (*apistructs.NotifyGroupD
 	result.Targets = group.Targets
 	result.DingdingList = uniqueTargetList(result.DingdingList)
 	result.DingdingWorkNoticeList = uniqueTargetList(result.DingdingWorkNoticeList)
+	result.Label = group.Label
 	return result, nil
 }
 

--- a/internal/core/messenger/notifygroup/group.service.go
+++ b/internal/core/messenger/notifygroup/group.service.go
@@ -293,7 +293,11 @@ func (n *notifyGroupService) GetNotifyGroupDetail(ctx context.Context, request *
 		return nil, errors.NewInternalServerError(err)
 	}
 	userIdStr := apis.GetUserID(ctx)
-	err = n.checkNotifyPermission(ctx, userIdStr, notifyGroup.ScopeType, notifyGroup.ScopeID, apistructs.GetAction)
+	scopeType, scopeID := notifyGroup.ScopeType, notifyGroup.ScopeID
+	if scopeType == apistructs.MSPScope {
+		scopeID, scopeType = notifyGroup.GetScopeDetail()
+	}
+	err = n.checkNotifyPermission(ctx, userIdStr, scopeType, scopeID, apistructs.GetAction)
 	if err != nil {
 		return nil, errors.NewPermissionError(apistructs.NotifyResource, apistructs.GetAction, err.Error())
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix failed to get notify detail due to msp_env scope type

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=572035&iterationID=12783&tab=ALL&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that failed to get notify detail due to msp_env scope type（修复了微服务治理中查询告警通知详情失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that failed to get notify detail due to msp_env scope type           |
| 🇨🇳 中文    |    修复了微服务治理中查询告警通知详情失败的问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
