### PR TITLE
refactor: Lengthen Python command box length

### DIFF
--- a/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/stagesOperations/customScriptDrawer/customScriptForm/render.go
+++ b/internal/apps/dop/component-protocol/components/auto-test-scenes/rightPage/fileDetail/fileConfig/scenesConfig/stagesOperations/customScriptDrawer/customScriptForm/render.go
@@ -38,7 +38,8 @@ const (
 )
 
 const (
-	defaultPythonImage       = "registry.erda.cloud/erda-actions/cdp-python:20210913-9f7576f9ef09e8bed32e2da4298f077328e532ea"
+	defaultPythonImage       = "registry.cn-beijing.aliyuncs.com/go_jingzhi/erda:0.1"
+	cdpPythonImage           = "registry.erda.cloud/erda-actions/cdp-python:20210913-9f7576f9ef09e8bed32e2da4298f077328e532ea"
 	defaultCustomScriptImage = "registry.erda.cloud/erda-actions/custom-script-action:20210519-01d2811"
 )
 
@@ -94,7 +95,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 		value.Image = data.CustomImage
 		value.Commands = data.Commands
 		if value.LanguageType == languagePython {
-			value.Commands = []string{data.Command}
+			value.Commands = []string{"echo '" + data.Command + "' >> test.py && python3 test.py"}
 			value.Image = data.PythonImage
 		}
 		valueByte, err := json.Marshal(value)
@@ -195,7 +196,7 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 				},
 				{
 					"label":     ca.sdk.I18n("image"),
-					"component": "input",
+					"component": "select",
 					"required":  true,
 					"key":       pythonImageKey,
 					"removeWhen": []interface{}{
@@ -208,10 +209,22 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 						},
 					},
 					"defaultValue": defaultPythonImage,
+					"componentProps": map[string]interface{}{
+						"options": []map[string]interface{}{
+							{
+								"name":  defaultPythonImage,
+								"value": defaultPythonImage,
+							},
+							{
+								"name":  cdpPythonImage,
+								"value": cdpPythonImage,
+							},
+						},
+					},
 				},
 				{
 					"label":     ca.sdk.I18n("image"),
-					"component": "input",
+					"component": "select",
 					"required":  true,
 					"key":       customImageKey,
 					"removeWhen": []interface{}{
@@ -224,6 +237,14 @@ func (ca *ComponentAction) Render(ctx context.Context, c *cptype.Component, scen
 						},
 					},
 					"defaultValue": defaultCustomScriptImage,
+					"componentProps": map[string]interface{}{
+						"options": []map[string]interface{}{
+							{
+								"name":  defaultCustomScriptImage,
+								"value": defaultCustomScriptImage,
+							},
+						},
+					},
 				},
 				{
 					"label":     ca.sdk.I18n("command"),


### PR DESCRIPTION
#### What this PR does / why we need it:
refactor: Lengthen Python command box length
feature: python scripts do not require input of cmd
refactor: supports image selection

#### Which issue(s) this PR fixes:
refactor: Lengthen Python command box length
feature: python scripts do not require input of cmd
refactor: supports image selection

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=575905&iterationID=12783&type=TASK)
- [python 命令框 不需要输入 cmd](https://erda.cloud/erda/dop/projects/387/issues/all?id=571020&iterationID=12783&type=REQUIREMENT)

#### Specified Reviewers:

/assign @sfwn @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
refactor： refactor: Lengthen Python command box length（加长 python 命令框长度）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        refactor: Lengthen Python command box length and feature: python scripts do not require input of cmd     |
| 🇨🇳 中文    |       加长 python 命令框长度 && python 命令框 不需要输入 cmd，只需要脚本内容即可  && 支持镜像可选  |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
