### PR TITLE
fix: `transaction-http-analysis` failed to order by avgDuration

### DIFF
--- a/internal/apps/msp/apm/service/view/table/transaction.go
+++ b/internal/apps/msp/apm/service/view/table/transaction.go
@@ -38,8 +38,9 @@ var (
 )
 
 var TransactionTableSortFieldSqlMap = map[string]string{
-	columnReqCount.Key:   "sum(elapsed_count::field)",
-	columnErrorCount.Key: "sum(if(eq(error::tag, 'true'),elapsed_count::field,0))",
+	columnReqCount.Key:    "sum(elapsed_count::field)",
+	columnErrorCount.Key:  "sum(if(eq(error::tag, 'true'),elapsed_count::field,0))",
+	columnAvgDuration.Key: "avg(elapsed_sum::field)",
 }
 
 type TransactionTableRow struct {
@@ -122,7 +123,7 @@ func (t *TransactionTableBuilder) GetTable(ctx context.Context) (*Table, error) 
 		"%s,"+
 		"sum(elapsed_count::field),"+
 		"sum(if(eq(error::tag, 'true'),elapsed_count::field,0)),"+
-		"sum(elapsed_sum::field)/sum(elapsed_count::field) "+
+		"avg(elapsed_sum::field) "+
 		"FROM %s "+
 		"WHERE (target_terminus_key::tag=$terminus_key OR source_terminus_key::tag=$terminus_key) "+
 		"%s "+


### PR DESCRIPTION
#### What this PR does / why we need it:
fix `transaction-http-analysis` failed to order by avgDuration

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=567488&iterationID=12783&tab=BUG&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that `transaction-http-analysis` failed to order by avgDuration（修复了http监控按平均相应时间排序失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that `transaction-http-analysis` failed to order by avgDuration           |
| 🇨🇳 中文    |     修复了http监控按平均相应时间排序失败的问题         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
