### PR TITLE
fix(ai-proxy): dashscope non-stream mode for ds response_type works now

### DIFF
--- a/internal/apps/ai-proxy/filters/dashscope-director/sdk/converter.go
+++ b/internal/apps/ai-proxy/filters/dashscope-director/sdk/converter.go
@@ -120,6 +120,17 @@ func ConvertDsResponseToOpenAIFormat(dsResp DsResponse, modelName string) (*open
 		}
 		ocs = append(ocs, oc)
 	}
+	if dsResp.Output.Text != "" {
+		oc := openai.ChatCompletionChoice{
+			Index: len(ocs),
+			Message: openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: dsResp.Output.Text,
+			},
+			FinishReason: openai.FinishReason(dsResp.Output.FinishReason),
+		}
+		ocs = append(ocs, oc)
+	}
 	resp := openai.ChatCompletionResponse{
 		ID:      dsResp.RequestID,
 		Object:  "chat.completion",

--- a/internal/apps/ai-proxy/filters/dashscope-director/sdk/resp.go
+++ b/internal/apps/ai-proxy/filters/dashscope-director/sdk/resp.go
@@ -22,8 +22,11 @@ type (
 		Usage     *DsRespStreamUsage      `json:"usage,omitempty"`
 	}
 	DsRespStreamChunkOutput struct {
+		// Stream fields
 		Choices []DsRespStreamChunkOutputChoice `json:"choices,omitempty"`
-		Text    string                          `json:"text,omitempty"`
+		// Non-Stream fields
+		Text         string `json:"text,omitempty"`
+		FinishReason string `json:"finish_reason,omitempty"`
 	}
 	DsRespStreamChunkOutputChoice struct {
 		Message      DsRespStreamChunkOutputChoiceMessage `json:"message,omitempty"`


### PR DESCRIPTION
#### What this PR does / why we need it:

ai-proxy return no choices when using aliyun dashscope non-stream mode for ds response_type.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=642480&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      dashscope non-stream mode for ds response_type works now        |
| 🇨🇳 中文    |   修复灵积非流式模式下的 ds 风格模型不可用的问题           |
