### PR TITLE
fix(codecov): use codecov/codecov-action@v4 instead of bash script

### DIFF
--- a/.github/workflows/ci-it-noneed.yml
+++ b/.github/workflows/ci-it-noneed.yml
@@ -153,7 +153,7 @@ jobs:
           name: pure-coverage
           path: ./coverage/
           search_artifacts: true
-      - name: very quick codecov
+      - name: Generate new codecov.yml
         shell: bash
         run: |
           rm codecov.yml
@@ -164,6 +164,8 @@ jobs:
               patch: off
           EOF
           cat codecov.yml
+      - name: Verify new codecov.yml
+        run: cat codecov.yml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci-it-noneed.yml
+++ b/.github/workflows/ci-it-noneed.yml
@@ -164,4 +164,10 @@ jobs:
               patch: off
           EOF
           cat codecov.yml
-          curl -s https://codecov.io/bash | bash -s - -s ./coverage/
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/
+          fail_ci_if_error: true
+          flags: by-github-actions

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -230,8 +230,12 @@ jobs:
           rm -fr ./coverage/proto-go
           rm -fr ./coverage/pure-coverage
       - name: Upload coverage to Codecov
-        run: |
-          curl -s https://codecov.io/bash | bash -s - -s ./coverage/
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/
+          fail_ci_if_error: true
+          flags: by-github-actions
       - name: Upload combined coverage reports to artifact
         uses: actions/upload-artifact@v3
         with:

--- a/internal/apps/ai-proxy/common/on.go
+++ b/internal/apps/ai-proxy/common/on.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// On .
 type On struct {
 	Key      string `json:"key" yaml:"key"`
 	Operator string `json:"operator" yaml:"operator"`

--- a/pkg/strutil/json_test.go
+++ b/pkg/strutil/json_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTryGetJsonStr(t *testing.T) {
+	type args struct {
+		v any
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "valid",
+			args: args{v: map[string]interface{}{"a": 1}},
+			want: `{"a":1}`,
+		},
+		{
+			name: "invalid",
+			args: args{v: make(chan int)},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, TryGetJsonStr(tt.args.v), "TryGetJsonStr(%v)", tt.args.v)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Use codecov/codecov-action@v4 instead of bash script to upload codecov reports.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=585546&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   use codecov-action@v4 to upload codecov reports           |
| 🇨🇳 中文    |    使用 codecov-action@v4 上传 codecov 报告         |
