### PR TITLE
chore: baseline dice_member user_id change to varchar(36)

### DIFF
--- a/.erda/migrations/.patches/patch-20210528-cmdb-base.sql
+++ b/.erda/migrations/.patches/patch-20210528-cmdb-base.sql
@@ -5,4 +5,4 @@ ALTER TABLE dice_member CONVERT TO CHARACTER SET utf8mb4;
 ALTER TABLE `dice_config_namespace_relation` MODIFY COLUMN `default_namespace` varchar (191) NOT NULL COMMENT '默认配置命名空间名称';
 ALTER TABLE `dice_config_namespace_relation` MODIFY COLUMN `namespace` varchar (191) NOT NULL COMMENT '配置命名空间名称';
 ALTER TABLE `dice_label_relations` MODIFY `ref_id` varchar (191) NOT NULL COMMENT '标签关联目标 id, eg: issue_id';
-ALTER TABLE `dice_member` MODIFY `user_id` varchar(191) NOT NULL DEFAULT '' COMMENT '用户Id';
+ALTER TABLE `dice_member` MODIFY `user_id` varchar(36) NOT NULL DEFAULT '' COMMENT '用户Id';

--- a/.erda/migrations/.patches/patch-20210528-cmdb-base.sql
+++ b/.erda/migrations/.patches/patch-20210528-cmdb-base.sql
@@ -4,4 +4,5 @@ ALTER TABLE dice_member CONVERT TO CHARACTER SET utf8mb4;
 
 ALTER TABLE `dice_config_namespace_relation` MODIFY COLUMN `default_namespace` varchar (191) NOT NULL COMMENT '默认配置命名空间名称';
 ALTER TABLE `dice_config_namespace_relation` MODIFY COLUMN `namespace` varchar (191) NOT NULL COMMENT '配置命名空间名称';
-ALTER TABLE dice_label_relations MODIFY `ref_id` varchar (191) NOT NULL COMMENT '标签关联目标 id, eg: issue_id'
+ALTER TABLE `dice_label_relations` MODIFY `ref_id` varchar (191) NOT NULL COMMENT '标签关联目标 id, eg: issue_id';
+ALTER TABLE `dice_member` MODIFY `user_id` varchar(191) NOT NULL DEFAULT '' COMMENT '用户Id';

--- a/.erda/migrations/cmdb/20210528-cmdb-base.sql
+++ b/.erda/migrations/cmdb/20210528-cmdb-base.sql
@@ -694,7 +694,7 @@ CREATE TABLE `dice_member`
     `application_id`   bigint(20) DEFAULT NULL COMMENT '应用Id',
     `application_name` varchar(64)           DEFAULT NULL COMMENT '应用名称',
     `role`             varchar(20)  NOT NULL DEFAULT '' COMMENT '角色: Manager/Developer/Tester/Guest',
-    `user_id`          varchar(255) NOT NULL DEFAULT '' COMMENT '用户Id',
+    `user_id`          varchar(191) NOT NULL DEFAULT '' COMMENT '用户Id',
     `email`            varchar(255)          DEFAULT NULL COMMENT '用户邮箱',
     `mobile`           varchar(40)           DEFAULT NULL,
     `nick`             varchar(128)          DEFAULT NULL COMMENT '用户昵称',

--- a/.erda/migrations/cmdb/20210528-cmdb-base.sql
+++ b/.erda/migrations/cmdb/20210528-cmdb-base.sql
@@ -694,7 +694,7 @@ CREATE TABLE `dice_member`
     `application_id`   bigint(20) DEFAULT NULL COMMENT '应用Id',
     `application_name` varchar(64)           DEFAULT NULL COMMENT '应用名称',
     `role`             varchar(20)  NOT NULL DEFAULT '' COMMENT '角色: Manager/Developer/Tester/Guest',
-    `user_id`          varchar(191) NOT NULL DEFAULT '' COMMENT '用户Id',
+    `user_id`          varchar(36)  NOT NULL DEFAULT '' COMMENT '用户Id',
     `email`            varchar(255)          DEFAULT NULL COMMENT '用户邮箱',
     `mobile`           varchar(40)           DEFAULT NULL,
     `nick`             varchar(128)          DEFAULT NULL COMMENT '用户昵称',

--- a/.erda/migrations/cmdb/20211221-dice-member-userID-varchar.sql
+++ b/.erda/migrations/cmdb/20211221-dice-member-userID-varchar.sql
@@ -1,1 +1,0 @@
-alter table `dice_member` modify `user_id` varchar(36) NOT NULL DEFAULT '' COMMENT '用户Id';

--- a/.erda/migrations/config.yml
+++ b/.erda/migrations/config.yml
@@ -734,7 +734,7 @@
     - scriptName: 20210714-update-report-meta-type.sql
       checksum: 7dd1b507fb6d1f2767e8d9dc52677b8ffa99e3ee4825ef47982870d1032c4c5a
     - scriptName: 20210528-cmdb-base.sql
-      checksum: ee7d00385c2622df90f4097d244b3364622471dc9c0b438ba25131b22ea68db3
+      checksum: 91e82fb0b124f37a7ac0aff618bd911493d45c54e17b9bab237daa81624ef67d
     - scriptName: 20210610-addIssueSubscriber.sql
       checksum: c5bfeed8273576b913edc7a94c1d10b7b4a4c37cb8555b7375a08294cd2edbc5
     - scriptName: 20210702-updateMbox.sql

--- a/.erda/migrations/config.yml
+++ b/.erda/migrations/config.yml
@@ -955,8 +955,6 @@
       checksum: ce3231c5afb76c8f254ddf880ce00a8eca98c063699d26f3005393514e9b5e05
     - scriptName: 20211222-dice-member-character.sql
       checksum: 07582b3282207fd93998058586025df3bb8e4b2d0ca8b86f29544b62fecadbcf
-    - scriptName: 20211221-dice-member-userID-varchar.sql
-      checksum: af49cd080c5cc801d1c6e4c11667e348ad77ed6979be1a0515ab105c44ff6a34
     - scriptName: 20211228-sp_metric_expression.sql
       checksum: ce53e43f08bfdde4af92d931b509cbd8fc718845c6ed531b665bba6bdc13b3af
     - scriptName: 21211228-project-home.sql

--- a/.erda/migrations/config.yml
+++ b/.erda/migrations/config.yml
@@ -734,7 +734,7 @@
     - scriptName: 20210714-update-report-meta-type.sql
       checksum: 7dd1b507fb6d1f2767e8d9dc52677b8ffa99e3ee4825ef47982870d1032c4c5a
     - scriptName: 20210528-cmdb-base.sql
-      checksum: 2a95650465d03300627f8f60e0e65666eb3a7da299597823a38f043510e3f74c
+      checksum: ee7d00385c2622df90f4097d244b3364622471dc9c0b438ba25131b22ea68db3
     - scriptName: 20210610-addIssueSubscriber.sql
       checksum: c5bfeed8273576b913edc7a94c1d10b7b4a4c37cb8555b7375a08294cd2edbc5
     - scriptName: 20210702-updateMbox.sql


### PR DESCRIPTION
#### What this PR does / why we need it:
baseline dice_member user_id change to varchar(36)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  baseline dice_member user_id change to varchar(36)            |
| 🇨🇳 中文    |    基线   dice_member user_id 修改为 varchar(36)         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
