### PR TITLE
fix(pipeline):  the agent is stuck in the waiting logs done due to prepare failure

### DIFF
--- a/internal/tools/pipeline/actionagent/execute.go
+++ b/internal/tools/pipeline/actionagent/execute.go
@@ -59,15 +59,16 @@ func (agent *Agent) Execute(r io.Reader) {
 		return
 	}
 
+	defer func() {
+		// defer write flag end line for tail
+		agent.writeEndFlagLine()
+	}()
+
 	// 2. prepare
 	agent.prepare()
 	if len(agent.Errs) > 0 {
 		return
 	}
-	defer func() {
-		// defer write flag end line for tail
-		agent.writeEndFlagLine()
-	}()
 
 	// 3. restore / store
 	agent.restore()

--- a/internal/tools/pipeline/actionagent/exit.go
+++ b/internal/tools/pipeline/actionagent/exit.go
@@ -46,11 +46,15 @@ func (agent *Agent) Exit() {
 }
 
 func (agent *Agent) writeEndFlagLine() {
-	if _, err := fmt.Fprintf(agent.EasyUse.RunMultiStdout, "\n%s\n", agent.EasyUse.FlagEndLineForTail); err != nil {
-		logrus.Println("stdout append flag err:", err)
+	if agent.EasyUse.RunMultiStdout != nil {
+		if _, err := fmt.Fprintf(agent.EasyUse.RunMultiStdout, "\n%s\n", agent.EasyUse.FlagEndLineForTail); err != nil {
+			logrus.Println("stdout append flag err:", err)
+		}
 	}
-	if _, err := fmt.Fprintf(agent.EasyUse.RunMultiStderr, "\n%s\n", agent.EasyUse.FlagEndLineForTail); err != nil {
-		logrus.Println("stderr append flag err:", err)
+	if agent.EasyUse.RunMultiStderr != nil {
+		if _, err := fmt.Fprintf(agent.EasyUse.RunMultiStderr, "\n%s\n", agent.EasyUse.FlagEndLineForTail); err != nil {
+			logrus.Println("stderr append flag err:", err)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
fix  the agent is stuck in the waiting logs done due to prepare failure

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=592755&iterationID=12783&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that the agent is stuck in the waiting logs done due to prepare failure（修复了agent在prepare失败时卡在等待结束标志的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix the bug that the agent is stuck in the waiting logs done due to prepare failure           |
| 🇨🇳 中文    |   修复了agent在prepare失败时卡在等待结束标志的问题           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
