### PR TITLE
feat: `dropper` processer support metric white list

### DIFF
--- a/cmd/monitor/collector/bootstrap-agent.yaml
+++ b/cmd/monitor/collector/bootstrap-agent.yaml
@@ -441,6 +441,7 @@ erda.oap.collector.exporter.collector@external_metrics:
 
 erda.oap.collector.processor.dropper@application-agent:
   metric_prefix: ${APPLICATION_AGENT_DROP_PREFIX}
+  white_list: ${APPLICATION_AGENT_WHITE_LIST}
 
 # ************* exporters *************
 

--- a/internal/apps/msp/apm/service/apm.service.service.go
+++ b/internal/apps/msp/apm/service/apm.service.service.go
@@ -70,9 +70,6 @@ func (s *apmServiceService) GetServiceLanguage(ctx context.Context, req *pb.GetS
 		if err != nil {
 			return nil, errors.NewInternalServerError(err)
 		}
-		if err != nil {
-			return nil, err
-		}
 		count := response.Results[0].Series[0].Rows[0].Values[0].GetNumberValue()
 		if count == 1 {
 			return &pb.GetServiceLanguageResponse{Language: language}, err


### PR DESCRIPTION
#### What this PR does / why we need it:
`dropper` processer support metric white list

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: `dropper` processer support metric white list（`dropper`支持指标白名单）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    `dropper` processer support metric white list          |
| 🇨🇳 中文    |     `dropper`支持指标白名单         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
