### PR TITLE
fix(ai-proxy): dashscope non-stream support vlm multipart

### DIFF
--- a/internal/apps/ai-proxy/filters/dashscope-director/sdk/converter_test.go
+++ b/internal/apps/ai-proxy/filters/dashscope-director/sdk/converter_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertDsResponseToOpenAIFormat_MultiPart(t *testing.T) {
+	dsRespJson := `
+{
+    "output": {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": [ { "text": "hello" } ]
+                }
+            }
+        ]
+    },
+    "usage": { "output_tokens": 75, "input_tokens": 572, "image_tokens": 391 },
+    "request_id": "b90e5d5e-e60d-9f5c-880e-f4fe28627673"
+}
+`
+	var dsResp DsResponse
+	err := json.Unmarshal([]byte(dsRespJson), &dsResp)
+	assert.NoError(t, err)
+	oaiResp, err := ConvertDsResponseToOpenAIFormat(dsResp, "qwen-vl-max")
+	assert.NoError(t, err)
+	assert.Equal(t, "qwen-vl-max", oaiResp.Model)
+	assert.Equal(t, "stop", string(oaiResp.Choices[0].FinishReason))
+	assert.Equal(t, "hello", oaiResp.Choices[0].Message.Content)
+}
+
+func TestDsResponseOutputContent_Content(t *testing.T) {
+	dsRespJson := `
+{
+    "output": {
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "hello"
+                }
+            }
+        ]
+    }
+}
+`
+	var dsResp DsResponse
+	err := json.Unmarshal([]byte(dsRespJson), &dsResp)
+	assert.NoError(t, err)
+	oaiResp, err := ConvertDsResponseToOpenAIFormat(dsResp, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", oaiResp.Choices[0].Message.Content)
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

dashscope non-stream support vlm multipart


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=646372&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  ai-proxy: dashscope non-stream support vlm multipart            |
| 🇨🇳 中文    |    ai-proxy: 灵积非流式支持 vlm multipart          |
