### PR TITLE
fix(monitor):  disk blk_read_bytes being negative due to `diffps`

### DIFF
--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions.go
@@ -210,6 +210,11 @@ var CkAggFunctions = map[string]*SQlAggFuncDefine{
 							}
 							seconds := float64(ctx.interval*int64(ctx.targetTimeUnit)) / float64(tsql.Second)
 							nextValue := nextV[id].(float64)
+							// diffps return value should not be negative
+							// erda issue: https://erda.cloud/erda/dop/projects/387/issues/all?id=581160&iterationID=12783&tab=BUG&type=BUG
+							if nextValue < currentV {
+								return 0, true
+							}
 							return (nextValue - currentV) / seconds, true
 						}
 					}

--- a/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions_test.go
+++ b/internal/tools/monitor/core/metric/query/es-tsql/influxql/ckFunctions_test.go
@@ -283,7 +283,7 @@ func TestAggregationHandlerFunction(t *testing.T) {
 			nextRow: map[string]interface{}{
 				"0e4b5b1082a11703": float64(111),
 			},
-			want: (111.0 - 222.0) / 60.0,
+			want: 0,
 		},
 
 		{


### PR DESCRIPTION
#### What this PR does / why we need it:
fix disk blk_read_bytes being negative due to `diffps`

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=581160&iterationID=12783&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that disk blk_read_bytes being negative due to `diffps` （修复了容器监控磁盘读写为负数的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that disk blk_read_bytes being negative due to `diffps`           |
| 🇨🇳 中文    |      修复了容器监控磁盘读写为负数的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
