### PR TITLE
fix: fix issue with xorm limit(0) causing no data retrieval

### DIFF
--- a/internal/tools/pipeline/providers/definition/db/define.go
+++ b/internal/tools/pipeline/providers/definition/db/define.go
@@ -254,7 +254,7 @@ func (client *Client) ListPipelineDefinition(req *pb.PipelineDefinitionListReque
 		engine = engine.Desc("d." + v)
 	}
 
-	if req.PageSize != 0 {
+	if req.PageSize > 0 {
 		engine = engine.Limit(int(req.PageSize), int((req.PageNo-1)*req.PageSize))
 	}
 

--- a/internal/tools/pipeline/providers/definition/db/define.go
+++ b/internal/tools/pipeline/providers/definition/db/define.go
@@ -254,12 +254,14 @@ func (client *Client) ListPipelineDefinition(req *pb.PipelineDefinitionListReque
 		engine = engine.Desc("d." + v)
 	}
 
-	var total int64
-	if total, err = engine.Limit(int(req.PageSize), int((req.PageNo-1)*req.PageSize)).
-		FindAndCount(&pipelineDefinitionSources); err != nil {
-		return nil, 0, err
+	if req.PageSize != 0 {
+		engine = engine.Limit(int(req.PageSize), int((req.PageNo-1)*req.PageSize))
 	}
 
+	var total int64
+	if total, err = engine.FindAndCount(&pipelineDefinitionSources); err != nil {
+		return nil, 0, err
+	}
 	return pipelineDefinitionSources, total, nil
 }
 

--- a/internal/tools/pipeline/providers/definition/db/define_test.go
+++ b/internal/tools/pipeline/providers/definition/db/define_test.go
@@ -15,12 +15,15 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"xorm.io/xorm/names"
 
@@ -161,6 +164,12 @@ func TestGetPipelineDefinition(t *testing.T) {
 
 func TestLimit(t *testing.T) {
 	dbname := filepath.Join(os.TempDir(), dbSourceName)
+
+	dir, file := filepath.Split(dbname)
+	name := strings.TrimSuffix(file, filepath.Ext(file))
+	randomName := fmt.Sprintf("%s-%s%s", name, strings.ReplaceAll(uuid.New().String(), "-", ""), filepath.Ext(file))
+	dbname = filepath.Join(dir, randomName)
+
 	defer func() {
 		os.Remove(dbname)
 	}()

--- a/internal/tools/pipeline/providers/definition/db/define_test.go
+++ b/internal/tools/pipeline/providers/definition/db/define_test.go
@@ -158,3 +158,136 @@ func TestGetPipelineDefinition(t *testing.T) {
 
 	assert.Equal(t, true, reflect.ValueOf(d).IsNil())
 }
+
+func TestLimit(t *testing.T) {
+	dbname := filepath.Join(os.TempDir(), dbSourceName)
+	defer func() {
+		os.Remove(dbname)
+	}()
+	sqlite3Db, err := sqlite3.NewSqlite3(dbname+"?mode="+mode, sqlite3.WithJournalMode(sqlite3.MEMORY))
+	sqlite3Db.DB().SetMapper(names.GonicMapper{})
+	if err != nil {
+		panic(err)
+	}
+
+	// migrator db
+	err = sqlite3Db.DB().Sync2(&PipelineDefinition{})
+	if err != nil {
+		panic(err)
+	}
+
+	err = sqlite3Db.DB().Sync2(&sourcedb.PipelineSource{})
+	if err != nil {
+		panic(err)
+	}
+
+	client := &Client{
+		Interface: sqlite3Db,
+	}
+
+	sourceClient := &sourcedb.Client{
+		Interface: sqlite3Db,
+	}
+
+	// insert definition
+	definitions := []*PipelineDefinition{
+		{ID: "1", Name: "1", PipelineSourceId: "1", Location: "1"},
+		{ID: "2", Name: "2", PipelineSourceId: "2", Location: "1"},
+		{ID: "3", Name: "3", PipelineSourceId: "3", Location: "2"},
+		{ID: "4", Name: "4", PipelineSourceId: "1", SoftDeletedAt: uint64(time.Now().UnixNano()), Location: "1"},
+		{ID: "5", Name: "5", PipelineSourceId: "1", Location: "1"},
+	}
+
+	sources := []*sourcedb.PipelineSource{
+		{ID: "1"},
+		{ID: "2"},
+		{ID: "3"},
+	}
+
+	for _, d := range definitions {
+		err = client.CreatePipelineDefinition(d)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	for _, s := range sources {
+		err = sourceClient.CreatePipelineSource(s)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	type Want struct {
+		Err   bool
+		count int64
+	}
+
+	testCase := []struct {
+		Desc     string
+		pageSize int64
+		pageNo   int64
+		location string
+		want     Want
+	}{
+		{
+			Desc:     "pageSize is 0",
+			pageSize: 0,
+			pageNo:   1,
+			location: "1",
+			want: Want{
+				Err:   false,
+				count: 3,
+			},
+		},
+		{
+			Desc:     "pageSize is less 0",
+			pageSize: -1,
+			pageNo:   1,
+			location: "1",
+			want: Want{
+				Err:   false,
+				count: 3,
+			},
+		},
+		{
+			Desc:     "pageNo is 0，offset will be ignored",
+			pageSize: 1,
+			pageNo:   0,
+			location: "1",
+			want: Want{
+				Err:   false,
+				count: 3,
+			},
+		},
+		{
+			Desc:     "pageNo is less 0, offset will be ignored",
+			pageSize: 1,
+			pageNo:   -1,
+			location: "1",
+			want: Want{
+				Err:   false,
+				count: 3,
+			},
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Log(tt.Desc)
+		_, count, err := client.ListPipelineDefinition(&definitionpb.PipelineDefinitionListRequest{
+			PageSize: int64(0),
+			PageNo:   int64(1),
+			Location: "1",
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		if tt.want.Err {
+			assert.NotNil(t, err)
+		}
+		assert.Equal(t, tt.want.count, count)
+
+	}
+
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
In the newer version of xorm, when using limit(0), the value of 0 is not ignored and will be appended as "LIMIT 0" in the sql. Therefore, special handling is required for cases where the value is 0.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=573578&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  fix: fix xorm limit(0)            |
| 🇨🇳 中文    |  修复xorm limit(0)导致查无数据的问题            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
