### PR TITLE
feat: diceyml env regexp support .-

### DIFF
--- a/pkg/parser/diceyml/servicename_visitor.go
+++ b/pkg/parser/diceyml/servicename_visitor.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// 检查 service name 合法性
 package diceyml
 
 import (
@@ -5,11 +20,11 @@ import (
 	"regexp"
 )
 
-var (
-	serviceNameRegex = regexp.MustCompile(`^((([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9]))$`)
-	// serviceNameMaxLen = 14 // service name 最长长度
-	envNameRegex = regexp.MustCompile(`^([-._a-zA-Z][-._a-zA-Z0-9]*)$`)
-)
+var serviceNameRegex = regexp.MustCompile("^((([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))$")
+
+// var serviceNameMaxLen = 14 // service name 最长长度
+
+var envNameRegex = regexp.MustCompile(`^([-._a-zA-Z][-._a-zA-Z0-9]*)$`)
 
 type ServiceNameVisitor struct {
 	DefaultVisitor

--- a/pkg/parser/diceyml/servicename_visitor.go
+++ b/pkg/parser/diceyml/servicename_visitor.go
@@ -1,18 +1,3 @@
-// Copyright (c) 2021 Terminus, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-// 检查 service name 合法性
 package diceyml
 
 import (
@@ -20,11 +5,11 @@ import (
 	"regexp"
 )
 
-var serviceNameRegex = regexp.MustCompile("^((([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))$")
-
-// var serviceNameMaxLen = 14 // service name 最长长度
-
-var envNameRegex = regexp.MustCompile("^([A-Za-z_][A-Za-z0-9_]*)$")
+var (
+	serviceNameRegex = regexp.MustCompile(`^((([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9]))$`)
+	// serviceNameMaxLen = 14 // service name 最长长度
+	envNameRegex = regexp.MustCompile(`^([-._a-zA-Z][-._a-zA-Z0-9]*)$`)
+)
 
 type ServiceNameVisitor struct {
 	DefaultVisitor
@@ -39,27 +24,32 @@ func NewServiceNameVisitor() DiceYmlVisitor {
 
 func (o *ServiceNameVisitor) VisitService(v DiceYmlVisitor, obj *Service) {
 	if !serviceNameRegex.MatchString(o.currentService) {
-		o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{"services"}, o.currentService)] = fmt.Errorf(
-			"service name[%s] not match regex:\n %s, \n e.g: aa.bb-cc.dd-ee", o.currentService, serviceNameRegex)
+		header := yamlHeaderRegexWithUpperHeader([]string{"services"}, o.currentService)
+		err := fmt.Errorf(
+			"service name[%s] does not match regex: %s, e.g: aa.bb-cc.dd-ee", o.currentService, serviceNameRegex)
+		o.collectErrors[header] = err
 	}
 
-	for k := range obj.Envs {
-		if !envNameRegex.MatchString(k) {
-			o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{"services", o.currentService, "envs"}, k)] = fmt.Errorf("env name [%s] not match regex:\n %s", k, envNameRegex)
-		}
-	}
+	o.checkEnvNames([]string{"services", o.currentService, "envs"}, obj.Envs)
 }
 
 func (o *ServiceNameVisitor) VisitObject(v DiceYmlVisitor, obj *Object) {
-	for k := range obj.Envs {
-		if !envNameRegex.MatchString(k) {
-			o.collectErrors[yamlHeaderRegexWithUpperHeader([]string{"envs"}, k)] = fmt.Errorf("env name [%s] not match regex:\n %s", k, envNameRegex)
-		}
-	}
+	o.checkEnvNames([]string{"envs"}, obj.Envs)
 }
 
 func ServiceNameCheck(obj *Object) ValidateError {
 	visitor := NewServiceNameVisitor()
 	obj.Accept(visitor)
 	return visitor.(*ServiceNameVisitor).collectErrors
+}
+
+func (o *ServiceNameVisitor) checkEnvNames(prefix []string, envs map[string]string) {
+	for k := range envs {
+		if !envNameRegex.MatchString(k) {
+			header := yamlHeaderRegexWithUpperHeader(prefix, k)
+			err := fmt.Errorf(
+				"env name [%s] not match regex: %s, e.g. 'my.env-name', or 'MY_ENV.NAME'", k, envNameRegex)
+			o.collectErrors[header] = err
+		}
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
diceyml env regexp support .-

New regexp from kubernetes env name rules: `[-._a-zA-Z][-._a-zA-Z0-9]*`

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  diceyml env regexp support .-            |
| 🇨🇳 中文    |    diceyml 正则支持 .-          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
