### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -86,7 +86,7 @@ func randMobile() string {
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	rs := make([]string, 8)
+	rs := make([]string, 0, 8)
 	for start := 0; start < 8; start++ {
 		rs = append(rs, strconv.Itoa(rand.Intn(10)))
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

The intention here should be to initialize a slice with a capacity of 8 rather than initializing the length of this slice. 

The only demo: https://go.dev/play/p/q1BcVCmvidW



#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @your-reviewer


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      fix slice init length        |
| 🇨🇳 中文    |         修复切片初始化的长度     |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
