### PR TITLE
fix: new cluster steve not ready

### DIFF
--- a/internal/apps/cmp/steve/aggregator.go
+++ b/internal/apps/cmp/steve/aggregator.go
@@ -257,6 +257,7 @@ func (a *Aggregator) prepareSteveServer(clusterInfo *clusterpb.ClusterInfo) {
 	if err := a.createPredefinedResource(clusterInfo.Name); err != nil {
 		logrus.Infof("failed to create predefined resource for cluster %s, %v. Skip starting steve server",
 			clusterInfo.Name, err)
+		a.server.Remove(clusterInfo.Name)
 		return
 	}
 	logrus.Infof("starting steve server for cluster %s", clusterInfo.Name)


### PR DESCRIPTION
#### What this PR does / why we need it:
fix new cluster steve not ready

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=635433&iterationID=12783&type=BUG)


#### Specified Reviewers:

/assign @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       fix new cluster steve not ready       |
| 🇨🇳 中文    |      修复云管中新集群的Steve not ready        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
