### PR TITLE
fix(cmp): dbclient sql build error

### DIFF
--- a/internal/apps/cmp/dbclient/records.go
+++ b/internal/apps/cmp/dbclient/records.go
@@ -83,11 +83,11 @@ func (r *recordsReader) ByUserIDs(userids ...string) *recordsReader {
 }
 
 func (r *recordsReader) ByCreateTime(beforeNSecs int) *recordsReader {
-	return r.updateDBEngine(r.db.Where("created_at > now() - interval %d second", beforeNSecs))
+	return r.updateDBEngine(r.db.Where("created_at > now() - interval ? second", beforeNSecs))
 }
 
 func (r *recordsReader) ByUpdateTime(beforeNSecs int) *recordsReader {
-	return r.updateDBEngine(r.db.Where("updated_at > now() - interval %d second", beforeNSecs))
+	return r.updateDBEngine(r.db.Where("updated_at > now() - interval ? second", beforeNSecs))
 }
 
 func (r *recordsReader) Limit(n int) *recordsReader {


### PR DESCRIPTION
#### What this PR does / why we need it:
```shell
(/go/src/github.com/erda-project/erda/internal/apps/cmp/dbclient/records.go:112) 
[2024-05-27 18:10:57]  Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '%d second) AND (status in (?,?)) AND (record_type in (?,?,?,?)) ORDER BY created' at line 1 
ERRO[2024-05-27 18:10:57.727492874] get create cluster record failed, error: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '%d second) AND (status in (?,?)) AND (record_type in (?,?,?,?)) ORDER BY created' at line 1 
```

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn @CeerDecy 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | fix dbclient sql build error             |
| 🇨🇳 中文    |   修复 cmp sql build error           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
