### PR TITLE
fix(monitor): addon alert cross workspace

### DIFF
--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_elasticsearch_cpu/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_elasticsearch_cpu/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"in",
         "tag":"addon_type",
         "value":[

--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_elasticsearch_mem/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_elasticsearch_mem/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"in",
         "tag":"addon_type",
         "value":[

--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_cpu/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_cpu/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"in",
         "tag":"addon_type",
         "value":[

--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_mem/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_mem/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"in",
         "tag":"addon_type",
         "value":[

--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_slave_status/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_mysql_slave_status/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"eq",
         "tag":"is_slave",
         "value":"true"

--- a/cmd/monitor/monitor/conf/alert/rules/addon/addon_redis_mem/analyzer_expression.json
+++ b/cmd/monitor/monitor/conf/alert/rules/addon/addon_redis_mem/analyzer_expression.json
@@ -8,6 +8,11 @@
         "value":"$org_name"
       },
       {
+        "operator":"ieq",
+        "tag":"workspace",
+        "value":"$workspace"
+      },
+      {
         "operator":"in",
         "tag":"addon_type",
         "value":[

--- a/internal/tools/monitor/core/alert/alert-apis/adapt/expression.go
+++ b/internal/tools/monitor/core/alert/alert-apis/adapt/expression.go
@@ -107,6 +107,7 @@ var (
 	filterOperatorRel = map[string]string{
 		"any":      OperatorTypeNone,
 		"eq":       OperatorTypeOne,
+		"ieq":      OperatorTypeOne,
 		"false":    OperatorTypeNone,
 		"in":       OperatorTypeMore,
 		"notIn":    OperatorTypeMore,


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix addon alert cross workspace.

Cause of the bug: Addon metrics only use `org_name` and  `addon_type` for filtering，and lack a namespace filter such as `terminus_key`、`tk` or `workspace`.

Addon metric event doesn't carry `terminus_key` as well as current MSP project workspace is capital-letters.
The existed operator can't support filter string which case-sensitive, so we introduced a new filter operator -`ieq` .

Result verification: 
<img width="1384" alt="image" src="https://github.com/erda-project/erda/assets/31346321/bfa7fbfc-2ff0-49d1-8c72-0c08f4641487">
![image](https://github.com/erda-project/erda/assets/31346321/63920f84-e7d6-4ad6-885e-dc5d30e13b36)


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=589326&iterationID=13633&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix addon alert cross workspace           |
| 🇨🇳 中文    |        修复 addon 告警跨环境问题      |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
