### PR TITLE
fix(pipeline): handle task time_begin & cost_time_sec if not set correctly

### DIFF
--- a/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait.go
+++ b/internal/tools/pipeline/providers/reconciler/taskrun/taskop/wait.go
@@ -141,6 +141,11 @@ func (w *wait) WhenTimeout() error {
 
 	w.QuitWaitTimeout = true
 	w.Task.Status = apistructs.PipelineStatusTimeout
+	// TimeBegin should be set at queue op, but for some scenarios such as pipeline component panic,
+	// it may skip queue op and directly enter wait op, so TimeBegin is not set.
+	if w.Task.TimeBegin.IsZero() {
+		w.Task.TimeBegin = w.Task.TimeUpdated // use last updated time as TimeBegin
+	}
 	w.Task.TimeEnd = time.Now()
 	w.Task.CostTimeSec = int64(w.Task.TimeEnd.Sub(w.Task.TimeBegin).Seconds())
 	_, err = w.Executor.Cancel(w.Ctx, w.Task)

--- a/internal/tools/pipeline/spec/pipeline_task.go
+++ b/internal/tools/pipeline/spec/pipeline_task.go
@@ -378,6 +378,19 @@ func (pt *PipelineTask) Convert2PB() *basepb.PipelineTaskDTO {
 
 		IsSnippet: pt.IsSnippet,
 	}
+	// handle time
+	if task.TimeEnd != nil && !task.TimeEnd.AsTime().IsZero() {
+		if task.TimeBegin == nil {
+			earlierTime := pt.TimeUpdated // use earlier time as timeBegin as much as possible
+			if pt.TimeEnd.Before(pt.TimeUpdated) {
+				earlierTime = pt.TimeEnd
+			}
+			task.TimeBegin = timestamppb.New(earlierTime) // for some scenarios, timeBegin is not set
+		}
+		if task.CostTimeSec < 0 {
+			task.CostTimeSec = int64(task.TimeEnd.AsTime().Sub(task.TimeBegin.AsTime()).Seconds())
+		}
+	}
 	if pt.SnippetPipelineID != nil {
 		task.SnippetPipelineID = pt.SnippetPipelineID
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

- use timeUpdated as timeBegin if task skip queue op due to conditions like component panic
- also set timeBegin & costTimeSec when convert to pb


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=620779&iterationID=12783&type=BUG)


#### Specified Reviewers:

/assign @chengjoey 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   handle task time_begin & cost_time_sec if not set correctly           |
| 🇨🇳 中文    |   处理 task 的 time_begin & cost_time_sec 当未正确设置时           |
