### PR TITLE
feat(pipeline): inject project/org default namespace for ci/cd pipeline

### DIFF
--- a/internal/apps/dop/endpoints/pipeline.go
+++ b/internal/apps/dop/endpoints/pipeline.go
@@ -95,6 +95,11 @@ func (e *Endpoints) pipelineCreate(ctx context.Context, r *http.Request, vars ma
 	if err != nil {
 		return errorresp.ErrResp(err)
 	}
+
+	// also add project/org default config namespace
+	reqPipeline.ConfigManageNamespaces = append(reqPipeline.ConfigManageNamespaces, makeOrgDefaultLevelCmsNs(app.OrgID)...)
+	reqPipeline.ConfigManageNamespaces = append(reqPipeline.ConfigManageNamespaces, makeProjectDefaultLevelCmsNs(app.ProjectID)...)
+
 	rules, err := e.branchRule.Query(apistructs.ProjectScope, int64(app.ProjectID))
 	if err != nil {
 		return errorresp.ErrResp(err)
@@ -165,6 +170,20 @@ func (e *Endpoints) pipelineDetail(ctx context.Context, r *http.Request, vars ma
 	}
 
 	return httpserver.OkResp(result)
+}
+
+func makeProjectDefaultLevelCmsNs(projectID uint64) []string {
+	// default need be added before custom
+	return []string{
+		fmt.Sprintf("project-%d-default", projectID),
+	}
+}
+
+func makeOrgDefaultLevelCmsNs(orgID uint64) []string {
+	// default need be added before custom
+	return []string{
+		fmt.Sprintf("org-%d-default", orgID),
+	}
 }
 
 func getPipelineDetailAndCheckPermission(svc pipelinepb.PipelineServiceServer, permission *permission.Permission, req apistructs.CICDPipelineDetailRequest, identityInfo apistructs.IdentityInfo) (*pipelinepb.PipelineDetailDTO, error) {

--- a/internal/apps/dop/endpoints/pipeline_test.go
+++ b/internal/apps/dop/endpoints/pipeline_test.go
@@ -182,3 +182,19 @@ func Test_pipelineList(t *testing.T) {
 	_, err = e.pipelineList(context.Background(), r, nil)
 	assert.NoError(t, err)
 }
+
+func Test_makeProjectDefaultLevelCmsNs(t *testing.T) {
+	projectNamespace1 := makeProjectDefaultLevelCmsNs(1)
+	assert.Equal(t, "project-1-default", projectNamespace1[0])
+
+	projectNamespace2 := makeProjectDefaultLevelCmsNs(2)
+	assert.Equal(t, "project-2-default", projectNamespace2[0])
+}
+
+func Test_makeOrgDefaultLevelCmsNs(t *testing.T) {
+	orgNamespace1 := makeOrgDefaultLevelCmsNs(1)
+	assert.Equal(t, "org-1-default", orgNamespace1[0])
+
+	orgNamespace2 := makeOrgDefaultLevelCmsNs(2)
+	assert.Equal(t, "org-2-default", orgNamespace2[0])
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
inject project/org default namespace for ci/cd pipeline


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Feature: Support inject project/org default namespace for ci/cd pipeline（为cicd流水线注入默认的项目/组织配置ns）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Support inject project/org default namespace for ci/cd pipeline           |
| 🇨🇳 中文    |    为cicd流水线注入默认的项目/组织配置ns          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
