### PR TITLE
fix(gh-ci): use `--system` instead of `--global` to make it work for all users

### DIFF
--- a/build/dockerfiles/base/Dockerfile
+++ b/build/dockerfiles/base/Dockerfile
@@ -7,9 +7,9 @@ ARG TARGETPLATFORM
 RUN apt remove -yq git
 COPY --from=git-from /opt/bitnami/git /opt/bitnami/git
 ENV PATH="/opt/bitnami/git/bin:${PATH}"
-# Set dev environment as safe git directory to prevent "dubious ownership" errors
-# see: https://github.com/moby/moby/pull/44946
-RUN git config --global --add safe.directory '*'
+# Set safe.directory to prevent "dubious ownership" errors, see: https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
+# use `--system` instead of `--global` to make it work for all users
+RUN mkdir -p /opt/bitnami/git/etc && touch /opt/bitnami/git/etc/gitconfig && git config --system --add safe.directory '*'
 
 # set timezone to CST
 RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime


### PR DESCRIPTION
#### What this PR does / why we need it:

use `--system` instead of `--global` to make it work for all users


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=604917&iterationID=12783&tab=ALL&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | use `--system` instead of `--global` to make it work for all users to prevent "dubious ownership" error          |
| 🇨🇳 中文    |  使用 `--system` 而不是 `--global` 使所有用户生效，来避免 "dubious ownership" 错误           |

