### PR TITLE
feat(collector): add `dropper` provider for application metric

### DIFF
--- a/cmd/monitor/collector/bootstrap-agent.yaml
+++ b/cmd/monitor/collector/bootstrap-agent.yaml
@@ -24,6 +24,11 @@ erda.oap.collector.core:
           - "erda.oap.collector.exporter.collector@metrics"
         batch_size: ${METRIC_PROMETHEUS_BATCH_SIZE:1024}
 
+      - receivers: [ "erda.oap.collector.receiver.collector" ]
+        processors:
+          - "erda.oap.collector.processor.dropper@application-agent"
+        exporters: [ "erda.oap.collector.exporter.collector@metrics" ]
+
     external_metrics:
       - receivers:
           - "erda.oap.collector.receiver.prometheus-remote-write@external_metrics"
@@ -45,6 +50,13 @@ erda.oap.collector.core:
 #  metric_sample: '{"name":"kubelet_cadvisor","timeUnixNano":1640936985459000000,"relations":null,"attributes":{"container":"manager","host_ip":"10.118.177.94","id":"/kubepods/burstable/pod164ec226-8106-4904-9bcb-0218a9b2b793/8367a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec","image":"sha256:6cd7bc0e0855164e7ff495c6ec9a37cf8657f8170fe97055ffba2c63343bcedd","instance":"virtual-kubelet-cn-hangzhou-k","name":"8367a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec","namespace":"default","pod":"elasticsearch-operator-776689d978-mjdzq","pod_name":"elasticsearch-operator-776689d978-mjdzq"},"dataPoints":{"container_cpu_usage_seconds_total":13995.161470334,"container_memory_max_usage_bytes":273977344}}'
 
 erda.oap.collector.receiver.prometheus-remote-write@default:
+
+erda.oap.collector.receiver.collector:
+  auth:
+    username: "${COLLECTOR_AUTH_USERNAME:collector}"
+    password: "${COLLECTOR_AUTH_PASSWORD:G$9767bP32drYFPWrK4XMLRMTatiM6cU}"
+    force: ${COLLECTOR_AUTH_FORCE:false}
+    skip: ${COLLECTOR_AUTH_SKIP:false}
 
 erda.oap.collector.receiver.prometheus-remote-write@external_metrics:
   remote_write_url: "${EXTERNAL_METRIC_REMOTE_WRITE_URL:/api/v1/external-prometheus-remote-write}"
@@ -372,6 +384,9 @@ erda.oap.collector.exporter.collector@external_metrics:
     content-type: "application/json; charset=UTF-8"
     content-encoding: "gzip"
     x-erda-cluster-key: ${DICE_CLUSTER_NAME}
+
+erda.oap.collector.processor.dropper@application-agent:
+  metric_prefix: ${APPLICATION_AGENT_DROP_PREFIX}
 
 # ************* exporters *************
 

--- a/internal/tools/monitor/oap/collector/plugins/all/all.go
+++ b/internal/tools/monitor/oap/collector/plugins/all/all.go
@@ -25,6 +25,7 @@ import (
 
 	// processors
 	_ "github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins/processors/aggregator"
+	_ "github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins/processors/dropper"
 	_ "github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins/processors/k8s-tagger"
 	_ "github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins/processors/modifier"
 	_ "github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins/processors/profile"

--- a/internal/tools/monitor/oap/collector/plugins/processors/dropper/provider.go
+++ b/internal/tools/monitor/oap/collector/plugins/processors/dropper/provider.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropper
+
+import (
+	"strings"
+
+	"github.com/erda-project/erda-infra/base/logs"
+	"github.com/erda-project/erda-infra/base/servicehub"
+	"github.com/erda-project/erda/internal/apps/msp/apm/trace"
+	"github.com/erda-project/erda/internal/tools/monitor/core/log"
+	"github.com/erda-project/erda/internal/tools/monitor/core/metric"
+	"github.com/erda-project/erda/internal/tools/monitor/core/profile"
+	"github.com/erda-project/erda/internal/tools/monitor/oap/collector/core/model"
+	"github.com/erda-project/erda/internal/tools/monitor/oap/collector/core/model/odata"
+	"github.com/erda-project/erda/internal/tools/monitor/oap/collector/plugins"
+)
+
+var providerName = plugins.WithPrefixProcessor("dropper")
+
+type config struct {
+	MetricPrefix string `file:"metric_prefix"`
+}
+
+type provider struct {
+	Cfg *config
+	Log logs.Logger
+}
+
+var _ model.Processor = (*provider)(nil)
+
+func (p *provider) ComponentClose() error {
+	return nil
+}
+
+func (p *provider) ComponentConfig() interface{} {
+	return p.Cfg
+}
+
+func (p *provider) ProcessMetric(item *metric.Metric) (*metric.Metric, error) {
+	if len(p.Cfg.MetricPrefix) > 0 && strings.HasPrefix(item.Name, p.Cfg.MetricPrefix) {
+		return nil, nil
+	}
+	return item, nil
+}
+
+func (p *provider) ProcessLog(item *log.Log) (*log.Log, error) { return item, nil }
+
+func (p *provider) ProcessSpan(item *trace.Span) (*trace.Span, error) { return item, nil }
+
+func (p *provider) ProcessRaw(item *odata.Raw) (*odata.Raw, error) { return item, nil }
+
+func (p *provider) ProcessProfile(*profile.ProfileIngest) (*profile.Output, error) {
+	return &profile.Output{}, nil
+}
+
+func (p *provider) Init(ctx servicehub.Context) error {
+	return nil
+}
+
+func init() {
+	servicehub.Register(providerName, &servicehub.Spec{
+		Services: []string{
+			providerName,
+		},
+		Description: "help to drop item by prefix name",
+		ConfigFunc: func() interface{} {
+			return &config{}
+		},
+		Creator: func() servicehub.Provider {
+			return &provider{}
+		},
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
add `dropper` provider for application metric

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=605800&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support add `dropper` provider for application metric（collector实现可以丢弃不需要的指标）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Support add `dropper` provider for application metric            |
| 🇨🇳 中文    |  collector实现可以丢弃不需要的指标            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
