### PR TITLE
fix(openapi): unknown unit 'd' in duration

### DIFF
--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -169,7 +169,7 @@ openapi-auth-uc:
   uc_redirect_addrs: "${SELF_PUBLIC_ADDR}"
   session_cookie_name: "${SESSION_COOKIE_NAME:OPENAPISESSION}"
   session_cookie_domain: "${COOKIE_DOMAIN}"
-  cookie_max_age: "${UC_COOKIE_MAX_AGE:7d}"
+  cookie_max_age: "${UC_COOKIE_MAX_AGE:168h}"
   cookie_same_site: "${UC_COOKIE_SAME_SITE:2}"
 openapi-auth-password:
   _enable: ${UC_ENABLED:true}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix unknown unit 'd' in duration


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that unknown unit 'd' in duration（修复了默认cookie过期时间的单位问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Fix the bug that unknown unit 'd' in duration             |
| 🇨🇳 中文    |    修复了默认cookie过期时间的单位问题          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
