### PR TITLE
fix: pod info table has not been GC

### DIFF
--- a/internal/tools/orchestrator/scheduler/instanceinfo/pod.go
+++ b/internal/tools/orchestrator/scheduler/instanceinfo/pod.go
@@ -136,8 +136,7 @@ func (r *PodReader) ByUid(uid string) *PodReader {
 }
 func (r *PodReader) ByUpdatedTime(beforeNSecs int) *PodReader {
 	// Use scheduler time query to avoid the inconsistency between sceduler and database time and cause the instance to GC by mistake
-	now := time.Now().Format("2006-01-02 15:04:05")
-	r.conditions = append(r.conditions, "updated_at < '"+now+"' - interval ? second")
+	r.conditions = append(r.conditions, "updated_at < now() - interval ? second")
 	r.values = append(r.values, beforeNSecs)
 	return r
 }

--- a/internal/tools/orchestrator/scheduler/instanceinfo/pod.go
+++ b/internal/tools/orchestrator/scheduler/instanceinfo/pod.go
@@ -137,7 +137,7 @@ func (r *PodReader) ByUid(uid string) *PodReader {
 func (r *PodReader) ByUpdatedTime(beforeNSecs int) *PodReader {
 	// Use scheduler time query to avoid the inconsistency between sceduler and database time and cause the instance to GC by mistake
 	now := time.Now().Format("2006-01-02 15:04:05")
-	r.conditions = append(r.conditions, "updated_at < "+now+" - interval ? second")
+	r.conditions = append(r.conditions, "updated_at < '"+now+"' - interval ? second")
 	r.values = append(r.values, beforeNSecs)
 	return r
 }

--- a/internal/tools/orchestrator/scheduler/instanceinfo/pod_test.go
+++ b/internal/tools/orchestrator/scheduler/instanceinfo/pod_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instanceinfo
+
+import "testing"
+
+func TestByUpdatedTime(t *testing.T) {
+	reader := &PodReader{
+		db:         nil,
+		conditions: make([]string, 0),
+		values:     make([]interface{}, 0),
+		limit:      1,
+	}
+	reader.ByUpdatedTime(3)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
fix: pod info table has not been GC

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=619012&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix pod info table has not been GC       |
| 🇨🇳 中文    |     修复pod_info表没有被GC，导致quota统计错误         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
