### PR TITLE
fix(streaming): return the connection to the pool after `PrepareBatch`

### DIFF
--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/external_metric/external_metrics.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/external_metric/external_metrics.go
@@ -99,7 +99,7 @@ func (bu *Builder) buildBatches(ctx context.Context, items []*metric.Metric) ([]
 
 		if _, ok := tableBatch[table]; !ok {
 			// nolint
-			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table)
+			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table, driver.WithReleaseConnection())
 			if err != nil {
 				return nil, err
 			}

--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/log/log.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/log/log.go
@@ -94,7 +94,7 @@ func (bu *Builder) buildBatches(ctx context.Context, items []*log.Log) ([]driver
 			return nil, fmt.Errorf("cannot get tenant table: %w", err)
 		}
 		if _, ok := tableBatch[table]; !ok {
-			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table)
+			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table, driver.WithReleaseConnection())
 			if err != nil {
 				return nil, err
 			}

--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/metric/metric.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/metric/metric.go
@@ -100,7 +100,7 @@ func NewBuilder(ctx servicehub.Context, logger logs.Logger, cfg *builder.Builder
 }
 
 func (bu *Builder) buildBatches(ctx context.Context, items []*metric.Metric) ([]driver.Batch, error) {
-	metaBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+bu.Loader.Database()+".metrics_meta")
+	metaBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+bu.Loader.Database()+".metrics_meta", driver.WithReleaseConnection())
 	if err != nil {
 		return nil, fmt.Errorf("prepare metrics_meta batch: %w", err)
 	}
@@ -113,7 +113,7 @@ func (bu *Builder) buildBatches(ctx context.Context, items []*metric.Metric) ([]
 
 		if _, ok := tableBatch[table]; !ok {
 			// nolint
-			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table)
+			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table, driver.WithReleaseConnection())
 			if err != nil {
 				return nil, err
 			}

--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/profile/profile.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/profile/profile.go
@@ -95,15 +95,15 @@ func (bu *Builder) BuildBatch(ctx context.Context, sourceBatch interface{}) ([]d
 }
 
 func (bu *Builder) buildBatches(ctx context.Context, items []*profile.Output) ([]driver.Batch, error) {
-	treeBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+treeTable)
+	treeBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+treeTable, driver.WithReleaseConnection())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tree table: %v", err)
 	}
-	segmentBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+segmentTable)
+	segmentBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+segmentTable, driver.WithReleaseConnection())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get segment table: %v", err)
 	}
-	dictBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+dictTable)
+	dictBatch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+dictTable, driver.WithReleaseConnection())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get dict table: %v", err)
 	}

--- a/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/span/span.go
+++ b/internal/tools/monitor/oap/collector/plugins/exporters/clickhouse/builder/span/span.go
@@ -88,7 +88,7 @@ func (bu *Builder) buildBatches(ctx context.Context, items []*trace.Span) ([]dri
 		}
 		if _, ok := tablebatch[table]; !ok {
 			// nolint
-			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table)
+			batch, err := bu.client.PrepareBatch(ctx, "INSERT INTO "+table, driver.WithReleaseConnection())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
return the connection to the pool after `PrepareBatch`
see [detail](https://github.com/ClickHouse/clickhouse-go/blob/8ad6ec6b95d8b0c96d00115bc2d69ff13083f94b/README.md?plain=1#L289-L293)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that streaming missing connection when batch write data（修复了streaming消费数据时链接耗尽的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that streaming missing connection when batch write data           |
| 🇨🇳 中文    |     修复了streaming消费数据时链接耗尽的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
