### PR TITLE
chore: refreshBasicInfo skip if empty

### DIFF
--- a/internal/apps/dop/providers/efficiency_measure/basic_info.go
+++ b/internal/apps/dop/providers/efficiency_measure/basic_info.go
@@ -17,6 +17,10 @@ package efficiency_measure
 import "context"
 
 func (p *provider) refreshBasicInfo() error {
+	if len(p.Cfg.OrgWhiteList) == 0 {
+		return nil
+	}
+	
 	userProjects, err := p.projDB.GetAllUserJoinedProjects(p.Cfg.OrgWhiteList)
 	if err != nil {
 		p.Log.Errorf("failed to get all user joined projects, err: %v", err)


### PR DESCRIPTION
#### What this PR does / why we need it:
refreshBasicInfo skip if empty

will cause error
```shell
ERRO[2024-10-22 11:18:42.567] failed to get all user joined projects, err: Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'erda.member.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by  module=efficiency-measure
ERRO[2024-10-22 11:18:42.567] failed to refresh basic user projects, err: Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'erda.member.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by  module=efficiency-measure

(/go/src/github.com/erda-project/erda/internal/core/legacy/dao/member.go:493) 
[2024-10-22 11:18:42]  Error 1055 (42000): Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'erda.member.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by 
```

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   refreshBasicInfo skip if empty           |
| 🇨🇳 中文    |   refreshBasicInfo 跳过空的场景，避免 sql 执行           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
