### PR TITLE
feat: get same mutex lock for registercenter and configcenter

### DIFF
--- a/internal/apps/msp/resource/deploy/coordinator/coordinator.go
+++ b/internal/apps/msp/resource/deploy/coordinator/coordinator.go
@@ -17,6 +17,7 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	mutex "github.com/erda-project/erda-infra/providers/etcd-mutex"
 	"strings"
 	"time"
 
@@ -293,6 +294,13 @@ func (p *provider) UnDeploy(resourceId string) error {
 	return nil
 }
 
+const (
+	ResourceRegisterCenter = "registercenter"
+	ResourceConfigCenter   = "config-center"
+
+	RegisterAndConfigMutexKey = "ConfigLoveRegister"
+)
+
 // mutexDeploy wraps a global distributed lock around the function deploy to ensure that only one instance of an addon of a certain type of engine is being
 // deployed within a cluster, to prevent duplicate instances from being pulled up.
 // deploy is the main logic for deployment.
@@ -302,7 +310,14 @@ func (p *provider) mutexDeploy(deploy func(request handlers.ResourceDeployReques
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*12)
 	defer cancel()
 
-	mu, err := p.Mutex.New(ctx, strings.Join([]string{req.Engine, req.Az}, "/"))
+	var err error
+	var mu mutex.Mutex
+
+	if req.Engine == ResourceRegisterCenter || req.Engine == ResourceConfigCenter {
+		mu, err = p.Mutex.New(ctx, strings.Join([]string{RegisterAndConfigMutexKey, req.Az}, "/"))
+	} else {
+		mu, err = p.Mutex.New(ctx, strings.Join([]string{req.Engine, req.Az}, "/"))
+	}
 	if err != nil {
 		p.Log.Errorf("[%s/%s] failed to New a global distributed lock (ETCD Mutex) before deploying: %v\n", req.Engine, req.Az, err)
 		return nil, errors.Wrapf(err, "failed to New ETCD Mutex for %s/%s", req.Engine, req.Az)

--- a/internal/apps/msp/resource/deploy/coordinator/coordinator.go
+++ b/internal/apps/msp/resource/deploy/coordinator/coordinator.go
@@ -17,12 +17,12 @@ package coordinator
 import (
 	"context"
 	"fmt"
-	mutex "github.com/erda-project/erda-infra/providers/etcd-mutex"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
+	mutex "github.com/erda-project/erda-infra/providers/etcd-mutex"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/apps/msp/instance/db"
 	"github.com/erda-project/erda/internal/apps/msp/resource/deploy/handlers"


### PR DESCRIPTION
#### What this PR does / why we need it:
get same mutex lock for registercenter and configcenter

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=629039&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       get same mutex lock for registercenter and configcenter       |
| 🇨🇳 中文    |      注册中心和配置中心获取同一把锁，避免它俩同时部署        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
