### PR TITLE
feat(monitor): add `erda` orgName in selector when download logs

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -230,7 +230,10 @@ jobs:
           rm -fr ./coverage/proto-go
           rm -fr ./coverage/pure-coverage
       - name: Upload coverage to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
+          echo ${#CODECOV_TOKEN}
           curl -s https://codecov.io/bash | bash -s - -s ./coverage/
       - name: Upload combined coverage reports to artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -230,10 +230,7 @@ jobs:
           rm -fr ./coverage/proto-go
           rm -fr ./coverage/pure-coverage
       - name: Upload coverage to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          echo ${#CODECOV_TOKEN}
           curl -s https://codecov.io/bash | bash -s - -s ./coverage/
       - name: Upload combined coverage reports to artifact
         uses: actions/upload-artifact@v3

--- a/internal/tools/monitor/core/log/query/log.query.service.go
+++ b/internal/tools/monitor/core/log/query/log.query.service.go
@@ -704,7 +704,7 @@ func toQuerySelector(req Request) (*storage.Selector, error) {
 		}
 		if meta := byExpressionRequest.GetQueryMeta(); meta != nil {
 			sel.Meta = storage.QueryMeta{
-				OrgNames:              []string{meta.GetOrgName()},
+				OrgNames:              []string{meta.GetOrgName(), "erda"},
 				MspEnvIds:             meta.GetMspEnvIds(),
 				Highlight:             meta.GetHighlight(),
 				PreferredBufferSize:   int(meta.GetPreferredBufferSize()),

--- a/internal/tools/monitor/core/log/query/log.query.service_test.go
+++ b/internal/tools/monitor/core/log/query/log.query.service_test.go
@@ -130,7 +130,7 @@ func Test_toQuerySelector(t *testing.T) {
 					},
 				},
 				Meta: storage.QueryMeta{
-					OrgNames:              []string{"erda"},
+					OrgNames:              []string{"erda", "erda"},
 					PreferredBufferSize:   10,
 					PreferredIterateStyle: storage.Scroll,
 				},

--- a/internal/tools/monitor/core/log/query/routes.go
+++ b/internal/tools/monitor/core/log/query/routes.go
@@ -136,7 +136,7 @@ func (p *provider) downloadLog(w http.ResponseWriter, r *http.Request, req *LogR
 			if req.IsFallBack {
 				sel.Options[storage.IsFallBack] = true
 			}
-			p.logQueryService.tryFillQueryMeta(r.Context(), sel, r.Header.Get("org"))
+			p.logQueryService.tryFillQueryMeta(r.Context(), sel, r.Header.Get("org"), "erda")
 			return sel, nil
 		},
 		func(item *pb.LogItem) error {


### PR DESCRIPTION
#### What this PR does / why we need it:
add `erda` orgName in selector when download logs


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support add `erda` orgName in selector when download logs （下载日志时默认增加查询erda组织）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Support add `erda` orgName in selector when download logs           |
| 🇨🇳 中文    |     下载日志时默认增加查询erda组织         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
