### PR TITLE
fix(ai-proxy): dashscope non-stream openai style

### DIFF
--- a/internal/apps/ai-proxy/filters/audit-after-llm-director/resp.go
+++ b/internal/apps/ai-proxy/filters/audit-after-llm-director/resp.go
@@ -45,7 +45,7 @@ func (f *Filter) OnResponseEOFImmutable(ctx context.Context, infor reverseproxy.
 		AuditId:            auditRecID,
 		ResponseAt:         timestamppb.New(f.firstResponseAt),
 		Status:             int32(infor.StatusCode()),
-		ActualResponseBody: string(decompress.TryDecompressBody(infor.Header(), infor.BodyBuffer())),
+		ActualResponseBody: string(decompress.TryDecompressBody(infor.Header(), f.DefaultResponseFilter.Buffer)),
 		ActualResponseHeader: func() string {
 			if actualHeader, err := json.Marshal(infor.Header()); err != nil {
 				return err.Error()

--- a/internal/apps/ai-proxy/filters/dashscope-director/util.go
+++ b/internal/apps/ai-proxy/filters/dashscope-director/util.go
@@ -15,6 +15,8 @@
 package dashscope_director
 
 import (
+	"fmt"
+
 	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
 	modelpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model/pb"
 	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
@@ -31,4 +33,18 @@ func getModelMeta(m *modelpb.Model) metadata.AliyunDashScopeModelMeta {
 	var meta metadata.AliyunDashScopeModelMeta
 	cputil.MustObjJSONTransfer(&m.Metadata, &meta)
 	return meta
+}
+
+func mustGetResponseType(modelMeta metadata.AliyunDashScopeModelMeta) metadata.AliyunDashScopeResponseType {
+	requestType := modelMeta.Public.RequestType
+	responseType := modelMeta.Public.ResponseType
+	if responseType == "" {
+		responseType = metadata.AliyunDashScopeResponseType(requestType.String())
+	}
+
+	if ok, err := responseType.Valid(); !ok {
+		panic(fmt.Errorf("metadata.public.response_type is invalid, err: %v", err))
+	}
+
+	return responseType
 }

--- a/internal/apps/ai-proxy/models/metadata/meta_dashscope.go
+++ b/internal/apps/ai-proxy/models/metadata/meta_dashscope.go
@@ -50,13 +50,13 @@ func (t AliyunDashScopeResponseType) String() string {
 }
 func (t AliyunDashScopeResponseType) Valid() (bool, error) {
 	if t.String() == "" {
-		return false, fmt.Errorf("empty request_type")
+		return false, fmt.Errorf("empty response_type")
 	}
 	switch t {
 	case AliyunDashScopeResponseTypeOpenAI, AliyunDashScopeResponseTypeDs:
 		return true, nil
 	default:
-		return false, fmt.Errorf("unknown request_type: %s", t)
+		return false, fmt.Errorf("unknown response_type: %s", t)
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- dashscope non-stream mode for openai response_type works now
- add missing actual_response_body


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=634273&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   dashscope non-stream mode for openai response_type models works now       |
| 🇨🇳 中文    |    修复百炼非流式模式下的 openai 风格模型不可用的问题          |

