### PR TITLE
fix(hepa): failed to delete `route` due to nil zoneInfo make panic

### DIFF
--- a/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/api_policy/impl/impl.go
@@ -896,7 +896,9 @@ func (impl GatewayApiPolicyServiceImpl) SetPackageDefaultPolicyConfig(category, 
 			if err != nil {
 				return "", err
 			}
-			zones = append(zones, *zone)
+			if zone != nil {
+				zones = append(zones, *zone)
+			}
 		}
 	}
 	policyEngine, err := apipolicy.GetPolicyEngine(category)

--- a/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/endpoint_api/impl/impl.go
@@ -1009,7 +1009,7 @@ func (impl GatewayOpenapiServiceImpl) UpdatePackage(orgId, id string, dto *gw.Pa
 			return
 		}
 		//老类型兼容
-		if z.Type == db.ZONE_TYPE_PACKAGE {
+		if z != nil && z.Type == db.ZONE_TYPE_PACKAGE {
 			_, err = (*impl.zoneBiz).UpdateZoneRoute(dao.ZoneId, zone.ZoneRoute{
 				zone.RouteConfig{
 					Hosts: domains,
@@ -2116,9 +2116,11 @@ func (impl GatewayOpenapiServiceImpl) TouchPackageApiZone(info endpoint_api.Pack
 			if err != nil {
 				return "", err
 			}
-			externalSvc, err = impl.createOrUpdateService(k8sAdapter, info, *z)
-			if err != nil {
-				return "", err
+			if z != nil {
+				externalSvc, err = impl.createOrUpdateService(k8sAdapter, info, *z)
+				if err != nil {
+					return "", err
+				}
 			}
 		}
 	}
@@ -2133,9 +2135,11 @@ func (impl GatewayOpenapiServiceImpl) TouchPackageApiZone(info endpoint_api.Pack
 		if err != nil {
 			return "", err
 		}
-		err = (*impl.policyBiz).RefreshZoneIngress(*z, *az, runtimeService.ProjectNamespace, useKong)
-		if err != nil {
-			return "", err
+		if z != nil {
+			err = (*impl.policyBiz).RefreshZoneIngress(*z, *az, runtimeService.ProjectNamespace, useKong)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 	return info.ZoneId, nil
@@ -2900,14 +2904,16 @@ func (impl GatewayOpenapiServiceImpl) deleteMSEApi(dao *orm.GatewayPackageApi, p
 		if err != nil {
 			return err
 		}
-		var k8sAdapter k8s.K8SAdapter
-		k8sAdapter, err = k8s.NewAdapter(pack.DiceClusterName)
-		if err != nil {
-			return err
-		}
-		err = k8sAdapter.DeleteService(ingressNamespace, strings.ToLower(zone.Name))
-		if err != nil {
-			return err
+		if zone != nil {
+			var k8sAdapter k8s.K8SAdapter
+			k8sAdapter, err = k8s.NewAdapter(pack.DiceClusterName)
+			if err != nil {
+				return err
+			}
+			err = k8sAdapter.DeleteService(ingressNamespace, strings.ToLower(zone.Name))
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/tools/orchestrator/hepa/services/openapi_rule/impl/impl.go
+++ b/internal/tools/orchestrator/hepa/services/openapi_rule/impl/impl.go
@@ -263,7 +263,7 @@ func (impl GatewayOpenapiRuleServiceImpl) setPackageApiKongPolicies(basePriority
 		if err != nil {
 			return false, err
 		}
-		if len(zoneInfo.KongPolicies) > 0 {
+		if zoneInfo != nil && len(zoneInfo.KongPolicies) > 0 {
 			// clear
 			err = (*impl.zoneBiz).SetZoneKongPoliciesWithoutDomainPolicy(packageApi.ZoneId, nil, helper)
 			if err != nil {
@@ -812,11 +812,13 @@ func (impl GatewayOpenapiRuleServiceImpl) pluginReq(gatewayProvider string, dto 
 		}
 
 		if gatewayProvider == mseCommon.MseProviderName && api.ZoneId != "" {
-			zone, err := (*impl.zoneBiz).GetZone(api.ZoneId)
+			z, err := (*impl.zoneBiz).GetZone(api.ZoneId)
 			if err != nil {
 				return nil, err
 			}
-			reqDto.ZoneName = strings.ToLower(zone.Name)
+			if z != nil {
+				reqDto.ZoneName = strings.ToLower(z.Name)
+			}
 		}
 	}
 	return reqDto, nil


### PR DESCRIPTION
#### What this PR does / why we need it:
fix hepa failed to delete `route` due to nil zoneInfo make panic


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that failed to delete `route` due to nil zoneInfo make panic（修复了hepa删除流量入口路由失败的问题）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Fix the bug that failed to delete `route` due to nil zoneInfo make panic           |
| 🇨🇳 中文    |      修复了hepa删除流量入口路由失败的问题        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
