### PR TITLE
feat(hepa): api proxy host pass-through set default as true

### DIFF
--- a/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy.go
+++ b/internal/tools/orchestrator/hepa/apipolicy/policies/proxy/policy.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/apipolicy"
 	annotationscommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/common"
+	"github.com/erda-project/erda/internal/tools/orchestrator/hepa/config"
 	gatewayproviders "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers"
 	providerDto "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/dto"
 	mseCommon "github.com/erda-project/erda/internal/tools/orchestrator/hepa/gateway-providers/mse/common"
@@ -42,7 +43,7 @@ func (policy Policy) CreateDefaultConfig(gatewayProvider string, ctx map[string]
 		ClientRespTimeout: 60,
 		ProxyReqTimeout:   60,
 		ProxyRespTimeout:  60,
-		HostPassthrough:   false,
+		HostPassthrough:   config.APIProxyPolicyHostPassThrough(),
 		SSLRedirect:       true,
 	}
 	dto.Switch = false

--- a/internal/tools/orchestrator/hepa/config/config.go
+++ b/internal/tools/orchestrator/hepa/config/config.go
@@ -14,6 +14,22 @@
 
 package config
 
+import "github.com/erda-project/erda/pkg/envconf"
+
+type Conf struct {
+	APIProxyPolicyHostPassThrough bool `file:"api_proxy_policy_host_pass_through" default:"true"`
+}
+
+var cfg Conf
+
+func Load() {
+	envconf.MustLoad(&cfg)
+}
+
+func APIProxyPolicyHostPassThrough() bool {
+	return cfg.APIProxyPolicyHostPassThrough
+}
+
 var ServerConf *ServerConfig
 var LogConf *LogConfig
 

--- a/internal/tools/orchestrator/hepa/provider.go
+++ b/internal/tools/orchestrator/hepa/provider.go
@@ -51,6 +51,7 @@ type provider struct {
 }
 
 func (p *provider) Init(ctx servicehub.Context) error {
+	config.Load()
 	config.ServerConf = &p.Cfg.Server
 	config.LogConf = &p.Cfg.Log
 	common.InitLogger()
@@ -58,6 +59,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	logrus.Info(version.String())
 	logrus.Infof("server conf: %+v", config.ServerConf)
 	logrus.Infof("log conf: %+v", config.LogConf)
+	logrus.Infof("default api proxy policy host pass through: %v", config.APIProxyPolicyHostPassThrough())
 	orgCache.CacheInit(p.Org)
 	p.HttpServer.GET("/api/gateway/openapi/metrics/*", func(resp http.ResponseWriter, req *http.Request) {
 		path := strings.Replace(req.URL.Path, "/api/gateway/openapi/metrics/charts", "/api/metrics", 1)


### PR DESCRIPTION
#### What this PR does / why we need it:
feat  api proxy host pass-through set default as true


#### Specified Reviewers:

/assign @luobily @wangzhuzhen 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: api proxy host pass-through set default as true（网关默认host透传设置开启）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  api proxy host pass-through set default as true            |
| 🇨🇳 中文    |     网关默认host透传设置开启         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
