### PR TITLE
fix(github-ci): upgrade actions/upload-artifact@v3 to v4

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           HOME=/root make proto-go-in-local
       - name: Upload proto-go As Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: proto-go
           path: ./api/proto-go
@@ -206,7 +206,7 @@ jobs:
           mkdir -p ./coverage
           go test -work -timeout=10s -failfast -race -cover -coverprofile=./coverage/${{ steps.cov-report-name.outputs.path }} -covermode=atomic -gcflags='-l -N' ${{ matrix.package-paths }}
       - name: Upload coverage As Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.cov-report-name.outputs.name }}
           path: ./coverage/${{ steps.cov-report-name.outputs.path }}
@@ -237,7 +237,7 @@ jobs:
           fail_ci_if_error: true
           flags: by-github-actions
       - name: Upload combined coverage reports to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pure-coverage
           path: ./coverage/

--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Fetch proto-go
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: proto-go
           path: ./api/proto-go
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Fetch proto-go
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: proto-go
           path: ./api/proto-go
@@ -171,7 +171,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Fetch proto-go
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: proto-go
           path: ./api/proto-go
@@ -222,7 +222,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./coverage/
       - name: Handle coverage reports

--- a/internal/apps/ai-proxy/filters/azure-director/filter.go
+++ b/internal/apps/ai-proxy/filters/azure-director/filter.go
@@ -17,6 +17,7 @@ package azure_director
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -262,7 +263,7 @@ func (f *AzureDirector) RewritePath(ctx context.Context) error {
 
 	rewrite, err := strconv.Unquote(f.processorArgs["RewritePath"])
 	if err != nil {
-		return errors.Errorf("failed to get RewritePath args, err: %v", err)
+		return fmt.Errorf("failed to get RewritePath args, err: %v", err)
 	}
 	if rewrite == "" {
 		return nil


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix deprecated actions/upload-artifact@v3 in GitHub CI.


#### Which issue(s) this PR fixes:

- Fixes CI #6487 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Fix deprecated actions/upload-artifact@v3 in GitHub CI.          |
| 🇨🇳 中文    |    修复 GitHub CI 中已弃用的 action/upload-artifact@v3。          |
