### PR TITLE
fix: uc login redirect dismatch under NodePort service

### DIFF
--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -162,6 +162,7 @@ openapi-auth-ory-kratos:
   ory_kratos_addr: "${ORY_KRATOS_ADDR:kratos-public}"
 openapi-auth-uc:
   _enable: ${UC_ENABLED:true}
+  platform_protocol: "${DICE_PROTOCOL:https}"
   weight: 100
   redirect_after_login: "${UI_PUBLIC_ADDR}"
   client_id: "${UC_CLIENT_ID:dice}"

--- a/internal/core/openapi/openapi-ng/auth/uc-session/login.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/login.go
@@ -124,7 +124,7 @@ func (p *provider) getScheme(r *http.Request) string {
 	if len(proto) > 0 {
 		return proto
 	}
-	return "https"
+	return p.Cfg.PlatformProtocol
 }
 
 func firstNonEmpty(ss ...string) string {
@@ -163,8 +163,11 @@ func (p *provider) getSessionDomain(host string) string {
 func (p *provider) getUCRedirectHost(referer, host string) string {
 	for _, addr := range p.Cfg.UCRedirectAddrs {
 		domain := addr
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			domain = h
+		// ignore service port
+		for _, v := range []string{addr, host} {
+			if h, _, err := net.SplitHostPort(v); err == nil {
+				domain = h
+			}
 		}
 		domains := strings.SplitN(domain, ".", -1)
 		l := len(domains)

--- a/internal/core/openapi/openapi-ng/auth/uc-session/login_test.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/login_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ucoauth
 
 import (

--- a/internal/core/openapi/openapi-ng/auth/uc-session/login_test.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/login_test.go
@@ -1,0 +1,82 @@
+package ucoauth
+
+import (
+	"testing"
+)
+
+func TestGetUCRedirectHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		referer    string
+		host       string
+		config     config
+		wantResult string
+	}{
+		{
+			name:    "Matching referer with UCRedirectAddrs",
+			referer: "https://erda.cloud/login",
+			host:    "erda.cloud",
+			config: config{
+				UCRedirectAddrs: []string{"openapi.erda.cloud"},
+			},
+			wantResult: "openapi.erda.cloud",
+		},
+		{
+			name:    "Non-matching referer with UCRedirectAddrs",
+			referer: "https://erda.cloud/login",
+			host:    "erda.cloud",
+			config: config{
+				UCRedirectAddrs: []string{"fake.erda.cloud"},
+			},
+			wantResult: "fake.erda.cloud",
+		},
+		{
+			name:    "Host with port number",
+			referer: "https://erda.cloud:8080/login",
+			host:    "erda.cloud:8080",
+			config: config{
+				UCRedirectAddrs: []string{"openapi.erda.cloud:8080"},
+			},
+			wantResult: "openapi.erda.cloud:8080",
+		},
+		{
+			name:    "Empty host",
+			referer: "https://erda.cloud:8080/login",
+			host:    "",
+			config: config{
+				UCRedirectAddrs: []string{"openapi.erda.cloud:8080"},
+			},
+			wantResult: "openapi.erda.cloud:8080",
+		},
+		{
+			name:    "Referer and host have different domains",
+			referer: "https://erda.cloud/login",
+			host:    "another.com",
+			config: config{
+				UCRedirectAddrs: []string{"openapi.erda.cloud"},
+			},
+			wantResult: "openapi.erda.cloud",
+		},
+		{
+			name:    "Empty host and Referer with diff port",
+			referer: "https://erda.cloud:8080/login",
+			host:    "",
+			config: config{
+				UCRedirectAddrs: []string{"openapi.erda.cloud:9090"},
+			},
+			wantResult: "openapi.erda.cloud:9090",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				Cfg: &tt.config,
+			}
+			got := p.getUCRedirectHost(tt.referer, tt.host)
+			if got != tt.wantResult {
+				t.Errorf("getUCRedirectHost() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}

--- a/internal/core/openapi/openapi-ng/auth/uc-session/provider.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/provider.go
@@ -31,6 +31,7 @@ import (
 
 type config struct {
 	Weight               int64         `file:"weight" default:"100"`
+	PlatformProtocol     string        `file:"platform_protocol" default:"https"`
 	RedirectAfterLogin   string        `file:"redirect_after_login"`
 	ClientID             string        `file:"client_id"`
 	UCAddr               string        `file:"uc_addr"`


### PR DESCRIPTION
#### What this PR does / why we need it:
UC login redirect dismatch under NodePort service.

Frontend fix: [4056](https://github.com/erda-project/erda-ui/pull/4056)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=627358&iterationID=13633&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix uc login redirect dismatch under NodePort service           |
| 🇨🇳 中文    |       修复平台使用 NodePort Service 登陆跳转不匹配       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
