### PR TITLE
chore: remove deprecated ioutil

### DIFF
--- a/bundle/addon_test.go
+++ b/bundle/addon_test.go
@@ -16,7 +16,7 @@ package bundle
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -72,7 +72,7 @@ func TestBundle_GetRuntimeAddonConfig(t *testing.T) {
   ]
 }
 `
-		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte(raw)))
+		resp.Body = io.NopCloser(bytes.NewReader([]byte(raw)))
 		return resp, nil
 	})
 

--- a/bundle/audit.go
+++ b/bundle/audit.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 
 	"github.com/erda-project/erda-proto-go/core/file/pb"
@@ -131,7 +130,7 @@ func (b *Bundle) ExportAuditExcel(orgID, userID, lang string, params url.Values)
 		return nil, nil, apierrors.ErrInvoke.InternalError(err)
 	}
 	if !resp.IsOK() {
-		bodyBytes, _ := ioutil.ReadAll(respBody)
+		bodyBytes, _ := io.ReadAll(respBody)
 		var downloadResp pb.FileDownloadFailResponse
 		if err := json.Unmarshal(bodyBytes, &downloadResp); err == nil {
 			return nil, nil, toPbAPIError(resp.StatusCode(), downloadResp.Error)

--- a/bundle/dicefile.go
+++ b/bundle/dicefile.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"time"
 
@@ -46,7 +45,7 @@ func (b *Bundle) DownloadDiceFile(uuid string) (io.ReadCloser, error) {
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 	if !resp.IsOK() {
-		bodyBytes, _ := ioutil.ReadAll(respBody)
+		bodyBytes, _ := io.ReadAll(respBody)
 		var downloadResp commonpb.ResponseHeader
 		if err := json.Unmarshal(bodyBytes, &downloadResp); err == nil {
 			return nil, toPbAPIError(resp.StatusCode(), downloadResp.Error)
@@ -71,7 +70,7 @@ func (b *Bundle) DeleteDiceFile(uuid string) error {
 		return apierrors.ErrInvoke.InternalError(err)
 	}
 	if !resp.IsOK() {
-		bodyBytes, _ := ioutil.ReadAll(respBody)
+		bodyBytes, _ := io.ReadAll(respBody)
 		var downloadResp commonpb.ResponseHeader
 		if err := json.Unmarshal(bodyBytes, &downloadResp); err == nil {
 			return toPbAPIError(resp.StatusCode(), downloadResp.Error)

--- a/bundle/env_config_test.go
+++ b/bundle/env_config_test.go
@@ -16,7 +16,7 @@ package bundle
 
 //import (
 //	"bytes"
-//	"io/ioutil"
+//	"io/"
 //	"net/http"
 //	"os"
 //	"reflect"
@@ -71,7 +71,7 @@ package bundle
 //  ]
 //}
 //`
-//		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte(raw)))
+//		resp.Body = io.NopCloser(bytes.NewReader([]byte(raw)))
 //		return resp, nil
 //	})
 //

--- a/bundle/release_test.go
+++ b/bundle/release_test.go
@@ -17,7 +17,7 @@ package bundle
 //import (
 //	"bytes"
 //	"encoding/json"
-//	"io/ioutil"
+//	"io"
 //	"net/http"
 //	"os"
 //	"reflect"
@@ -62,7 +62,7 @@ package bundle
 //			Header:     make(http.Header, 0),
 //		}
 //		resp.Header.Set("Content-Type", "application/x-yaml; charset=utf-8")
-//		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte(raw)))
+//		resp.Body = io.NopCloser(bytes.NewReader([]byte(raw)))
 //		return resp, nil
 //	})
 //
@@ -98,13 +98,13 @@ package bundle
 //		// check method
 //		assert.Equal(t, "PUT", req.Method)
 //		// check body
-//		body, _ := ioutil.ReadAll(req.Body)
+//		body, _ := io.ReadAll(req.Body)
 //		var reqBody apistructs.ReleaseReferenceUpdateRequest
 //		json.Unmarshal(body, &reqBody)
 //		steps = append(steps, reqBody.Increase)
 //
 //		resp.Header.Set("Content-Type", "application/json; charset=utf-8")
-//		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte(`{"success":true}`)))
+//		resp.Body = io.NopCloser(bytes.NewReader([]byte(`{"success":true}`)))
 //		return resp, nil
 //	})
 //

--- a/bundle/steve.go
+++ b/bundle/steve.go
@@ -17,7 +17,7 @@ package bundle
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -59,7 +59,7 @@ func (b *Bundle) GetSteveResource(req *apistructs.SteveRequest) (data.Object, er
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
@@ -101,7 +101,7 @@ func (b *Bundle) ListSteveResource(req *apistructs.SteveRequest) (data.Object, e
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
@@ -145,7 +145,7 @@ func (b *Bundle) UpdateSteveResource(req *apistructs.SteveRequest) (data.Object,
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
@@ -189,7 +189,7 @@ func (b *Bundle) CreateSteveResource(req *apistructs.SteveRequest) (data.Object,
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, apierrors.ErrInvoke.InternalError(err)
 	}
@@ -230,7 +230,7 @@ func (b *Bundle) DeleteSteveResource(req *apistructs.SteveRequest) error {
 		return apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return apierrors.ErrInvoke.InternalError(err)
 	}

--- a/bundle/steve_node.go
+++ b/bundle/steve_node.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/erda-project/erda/apistructs"
@@ -55,7 +55,7 @@ func (b *Bundle) PatchNode(req *apistructs.SteveRequest) error {
 		return apierrors.ErrInvoke.InternalError(err)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return apierrors.ErrInvoke.InternalError(err)
 	}

--- a/cmd/action-runner/main.go
+++ b/cmd/action-runner/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -43,7 +42,7 @@ func main() {
 func readConfig(path string) *actionrunner.Conf {
 	var conf actionrunner.Conf
 	if len(path) > 0 {
-		byts, err := ioutil.ReadFile(path)
+		byts, err := os.ReadFile(path)
 		if err != nil {
 			logrus.Error(err)
 			os.Exit(-1)

--- a/internal/apps/ai-proxy/filters/bailian-director/sdk.go
+++ b/internal/apps/ai-proxy/filters/bailian-director/sdk.go
@@ -30,7 +30,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -187,7 +187,7 @@ func (cc *CompletionClient) Complete(request *CompletionRequest) (_response *Com
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apps/cmp/endpoints/aliyun_action_proxy.go
+++ b/internal/apps/cmp/endpoints/aliyun_action_proxy.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -109,7 +109,7 @@ func (e *Endpoints) DoRemoteAction(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 	w.WriteHeader(response.StatusCode)
-	respBody, err := ioutil.ReadAll(response.Body)
+	respBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		logrus.Errorf("read body falied, err:%+v", err)
 	}

--- a/internal/apps/cmp/endpoints/cloud_resource_oss.go
+++ b/internal/apps/cmp/endpoints/cloud_resource_oss.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -154,7 +154,7 @@ func (e *Endpoints) CreateOSS(ctx context.Context, r *http.Request, vars map[str
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		err := fmt.Errorf("failed to unmarshal create oss request: %v", err)
-		content, _ := ioutil.ReadAll(r.Body)
+		content, _ := io.ReadAll(r.Body)
 		logrus.Errorf("%s, request:%v", err.Error(), content)
 		return mkResponse(apistructs.CreateCloudResourceOssResponse{
 			Header: apistructs.Header{

--- a/internal/apps/cmp/endpoints/cloud_resource_redis.go
+++ b/internal/apps/cmp/endpoints/cloud_resource_redis.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -181,7 +181,7 @@ func (e *Endpoints) CreateRedis(ctx context.Context, r *http.Request, vars map[s
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		err := fmt.Errorf("failed to unmarshal create redis request: %v", err)
-		content, _ := ioutil.ReadAll(r.Body)
+		content, _ := io.ReadAll(r.Body)
 		logrus.Errorf("%s, request:%v", err.Error(), content)
 		return mkResponse(apistructs.CreateCloudResourceRedisResponse{
 			Header: apistructs.Header{

--- a/internal/apps/cmp/endpoints/metrics.go
+++ b/internal/apps/cmp/endpoints/metrics.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -114,6 +114,6 @@ func InternalReverseHandler(handler func(context.Context, *http.Request, map[str
 func handleRequest(r *http.Request) {
 	// base64 decode request body if declared in header
 	if strutil.Equal(r.Header.Get(httpserver.Base64EncodedRequestBody), "true", true) {
-		r.Body = ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
+		r.Body = io.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
 	}
 }

--- a/internal/apps/cmp/steve/middleware/audit.go
+++ b/internal/apps/cmp/steve/middleware/audit.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
@@ -84,9 +84,9 @@ func (a *Auditor) AuditMiddleWare(next http.Handler) http.Handler {
 			ctx  map[string]interface{}
 		)
 		if req.Body != nil {
-			body, _ = ioutil.ReadAll(req.Body)
+			body, _ = io.ReadAll(req.Body)
 		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		clusterName := vars["clusterName"]
 		typ := vars["type"]

--- a/internal/apps/dop/dicehub/release/provider.go
+++ b/internal/apps/dop/dicehub/release/provider.go
@@ -17,7 +17,7 @@ package release
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -183,7 +183,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 
 						var body []byte
 						if r.Body != nil {
-							body, _ = ioutil.ReadAll(r.Body)
+							body, _ = io.ReadAll(r.Body)
 						} else {
 							return nil
 						}
@@ -195,7 +195,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 						isProjectRelease, ok := m["isProjectRelease"].(bool)
 						if !ok || !isProjectRelease {
 							logrus.Debugf("Decoder of ReleaseCreateRequest: not a project release, skip")
-							r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+							r.Body = io.NopCloser(bytes.NewBuffer(body))
 							break
 						}
 
@@ -216,7 +216,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 
 						var body []byte
 						if r.Body != nil {
-							body, _ = ioutil.ReadAll(r.Body)
+							body, _ = io.ReadAll(r.Body)
 						} else {
 							return nil
 						}
@@ -228,7 +228,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 						modes, ok := m["modes"].(map[string]interface{})
 						if !ok {
 							logrus.Debugf("Decoder of ReleaseUpdateRequest: not a project release, skip")
-							r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+							r.Body = io.NopCloser(bytes.NewBuffer(body))
 							break
 						}
 

--- a/internal/apps/dop/endpoints/attempt.go
+++ b/internal/apps/dop/endpoints/attempt.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -69,7 +69,7 @@ func (e *Endpoints) ExecuteAttemptTest(ctx context.Context, r *http.Request, var
 	}
 
 	var body apistructs.APITestReq
-	bodyData, err := ioutil.ReadAll(r.Body)
+	bodyData, err := io.ReadAll(r.Body)
 	if err != nil {
 		return apierrors.AttemptExecuteAPITest.InvalidParameter("invalid body").ToResp(), nil
 	}
@@ -208,9 +208,9 @@ func (e *Endpoints) ExecuteAttemptTest(ctx context.Context, r *http.Request, var
 	}
 
 	if request.Body != nil {
-		if data, err := ioutil.ReadAll(request.Body); err == nil {
+		if data, err := io.ReadAll(request.Body); err == nil {
 			logrus.Infof("requesting body: %s", string(data))
-			request.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+			request.Body = io.NopCloser(bytes.NewBuffer(data))
 		}
 	}
 	logrus.Infof("requesting: %+v", *request)
@@ -224,7 +224,7 @@ func (e *Endpoints) ExecuteAttemptTest(ctx context.Context, r *http.Request, var
 		logrus.Errorf("failed Do request, request: %+v, err: %v", *request, err)
 		return apierrors.AttemptExecuteAPITest.InternalError(errors.Wrap(err, "请求失败")).ToResp(), nil
 	}
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		return apierrors.AttemptExecuteAPITest.InternalError(errors.Wrap(err, "读取响应失败")).ToResp(), nil
 	}

--- a/internal/apps/dop/endpoints/autotests_space_test.go
+++ b/internal/apps/dop/endpoints/autotests_space_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -44,7 +44,7 @@ func TestCopyAutoTestSpaceV2(t *testing.T) {
 		ID: 1,
 	}
 	bodyDat, _ := json.Marshal(body)
-	r := &http.Request{Body: ioutil.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
+	r := &http.Request{Body: io.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
 
 	autotestSvc := atv2.New()
 	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(autotestSvc), "GetSpace", func(svc *atv2.Service, id uint64) (*apistructs.AutoTestSpace, error) {
@@ -74,7 +74,7 @@ func TestExportAutoTestSpace(t *testing.T) {
 		ID: 1,
 	}
 	bodyDat, _ := json.Marshal(body)
-	r := &http.Request{Body: ioutil.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
+	r := &http.Request{Body: io.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
 
 	autotestSvc := atv2.New()
 	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(autotestSvc), "GetSpace", func(svc *atv2.Service, id uint64) (*apistructs.AutoTestSpace, error) {

--- a/internal/apps/dop/endpoints/metrics.go
+++ b/internal/apps/dop/endpoints/metrics.go
@@ -17,7 +17,7 @@ package endpoints
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -61,6 +61,6 @@ func InternalReverseHandler(handler func(context.Context, *http.Request, map[str
 func handleRequest(r *http.Request) {
 	// base64 decode request body if declared in header
 	if strutil.Equal(r.Header.Get(httpserver.Base64EncodedRequestBody), "true", true) {
-		r.Body = ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
+		r.Body = io.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
 	}
 }

--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -506,7 +506,7 @@ func (e *Endpoints) pipelineRerun(ctx context.Context, r *http.Request, vars map
 	}
 
 	var rerunReq pipelinepb.PipelineRerunRequest
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		return apierrors.ErrRerunPipeline.InvalidParameter(err).ToResp(), nil
 	}
@@ -557,7 +557,7 @@ func (e *Endpoints) pipelineRerunFailed(ctx context.Context, r *http.Request, va
 	}
 
 	var rerunFailedReq pipelinepb.PipelineRerunFailedRequest
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		return apierrors.ErrRerunPipeline.InvalidParameter(err).ToResp(), nil
 	}

--- a/internal/apps/dop/endpoints/project.go
+++ b/internal/apps/dop/endpoints/project.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -62,7 +62,7 @@ func (e *Endpoints) CreateProject(ctx context.Context, r *http.Request, vars map
 	if r.Body == nil {
 		return apierrors.ErrCreateProject.MissingParameter("body").ToResp(), nil
 	}
-	bodyData, err := ioutil.ReadAll(r.Body)
+	bodyData, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Errorln("failed to read request body")
 		return apierrors.ErrCreateProject.InvalidParameter(err).ToResp(), nil

--- a/internal/apps/dop/endpoints/project_pipeline_test.go
+++ b/internal/apps/dop/endpoints/project_pipeline_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -164,7 +164,7 @@ stages:
 				t.Error(err)
 			}
 			reader := bytes.NewReader([]byte(dat))
-			body := ioutil.NopCloser(reader)
+			body := io.NopCloser(reader)
 			r := &http.Request{
 				Header: http.Header{
 					"Internal-Client": []string{"pipeline"},

--- a/internal/apps/dop/endpoints/scenesets_test.go
+++ b/internal/apps/dop/endpoints/scenesets_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -47,7 +47,7 @@ func TestExportAutoSceneSet(t *testing.T) {
 		SpaceID:  1,
 	}
 	bodyDat, _ := json.Marshal(body)
-	r := &http.Request{Body: ioutil.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
+	r := &http.Request{Body: io.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
 	autotestSvc := atv2.New()
 	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(autotestSvc), "GetSpace", func(svc *atv2.Service, id uint64) (*apistructs.AutoTestSpace, error) {
 		return nil, fmt.Errorf("not found")
@@ -79,7 +79,7 @@ func TestImportAutoSceneSet(t *testing.T) {
 		FileType: apistructs.TestSceneSetFileTypeExcel,
 	}
 	bodyDat, _ := json.Marshal(body)
-	r := &http.Request{Body: ioutil.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
+	r := &http.Request{Body: io.NopCloser(bytes.NewReader(bodyDat)), ContentLength: 100}
 	url, err := url.Parse("https://unit.test/api/autotests/scenesets/actions/import?projectID=1&spaceID=1&fileType=excel")
 	if err != nil {
 		t.Error(err)

--- a/internal/apps/dop/providers/issue/core/file.go
+++ b/internal/apps/dop/providers/issue/core/file.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -805,7 +804,7 @@ func (i *IssueService) ExportExcel2(data [][]string, sheetName string) (string, 
 	diceFile, err := i.bdl.UploadFile(filetypes.FileUploadRequest{
 		FileNameWithExt: sheetName + ".xlsx",
 		ByteSize:        int64(buff.Len()),
-		FileReader:      ioutil.NopCloser(&buff),
+		FileReader:      io.NopCloser(&buff),
 		From:            "issue",
 		IsPublic:        true,
 		Encrypt:         false,

--- a/internal/apps/dop/providers/publishitem/offline_helper.go
+++ b/internal/apps/dop/providers/publishitem/offline_helper.go
@@ -22,7 +22,7 @@ import (
 	"image"
 	"image/jpeg"
 	"image/png"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -226,7 +226,7 @@ func parseIpaFile(plistFile *zip.File) (*IosAppInfo, error) {
 	}
 	defer rc.Close()
 
-	buf, err := ioutil.ReadAll(rc)
+	buf, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func getAppStoreURL(bundleID string) string {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Errorf("get app store url err: %v", err)
 		return ""

--- a/internal/apps/dop/providers/publishitem/publish.item.service.go
+++ b/internal/apps/dop/providers/publishitem/publish.item.service.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -662,7 +661,7 @@ func (s *PublishItemService) CreateOffLineVersion(param apistructs.CreateOffLine
 			return "", err
 		}
 		plistFile := "/tmp/" + t + "/install.plist"
-		if err = ioutil.WriteFile(plistFile, []byte(installPlistContent), os.ModePerm); err != nil {
+		if err = os.WriteFile(plistFile, []byte(installPlistContent), os.ModePerm); err != nil {
 			return "", err
 		}
 		defer func() {

--- a/internal/apps/dop/services/assetsvc/create.go
+++ b/internal/apps/dop/services/assetsvc/create.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -1309,7 +1309,7 @@ func (svc *Service) readSpec(ctx context.Context, req *apistructs.APIAssetVersio
 		if err != nil {
 			return fmt.Errorf("failed to get spec from file: %v", err)
 		}
-		fileBytes, err := ioutil.ReadAll(fr)
+		fileBytes, err := io.ReadAll(fr)
 		if err != nil {
 			return fmt.Errorf("failed to read from file: %v", err)
 		}

--- a/internal/apps/dop/services/autotest_v2/export.go
+++ b/internal/apps/dop/services/autotest_v2/export.go
@@ -17,7 +17,7 @@ package autotestv2
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"time"
 
@@ -231,7 +231,7 @@ func (svc *Service) ExportFile(record *dao.TestFileRecord) {
 	uploadReq := filetypes.FileUploadRequest{
 		FileNameWithExt: fileName,
 		ByteSize:        int64(w.Len()),
-		FileReader:      ioutil.NopCloser(&w),
+		FileReader:      io.NopCloser(&w),
 		From:            "Autotest space",
 		IsPublic:        true,
 		ExpiredAt:       nil,
@@ -325,7 +325,7 @@ func (svc *Service) ExportSceneSetFile(record *dao.TestFileRecord) {
 	uploadReq := filetypes.FileUploadRequest{
 		FileNameWithExt: fileName,
 		ByteSize:        int64(w.Len()),
-		FileReader:      ioutil.NopCloser(&w),
+		FileReader:      io.NopCloser(&w),
 		From:            "Autotest Scene Set",
 		IsPublic:        true,
 		ExpiredAt:       nil,

--- a/internal/apps/dop/services/certificate/certificate.go
+++ b/internal/apps/dop/services/certificate/certificate.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 
@@ -122,7 +122,7 @@ func (c *Certificate) Create(userID string, createReq *apistructs.CertificateCre
 			}
 
 			// 上传文件
-			fileByte, err := ioutil.ReadFile("/tmp/debug.keystore")
+			fileByte, err := os.ReadFile("/tmp/debug.keystore")
 			if err != nil {
 				return nil, errors.Errorf("failed to read debug.keystore file, (%+v)", err)
 			}
@@ -131,7 +131,7 @@ func (c *Certificate) Create(userID string, createReq *apistructs.CertificateCre
 				FileNameWithExt: "debug.keystore",
 				Creator:         userID,
 				ByteSize:        int64(len(fileByte)),
-				FileReader:      ioutil.NopCloser(bytes.NewReader(fileByte)),
+				FileReader:      io.NopCloser(bytes.NewReader(fileByte)),
 			}
 
 			debugFileInfo, err := c.bdl.UploadFile(uploadFileReq)
@@ -154,14 +154,14 @@ func (c *Certificate) Create(userID string, createReq *apistructs.CertificateCre
 			}
 
 			// 上传文件
-			fileByte, err = ioutil.ReadFile("/tmp/release.keystore")
+			fileByte, err = os.ReadFile("/tmp/release.keystore")
 			if err != nil {
 				return nil, errors.Errorf("failed to read release.keystore file, (%+v)", err)
 			}
 
 			uploadFileReq.FileNameWithExt = "release.keystore"
 			uploadFileReq.ByteSize = int64(len(fileByte))
-			uploadFileReq.FileReader = ioutil.NopCloser(bytes.NewReader(fileByte))
+			uploadFileReq.FileReader = io.NopCloser(bytes.NewReader(fileByte))
 			releaseFileInfo, err := c.bdl.UploadFile(uploadFileReq)
 			if err != nil {
 				return nil, errors.Errorf("failed to read upload release.keystore file, (%+v)", err)

--- a/internal/apps/dop/services/code_coverage/code_coverage.go
+++ b/internal/apps/dop/services/code_coverage/code_coverage.go
@@ -16,7 +16,7 @@ package code_coverage
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"time"
@@ -225,7 +225,7 @@ func (svc *CodeCoverage) EndCallBack(req apistructs.CodeCoverageUpdateRequest) e
 		}
 		defer f.Close()
 
-		tempAddr, err := ioutil.TempDir("", "jacoco_xml_tar_gz")
+		tempAddr, err := os.MkdirTemp("", "jacoco_xml_tar_gz")
 		if err != nil {
 			return err
 		}
@@ -236,12 +236,12 @@ func (svc *CodeCoverage) EndCallBack(req apistructs.CodeCoverageUpdateRequest) e
 			return err
 		}
 
-		fileBytes, err := ioutil.ReadAll(f)
+		fileBytes, err := io.ReadAll(f)
 		if err != nil {
 			return err
 		}
 
-		err = ioutil.WriteFile(fmt.Sprintf("%v/%v", tempAddr, xmlTarFileName), fileBytes, 0777)
+		err = os.WriteFile(fmt.Sprintf("%v/%v", tempAddr, xmlTarFileName), fileBytes, 0777)
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func (svc *CodeCoverage) EndCallBack(req apistructs.CodeCoverageUpdateRequest) e
 			return err
 		}
 
-		all, err := ioutil.ReadAll(file)
+		all, err := io.ReadAll(file)
 		if err != nil {
 			return err
 		}

--- a/internal/apps/dop/services/project/export_package.go
+++ b/internal/apps/dop/services/project/export_package.go
@@ -17,7 +17,6 @@ package project
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -466,7 +465,7 @@ func (p *Project) ExportProjectPackage(record *dao.TestFileRecord) {
 		return
 	}
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "*")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		logrus.Error(apierrors.ErrExportProjectPackage.InternalError(err))
 		if err := p.UpdateFileRecord(apistructs.TestFileRecordRequest{ID: id, State: apistructs.FileRecordStateFail, ErrorInfo: err}); err != nil {

--- a/internal/apps/dop/services/project/import_package.go
+++ b/internal/apps/dop/services/project/import_package.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -305,7 +304,7 @@ func (p *Project) ImportProjectPackage(record *dao.TestFileRecord) {
 		return
 	}
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "*")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		logrus.Error(apierrors.ErrExportProjectPackage.InternalError(err))
 		if err := p.UpdateFileRecord(apistructs.TestFileRecordRequest{ID: id, State: apistructs.FileRecordStateFail, ErrorInfo: err}); err != nil {

--- a/internal/apps/dop/services/project/project_package.go
+++ b/internal/apps/dop/services/project/project_package.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -156,7 +155,7 @@ func (t *PackageDataDirector) GenAndUploadZipPackage() (string, error) {
 	projectPackage := t.Creator.GetProjectPackage()
 	tempDir := t.Creator.GetTempDir()
 
-	zipTmpFile, err := ioutil.TempFile("", packageProjectTempPrefix)
+	zipTmpFile, err := os.CreateTemp("", packageProjectTempPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/internal/apps/dop/services/project/project_template.go
+++ b/internal/apps/dop/services/project/project_template.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -109,7 +108,7 @@ func (t *TemplateDataDirector) GenAndUploadZipPackage() (string, error) {
 		t.errs = append(t.errs, err)
 		return "", err
 	}
-	zipTmpFile, err := ioutil.TempFile("", tempPrefix)
+	zipTmpFile, err := os.CreateTemp("", tempPrefix)
 	if err != nil {
 		t.errs = append(t.errs, err)
 		return "", err

--- a/internal/apps/dop/services/testcase/export.go
+++ b/internal/apps/dop/services/testcase/export.go
@@ -16,7 +16,6 @@ package testcase
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -136,7 +135,7 @@ func (svc *Service) ExportTestCases(req *apistructs.TestCaseExportRequest, sheet
 		}
 	}
 
-	f, err := ioutil.TempFile("", "export.*")
+	f, err := os.CreateTemp("", "export.*")
 	if err != nil {
 		return "", apierrors.ErrExportTestCases.InternalError(err)
 	}

--- a/internal/apps/msp/apm/adapter/provider.go
+++ b/internal/apps/msp/apm/adapter/provider.go
@@ -15,7 +15,7 @@
 package adapter
 
 import (
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 
@@ -46,7 +46,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	p.libraries = make([]*InstrumentationLibrary, 0)
 	p.templates = make(map[string]*InstrumentationLibraryTemplate)
 	for _, file := range p.Cfg.LibraryFiles {
-		f, err := ioutil.ReadFile(file)
+		f, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		p.libraries = append(p.libraries, libs...)
 	}
 	for _, file := range p.Cfg.ConfigFiles {
-		f, err := ioutil.ReadFile(file)
+		f, err := os.ReadFile(file)
 		if err != nil {
 			return err
 		}

--- a/internal/apps/msp/apm/checker/plugins/http/triggering/triggering.go
+++ b/internal/apps/msp/apm/checker/plugins/http/triggering/triggering.go
@@ -15,7 +15,7 @@
 package triggering
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +65,7 @@ func (condition *Triggering) Executor(resp *http.Response) bool {
 func (condition *Triggering) BodyStrategy(resp *http.Response) bool {
 	var body string
 	if resp.Body != nil {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false
 		}

--- a/internal/apps/msp/apm/checker/plugins/http/triggering/triggering_test.go
+++ b/internal/apps/msp/apm/checker/plugins/http/triggering/triggering_test.go
@@ -16,7 +16,7 @@ package triggering
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -70,14 +70,14 @@ func TestTriggering_HttpCodeStrategy(t *testing.T) {
 }
 
 func TestTriggering_BodyStrategy(t *testing.T) {
-	body1 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body2 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body3 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body4 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body5 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body6 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body7 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
-	body8 := ioutil.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body1 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body2 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body3 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body4 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body5 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body6 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body7 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
+	body8 := io.NopCloser(bytes.NewReader([]byte("This is a test body, hello world!")))
 	type fields struct {
 		Key     string
 		Operate string

--- a/internal/apps/msp/apm/log-service/query/provider.go
+++ b/internal/apps/msp/apm/log-service/query/provider.go
@@ -15,7 +15,7 @@
 package log_service
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/jinzhu/gorm"
 	"gopkg.in/yaml.v3"
@@ -68,7 +68,7 @@ type provider struct {
 
 func (p *provider) Init(ctx servicehub.Context) error {
 	if len(p.Cfg.IndexFieldSettings.File) > 0 {
-		f, err := ioutil.ReadFile(p.Cfg.IndexFieldSettings.File)
+		f, err := os.ReadFile(p.Cfg.IndexFieldSettings.File)
 		if err != nil {
 			return err
 		}

--- a/internal/apps/msp/apm/metric/routes.go
+++ b/internal/apps/msp/apm/metric/routes.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -171,8 +171,8 @@ func (p *provider) getMetricFromSQL(r *http.Request) (metric string) {
 		return strings.TrimSpace(getMetricFromSQL(q))
 	} else {
 		if params.Get("ql") == "influxql:ast" {
-			byts, err := ioutil.ReadAll(r.Body)
-			r.Body = ioutil.NopCloser(bytes.NewReader(byts))
+			byts, err := io.ReadAll(r.Body)
+			r.Body = io.NopCloser(bytes.NewReader(byts))
 			if err == nil {
 				var body struct {
 					From []string `json:"from"`

--- a/internal/apps/msp/apm/trace/query/trace.service.go
+++ b/internal/apps/msp/apm/trace/query/trace.service.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strconv"
@@ -449,7 +448,7 @@ func (s *TraceService) CreateTraceDebug(ctx context.Context, req *pb.CreateTrace
 		return nil, errors.NewInternalServerError(err)
 	}
 	responseCode := response.StatusCode
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 
 	defer func(Body io.ReadCloser) {
 		err := Body.Close()
@@ -516,7 +515,7 @@ func composeTraceRequestHistory(req *pb.CreateTraceDebugRequest) (*db.TraceReque
 
 func (s *TraceService) sendHTTPRequest(err error, req *pb.CreateTraceDebugRequest) (*http.Response, error) {
 	client := &http.Client{}
-	params := ioutil.NopCloser(strings.NewReader(req.Body))
+	params := io.NopCloser(strings.NewReader(req.Body))
 	request, err := http.NewRequest(req.Method, req.Url, params)
 	if err != nil {
 		return nil, errors.NewInternalServerError(err)

--- a/internal/apps/msp/registercenter/nacos/adapter.go
+++ b/internal/apps/msp/registercenter/nacos/adapter.go
@@ -17,7 +17,7 @@ package nacos
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -187,7 +187,7 @@ func (a *Adapter) EnableHTTPService(namespace string, service *pb.EnableHTTPServ
 	if err != nil {
 		return nil, err
 	}
-	byts, err = ioutil.ReadAll(resp.Body)
+	byts, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/file/file.service_download.go
+++ b/internal/core/file/file.service_download.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -120,7 +119,7 @@ func (s *fileService) DownloadFile(w io.Writer, file db.File) (headers map[strin
 			return nil, apierrors.ErrDownloadFileDecrypt.InternalError(err)
 		}
 		// 获取文件内容
-		fileBytes, err := ioutil.ReadAll(reader)
+		fileBytes, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, apierrors.ErrDownloadFileDecrypt.InternalError(err)
 		}

--- a/internal/core/file/file.service_upload.go
+++ b/internal/core/file/file.service_upload.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -78,7 +78,7 @@ func (s *fileService) UploadFile(req filetypes.FileUploadRequest) (*pb.File, err
 
 	// 加密存储（信封加密）
 	if req.Encrypt {
-		fileBytes, err := ioutil.ReadAll(req.FileReader)
+		fileBytes, err := io.ReadAll(req.FileReader)
 		if err != nil {
 			return nil, apierrors.ErrUploadFileEncrypt.InternalError(err)
 		}
@@ -101,7 +101,7 @@ func (s *fileService) UploadFile(req filetypes.FileUploadRequest) (*pb.File, err
 		if err != nil {
 			return nil, apierrors.ErrUploadFileEncrypt.InternalError(err)
 		}
-		fileReader = ioutil.NopCloser(bytes.NewBuffer(ciphertext))
+		fileReader = io.NopCloser(bytes.NewBuffer(ciphertext))
 	}
 
 	if err := storager.Write(handledPath, fileReader); err != nil {

--- a/internal/core/legacy/conf/conf.go
+++ b/internal/core/legacy/conf/conf.go
@@ -17,7 +17,7 @@ package conf
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -101,7 +101,7 @@ func initAuditTemplate() {
 }
 
 func genTempFromFiles(fileName string) apistructs.AuditTemplateMap {
-	templateJSON, err := ioutil.ReadFile(fileName)
+	templateJSON, err := os.ReadFile(fileName)
 	if err != nil {
 		panic(err)
 	}
@@ -119,17 +119,16 @@ func genTempFromFiles(fileName string) apistructs.AuditTemplateMap {
 }
 
 func getAllFiles(pathname string, perms []model.RolePermission) []model.RolePermission {
-	rd, err := ioutil.ReadDir(pathname)
+	entries, err := os.ReadDir(pathname)
 	if err != nil {
 		panic(err)
 	}
-	for _, fi := range rd {
-		if fi.IsDir() {
-			fullDir := pathname + "/" + fi.Name()
-			perms = getAllFiles(fullDir, perms)
+	for _, entry := range entries {
+		fullPath := filepath.Join(pathname, entry.Name())
+		if entry.IsDir() {
+			perms = getAllFiles(fullPath, perms)
 		} else {
-			fullName := pathname + "/" + fi.Name()
-			yamlFile, err := ioutil.ReadFile(fullName)
+			yamlFile, err := os.ReadFile(fullPath)
 			if err != nil {
 				panic(err)
 			}

--- a/internal/core/legacy/endpoints/image.go
+++ b/internal/core/legacy/endpoints/image.go
@@ -17,7 +17,7 @@ package endpoints
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -82,7 +82,7 @@ func (e *Endpoints) UploadImage(ctx context.Context, r *http.Request, vars map[s
 	}
 
 	// 上传文件至网盘
-	fileBytes, err := ioutil.ReadAll(file)
+	fileBytes, err := io.ReadAll(file)
 	if err != nil {
 		return apierrors.ErrUploadImage.InternalError(err).ToResp(), nil
 	}
@@ -109,7 +109,7 @@ func GetImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filename := strutil.Concat("/", avatarPrefix, "/", vars["imageName"])
-	fileBytes, err := ioutil.ReadFile(filename)
+	fileBytes, err := os.ReadFile(filename)
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/internal/core/legacy/endpoints/project.go
+++ b/internal/core/legacy/endpoints/project.go
@@ -17,7 +17,7 @@ package endpoints
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -48,7 +48,7 @@ func (e *Endpoints) CreateProject(ctx context.Context, r *http.Request, vars map
 	if r.Body == nil {
 		return apierrors.ErrCreateProject.MissingParameter("body").ToResp(), nil
 	}
-	bodyData, err := ioutil.ReadAll(r.Body)
+	bodyData, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Errorln("failed to read request body")
 		return apierrors.ErrCreateProject.InvalidParameter(err).ToResp(), nil
@@ -113,7 +113,7 @@ func (e *Endpoints) UpdateProject(ctx context.Context, r *http.Request, vars map
 		return apierrors.ErrUpdateProject.MissingParameter("body").ToResp(), nil
 	}
 	var projectUpdateReq apistructs.ProjectUpdateBody
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return apierrors.ErrUpdateProject.InvalidParameter(err).ToResp(), nil
 	}

--- a/internal/core/legacy/endpoints/project_workspace.go
+++ b/internal/core/legacy/endpoints/project_workspace.go
@@ -17,7 +17,7 @@ package endpoints
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -47,7 +47,7 @@ func (e *Endpoints) CreateProjectWorkSpace(ctx context.Context, r *http.Request,
 	if r.Body == nil {
 		return apierrors.ErrCreateProjectWorkspaceAbilities.MissingParameter("body").ToResp(), nil
 	}
-	bodyData, err := ioutil.ReadAll(r.Body)
+	bodyData, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Errorln("failed to read request body")
 		return apierrors.ErrCreateProjectWorkspaceAbilities.InvalidParameter(err).ToResp(), nil
@@ -155,7 +155,7 @@ func (e *Endpoints) UpdateProjectWorkSpace(ctx context.Context, r *http.Request,
 	if r.Body == nil {
 		return apierrors.ErrUpdateProjectWorkspaceAbilities.MissingParameter("body").ToResp(), nil
 	}
-	bodyData, err := ioutil.ReadAll(r.Body)
+	bodyData, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Errorln("failed to read request body")
 		return apierrors.ErrUpdateProjectWorkspaceAbilities.InvalidParameter(err).ToResp(), nil

--- a/internal/core/messenger/eventbox/subscriber/dingding/dingding.go
+++ b/internal/core/messenger/eventbox/subscriber/dingding/dingding.go
@@ -17,7 +17,7 @@ package dingding
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/url"
 	"time"
@@ -232,7 +232,7 @@ func (d *DDSubscriber) DINGDINGSend(u string, m *DDMessage) error {
 		logrus.Error(err)
 		return errors.Wrap(DINGDINGSendErr, err.Error())
 	}
-	body, err := ioutil.ReadAll(&buf)
+	body, err := io.ReadAll(&buf)
 	if err != nil {
 		err = errors.Errorf("DingDing publish: %v, err: %v", u, err)
 		logrus.Error(err)

--- a/internal/core/messenger/eventbox/subscriber/dingding_worknotice/dingding_worknotice.go
+++ b/internal/core/messenger/eventbox/subscriber/dingding_worknotice/dingding_worknotice.go
@@ -17,7 +17,7 @@ package dingding_worknotice
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 
@@ -141,7 +141,7 @@ func (s WorkNoticeSubscriber) worknoticeSend(u, agentID string, userIDList []str
 		logrus.Error(err)
 		return errors.Wrap(ErrSend, err.Error())
 	}
-	bodybuf, err := ioutil.ReadAll(&buf)
+	bodybuf, err := io.ReadAll(&buf)
 	if err != nil {
 		err = errors.Errorf("WorkNotice publish: %v, err: %v", u, err)
 		logrus.Error(err)

--- a/internal/core/openapi/legacy/api/apis/monitor/monitor_orgs_logs_center_rules_create.go
+++ b/internal/core/openapi/legacy/api/apis/monitor/monitor_orgs_logs_center_rules_create.go
@@ -16,7 +16,7 @@ package monitor
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/core/openapi/legacy/api/apis"
@@ -38,7 +38,7 @@ var MONITOR_ORG_LOGS_RULES_CREATE = apis.ApiSpec{
 func auditOrgOperatorBlock(tmp apistructs.TemplateName) func(ctx *spec.AuditContext) error {
 	return func(ctx *spec.AuditContext) error {
 		reqBody := apistructs.LogMetricConfig{}
-		body, err := ioutil.ReadAll(ctx.Request.Body)
+		body, err := io.ReadAll(ctx.Request.Body)
 		if err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@ func auditOrgOperatorBlock(tmp apistructs.TemplateName) func(ctx *spec.AuditCont
 				return err
 			}
 		}
-		body, err = ioutil.ReadAll(ctx.Response.Body)
+		body, err = io.ReadAll(ctx.Response.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/core/openapi/legacy/api/apis/monitor/msp_addon_logs_rules_create.go
+++ b/internal/core/openapi/legacy/api/apis/monitor/msp_addon_logs_rules_create.go
@@ -16,7 +16,7 @@ package monitor
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"github.com/erda-project/erda/apistructs"
@@ -39,7 +39,7 @@ var MSP_ADDON_LOGS_RULES_CREATE = apis.ApiSpec{
 func auditOperatorBlock(tmp apistructs.TemplateName) func(ctx *spec.AuditContext) error {
 	return func(ctx *spec.AuditContext) error {
 		reqBody := apistructs.LogMetricConfig{}
-		body, err := ioutil.ReadAll(ctx.Request.Body)
+		body, err := io.ReadAll(ctx.Request.Body)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func auditOperatorBlock(tmp apistructs.TemplateName) func(ctx *spec.AuditContext
 		if project == nil {
 			return nil
 		}
-		body, err = ioutil.ReadAll(ctx.Response.Body)
+		body, err = io.ReadAll(ctx.Response.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/core/openapi/legacy/api/apis/openapi/doc_json.go
+++ b/internal/core/openapi/legacy/api/apis/openapi/doc_json.go
@@ -15,7 +15,7 @@
 package openapi
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -45,7 +45,7 @@ func getSwaggerJSON() []byte {
 		if err != nil {
 			logrus.Errorf("getSwaggerJSON: %v", err)
 		}
-		content, err := ioutil.ReadAll(f)
+		content, err := io.ReadAll(f)
 		if err != nil {
 			logrus.Errorf("getSwaggerJSON: %v", err)
 		}

--- a/internal/core/openapi/legacy/api/apis/openapi/openapi_doc.go
+++ b/internal/core/openapi/legacy/api/apis/openapi/openapi_doc.go
@@ -15,7 +15,7 @@
 package openapi
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -46,7 +46,7 @@ func getOpenAPIDocContent() []byte {
 		if err != nil {
 			logrus.Errorf("getOpenAPIDoc: %v", err)
 		}
-		content, err := ioutil.ReadAll(f)
+		content, err := io.ReadAll(f)
 		if err != nil {
 			logrus.Errorf("getOpenAPIDoc: %v", err)
 		}

--- a/internal/core/openapi/legacy/api/apis/openapi/openapi_event_doc.go
+++ b/internal/core/openapi/legacy/api/apis/openapi/openapi_event_doc.go
@@ -15,7 +15,7 @@
 package openapi
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -46,7 +46,7 @@ func getEventDocContent() []byte {
 		if err != nil {
 			logrus.Errorf("getEventDocContent: %v", err)
 		}
-		content, err := ioutil.ReadAll(f)
+		content, err := io.ReadAll(f)
 		if err != nil {
 			logrus.Errorf("getEventDocContent: %v", err)
 		}

--- a/internal/core/openapi/legacy/component-protocol/protocol.go
+++ b/internal/core/openapi/legacy/component-protocol/protocol.go
@@ -17,7 +17,7 @@ package component_protocol
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -78,7 +78,7 @@ func InitDefaultCompProtocols(path string) {
 			panic(err)
 		}
 	}()
-	rd, err := ioutil.ReadDir(path)
+	rd, err := os.ReadDir(path)
 	if err != nil {
 		return
 	}
@@ -88,7 +88,7 @@ func InitDefaultCompProtocols(path string) {
 			InitDefaultCompProtocols(fullDir)
 		} else {
 			fullName := path + "/" + fi.Name()
-			yamlFile, er := ioutil.ReadFile(fullName)
+			yamlFile, er := os.ReadFile(fullName)
 			if er != nil {
 				err = er
 				return

--- a/internal/core/openapi/legacy/proxy/http/modifyresponse.go
+++ b/internal/core/openapi/legacy/proxy/http/modifyresponse.go
@@ -17,7 +17,6 @@ package http
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -82,11 +81,11 @@ func getModifyResponse(rw http.ResponseWriter) func(*http.Response) error {
 			beginTime := request.Context().Value("beginTime").(time.Time)
 			cache := request.Context().Value("cache").(*sync.Map)
 			request.Body = reqBody
-			resBody, err := ioutil.ReadAll(res.Body)
+			resBody, err := io.ReadAll(res.Body)
 			if err != nil {
 				return err
 			}
-			res.Body = ioutil.NopCloser(bytes.NewReader(resBody))
+			res.Body = io.NopCloser(bytes.NewReader(resBody))
 			orgIDStr := request.Header.Get("Org-ID")
 			orgID, _ := strconv.ParseInt(orgIDStr, 10, 64)
 			auditContext := &apispec.AuditContext{
@@ -110,7 +109,7 @@ func getModifyResponse(rw http.ResponseWriter) func(*http.Response) error {
 						logrus.Errorf("audit panic url:%s , err:%s", request.RequestURI, err)
 					}
 				}()
-				auditContext.Response.Body = ioutil.NopCloser(bytes.NewReader(resBody))
+				auditContext.Response.Body = io.NopCloser(bytes.NewReader(resBody))
 				err := spec.Audit(auditContext)
 				if err != nil {
 					logrus.Errorf("audit failed url:%s , err:%s", request.RequestURI, err)

--- a/internal/core/openapi/legacy/reverseproxy.go
+++ b/internal/core/openapi/legacy/reverseproxy.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -72,19 +72,19 @@ func (r *ReverseProxyWithAuth) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 		})
 		start := time.Now()
 		if !spec.ChunkAPI && spec.Audit != nil {
-			reqBody, err := ioutil.ReadAll(req.Body)
+			reqBody, err := io.ReadAll(req.Body)
 			errStr := fmt.Sprintf("read body failed: %v", err)
 			if err != nil {
 				logrus.Error(errStr)
 				http.Error(rw, errStr, http.StatusBadRequest)
 				return
 			}
-			c := context.WithValue(req.Context(), "reqBody", ioutil.NopCloser(bytes.NewReader(reqBody)))
+			c := context.WithValue(req.Context(), "reqBody", io.NopCloser(bytes.NewReader(reqBody)))
 			c = context.WithValue(c, "bundle", r.bundle)
 			c = context.WithValue(c, "beginTime", time.Now())
 			c = context.WithValue(c, "cache", r.cache)
 			req = req.WithContext(c)
-			req.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
 			r.httpProxy.ServeHTTP(rw, req)
 		} else {
 			r.httpProxy.ServeHTTP(rw, req)

--- a/internal/core/user/impl/uc/user.go
+++ b/internal/core/user/impl/uc/user.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -248,7 +248,7 @@ func (a *UCUserAuth) GetCurrentUser(headers http.Header) (common.UserInfo, error
 	var info CurrentUser
 	d := json.NewDecoder(&me)
 	if err := d.Decode(&info); err != nil {
-		buffered, _ := ioutil.ReadAll(d.Buffered())
+		buffered, _ := io.ReadAll(d.Buffered())
 		err := errors.Wrapf(err, "GetCurrentUser: decode fail: %v", string(buffered))
 		return common.UserInfo{}, err
 	}

--- a/internal/pkg/extension/action_test.go
+++ b/internal/pkg/extension/action_test.go
@@ -15,7 +15,6 @@
 package extension
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -25,7 +24,7 @@ import (
 )
 
 func Test_action_isThereSpecFile(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	dir, err := os.MkdirTemp(os.TempDir(), "*")
 	defer os.RemoveAll(dir)
 	assert.NoError(t, err)
 

--- a/internal/pkg/extension/extension.service.go
+++ b/internal/pkg/extension/extension.service.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -785,7 +785,7 @@ func (s *provider) GetExtensionByGit(name, d string, file ...string) (*pb.Extens
 func getGitFileContents(d string, file ...string) ([]string, error) {
 	var resp []string
 	// dirName is a random string
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	dir, err := os.MkdirTemp(os.TempDir(), "*")
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +842,7 @@ func getGitFileContents(d string, file ...string) ([]string, error) {
 			resp = append(resp, "")
 			continue
 		}
-		str, err := ioutil.ReadAll(f)
+		str, err := io.ReadAll(f)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/extension/source.go
+++ b/internal/pkg/extension/source.go
@@ -17,7 +17,6 @@ package extension
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,7 +79,7 @@ func (g *GitExtensionSource) match(addr string) bool {
 func (g *GitExtensionSource) add(addr string) error {
 	_, ok := g.GitCloneAddr.Load(addr)
 	if !ok {
-		dir, err := ioutil.TempDir(os.TempDir(), "*")
+		dir, err := os.MkdirTemp(os.TempDir(), "*")
 		if err != nil {
 			logrus.Errorf("gitExtensionSource tempDir error %v", err)
 			return err
@@ -94,7 +93,7 @@ func (g *GitExtensionSource) add(addr string) error {
 			return err
 		}
 
-		fileInfoList, err := ioutil.ReadDir(dir)
+		fileInfoList, err := os.ReadDir(dir)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/extension/source_test.go
+++ b/internal/pkg/extension/source_test.go
@@ -16,7 +16,6 @@ package extension
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -37,7 +36,7 @@ func TestAddSyncExtension(t *testing.T) {
 	})
 	defer patch1.Unpatch()
 
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	dir, err := os.MkdirTemp(os.TempDir(), "*")
 	assert.NoError(t, err)
 
 	err = AddSyncExtension(dir)
@@ -54,7 +53,7 @@ func TestFileExtensionSource_add(t *testing.T) {
 	})
 	defer patch1.Unpatch()
 
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	dir, err := os.MkdirTemp(os.TempDir(), "*")
 	assert.NoError(t, err)
 
 	err = file.add(dir)
@@ -62,12 +61,12 @@ func TestFileExtensionSource_add(t *testing.T) {
 }
 
 func Test_isDir(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "*")
+	dir, err := os.MkdirTemp(os.TempDir(), "*")
 	assert.NoError(t, err)
 	got := isDir(dir)
 	assert.True(t, got)
 
-	file, err := ioutil.TempFile(os.TempDir(), "*")
+	file, err := os.CreateTemp(os.TempDir(), "*")
 	assert.NoError(t, err)
 	got = isDir(file.Name())
 	assert.True(t, !got)

--- a/internal/tools/cluster-manager/dialer/server/dialer_test.go
+++ b/internal/tools/cluster-manager/dialer/server/dialer_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -133,7 +132,7 @@ func Test_DialerContext(t *testing.T) {
 		t.Errorf("status:%d expect:200", resp.StatusCode)
 		return
 	}
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 	if string(respBody) != "Hello, world!" {
 		t.Errorf("respBody:%s, expect:Hello, world!", respBody)
 		return

--- a/internal/tools/cluster-manager/dialer/server/tunnel-server_test.go
+++ b/internal/tools/cluster-manager/dialer/server/tunnel-server_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -101,7 +100,7 @@ func Test_netportal(t *testing.T) {
 		t.Errorf("status:%d expect:200", resp.StatusCode)
 		return
 	}
-	respBody, _ := ioutil.ReadAll(resp.Body)
+	respBody, _ := io.ReadAll(resp.Body)
 	if string(respBody) != "Hello, world!" {
 		t.Errorf("respBody:%s, expect:Hello, world!", respBody)
 		return

--- a/internal/tools/gittar/api/repo.go
+++ b/internal/tools/gittar/api/repo.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"sort"
@@ -526,7 +525,7 @@ func GetRepoBlobRange(context *webcontext.Context) {
 	since := context.GetQueryInt32("since", 1)
 	to := context.GetQueryInt32("to", 10)
 	if isTextFile {
-		d, err := ioutil.ReadAll(dataRc)
+		d, err := io.ReadAll(dataRc)
 		if err != nil {
 			context.Abort(err)
 			return
@@ -606,7 +605,7 @@ func GetRepoBlob(context *webcontext.Context) {
 		since := context.GetQueryInt32("since", 1)
 		to := context.GetQueryInt32("to", 10)
 		if isTextFile {
-			d, _ := ioutil.ReadAll(dataRc)
+			d, _ := io.ReadAll(dataRc)
 			buf = append(buf, d...)
 			line := fmt.Sprintf("%s,%s", strconv.Itoa(since), strconv.Itoa(to))
 			matchLine := fmt.Sprintf("@@ %s+%s @@", line, line)
@@ -666,7 +665,7 @@ func GetRepoBlob(context *webcontext.Context) {
 			Size:    treeEntry.Size(),
 		}
 		if isTextFile {
-			d, _ := ioutil.ReadAll(dataRc)
+			d, _ := io.ReadAll(dataRc)
 			buf = append(buf, d...)
 
 			blobData.Content = string(buf)

--- a/internal/tools/gittar/pkg/gitmodule/repo_edit_test.go
+++ b/internal/tools/gittar/pkg/gitmodule/repo_edit_test.go
@@ -15,7 +15,6 @@
 package gitmodule
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -64,7 +63,7 @@ func cleanupTestRepo(t *testing.T, r *git.Repository) {
 
 func createTestRepo(t *testing.T, path, f string) (*git.Repository, string) {
 	// figure out where we can create the test repo
-	rootPath, err := ioutil.TempDir("", "repo")
+	rootPath, err := os.MkdirTemp("", "repo")
 	checkFatal(t, err)
 	repo, err := git.InitRepository(rootPath, false)
 	checkFatal(t, err)
@@ -79,7 +78,7 @@ func createTestRepo(t *testing.T, path, f string) (*git.Repository, string) {
 	}
 
 	rootPath = rootPath + "/" + f
-	err = ioutil.WriteFile(rootPath, []byte("foo\n"), 0644)
+	err = os.WriteFile(rootPath, []byte("foo\n"), 0644)
 
 	checkFatal(t, err)
 

--- a/internal/tools/monitor/core/alert/alert-apis/provider.go
+++ b/internal/tools/monitor/core/alert/alert-apis/provider.go
@@ -17,7 +17,7 @@ package apis
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -119,7 +119,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 		}
 	}
 	p.alertConditions = make([]*AlertConditions, 0)
-	f, err := ioutil.ReadFile(p.C.AlertConditions)
+	f, err := os.ReadFile(p.C.AlertConditions)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/monitor/core/collector/utils.go
+++ b/internal/tools/monitor/core/collector/utils.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -38,7 +37,7 @@ func ReadGzip(body io.ReadCloser) ([]byte, error) {
 		return []byte{}, err
 	}
 	defer gzipReader.Close()
-	return ioutil.ReadAll(gzipReader)
+	return io.ReadAll(gzipReader)
 }
 
 // ReadRequestBody .
@@ -57,7 +56,7 @@ func ReadRequestBody(req *http.Request) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	res, err := ioutil.ReadAll(reader)
+	res, err := io.ReadAll(reader)
 	return res, err
 }
 

--- a/internal/tools/monitor/core/collector/utils_test.go
+++ b/internal/tools/monitor/core/collector/utils_test.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strings"
@@ -38,7 +37,7 @@ func TestReadRequestBody_b64_gzip(t *testing.T) {
 	r, err := ReadRequestBodyReader(req)
 
 	assert.Nil(t, err)
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, bodyContent, string(body))
 }
@@ -50,7 +49,7 @@ func TestReadRequestBody_b64(t *testing.T) {
 	r, err := ReadRequestBodyReader(req)
 
 	assert.Nil(t, err)
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, bodyContent, string(body))
 }
@@ -61,7 +60,7 @@ func TestReadRequestBody(t *testing.T) {
 	r, err := ReadRequestBodyReader(req)
 
 	assert.Nil(t, err)
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	assert.Nil(t, err)
 	assert.Equal(t, bodyContent, string(body))
 }
@@ -72,7 +71,7 @@ func mockRequest(body io.Reader) *http.Request {
 }
 
 func gzipRequest(req *http.Request) {
-	content, err := ioutil.ReadAll(req.Body)
+	content, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -90,7 +89,7 @@ func gzipRequest(req *http.Request) {
 	body := io.Reader(bytes.NewReader(b.Bytes()))
 	rc, ok := (body).(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 
 	req.Body = rc
@@ -98,7 +97,7 @@ func gzipRequest(req *http.Request) {
 }
 
 func b64Request(req *http.Request) {
-	content, err := ioutil.ReadAll(req.Body)
+	content, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -106,7 +105,7 @@ func b64Request(req *http.Request) {
 	body := io.Reader(strings.NewReader(base64.StdEncoding.EncodeToString(content)))
 	rc, ok := (body).(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 	req.Body = rc
 	req.Header.Set("Custom-Content-Encoding", "base64")

--- a/internal/tools/monitor/core/dataview/dashboard_file.go
+++ b/internal/tools/monitor/core/dataview/dashboard_file.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
@@ -312,7 +311,7 @@ func (p *provider) ExportTask(id string) {
 	request := filetypes.FileUploadRequest{
 		FileNameWithExt: filename,
 		ByteSize:        int64(reader.Len()),
-		FileReader:      ioutil.NopCloser(reader),
+		FileReader:      io.NopCloser(reader),
 		From:            "Custom Dashboard",
 		IsPublic:        true,
 		ExpiredAt:       nil,

--- a/internal/tools/monitor/core/expression/expression.service.go
+++ b/internal/tools/monitor/core/expression/expression.service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,7 +124,7 @@ func (e *expressionService) readMetricRule(root string) error {
 				f = append(f, dir...)
 				return nil
 			}
-			f, err := ioutil.ReadFile(path)
+			f, err := os.ReadFile(path)
 			expression := &pb.Expression{}
 			err = json.Unmarshal(f, expression)
 			if err != nil {
@@ -165,7 +164,7 @@ func (e *expressionService) readAlertRule(root string) error {
 				f = append(f, dir...)
 				return nil
 			}
-			f, err := ioutil.ReadFile(path)
+			f, err := os.ReadFile(path)
 			allRoute := strings.Split(path, "/")
 			alertIndex := allRoute[len(allRoute)-2]
 			alertType := allRoute[len(allRoute)-3]

--- a/internal/tools/monitor/core/log/persist/v1/storage.go
+++ b/internal/tools/monitor/core/log/persist/v1/storage.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 	"unsafe"
@@ -104,7 +103,7 @@ func gzipContent(content string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 func compressWithPipe(reader io.Reader) (io.Reader, error) {
@@ -128,7 +127,7 @@ func gzipContentV2(content string, reusedWriter *gzip.Writer) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 func compressWithPipeV2(reader io.Reader, reusedWriter *gzip.Writer) (io.Reader, error) {

--- a/internal/tools/monitor/core/metric/query/metricq/export.go
+++ b/internal/tools/monitor/core/metric/query/metricq/export.go
@@ -101,7 +101,7 @@ func downloadExcelFile(w http.ResponseWriter, data interface{}) interface{} {
 // 		ql = "influxql"
 // 	}
 // 	if len(q) == 0 {
-// 		byts, err := ioutil.ReadAll(r.Body)
+// 		byts, err := io.ReadAll(r.Body)
 // 		if err == nil {
 // 			q = string(byts)
 // 		}

--- a/internal/tools/monitor/core/metric/query/metricq/routes.go
+++ b/internal/tools/monitor/core/metric/query/metricq/routes.go
@@ -17,7 +17,7 @@ package metricq
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/erda-project/erda-infra/providers/httpserver"
@@ -75,7 +75,7 @@ func (p *provider) queryMetrics(r *http.Request) interface{} {
 		ql = "influxql"
 	}
 	if len(q) == 0 {
-		byts, err := ioutil.ReadAll(r.Body)
+		byts, err := io.ReadAll(r.Body)
 		if err == nil {
 			q = string(byts)
 		}
@@ -115,7 +115,7 @@ func (p *provider) queryExternalMetrics(r *http.Request) interface{} {
 		ql = "influxql"
 	}
 	if len(q) == 0 {
-		byts, err := ioutil.ReadAll(r.Body)
+		byts, err := io.ReadAll(r.Body)
 		if err == nil {
 			q = string(byts)
 		}

--- a/internal/tools/monitor/core/metric/query/metricq/routes_v1.go
+++ b/internal/tools/monitor/core/metric/query/metricq/routes_v1.go
@@ -17,7 +17,7 @@ package metricq
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -108,7 +108,7 @@ func getQueryStatement(name, agg string, r *http.Request) string {
 	if r.Method == http.MethodGet {
 		return fmt.Sprintf("%s?%s", path, r.URL.RawQuery)
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	return fmt.Sprintf("%s?%s", path, bytes.NewBuffer(body).String())
 }
 

--- a/internal/tools/monitor/core/metric/query/provider.go
+++ b/internal/tools/monitor/core/metric/query/provider.go
@@ -17,7 +17,7 @@ package query
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"time"
@@ -133,11 +133,11 @@ func (p *provider) Init(ctx servicehub.Context) error {
 						}
 					}
 					if statement != nil {
-						body, err := ioutil.ReadAll(r.Body)
+						body, err := io.ReadAll(r.Body)
 						if err != nil {
 							return errors.NewInvalidParameterError("statement", err.Error())
 						}
-						r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+						r.Body = io.NopCloser(bytes.NewBuffer(body))
 						*statement = string(body)
 						if len(*statement) > 0 {
 							if _, ok := data.(*pb.QueryWithTableFormatRequest); ok {

--- a/internal/tools/monitor/dashboard/org-apis/permission.go
+++ b/internal/tools/monitor/dashboard/org-apis/permission.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -216,11 +216,11 @@ func (p *provider) checkOrgByClusters(ctx httpserver.Context, clusters []*resour
 
 func (p *provider) getOrgIDNameFromBody(ctx httpserver.Context) (string, error) {
 	req := ctx.Request()
-	byts, err := ioutil.ReadAll(req.Body)
+	byts, err := io.ReadAll(req.Body)
 	if err != nil {
 		return "", err
 	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(byts))
+	req.Body = io.NopCloser(bytes.NewReader(byts))
 	var body struct {
 		OrgName string `json:"org_name"`
 	}

--- a/internal/tools/monitor/extensions/loghub/index/query/provider.go
+++ b/internal/tools/monitor/extensions/loghub/index/query/provider.go
@@ -15,7 +15,7 @@
 package query
 
 import (
-	"io/ioutil"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -85,7 +85,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	p.db = db.New(p.mysql)
 
 	if len(p.C.IndexFieldSettings.File) > 0 {
-		f, err := ioutil.ReadFile(p.C.IndexFieldSettings.File)
+		f, err := os.ReadFile(p.C.IndexFieldSettings.File)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/monitor/notify/template/query/provider.go
+++ b/internal/tools/monitor/notify/template/query/provider.go
@@ -16,7 +16,6 @@ package query
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -123,7 +122,7 @@ func (p *provider) Init(ctx servicehub.Context) error {
 				if err != nil {
 					return nil
 				}
-				f, err := ioutil.ReadFile(p)
+				f, err := os.ReadFile(p)
 				var model model.Model
 				err = yaml.Unmarshal(f, &model)
 				if err != nil {

--- a/internal/tools/monitor/oap/collector/plugins/receivers/jaeger/interceptor.go
+++ b/internal/tools/monitor/oap/collector/plugins/receivers/jaeger/interceptor.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -45,7 +45,7 @@ func ThriftDecoder(r *http.Request, entity interface{}) error {
 		return errors.New(fmt.Sprintf("Unsupported content type: %v", html.EscapeString(contentType)))
 	}
 	if spansRequest, ok := entity.(*jaegerpb.PostSpansRequest); ok {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/monitor/oap/collector/plugins/receivers/opentelemetry/interceptor.go
+++ b/internal/tools/monitor/oap/collector/plugins/receivers/opentelemetry/interceptor.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -146,9 +146,9 @@ func readBody(req *http.Request) ([]byte, error) {
 		defer func() {
 			_ = r.Close()
 		}()
-		return ioutil.ReadAll(r)
+		return io.ReadAll(r)
 	}
-	return ioutil.ReadAll(req.Body)
+	return io.ReadAll(req.Body)
 }
 
 func getStringValue(value *otlpv11.AnyValue) string {

--- a/internal/tools/orchestrator/hepa/common/log_helper.go
+++ b/internal/tools/orchestrator/hepa/common/log_helper.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -95,7 +94,7 @@ func AccessLogWrap(log *logrus.Logger) transport.ServiceOption {
 			recorder.Code = 502
 			path := httpReq.URL.RequestURI()
 			start := time.Now()
-			reqBody, err := ioutil.ReadAll(httpReq.Body)
+			reqBody, err := io.ReadAll(httpReq.Body)
 			if err != nil {
 				return
 			}

--- a/internal/tools/orchestrator/scheduler/endpoints/endpoints.go
+++ b/internal/tools/orchestrator/scheduler/endpoints/endpoints.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -115,7 +115,7 @@ func (h *HTTPEndpoints) LabelList(ctx context.Context, r *http.Request, vars map
 func (h *HTTPEndpoints) SetNodeLabels(ctx context.Context, r *http.Request, vars map[string]string) (
 	httpserver.Responser, error) {
 	//h.metric.TotalCounter.WithLabelValues(metric.LableTotal).Add(1)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		errstr := "Invalid request body"
 		logrus.Error(errstr)

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/terminal.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/terminal.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -153,7 +153,7 @@ func (k *Kubernetes) Terminal(namespace, podname, containername string, upperCon
 				return nil, err
 			}
 			logrus.Debugf("connect to %s request info: %+v", execURL.String(), resp.Request)
-			respBody, _ := ioutil.ReadAll(resp.Body)
+			respBody, _ := io.ReadAll(resp.Body)
 			logrus.Debugf("connect to %s response body: %s", execURL.String(), string(respBody))
 			return nil, err
 		}

--- a/internal/tools/orchestrator/services/deployment/deployment_context_test.go
+++ b/internal/tools/orchestrator/services/deployment/deployment_context_test.go
@@ -15,7 +15,6 @@
 package deployment
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -364,7 +363,7 @@ func genFakeFSM(specPath ...string) *DeployFSMContext {
 		d: &log.DeployLogHelper{},
 	}
 	if len(specPath) > 0 {
-		b, err := ioutil.ReadFile(specPath[0])
+		b, err := os.ReadFile(specPath[0])
 		if err != nil {
 			panic(err)
 		}

--- a/internal/tools/pipeline/actionagent/callback.go
+++ b/internal/tools/pipeline/actionagent/callback.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -68,7 +67,7 @@ func (agent *Agent) Callback() {
 		agent.AppendError(err)
 		return
 	}
-	mb, err := ioutil.ReadAll(r)
+	mb, err := io.ReadAll(r)
 	if err != nil {
 		if err == io.EOF {
 			return

--- a/internal/tools/pipeline/actionagent/callback_reporter.go
+++ b/internal/tools/pipeline/actionagent/callback_reporter.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -157,7 +157,7 @@ func (cr *CenterCallbackReporter) GetCmsFile(uuid string, absPath string) error 
 			uuid, err)
 	}
 	if !resp.IsOK() {
-		bodyBytes, _ := ioutil.ReadAll(respBody)
+		bodyBytes, _ := io.ReadAll(respBody)
 		return errors.Errorf("failed to download cms file, uuid: %s, err: %v",
 			uuid, string(bodyBytes))
 	}

--- a/internal/tools/pipeline/actionagent/execute.go
+++ b/internal/tools/pipeline/actionagent/execute.go
@@ -18,7 +18,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -88,7 +87,7 @@ func (agent *Agent) Execute(r io.Reader) {
 
 func (agent *Agent) parseArg(r io.Reader) {
 	// base64 decode
-	encodedArg, err := ioutil.ReadAll(r)
+	encodedArg, err := io.ReadAll(r)
 	if err != nil {
 		agent.AppendError(err)
 		return

--- a/internal/tools/pipeline/actionagent/file_watch.go
+++ b/internal/tools/pipeline/actionagent/file_watch.go
@@ -17,7 +17,6 @@ package actionagent
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -69,7 +68,7 @@ func (agent *Agent) stop() {
 func metaFileFullHandler(agent *Agent) filewatch.FullHandler {
 	return func(r io.ReadCloser) error {
 		// 一次性读取
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}

--- a/internal/tools/pipeline/actionagent/file_watch_test.go
+++ b/internal/tools/pipeline/actionagent/file_watch_test.go
@@ -17,7 +17,6 @@ package actionagent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -127,7 +126,7 @@ func TestCheckForBreakpointOnFailure(t *testing.T) {
 				},
 			}
 
-			tmpFile, err := ioutil.TempFile("", "breakpoint")
+			tmpFile, err := os.CreateTemp("", "breakpoint")
 			assert.NoError(t, err)
 			fileName := tmpFile.Name()
 			defer os.Remove(fileName)

--- a/internal/tools/pipeline/actionagent/step_restore.go
+++ b/internal/tools/pipeline/actionagent/step_restore.go
@@ -16,7 +16,6 @@ package actionagent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,7 +101,7 @@ func (agent *Agent) restoreCache(tarFile, tarExecPath string) (err error) {
 		return fmt.Errorf("untar file: %s size: %d bytes exceed limit size: %d bytes", tarFile, tarFileSize.Bytes(),
 			agent.MaxCacheFileSizeMB.Bytes())
 	}
-	tmpDir, err := ioutil.TempDir(cacheTempDir, cacheTempPrefix)
+	tmpDir, err := os.MkdirTemp(cacheTempDir, cacheTempPrefix)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/pipeline/actionagent/step_sore_test.go
+++ b/internal/tools/pipeline/actionagent/step_sore_test.go
@@ -15,7 +15,6 @@
 package actionagent
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,7 +28,7 @@ import (
 func TestStoreAndRestore(t *testing.T) {
 	tmpCacheDir := "/tmp"
 	tmpCachePrefix := "tmp"
-	tmpDir, err := ioutil.TempDir(tmpCacheDir, tmpCachePrefix)
+	tmpDir, err := os.MkdirTemp(tmpCacheDir, tmpCachePrefix)
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
 	agent := Agent{MaxCacheFileSizeMB: 1 * datasize.MB}

--- a/internal/tools/pipeline/actionagent/step_store.go
+++ b/internal/tools/pipeline/actionagent/step_store.go
@@ -16,7 +16,7 @@ package actionagent
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -75,7 +75,7 @@ func (agent *Agent) storeCache(tarFile, cachePath string) (err error) {
 		return fmt.Errorf("tar path: %s size: %d bytes exceed limit size: %d bytes", cachePath, cachePathSize.Bytes(),
 			agent.MaxCacheFileSizeMB.Bytes())
 	}
-	tmpFile, err := ioutil.TempFile(cacheTempDir, cacheTempPrefix)
+	tmpFile, err := os.CreateTemp(cacheTempDir, cacheTempPrefix)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/pipeline/actionagent/uploaddir.go
+++ b/internal/tools/pipeline/actionagent/uploaddir.go
@@ -15,7 +15,6 @@
 package actionagent
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -49,7 +48,7 @@ func (agent *Agent) uploadDir() {
 	}
 
 	// 遍历目录
-	files, err := ioutil.ReadDir(agent.EasyUse.ContainerUploadDir)
+	files, err := os.ReadDir(agent.EasyUse.ContainerUploadDir)
 	if err != nil {
 		agent.AppendError(err)
 		return

--- a/internal/tools/pipeline/pipengine/actionexecutor/plugins/apitest/logic/log_collector.go
+++ b/internal/tools/pipeline/pipengine/actionexecutor/plugins/apitest/logic/log_collector.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 	"time"
 
@@ -71,7 +71,7 @@ func newLogger() *logrus.Logger {
 			DisableLevelTruncation: true,
 		},
 	})
-	l.SetOutput(ioutil.Discard)
+	l.SetOutput(io.Discard)
 	l.AddHook(&CollectorHook{})
 	return l
 }

--- a/internal/tools/pipeline/precheck/checkers/actionchecker/api_register/api-register.go
+++ b/internal/tools/pipeline/precheck/checkers/actionchecker/api_register/api-register.go
@@ -86,7 +86,7 @@ func (b *apiRegister) Check(ctx context.Context, data interface{}, itemsForCheck
 	// if actualAction.Params != nil {
 	// 	swagger, ok := actualAction.Params["swagger_path"]
 	// 	if ok {
-	// 		sjson, err := ioutil.ReadFile(swagger.(string))
+	// 		sjson, err := os.ReadFile(swagger.(string))
 	// 		if err != nil {
 	// 			abort = false
 	// 			//messages = append(messages, fmt.Sprintf("invalid param 'swagger_json', value: %s", swagger))

--- a/internal/tools/pipeline/providers/pipeline/create_v2_test.go
+++ b/internal/tools/pipeline/providers/pipeline/create_v2_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -239,7 +239,7 @@ func createV2(url string) (result benchmarkPipelineCreateRes) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		result.err = err
 		return
@@ -350,7 +350,7 @@ func createFDPPipelineAutoRun(idx int, url string) (result benchmarkPipelineCrea
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		result.err = err
 		return
@@ -393,7 +393,7 @@ func createQueue(idx int, url string) (result benchmarkQueueCreateRes) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		result.err = err
 		return

--- a/pkg/filehelper/append_test.go
+++ b/pkg/filehelper/append_test.go
@@ -15,7 +15,7 @@
 package filehelper
 
 //import (
-//	"io/ioutil"
+//	"io"
 //	"os"
 //	"testing"
 //
@@ -24,7 +24,7 @@ package filehelper
 //
 //func TestAppend(t *testing.T) {
 //	tmpDir := os.TempDir()
-//	f, err := ioutil.TempFile(tmpDir, "")
+//	f, err := os.CreateTemp(tmpDir, "")
 //	assert.NoError(t, err)
 //	defer func() {
 //		f.Close()
@@ -32,7 +32,7 @@ package filehelper
 //	}()
 //	assert.NoError(t, Append(f.Name(), "action meta: hello=world\n"))
 //	assert.NoError(t, Append(f.Name(), "action meta: key=value\n"))
-//	b, err := ioutil.ReadAll(f)
+//	b, err := io.ReadAll(f)
 //	assert.NoError(t, err)
 //	t.Log("write: ", string(b))
 //}

--- a/pkg/http/httpclient/request_test.go
+++ b/pkg/http/httpclient/request_test.go
@@ -155,7 +155,7 @@ import (
 ////		Header("User-ID", "2").
 ////		MultipartFormDataBody(map[string]MultipartItem{
 ////			"file":  {Reader: f, Filename: "xxx.xxx"},
-////			"other": {Reader: ioutil.NopCloser(strings.NewReader("hello world!"))},
+////			"other": {Reader: io.NopCloser(strings.NewReader("hello world!"))},
 ////		}).Do().Body(&body)
 ////	assert.NoError(t, err)
 ////	fmt.Println(body.String())

--- a/pkg/http/httpserver/server.go
+++ b/pkg/http/httpserver/server.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/http/pprof"
@@ -258,7 +257,7 @@ func (s *Server) internalReverseHandler(handler func(context.Context, *http.Requ
 func handleRequest(r *http.Request) {
 	// base64 decode request body if declared in header
 	if strutil.Equal(r.Header.Get(Base64EncodedRequestBody), "true", true) {
-		r.Body = ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
+		r.Body = io.NopCloser(base64.NewDecoder(base64.StdEncoding, r.Body))
 	}
 }
 

--- a/pkg/http/httpserver/server_test.go
+++ b/pkg/http/httpserver/server_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -40,7 +40,7 @@ func TestServer_Base64EncodeRequestBody(t *testing.T) {
 				Path:   "/base64-test",
 				Method: http.MethodPost,
 				Handler: func(ctx context.Context, r *http.Request, vars map[string]string) (httpserver.Responser, error) {
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/k8s/node/drain/node_test.go
+++ b/pkg/k8s/node/drain/node_test.go
@@ -17,7 +17,7 @@ package drain
 //import (
 //	"context"
 //	"encoding/json"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"sigs.k8s.io/yaml"
@@ -151,7 +151,7 @@ package drain
 //	}
 //
 //	// get deployment yaml file
-//	content, err := ioutil.ReadFile(path)
+//	content, err := os.ReadFile(path)
 //	if err != nil {
 //		return
 //	}
@@ -171,7 +171,7 @@ package drain
 //
 //func getPodSpec(path string) (pod *corev1.Pod, err error) {
 //	// get pod yaml file
-//	content, err := ioutil.ReadFile(path)
+//	content, err := os.ReadFile(path)
 //	if err != nil {
 //		return
 //	}

--- a/pkg/kms/kms_test.go
+++ b/pkg/kms/kms_test.go
@@ -18,7 +18,7 @@ package kms
 //	"context"
 //	"encoding/base64"
 //	"fmt"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/davecgh/go-spew/spew"
@@ -165,11 +165,11 @@ package kms
 //	// 本地使用 DEK 加密一个数据
 //	// 加密 /etc/hosts
 //	const etcHosts = "/etc/hosts"
-//	hosts, err := ioutil.ReadFile(etcHosts)
+//	hosts, err := os.ReadFile(etcHosts)
 //	assert.NoError(t, err)
 //	additionalData := []byte(etcHosts)
 //	ciphertext, err := kmscrypto.AesGcmEncrypt(dek, hosts, additionalData)
-//	ioutil.WriteFile("/tmp/hosts_decrypted", ciphertext, 0644)
+//	os.WriteFile("/tmp/hosts_decrypted", ciphertext, 0644)
 //	assert.NoError(t, err)
 //	// 内存中清除明文 dek
 //	dek = nil

--- a/pkg/parser/pipelineyml/graph_pipelineyml_test.go
+++ b/pkg/parser/pipelineyml/graph_pipelineyml_test.go
@@ -17,7 +17,7 @@ package pipelineyml
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -27,7 +27,7 @@ import (
 )
 
 func TestConvertGraphPipelineYml(t *testing.T) {
-	fb, err := ioutil.ReadFile("./samples/graph_pipelineyml.yaml")
+	fb, err := os.ReadFile("./samples/graph_pipelineyml.yaml")
 	assert.NoError(t, err)
 	b, err := ConvertGraphPipelineYmlContent(fb)
 	assert.NoError(t, err)
@@ -35,7 +35,7 @@ func TestConvertGraphPipelineYml(t *testing.T) {
 }
 
 func TestConvertToGraphPipelineYml(t *testing.T) {
-	fb, err := ioutil.ReadFile("./samples/pipeline_cicd.yml")
+	fb, err := os.ReadFile("./samples/pipeline_cicd.yml")
 	assert.NoError(t, err)
 	graph, err := ConvertToGraphPipelineYml(fb)
 	assert.NoError(t, err)
@@ -97,7 +97,7 @@ func Test_cronCompensatorReset(t *testing.T) {
 }
 
 func TestTest(t *testing.T) {
-	b, err := ioutil.ReadFile("./samples/trigger.yml")
+	b, err := os.ReadFile("./samples/trigger.yml")
 	assert.NoError(t, err)
 	newYml, err := ConvertToGraphPipelineYml(b)
 	assert.NoError(t, err)

--- a/pkg/parser/pipelineyml/on_test.go
+++ b/pkg/parser/pipelineyml/on_test.go
@@ -16,14 +16,14 @@ package pipelineyml
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOn(t *testing.T) {
-	b, err := ioutil.ReadFile("./samples/on.yml")
+	b, err := os.ReadFile("./samples/on.yml")
 	assert.NoError(t, err)
 	newYml, err := ConvertToGraphPipelineYml(b)
 	assert.NoError(t, err)

--- a/pkg/parser/pipelineyml/pipelineymlv1/gogenerate/builtin_action_spec.go
+++ b/pkg/parser/pipelineyml/pipelineymlv1/gogenerate/builtin_action_spec.go
@@ -20,7 +20,6 @@ package main
 //	"encoding/json"
 //	"fmt"
 //	"io"
-//	"io/ioutil"
 //	"os"
 //	"path"
 //
@@ -50,13 +49,13 @@ package main
 //
 //	actionDir := "../../../../cmd/actions"
 //
-//	fs, err := ioutil.ReadDir(actionDir)
+//	fs, err := os.ReadDir(actionDir)
 //	if err != nil {
 //		panic(err)
 //	}
 //	actionJson := "["
 //	for _, f := range fs {
-//		b, err := ioutil.ReadFile(path.Join(actionDir, f.Name(), "spec.yml"))
+//		b, err := os.ReadFile(path.Join(actionDir, f.Name(), "spec.yml"))
 //		if err != nil {
 //			panic(err)
 //		}

--- a/pkg/parser/pipelineyml/pipelineymlv1/pipelineyml_test.go
+++ b/pkg/parser/pipelineyml/pipelineymlv1/pipelineyml_test.go
@@ -16,7 +16,7 @@ package pipelineymlv1
 
 //import (
 //	"fmt"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/stretchr/testify/require"
@@ -25,7 +25,7 @@ package pipelineymlv1
 //)
 //
 //func TestPipelineYml_Unmarshal(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-anchor.yml")
+//	b, err := os.ReadFile("../pipeline-anchor.yml")
 //	require.NoError(t, err)
 //	y := New(b)
 //	err = y.Parse()
@@ -33,7 +33,7 @@ package pipelineymlv1
 //}
 //
 //func TestPipelineYml_Parse(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-get-put.yml")
+//	b, err := os.ReadFile("../pipeline-get-put.yml")
 //	require.NoError(t, err)
 //	y := New(b)
 //	err = y.Parse()
@@ -53,7 +53,7 @@ package pipelineymlv1
 //}
 //
 //func TestPipelineYml_Triggers(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-trigger.yml")
+//	b, err := os.ReadFile("../pipeline-trigger.yml")
 //	require.NoError(t, err)
 //
 //	y := New(b)
@@ -63,7 +63,7 @@ package pipelineymlv1
 //}
 //
 //func TestPipelinYmlDuplicate(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-duplicate.yml")
+//	b, err := os.ReadFile("../pipeline-duplicate.yml")
 //	require.NoError(t, err)
 //
 //	y := New(b)
@@ -74,7 +74,7 @@ package pipelineymlv1
 //}
 //
 //func TestPipelinYmlErrTasktype(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-err-tasktype.yml")
+//	b, err := os.ReadFile("../pipeline-err-tasktype.yml")
 //	require.NoError(t, err)
 //
 //	y := New(b)
@@ -85,7 +85,7 @@ package pipelineymlv1
 //}
 //
 //func TestPipelineYml_ValidateSingleTaskConfig(t *testing.T) {
-//	b, err := ioutil.ReadFile("../pipeline-decode.yml")
+//	b, err := os.ReadFile("../pipeline-decode.yml")
 //	require.NoError(t, err)
 //
 //	y := New(b)

--- a/pkg/parser/pipelineyml/upgrade_v1_test.go
+++ b/pkg/parser/pipelineyml/upgrade_v1_test.go
@@ -16,14 +16,14 @@ package pipelineyml
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpgradeYmlFromV1(t *testing.T) {
-	b, err := ioutil.ReadFile("./pipelineymlv1/samples/pipeline.yml")
+	b, err := os.ReadFile("./pipelineymlv1/samples/pipeline.yml")
 	assert.NoError(t, err)
 	newYmlByte, err := UpgradeYmlFromV1(b)
 	assert.NoError(t, err)
@@ -32,7 +32,7 @@ func TestUpgradeYmlFromV1(t *testing.T) {
 }
 
 func TestUpgradeYmlFromV1_PampasBlog(t *testing.T) {
-	b, err := ioutil.ReadFile("./pipelineymlv1/samples/pipeline-pampas-blog.yml")
+	b, err := os.ReadFile("./pipelineymlv1/samples/pipeline-pampas-blog.yml")
 	assert.NoError(t, err)
 	newYmlByte, err := UpgradeYmlFromV1(b)
 	assert.NoError(t, err)

--- a/pkg/qaparser/surefilexml/ingest.go
+++ b/pkg/qaparser/surefilexml/ingest.go
@@ -15,7 +15,6 @@
 package surefilexml
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -71,7 +70,7 @@ func IngestFiles(filenames []string) ([]*pb.TestSuite, error) {
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
 func IngestFile(filename string) ([]*pb.TestSuite, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/qaparser/testngxml/ingest.go
+++ b/pkg/qaparser/testngxml/ingest.go
@@ -16,7 +16,7 @@ package testngxml
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"time"
 
@@ -43,7 +43,7 @@ func IngestFiles(filenames []string) ([]*NgTestResult, error) {
 // IngestFile will parse the given XML file and return a slice of all contained
 // JUnit test suite definitions.
 func IngestFile(filename string) (*NgTestResult, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/qaparser/testngxml/parser_test.go
+++ b/pkg/qaparser/testngxml/parser_test.go
@@ -23,7 +23,7 @@ import (
 //import (
 //	"encoding/json"
 //	"fmt"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/sirupsen/logrus"
@@ -41,7 +41,7 @@ import (
 //}
 //
 //func TestIngest(t *testing.T) {
-//	bs, err := ioutil.ReadFile("../testdata/testng-results.xml")
+//	bs, err := os.ReadFile("../testdata/testng-results.xml")
 //	assert.Nil(t, err)
 //
 //	ng, err := Ingest(bs)

--- a/pkg/swagger/load_test.go
+++ b/pkg/swagger/load_test.go
@@ -15,14 +15,14 @@
 package swagger_test
 
 //import (
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/erda-project/erda/pkg/swagger"
 //)
 //
 //func TestMarshalYAML(t *testing.T) {
-//	data, err := ioutil.ReadFile("./oas3/testdata/gaia-oas2.json")
+//	data, err := os.ReadFile("./oas3/testdata/gaia-oas2.json")
 //	if err != nil {
 //		t.Error(err)
 //	}

--- a/pkg/swagger/oas3/expand_test.go
+++ b/pkg/swagger/oas3/expand_test.go
@@ -35,7 +35,7 @@ func TestToYaml(t *testing.T) {
 //// go test -v -run TestExpandBigSwagger
 //func TestExpandBigSwagger(t *testing.T) {
 //
-//	data, err := ioutil.ReadFile("./testdata/gaia-oas3.json")
+//	data, err := os.ReadFile("./testdata/gaia-oas3.json")
 //	if err != nil {
 //		t.Fatalf("failed to ReadFile, err: %v", err)
 //	}
@@ -89,7 +89,7 @@ func TestToYaml(t *testing.T) {
 //}
 
 //func TestOAS2To3(t *testing.T) {
-//	data, err := ioutil.ReadFile("./testdata/swagger_all.json")
+//	data, err := os.ReadFile("./testdata/swagger_all.json")
 //	if err != nil {
 //		t.Error(err)
 //	}

--- a/pkg/swagger/oas3/marshal_test.go
+++ b/pkg/swagger/oas3/marshal_test.go
@@ -17,7 +17,7 @@ package oas3_test
 // timeout
 //import (
 //	"bytes"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/erda-project/erda/pkg/swagger/oas3"
@@ -28,7 +28,7 @@ package oas3_test
 //// 测试 MarshalYaml 序列化结果的一致性
 //// 重复执行序列化 100 次, 如果发生两次结果值不一致, 则测试失败
 //func TestMarshalYamlConsistency(t *testing.T) {
-//	data, err := ioutil.ReadFile(petstore)
+//	data, err := os.ReadFile(petstore)
 //	if err != nil {
 //		t.Fatalf("failed to ReadFile: %v", err)
 //	}

--- a/pkg/swagger/oas3/validate_test.go
+++ b/pkg/swagger/oas3/validate_test.go
@@ -16,7 +16,7 @@ package oas3_test
 
 //import (
 //	"context"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/erda-project/erda/pkg/swagger"
@@ -31,7 +31,7 @@ package oas3_test
 //
 //// go test -v -run TestValidateOAS3
 //func TestValidateOAS3(t *testing.T) {
-//	data, err := ioutil.ReadFile(testFile2)
+//	data, err := os.ReadFile(testFile2)
 //	if err != nil {
 //		t.Errorf("failed to ReadFile, err: %v", err)
 //	}

--- a/pkg/swagger/openapi/validate_test.go
+++ b/pkg/swagger/openapi/validate_test.go
@@ -16,7 +16,7 @@ package openapi_test
 
 //import (
 //	"context"
-//	"io/ioutil"
+//	"os"
 //	"testing"
 //
 //	"github.com/getkin/kin-openapi/openapi2"
@@ -29,7 +29,7 @@ package openapi_test
 //
 //// go test -v -run TestValidateOAS3
 //func TestValidateOAS3(t *testing.T) {
-//	data, err := ioutil.ReadFile(testFile)
+//	data, err := os.ReadFile(testFile)
 //	if err != nil {
 //		t.Errorf("failed to ReadFile, err: %v", err)
 //	}

--- a/tools/cli/cmd/create.go
+++ b/tools/cli/cmd/create.go
@@ -18,7 +18,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -69,7 +68,7 @@ func ProjectCreate(ctx *command.Context, org, project, desc, pkg string, envs []
 			if err != nil {
 				return err
 			}
-			zipTmpFile, err := ioutil.TempFile("", "project-package-*.zip")
+			zipTmpFile, err := os.CreateTemp("", "project-package-*.zip")
 			if err != nil {
 				return err
 			}

--- a/tools/cli/cmd/extensions.go
+++ b/tools/cli/cmd/extensions.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -101,13 +100,13 @@ func getRegistryAuths() (map[string]DockerAuth, error) {
 		}
 	}
 	if _, err := os.Stat(dockerConfigFilePath); os.IsNotExist(err) {
-		err = ioutil.WriteFile(dockerConfigFilePath, []byte("{}"), 0755)
+		err = os.WriteFile(dockerConfigFilePath, []byte("{}"), 0755)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	fileBytes, err := ioutil.ReadFile(dockerConfigFilePath)
+	fileBytes, err := os.ReadFile(dockerConfigFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +153,7 @@ func saveRegistryAuth(auths map[string]DockerAuth) error {
 	dockerConfigFilePath := path.Join(dockerConfigPath, "config.json")
 	var config map[string]interface{}
 
-	fileBytes, err := ioutil.ReadFile(dockerConfigFilePath)
+	fileBytes, err := os.ReadFile(dockerConfigFilePath)
 	if err != nil {
 		return err
 	}
@@ -165,7 +164,7 @@ func saveRegistryAuth(auths map[string]DockerAuth) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dockerConfigFilePath, resultBytes, 0755)
+	return os.WriteFile(dockerConfigFilePath, resultBytes, 0755)
 }
 
 func getImageRegistry(image string) string {

--- a/tools/cli/cmd/extensions_pull.go
+++ b/tools/cli/cmd/extensions_pull.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -93,10 +92,10 @@ func RunExtensionsPull(ctx *command.Context, extension string, dir string) error
 }
 
 func saveExtension(workDir string, extVersion apistructs.ExtensionVersion) {
-	ioutil.WriteFile(path.Join(workDir, "dice.yml"), []byte(extVersion.Dice.(string)), 0755)
-	ioutil.WriteFile(path.Join(workDir, "spec.yml"), []byte(extVersion.Spec.(string)), 0755)
-	ioutil.WriteFile(path.Join(workDir, "swagger.yml"), []byte(extVersion.Swagger.(string)), 0755)
-	ioutil.WriteFile(path.Join(workDir, "README.md"), []byte(extVersion.Readme), 0755)
+	os.WriteFile(path.Join(workDir, "dice.yml"), []byte(extVersion.Dice.(string)), 0755)
+	os.WriteFile(path.Join(workDir, "spec.yml"), []byte(extVersion.Spec.(string)), 0755)
+	os.WriteFile(path.Join(workDir, "swagger.yml"), []byte(extVersion.Swagger.(string)), 0755)
+	os.WriteFile(path.Join(workDir, "README.md"), []byte(extVersion.Readme), 0755)
 }
 
 func replaceDiceRegistry(diceBytes []byte, typ string, registry string) ([]byte, map[string]string, error) {

--- a/tools/cli/cmd/extensions_push.go
+++ b/tools/cli/cmd/extensions_push.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -54,7 +53,7 @@ func RunExtensionsPush(ctx *command.Context, force bool, all bool, dir, registry
 		workDir = dir
 	}
 
-	specBytes, err := ioutil.ReadFile(path.Join(workDir, "spec.yml"))
+	specBytes, err := os.ReadFile(path.Join(workDir, "spec.yml"))
 	if err != nil {
 		return err
 	}
@@ -72,7 +71,7 @@ func RunExtensionsPush(ctx *command.Context, force bool, all bool, dir, registry
 	request.All = all
 	request.IsDefault = specData.IsDefault
 
-	diceBytes, err := ioutil.ReadFile(path.Join(workDir, "dice.yml"))
+	diceBytes, err := os.ReadFile(path.Join(workDir, "dice.yml"))
 
 	if registry != "" && err == nil {
 		diceBytes, _, err = replaceDiceRegistry(diceBytes, specData.Type, registry)
@@ -85,11 +84,11 @@ func RunExtensionsPush(ctx *command.Context, force bool, all bool, dir, registry
 		request.DiceYml = string(diceBytes)
 	}
 
-	readmeBytes, err := ioutil.ReadFile(path.Join(workDir, "README.md"))
+	readmeBytes, err := os.ReadFile(path.Join(workDir, "README.md"))
 	if err == nil {
 		request.Readme = string(readmeBytes)
 	}
-	swaggerBytes, err := ioutil.ReadFile(path.Join(workDir, "swagger.yml"))
+	swaggerBytes, err := os.ReadFile(path.Join(workDir, "swagger.yml"))
 	if err == nil {
 		request.SwaggerYml = string(swaggerBytes)
 	}

--- a/tools/cli/cmd/extensions_retag.go
+++ b/tools/cli/cmd/extensions_retag.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -87,7 +86,7 @@ func RunExtensionsReTag(ctx *command.Context, dir string, registry string, outpu
 			}
 		}
 	}
-	err := ioutil.WriteFile(output, []byte(outTxt), os.ModePerm)
+	err := os.WriteFile(output, []byte(outTxt), os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -118,7 +117,7 @@ func GetExtMetas(dir string) []ExtensionInfo {
 				Path: relPath,
 			}
 			if checkPath(specFile) == nil {
-				specBytes, err := ioutil.ReadFile(specFile)
+				specBytes, err := os.ReadFile(specFile)
 				if err != nil {
 					ext.SpecErr = err
 				}
@@ -130,7 +129,7 @@ func GetExtMetas(dir string) []ExtensionInfo {
 				ext.Spec = spec
 
 				if checkPath(diceFile) == nil {
-					diceBytes, err := ioutil.ReadFile(diceFile)
+					diceBytes, err := os.ReadFile(diceFile)
 					if err != nil {
 						ext.DiceErr = errors.Wrap(err, "failed to read dice "+diceFile)
 					}

--- a/tools/cli/cmd/gw_create.go
+++ b/tools/cli/cmd/gw_create.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -104,7 +104,7 @@ func RunGwCreate(ctx *command.Context, scene string, orgName string, projectID i
 		return err
 	}
 	defer func() {
-		data, err := ioutil.ReadAll(response.Body)
+		data, err := io.ReadAll(response.Body)
 		if err != nil {
 			ctx.Error("failed to ReadAll: %v", err)
 			return

--- a/tools/cli/cmd/gw_del.go
+++ b/tools/cli/cmd/gw_del.go
@@ -16,7 +16,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -97,7 +97,7 @@ func RunGwDel(ctx *command.Context, pkgID, input, orgName string) error {
 			return errors.Wrap(err, "failed to do Delete")
 		}
 		if response.StatusCode >= 300 || response.StatusCode < 200 {
-			data, _ := ioutil.ReadAll(response.Body)
+			data, _ := io.ReadAll(response.Body)
 			_ = response.Body.Close()
 			ctx.Error("failed to Delete [%v] %s %s %s\n", i, request.GetUrl(), response.Status, string(data))
 		}

--- a/tools/cli/cmd/gw_gc.go
+++ b/tools/cli/cmd/gw_gc.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -119,7 +118,7 @@ func RunGwGc(context *command.Context, input, output, cluster, kongAdmin string,
 	defer out.Close()
 
 	// read from file
-	in, err := ioutil.ReadFile(input)
+	in, err := os.ReadFile(input)
 	if err != nil {
 		return err
 	}
@@ -213,7 +212,7 @@ func deleteItem(ctx command.Context, w io.Writer, item InvalidEndpointsItem, kon
 			return nil
 		}
 		ctx.Warn("failed to delete")
-		if data, err := ioutil.ReadAll(response.Body); err == nil {
+		if data, err := io.ReadAll(response.Body); err == nil {
 			defer response.Body.Close()
 			_, _ = fmt.Fprint(w, string(data))
 		}

--- a/tools/cli/cmd/migrate_lint.go
+++ b/tools/cli/cmd/migrate_lint.go
@@ -16,8 +16,8 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -116,7 +116,7 @@ func (w *walk) filenames() []string {
 }
 
 func (w *walk) walk(input, suffix string) *walk {
-	infos, err := ioutil.ReadDir(input)
+	infos, err := os.ReadDir(input)
 	if err != nil {
 		w.files = append(w.files, input)
 		return w

--- a/tools/cli/cmd/migrate_mkpy.go
+++ b/tools/cli/cmd/migrate_mkpy.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ var MigratePy = command.Command{
 }
 
 func RunMigrateMkPy(ctx *command.Context, workdir, module, name string, tables []string) error {
-	moduleInfos, err := ioutil.ReadDir(workdir)
+	moduleInfos, err := os.ReadDir(workdir)
 	if err != nil {
 		return err
 	}
@@ -85,9 +84,9 @@ func RunMigrateMkPy(ctx *command.Context, workdir, module, name string, tables [
 		if moduleInfo.Name() == module {
 			validModule = true
 		}
-		fileInfos, err := ioutil.ReadDir(moduleInfo.Name())
+		fileInfos, err := os.ReadDir(moduleInfo.Name())
 		if err != nil {
-			return errors.Wrap(err, "failed to ReadDir, directory name: %s")
+			return errors.Wrapf(err, "failed to ReadDir, directory name: %s", moduleInfo.Name())
 		}
 		for _, fileInfo := range fileInfos {
 			if fileInfo.IsDir() {
@@ -113,7 +112,7 @@ func RunMigrateMkPy(ctx *command.Context, workdir, module, name string, tables [
 	}
 
 	if !requirementsExists {
-		if err = ioutil.WriteFile(filepath.Join(workdir, module, pygrator.RequirementsFilename),
+		if err = os.WriteFile(filepath.Join(workdir, module, pygrator.RequirementsFilename),
 			[]byte(pygrator.BaseRequirements), 0644); err != nil {
 			return errors.Wrap(err, "failed to generate requirements.txt")
 		}

--- a/tools/cli/cmd/migrate_mkpypkg.go
+++ b/tools/cli/cmd/migrate_mkpypkg.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -79,7 +79,7 @@ func RunMigrateMkPyPkg(ctx *command.Context, host string, port int, username, pa
 		data: nil,
 	}
 
-	developerScript.data, err = ioutil.ReadFile(filename)
+	developerScript.data, err = os.ReadFile(filename)
 	if err != nil {
 		return errors.Wrap(err, "failed to read file")
 	}
@@ -99,7 +99,7 @@ func RunMigrateMkPyPkg(ctx *command.Context, host string, port int, username, pa
 		Commit: commit,
 	}
 
-	p.Requirements, err = ioutil.ReadFile(requirements)
+	p.Requirements, err = os.ReadFile(requirements)
 	if err != nil {
 		logrus.WithError(err).Warnln("failed to read requirements.txt, use default")
 		p.Requirements = []byte(pygrator.BaseRequirements)


### PR DESCRIPTION
#### What this PR does / why we need it:
Deprecated: As of Go 1.16.
Almost all functions can be replaced directly. 
`ReadDir` now returns different struct from before.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  remove deprecated ioutil            |
| 🇨🇳 中文    |    移除废弃的 ioutil          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
