### PR TITLE
feat: sync general monitor config

### DIFF
--- a/.erda/migrations/monitor/20250115-sp_monitor_config_register-add-log.sql
+++ b/.erda/migrations/monitor/20250115-sp_monitor_config_register-add-log.sql
@@ -1,0 +1,1 @@
+INSERT INTO `sp_monitor_config_register` (`scope`, `scope_id`, `namespace`, `type`, `names`, `filters`, `enable`, `update_time`, `desc`, `hash`) VALUES ('org','','','log','*','[]',1,'2025-01-15 00:00:00','','log_common')

--- a/api/proto/core/monitor/settings/settings.proto
+++ b/api/proto/core/monitor/settings/settings.proto
@@ -16,7 +16,7 @@ service SettingsService {
       check_token: true,
     }
   };
-  
+
   rpc GetSettings (GetSettingsRequest) returns (GetSettingsResponse)  {
     option (google.api.http) = {
       get: "/api/global/settings?org_id={orgID}"
@@ -36,6 +36,13 @@ service SettingsService {
     };
   }
 
+  rpc PutSettingsWithType(PutSettingsWithTypeRequest) returns (PutSettingsWithTypeResponse) {
+    option (google.api.http) = {
+      put: "/api/global/settings/{monitorType}?org_id={orgID}&namespace={namespace}",
+      body: "data"
+    };
+  }
+
   rpc RegisterMonitorConfig (RegisterMonitorConfigRequest) returns (RegisterMonitorConfigResponse)  {
     option (google.api.http) = {
       put: "/api/config/register",
@@ -49,7 +56,7 @@ message GetSettingsRequest {
   int64 orgID = 1 [(validate.rules).int64.gt = 0];
   string workspace = 2;
 }
-  
+
 message GetSettingsResponse {
   map<string, ConfigGroups> data = 1;
 }
@@ -59,8 +66,19 @@ message PutSettingsRequest {
   map<string, ConfigGroups> data = 1;
   int64 orgID = 2 [(validate.rules).int64.gt = 0];
 }
-  
+
 message PutSettingsResponse {
+  string data = 1;
+}
+
+message PutSettingsWithTypeRequest {
+  ConfigGroup data = 1;
+  int64 orgID = 2 [(validate.rules).int64.gt = 0];
+  string namespace = 3;
+  string monitorType = 4;
+}
+
+message PutSettingsWithTypeResponse {
   string data = 1;
 }
 
@@ -80,7 +98,7 @@ message MonitorConfig {
   bool enable = 7;
   string desc = 8;
 }
-  
+
 message RegisterMonitorConfigResponse {
   string data = 1;
 }

--- a/internal/tools/monitor/common/db/monitor_config_register.go
+++ b/internal/tools/monitor/common/db/monitor_config_register.go
@@ -16,6 +16,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/jinzhu/gorm"
 )
@@ -42,6 +43,23 @@ func (m *MonitorConfigRegisterDB) ListRegisterByOrgId(orgId string) ([]SpMonitor
 func (m *MonitorConfigRegisterDB) ListRegisterByType(tpy string) ([]SpMonitorConfigRegister, error) {
 	var res = make([]SpMonitorConfigRegister, 0)
 	if err := m.Model(&SpMonitorConfigRegister{}).Where("type = ?", tpy).Find(&res).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return make([]SpMonitorConfigRegister, 0), nil
+		}
+		return nil, err
+	}
+	return res, nil
+}
+
+func (m *MonitorConfigRegisterDB) ListRegisterWithFilter(filters map[string]any) ([]SpMonitorConfigRegister, error) {
+	var res = make([]SpMonitorConfigRegister, 0)
+	tx := m.Model(&SpMonitorConfigRegister{})
+	for k, v := range filters {
+		key := k
+		value := v
+		tx = tx.Where(fmt.Sprintf("`%s` = ?", key), value)
+	}
+	if err := tx.Find(&res).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return make([]SpMonitorConfigRegister, 0), nil
 		}

--- a/internal/tools/monitor/common/db/monitor_config_register.go
+++ b/internal/tools/monitor/common/db/monitor_config_register.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"errors"
+
+	"github.com/jinzhu/gorm"
+)
+
+type MonitorConfigRegisterDB struct {
+	*gorm.DB
+}
+
+func NewMonitorConfigRegisterDB(db *gorm.DB) *MonitorConfigRegisterDB {
+	return &MonitorConfigRegisterDB{db}
+}
+
+func (m *MonitorConfigRegisterDB) ListRegisterByOrgId(orgId string) ([]SpMonitorConfigRegister, error) {
+	var res = make([]SpMonitorConfigRegister, 0)
+	if err := m.Model(&SpMonitorConfigRegister{}).Where("scope = 'org' and scope_id = ?", orgId).Find(&res).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return make([]SpMonitorConfigRegister, 0), nil
+		}
+		return nil, err
+	}
+	return res, nil
+}
+
+func (m *MonitorConfigRegisterDB) ListRegisterByType(tpy string) ([]SpMonitorConfigRegister, error) {
+	var res = make([]SpMonitorConfigRegister, 0)
+	if err := m.Model(&SpMonitorConfigRegister{}).Where("type = ?", tpy).Find(&res).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return make([]SpMonitorConfigRegister, 0), nil
+		}
+		return nil, err
+	}
+	return res, nil
+}

--- a/internal/tools/monitor/common/db/table.go
+++ b/internal/tools/monitor/common/db/table.go
@@ -18,8 +18,9 @@ import "time"
 
 // table name
 const (
-	InstanceTenantTable = "tb_tmc_instance_tenant"
-	MonitorTable        = "sp_monitor"
+	InstanceTenantTable          = "tb_tmc_instance_tenant"
+	MonitorTable                 = "sp_monitor"
+	SpMonitorConfigRegisterTable = `sp_monitor_config_register`
 )
 
 type (
@@ -49,6 +50,20 @@ type (
 		Created     time.Time `gorm:"column:created;default:CURRENT_TIMESTAMP"`
 		Updated     time.Time `gorm:"column:updated;default:CURRENT_TIMESTAMP"`
 	}
+
+	SpMonitorConfigRegister struct {
+		ID         int       `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+		Scope      string    `gorm:"column:scope;not null" json:"scope"`                  // org
+		ScopeID    string    `gorm:"column:scope_id;not null;default:''" json:"scope_id"` // org_id
+		Namespace  string    `gorm:"column:namespace;not null" json:"namespace"`          // dev,test,staging,prod,other
+		Type       string    `gorm:"column:type;not null" json:"type"`                    // metric、log
+		Names      string    `gorm:"column:names;not null" json:"names"`
+		Filters    string    `gorm:"column:filters;not null;default:''" json:"filters"`
+		Enable     bool      `gorm:"column:enable;not null;default:1" json:"enable"`
+		UpdateTime time.Time `gorm:"column:update_time;not null" json:"update_time"`
+		Desc       string    `gorm:"column:desc;not null;default:''" json:"desc"`
+		Hash       string    `gorm:"column:hash;not null;unique" json:"hash"`
+	}
 )
 
 func (InstanceTenant) TableName() string {
@@ -57,4 +72,8 @@ func (InstanceTenant) TableName() string {
 
 func (Monitor) TableName() string {
 	return MonitorTable
+}
+
+func (*SpMonitorConfigRegister) TableName() string {
+	return SpMonitorConfigRegisterTable
 }

--- a/internal/tools/monitor/core/settings/monitor.go
+++ b/internal/tools/monitor/core/settings/monitor.go
@@ -185,6 +185,10 @@ type monitorConfigRegister struct {
 	Hash       string    `json:"hash" gorm:"column:hash"`
 }
 
+func (s *settingsService) generateKey(orgID, ns string) string {
+	return md5x.SumString(orgID + "/" + ns).String16()
+}
+
 func (s *settingsService) updateMonitorConfig(tx *gorm.DB, orgid int64, orgName, ns, group string, keys map[string]interface{}) error {
 	if ns == "general" {
 		ns = ""

--- a/internal/tools/monitor/core/settings/retention-strategy/routers_test.go
+++ b/internal/tools/monitor/core/settings/retention-strategy/routers_test.go
@@ -1,0 +1,30 @@
+package retention
+
+import (
+	"fmt"
+	"github.com/erda-project/erda/pkg/router"
+	"testing"
+)
+
+func TestRouter(t *testing.T) {
+	matcher := router.New()
+	matcher.Add("application_*", []*router.KeyValue{
+		{
+			Key:   "application_key",
+			Value: "application",
+		},
+	}, "application")
+	matcher.Add("*", []*router.KeyValue{
+		{
+			Key:   "terminus_key",
+			Value: "terminus",
+		},
+	}, "")
+
+	find := matcher.Find("applicatdfsdfffion_sss*", map[string]string{
+		"terminus_key": "terminus",
+		//"terminus_value": "123",
+	})
+
+	fmt.Println(find)
+}

--- a/internal/tools/monitor/core/settings/settings.service.go
+++ b/internal/tools/monitor/core/settings/settings.service.go
@@ -65,6 +65,9 @@ type settingsService struct {
 }
 
 func (s *settingsService) PutSettingsWithType(ctx context.Context, req *pb.PutSettingsWithTypeRequest) (*pb.PutSettingsWithTypeResponse, error) {
+	if req.Namespace == "general" {
+		req.Namespace = ""
+	}
 	orgName, err := s.getOrgName(req.OrgID)
 	if err != nil {
 		return nil, err

--- a/internal/tools/monitor/core/settings/sync_config.go
+++ b/internal/tools/monitor/core/settings/sync_config.go
@@ -16,13 +16,14 @@ package settings
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-
-	"google.golang.org/protobuf/types/known/structpb"
+	"strconv"
+	"strings"
 
 	"github.com/erda-project/erda-proto-go/core/monitor/settings/pb"
 	orgpb "github.com/erda-project/erda-proto-go/core/org/pb"
-	"github.com/erda-project/erda/internal/tools/monitor/oap/collector/lib"
+	"github.com/erda-project/erda/internal/tools/monitor/common/db"
 	"github.com/erda-project/erda/pkg/common/apis"
 	"github.com/erda-project/erda/pkg/discover"
 )
@@ -35,92 +36,115 @@ func (p *provider) syncCreateOrgMonitorConfig() error {
 	if err != nil {
 		return err
 	}
-	defCfg := p.settingsService.getDefaultConfig(apis.Language(context.Background()), "")
+	client := db.New(p.DB)
+	defaultConfig := p.settingsService.getDefaultConfig(apis.Language(context.Background()), "")
 	for _, org := range allOrgs.List {
-		defSetting := &pb.PutSettingsRequest{
-			Data: make(map[string]*pb.ConfigGroups),
+		var registers []db.SpMonitorConfigRegister
+		monitorRegisters, err := client.MonitorConfigRegister.ListRegisterByOrgId(strconv.FormatUint(org.ID, 10))
+		if err != nil {
+			p.Log.Errorf("failed to get monitor config register by orgId: %d, err: %v", org.ID, err)
+			return err
 		}
-		for ns, cfg := range defCfg {
-			if ns == "general" {
+
+		logRegisters, err := client.MonitorConfigRegister.ListRegisterByType("log")
+		if err != nil {
+			p.Log.Errorf("failed to get monitor config register by type: log, err: %v", err)
+			return err
+		}
+		registers = make([]db.SpMonitorConfigRegister, 0, len(logRegisters)+len(monitorRegisters))
+		registers = append(registers, monitorRegisters...)
+		registers = append(registers, logRegisters...)
+
+		for _, register := range registers {
+			if !p.isEmptyConfig(&register, org) {
 				continue
 			}
-			for _, monitorType := range p.Cfg.SyncMonitorTypes {
-				isEmpty := p.isEmptyConfig(monitorType, ns, org)
-				if !isEmpty {
-					continue
-				}
-				monitorTTL := p.getTTL(monitorType, cfg)
-				if monitorTTL == nil {
-					continue
-				}
-				if defSetting.Data[ns] == nil {
-					defSetting.Data[ns] = &pb.ConfigGroups{
-						Groups: []*pb.ConfigGroup{
-							{
-								Key: "monitor",
-								Items: []*pb.ConfigItem{
-									{
-										Key:   fmt.Sprintf("%s_ttl", monitorType),
-										Value: monitorTTL,
-									},
-								},
-							},
-						},
-					}
-				} else {
-					defSetting.Data[ns].Groups[0].Items = append(defSetting.Data[ns].Groups[0].Items, &pb.ConfigItem{
-						Key:   fmt.Sprintf("%s_ttl", monitorType),
-						Value: monitorTTL,
-					})
-				}
+
+			nsConfig := defaultConfig[register.Namespace]
+			defConfig := nsConfig["monitor"]
+
+			req := &pb.PutSettingsWithTypeRequest{
+				OrgID: int64(org.ID),
+				Data: &pb.ConfigGroup{
+					Key:   "monitor",
+					Items: make([]*pb.ConfigItem, 0),
+				},
+				Namespace:   register.Namespace,
+				MonitorType: register.Type,
 			}
-		}
-		if len(defSetting.Data) > 0 {
-			defSetting.OrgID = int64(org.ID)
-			if _, err := p.settingsService.PutSettings(apis.WithInternalClientContext(context.Background(), discover.SvcMonitor), defSetting); err != nil {
-				p.Log.Errorf("failed to create default monitor config for org: %s, err: %v", org.Name, err)
+
+			var ttlItem *pb.ConfigItem
+			var hotTTLItem *pb.ConfigItem
+
+			switch register.Type {
+			case "log":
+				ttlItem = defConfig[LogsTTLKey]
+				hotTTLItem = defConfig[LogsHotTTLKey]
+			case "metric":
+				ttlItem = defConfig[MetricsTTLKey]
+				hotTTLItem = defConfig[MetricsHotTTLKey]
+			}
+
+			if ttlItem == nil {
+				err = fmt.Errorf("ttl item is nil, monitor type: %s", register.Type)
+				p.Log.Error(err)
+				return err
+			}
+			if hotTTLItem == nil {
+				err = fmt.Errorf("hot_ttl item is nil, monitor type: %s", register.Type)
+				p.Log.Error(err)
+				return err
+			}
+
+			req.Data.Items = append(req.Data.Items, ttlItem)
+			req.Data.Items = append(req.Data.Items, hotTTLItem)
+
+			if _, err := p.settingsService.PutSettingsWithType(context.Background(), req); err != nil {
+				p.Log.Errorf("failed to put settings with monitor type: %s, err: %v", register.Type, err)
+				return err
 			}
 		}
 	}
+
 	return nil
 }
 
-func (p *provider) isEmptyConfig(monitorType string, ns string, org *orgpb.Org) bool {
-	var key string
-	switch monitorType {
-	case "logs":
-		tags := map[string]string{
-			lib.DiceOrgNameKey: org.Name,
-			lib.DiceWorkspace:  ns,
+type KeyValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (p *provider) isEmptyConfig(register *db.SpMonitorConfigRegister, org *orgpb.Org) bool {
+	var kvs []KeyValue
+	if err := json.Unmarshal([]byte(register.Filters), &kvs); err != nil {
+		p.Log.Errorf("failed to unmarshal filters, filters: %s, err: %v", register.Filters, err)
+		return false
+	}
+	filters := make(map[string]string)
+	for _, kv := range kvs {
+		filters[kv.Key] = kv.Value
+	}
+
+	names := strings.Split(register.Names, ",")
+
+	switch register.Type {
+	case "log":
+		orgName, err := p.settingsService.getOrgName(int64(org.ID))
+		if err != nil {
+			p.Log.Errorf("failed to get org name, err: %v", err)
+			return false
 		}
-		key = p.LogRetention.GetConfigKey("container", tags)
-	case "metrics":
-		tags := map[string]string{
-			lib.OrgNameKey:    org.Name,
-			lib.DiceWorkspace: ns,
+		filters["dice_org_name"] = orgName
+		for _, name := range names {
+			return len(p.LogRetention.GetConfigKey(name, filters)) == 0
 		}
-		key = p.MetricRetention.GetConfigKey("docker_container_summary", tags)
+
+	case "metric":
+		for _, name := range names {
+			return len(p.MetricRetention.GetConfigKey(name, filters)) == 0
+		}
 	default:
 		return false
 	}
-	return len(key) == 0
-}
-
-func (p *provider) getTTL(monitorType string, cfg map[string]map[string]*pb.ConfigItem) *structpb.Value {
-	if cfg == nil {
-		return nil
-	}
-	monitorCfg := cfg["monitor"]
-	if monitorCfg == nil {
-		return nil
-	}
-	ttl := monitorCfg[fmt.Sprintf("%s_ttl", monitorType)]
-	return ttl.Value
-}
-
-func (p *provider) autoCreateOrgMonitorConfig(orgID uint64) error {
-	p.settingsService.PutSettings(context.Background(), &pb.PutSettingsRequest{
-		OrgID: int64(orgID),
-	})
-	return nil
+	return false
 }

--- a/internal/tools/monitor/core/settings/types.go
+++ b/internal/tools/monitor/core/settings/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Terminus, Inc.
+// Copyright (c) 2025 Terminus, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package db
+package settings
 
-import "github.com/jinzhu/gorm"
-
-// DB .
-type DB struct {
-	*gorm.DB
-	Monitor               MonitorDb
-	InstanceTenant        InstanceTenantDb
-	MonitorConfigRegister *MonitorConfigRegisterDB
-}
-
-// New .
-func New(db *gorm.DB) *DB {
-	return &DB{
-		DB:                    db,
-		Monitor:               MonitorDb{db},
-		InstanceTenant:        InstanceTenantDb{db},
-		MonitorConfigRegister: NewMonitorConfigRegisterDB(db),
-	}
-}
-
-// Begin .
-func (db *DB) Begin() *DB {
-	return New(db.DB.Begin())
-}
+const (
+	LogsTTLKey       = `logs_ttl`
+	LogsHotTTLKey    = `logs_hot_ttl`
+	MetricsTTLKey    = `metrics_ttl`
+	MetricsHotTTLKey = `metrics_hot_ttl`
+)


### PR DESCRIPTION
#### What this PR does / why we need it:

sync general monitor config, write `log` or `metric` into separate table under `org`

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [general log Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=733874&iterationID=12783&type=TASK)
- [general metric Erda Issue](https://erda.cloud/erda/dop/projects/387/issues/all?id=733875&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @iutx @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |        sync general monitor config, write `log` or `metric` into separate table under `org`      |
| 🇨🇳 中文    |       同步非应用的监控配置，将 `log` 或 `metric` 写入 `org` 下的单独表中       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
