### PR TITLE
fix(gh-ci):  set safe.directory at Dockerfile side to prevent "dubious ownership" errors

### DIFF
--- a/.erda/pipelines/ci-build-ce.yml
+++ b/.erda/pipelines/ci-build-ce.yml
@@ -42,7 +42,7 @@ stages:
       - custom-script:
           alias: build-erda
           description: 运行自定义命令
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions

--- a/.erda/pipelines/ci-deploy.yml
+++ b/.erda/pipelines/ci-deploy.yml
@@ -60,7 +60,7 @@ stages:
   - stage:
       - custom-script:
           alias: build-erda
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           commands:
             - cd ${{ dirs.erda }}
             - mkdir -p extensions
@@ -83,7 +83,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -101,7 +101,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-agent
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           commands:
             - cd ${{ dirs.erda }}
             - export ERDA_VERSION=${{ outputs.extract-repo-version.major_minor_version }}
@@ -138,7 +138,7 @@ stages:
             mem: 1024
       - custom-script:
           alias: build-erda-cli-linux
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)
@@ -156,7 +156,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli-mac
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -68,7 +68,7 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/erda-base:20240603
+      image: registry.erda.cloud/erda/erda-base:20240606
     needs:
       - PREPARE
     steps:
@@ -100,7 +100,7 @@ jobs:
   CODE-CHECK:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/erda-base:20240603
+      image: registry.erda.cloud/erda/erda-base:20240606
     needs:
       - PREPARE
     steps:
@@ -145,7 +145,7 @@ jobs:
   CODE-TEST:
     runs-on: ubuntu-latest
     container:
-      image: registry.erda.cloud/erda/erda-base:20240603
+      image: registry.erda.cloud/erda/erda-base:20240606
     needs:
       - PREPARE
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run-test:
 	go run tools/gotools/go-test-sum/main.go
 
 full-test:
-	docker run --rm -ti -v $$(pwd):/go/src/output registry.erda.cloud/erda/erda-base:20240603 \
+	docker run --rm -ti -v $$(pwd):/go/src/output registry.erda.cloud/erda/erda-base:20240606 \
 		bash -c 'cd /go/src/output && build/scripts/test_in_container.sh'
 
 # docker image

--- a/build/dockerfiles/base/Dockerfile
+++ b/build/dockerfiles/base/Dockerfile
@@ -7,6 +7,9 @@ ARG TARGETPLATFORM
 RUN apt remove -yq git
 COPY --from=git-from /opt/bitnami/git /opt/bitnami/git
 ENV PATH="/opt/bitnami/git/bin:${PATH}"
+# Set dev environment as safe git directory to prevent "dubious ownership" errors
+# see: https://github.com/moby/moby/pull/44946
+RUN git config --global --add safe.directory '*'
 
 # set timezone to CST
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime

--- a/build/dockerfiles/base/sbom-amd64.txt
+++ b/build/dockerfiles/base/sbom-amd64.txt
@@ -84,8 +84,8 @@
   dirmngr                                2.2.40-1.1                      deb      
   dist                                   (devel)                         golang   
   doc                                    (devel)                         golang   
-  docker-ce                              5:26.1.3-1~debian.12~bookworm   deb      
-  docker-ce-cli                          5:26.1.3-1~debian.12~bookworm   deb      
+  docker-ce                              5:26.1.4-1~debian.12~bookworm   deb      
+  docker-ce-cli                          5:26.1.4-1~debian.12~bookworm   deb      
   dpkg                                   1.21.22                         deb      
   e2fsprogs                              1.47.0-2                        deb      
   eastasianwidth                         0.2.0                           npm      
@@ -188,8 +188,8 @@
   libapr1                                1.7.2-3                         deb      
   libaprutil1                            1.6.3-1                         deb      
   libapt-pkg6.0                          2.6.1                           deb      
-  libarchive                             3.6.2-1                         deb      
-  libarchive13                           3.6.2-1                         deb      
+  libarchive                             3.6.2-1+deb12u1                 deb      
+  libarchive13                           3.6.2-1+deb12u1                 deb      
   libasan8                               12.2.0-14                       deb      
   libassuan                              2.5.5-5                         deb      
   libassuan0                             2.5.5-5                         deb      
@@ -600,8 +600,8 @@
   sq                                     0.27.0-2+b1                     deb      
   sqlite3                                3.40.1-2                        deb      
   ssri                                   10.0.5                          npm      
-  stdlib                                 1.21.10                         golang   
-  stdlib                                 go1.21.10                       golang   
+  stdlib                                 1.21.11                         golang   
+  stdlib                                 go1.21.11                       golang   
   stdlib                                 1.19.13                         golang   
   stdlib                                 go1.19.13                       golang   
   string-locale-compare                  1.1.0                           npm      

--- a/build/dockerfiles/base/sbom-arm64.txt
+++ b/build/dockerfiles/base/sbom-arm64.txt
@@ -84,8 +84,8 @@
   dirmngr                                2.2.40-1.1                      deb      
   dist                                   (devel)                         golang   
   doc                                    (devel)                         golang   
-  docker-ce                              5:26.1.3-1~debian.12~bookworm   deb      
-  docker-ce-cli                          5:26.1.3-1~debian.12~bookworm   deb      
+  docker-ce                              5:26.1.4-1~debian.12~bookworm   deb      
+  docker-ce-cli                          5:26.1.4-1~debian.12~bookworm   deb      
   dpkg                                   1.21.22                         deb      
   e2fsprogs                              1.47.0-2                        deb      
   eastasianwidth                         0.2.0                           npm      
@@ -188,8 +188,8 @@
   libapr1                                1.7.2-3                         deb      
   libaprutil1                            1.6.3-1                         deb      
   libapt-pkg6.0                          2.6.1                           deb      
-  libarchive                             3.6.2-1                         deb      
-  libarchive13                           3.6.2-1                         deb      
+  libarchive                             3.6.2-1+deb12u1                 deb      
+  libarchive13                           3.6.2-1+deb12u1                 deb      
   libasan8                               12.2.0-14                       deb      
   libassuan                              2.5.5-5                         deb      
   libassuan0                             2.5.5-5                         deb      
@@ -600,8 +600,8 @@
   sq                                     0.27.0-2+b1                     deb      
   sqlite3                                3.40.1-2                        deb      
   ssri                                   10.0.5                          npm      
-  stdlib                                 1.21.10                         golang   
-  stdlib                                 go1.21.10                       golang   
+  stdlib                                 1.21.11                         golang   
+  stdlib                                 go1.21.11                       golang   
   stdlib                                 1.19.13                         golang   
   stdlib                                 go1.19.13                       golang   
   string-locale-compare                  1.1.0                           npm      

--- a/build/scripts/buildkit_image.sh
+++ b/build/scripts/buildkit_image.sh
@@ -4,7 +4,7 @@ set -o errexit -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-BASE_DOCKER_IMAGE=registry.erda.cloud/erda/erda-base:20240603
+BASE_DOCKER_IMAGE=registry.erda.cloud/erda/erda-base:20240606
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
 DOCKERFILE=./build/dockerfiles
 

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -35,7 +35,7 @@ ARCH="${ARCH:-$(go env GOARCH)}"
 VERSION="$(build/scripts/make-version.sh)"
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
 DOCKERFILE_DEFAULT="build/dockerfiles/Dockerfile"
-BASE_DOCKER_IMAGE="registry.erda.cloud/erda/erda-base:20240603"
+BASE_DOCKER_IMAGE="registry.erda.cloud/erda/erda-base:20240606"
 DOCKERFILE=${DOCKERFILE_DEFAULT}
 
 # setup single module envionment variables

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -146,7 +146,7 @@ stages:
           disable: true
       - custom-script:
           alias: build-erda-cli-linux
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)
@@ -164,7 +164,7 @@ stages:
             mem: 2048
       - custom-script:
           alias: build-erda-cli-mac
-          image: registry.erda.cloud/erda/erda-base:20240603
+          image: registry.erda.cloud/erda/erda-base:20240606
           description: 运行自定义命令
           commands:
             - workDir=$(pwd)


### PR DESCRIPTION
#### What this PR does / why we need it:

set safe.directory at Dockerfile side to prevent "dubious ownership" errors


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=604917&iterationID=12783&tab=ALL&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    fix github ci: set safe.directory at Dockerfile side to prevent "dubious ownership" errors          |
| 🇨🇳 中文    |   修复 github ci: 在 Dockerfile 侧设置 safe.directory 来避免 "dubious ownership" 错误          |
