### PR TITLE
fix(pipeline): pipeline taskOP `queue` panic due to nil flink taskManager status

### DIFF
--- a/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sflink/util.go
+++ b/internal/tools/pipeline/pipengine/actionexecutor/plugins/k8sflink/util.go
@@ -285,6 +285,9 @@ func composeStatusDesc(status flinkoperatorv1beta1.FlinkClusterStatus) apistruct
 		statusDesc.Status = apistructs.StatusStoppedByKilled
 		return statusDesc
 	}
+	if status.Components.TaskManager == nil {
+		return statusDesc
+	}
 	switch status.Components.TaskManager.State {
 	case flinkoperatorv1beta1.ComponentStateReady,
 		flinkoperatorv1beta1.ComponentStateNotReady,


### PR DESCRIPTION
#### What this PR does / why we need it:
fix pipeline taskOP `queue` panic due to nil flink taskManager status

#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that pipeline taskOP `queue` panic due to nil flink taskManager status （修复了由于升级flink导致状态空指针的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  Fix the bug that pipeline taskOP `queue` panic due to nil flink taskManager status            |
| 🇨🇳 中文    |      修复了由于升级flink导致状态空指针的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
