### PR TITLE
fix(orchestrator): pod info sync duplicate

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/instanceinfosync/pod.go
@@ -410,11 +410,16 @@ func updatePodAndInstance(dbclient *instanceinfo.Client, podlist *corev1.PodList
 			CpuRequest:      cpurequest,
 			CpuLimit:        cpulimit,
 		}
-		podsinfo, err := podr.ByUid(string(pod.UID)).Do()
-		if len(podsinfo) > 0 {
-			podinfo.ID = podsinfo[0].ID
+
+		podsInfo, err := podr.ByCluster(cluster).ByUid(string(pod.UID)).Do()
+		if err != nil {
+			return orgs, fmt.Errorf("query pod (cluster: %s) by uuid %s err, %+v",
+				cluster, string(pod.UID), err)
+		}
+		if len(podsInfo) > 0 {
+			podinfo.ID = podsInfo[0].ID
 			if delete {
-				if err := podw.Delete(podsinfo[0].ID); err != nil {
+				if err := podw.DeleteByPodUid(cluster, string(pod.UID)); err != nil {
 					return orgs, err
 				}
 			} else if err := podw.Update(podinfo); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
Reader `values` doesn't reset, will cause where condition error.
Delete history duplicate data with cluster and pod uid when pod event is delete.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=615876&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix pod info sync duplicate          |
| 🇨🇳 中文    |  修复 pod 数据同步重复            |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
