### PR TITLE
fix: terminal masking sensitive env leak

### DIFF
--- a/internal/tools/orchestrator/conf/conf.go
+++ b/internal/tools/orchestrator/conf/conf.go
@@ -16,6 +16,7 @@
 package conf
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -54,12 +55,15 @@ type Conf struct {
 	// Conf for scheduler
 	DefaultRuntimeExecutor string `env:"DEFAULT_RUNTIME_EXECUTOR" default:"MARATHON"`
 	// TraceLogEnv shows the key of environment variable defined for tracing log
-	TraceLogEnv           string `env:"TRACELOGENV" default:"TERMINUS_DEFINE_TAG"`
-	WsDiceRootDomain      string `env:"WS_DICE_ROOT_DOMAIN" default:"app.terminus.io,erda.cloud"`
-	TerminalSecurity      bool   `env:"TERMINAL_SECURITY" default:"false"`
-	ExecutorClientTimeout int    `env:"EXECUTOR_CLIENT_TIMEOUT" default:"10"`
-	CustomRegCredSecret   string `env:"CUSTOM_REGCRED_SECRET" default:"regcred"`
-	ErdaNamespace         string `env:"DICE_NAMESPACE" default:"default"`
+	TraceLogEnv               string `env:"TRACELOGENV" default:"TERMINUS_DEFINE_TAG"`
+	WsDiceRootDomain          string `env:"WS_DICE_ROOT_DOMAIN" default:"app.terminus.io,erda.cloud"`
+	TerminalSecurity          bool   `env:"TERMINAL_SECURITY" default:"false"`
+	TerminalMasking           bool   `env:"TERMINAL_MASKING" default:"false"`
+	TerminalSensitiveKeywords string `env:"TERMINAL_SENSITIVE_KEYWORDS" default:""`
+	TerminalMaskKeepFirstChar bool   `env:"TERMINAL_MASK_KEEP_FIRST_CHAR" default:"false"`
+	ExecutorClientTimeout     int    `env:"EXECUTOR_CLIENT_TIMEOUT" default:"10"`
+	CustomRegCredSecret       string `env:"CUSTOM_REGCRED_SECRET" default:"regcred"`
+	ErdaNamespace             string `env:"DICE_NAMESPACE" default:"default"`
 }
 
 var cfg Conf
@@ -196,6 +200,17 @@ func TraceLogEnv() string {
 // TerminalSecurity return cfg.TerminalSecurity
 func TerminalSecurity() bool {
 	return cfg.TerminalSecurity
+}
+func TerminalMasking() bool {
+	return cfg.TerminalMasking
+}
+
+func TerminalSensitiveKeywords() []string {
+	return strings.Split(cfg.TerminalSensitiveKeywords, ",")
+}
+
+func TerminalMaskKeepFirstChar() bool {
+	return cfg.TerminalMaskKeepFirstChar
 }
 
 func ExecutorClientTimeout() time.Duration {

--- a/pkg/security/mask/mask.go
+++ b/pkg/security/mask/mask.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/erda-project/erda/pkg/strutil"
+)
+
+const (
+	thresholdSize = 1024
+)
+
+var (
+	defaultSensitiveEnvKeywords = []string{"pass", "key", "secret", "token", "pwd"}
+	placeholder                 = "*"
+	placeholderLength           = 5
+)
+
+type SensitiveEnv struct {
+	passRegexp       *regexp.Regexp
+	bufferPool       *sync.Pool
+	keywords         []string
+	keepFirstChar    bool
+	stripANSIEscapes bool
+}
+
+type SensitiveEnvOption func(*SensitiveEnv)
+
+func WithKeepFirstChar() SensitiveEnvOption {
+	return func(m *SensitiveEnv) {
+		m.keepFirstChar = true
+	}
+}
+
+func WithStripANSIEscapes() SensitiveEnvOption {
+	return func(m *SensitiveEnv) {
+		m.stripANSIEscapes = true
+	}
+}
+
+func WithKeywords(keywords []string) SensitiveEnvOption {
+	return func(m *SensitiveEnv) {
+		m.keywords = keywords
+	}
+}
+
+func NewSensitiveEnv(options ...SensitiveEnvOption) *SensitiveEnv {
+	m := &SensitiveEnv{
+		bufferPool: &sync.Pool{
+			New: func() any {
+				b := make([]byte, 0, 1024)
+				return &b
+			},
+		},
+	}
+
+	for _, option := range options {
+		option(m)
+	}
+
+	if len(m.keywords) == 0 {
+		m.keywords = defaultSensitiveEnvKeywords
+	}
+
+	pattern := `(?i)(?:` + strings.Join(m.keywords, "|") + `)[^\s\0]*=([^\s\0]+)`
+	m.passRegexp = regexp.MustCompile(pattern)
+	return m
+}
+
+func (m *SensitiveEnv) Process(input []byte) []byte {
+	if m.stripANSIEscapes {
+		input = strutil.StripANSIEscapes(input)
+	}
+
+	if len(input) <= thresholdSize {
+		return m.passRegexp.ReplaceAllFunc(input, m.handler)
+	}
+
+	b := m.bufferPool.Get().(*[]byte)
+	defer m.bufferPool.Put(b)
+	*b = (*b)[:0]
+
+	result := m.passRegexp.ReplaceAllFunc(input, m.handler)
+	*b = append(*b, result...)
+	return *b
+}
+
+func (m *SensitiveEnv) handler(a []byte) []byte {
+	if i := bytes.IndexByte(a, '='); i != -1 {
+		offset := 0
+		if m.keepFirstChar {
+			offset = 1
+		}
+		maskStartIndex := i + offset + 1
+		if len(a) >= maskStartIndex {
+			a = append(a[:maskStartIndex], strings.Repeat(placeholder, placeholderLength-offset)...)
+		}
+	}
+	return a
+}

--- a/pkg/security/mask/mask_test.go
+++ b/pkg/security/mask/mask_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mask
+
+import (
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSensitiveEnv_Options(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []SensitiveEnvOption
+		expected *SensitiveEnv
+	}{
+		{
+			name:    "default options",
+			options: nil,
+			expected: &SensitiveEnv{
+				keywords: defaultSensitiveEnvKeywords,
+			},
+		},
+		{
+			name: "with keep first char",
+			options: []SensitiveEnvOption{
+				WithKeepFirstChar(),
+			},
+			expected: &SensitiveEnv{
+				keywords:      defaultSensitiveEnvKeywords,
+				keepFirstChar: true,
+			},
+		},
+		{
+			name: "with strip ANSI escapes",
+			options: []SensitiveEnvOption{
+				WithStripANSIEscapes(),
+			},
+			expected: &SensitiveEnv{
+				keywords:         defaultSensitiveEnvKeywords,
+				stripANSIEscapes: true,
+			},
+		},
+		{
+			name: "with custom keywords",
+			options: []SensitiveEnvOption{
+				WithKeywords([]string{"password", "api_key"}),
+			},
+			expected: &SensitiveEnv{
+				keywords: []string{"password", "api_key"},
+			},
+		},
+		{
+			name: "with all options",
+			options: []SensitiveEnvOption{
+				WithKeepFirstChar(),
+				WithStripANSIEscapes(),
+				WithKeywords([]string{"password", "api_key"}),
+			},
+			expected: &SensitiveEnv{
+				keywords:         []string{"password", "api_key"},
+				keepFirstChar:    true,
+				stripANSIEscapes: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewSensitiveEnv(tt.options...)
+			assert.Equal(t, tt.expected.keywords, m.keywords)
+			assert.Equal(t, tt.expected.keepFirstChar, m.keepFirstChar)
+			assert.Equal(t, tt.expected.stripANSIEscapes, m.stripANSIEscapes)
+			assert.NotNil(t, m.passRegexp)
+			assert.NotNil(t, m.bufferPool)
+		})
+	}
+}
+
+func TestSensitiveEnv_Process(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		options  []SensitiveEnvOption
+		expected []byte
+	}{
+		{
+			name:     "empty input",
+			input:    []byte(""),
+			options:  nil,
+			expected: []byte(""),
+		},
+		{
+			name:     "no sensitive data",
+			input:    []byte("hello world"),
+			options:  nil,
+			expected: []byte("hello world"),
+		},
+		{
+			name:     "password masking",
+			input:    []byte("password=secret123"),
+			options:  nil,
+			expected: []byte("password=*****"),
+		},
+		{
+			name:     "password masking, with empty value",
+			input:    []byte("password="),
+			options:  nil,
+			expected: []byte("password="),
+		},
+		{
+			name:     "password masking, with only 1 value",
+			input:    []byte("password=1"),
+			options:  nil,
+			expected: []byte("password=*****"),
+		},
+		{
+			name:     "token masking",
+			input:    []byte("api_token=abc123xyz"),
+			options:  nil,
+			expected: []byte("api_token=*****"),
+		},
+		{
+			name:     "keep first char",
+			input:    []byte("password=secret123"),
+			options:  []SensitiveEnvOption{WithKeepFirstChar()},
+			expected: []byte("password=s****"),
+		},
+		{
+			name:     "keep first char when value's length only 1",
+			input:    []byte("password=s"),
+			options:  []SensitiveEnvOption{WithKeepFirstChar()},
+			expected: []byte("password=s****"),
+		},
+		{
+			name:     "custom keywords",
+			input:    []byte("custom_key=value123"),
+			options:  []SensitiveEnvOption{WithKeywords([]string{"custom"})},
+			expected: []byte("custom_key=*****"),
+		},
+		{
+			name:     "multiple sensitive values",
+			input:    []byte("password=secret123 token=abc123"),
+			options:  nil,
+			expected: []byte("password=***** token=*****"),
+		},
+		{
+			name:     "case insensitive",
+			input:    []byte("PASSWORD=secret123 Token=abc123"),
+			options:  nil,
+			expected: []byte("PASSWORD=***** Token=*****"),
+		},
+		{
+			name:     "with ANSI escapes",
+			input:    []byte("MYSQL_\u001B[31mPA\u001B[0mSSWORD=hello123"),
+			options:  []SensitiveEnvOption{WithStripANSIEscapes()},
+			expected: []byte("MYSQL_PASSWORD=*****"),
+		},
+		{
+			name:     "start with ANSI escapes",
+			input:    []byte("\u001B[31mPA\u001B[0mSSWORD=hello123"),
+			options:  []SensitiveEnvOption{WithStripANSIEscapes()},
+			expected: []byte("PASSWORD=*****"),
+		},
+		{
+			name:     "large input",
+			input:    []byte("password=" + strings.Repeat("x", math.MaxUint16)),
+			options:  nil,
+			expected: []byte("password=*****"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewSensitiveEnv(tt.options...)
+			result := m.Process(tt.input)
+			assert.Equal(t, string(tt.expected), string(result))
+		})
+	}
+}
+
+func TestSensitiveEnv_Concurrent(t *testing.T) {
+	m := NewSensitiveEnv()
+	wg := sync.WaitGroup{}
+	concurrency := 100
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result := m.Process([]byte("password=secret123"))
+			assert.Equal(t, "password=*****", string(result))
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/strutil/escape.go
+++ b/pkg/strutil/escape.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil
+
+import "regexp"
+
+const ansiEscapeRegex = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var ansiEscapeRegexp = regexp.MustCompile(ansiEscapeRegex)
+
+func StripANSIEscapes(b []byte) []byte {
+	return ansiEscapeRegexp.ReplaceAll(b, []byte{})
+}
+
+func StripANSIEscapesString(s string) string {
+	return ansiEscapeRegexp.ReplaceAllString(s, "")
+}

--- a/pkg/strutil/escape_test.go
+++ b/pkg/strutil/escape_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strutil
+
+import (
+	"testing"
+)
+
+func TestStripANSIEscapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "No escape sequences",
+			input:    []byte("Hello, World!"),
+			expected: []byte("Hello, World!"),
+		},
+		{
+			name:     "With escape sequences",
+			input:    []byte("\u001B[31mHello, World!\u001B[0m"),
+			expected: []byte("Hello, World!"),
+		},
+		{
+			name:     "Mixed content",
+			input:    []byte("Normal \u001B[31mRed\u001B[0m Text"),
+			expected: []byte("Normal Red Text"),
+		},
+		{
+			name:     "Empty input",
+			input:    []byte(""),
+			expected: []byte(""),
+		},
+		{
+			name:     "With color matched",
+			input:    []byte(`MYSQLX_[01;31m[KPAS[m[KSWORD,ALIYUN_[01;31m[KSECRET[m[K_KEY`),
+			expected: []byte(`MYSQLX_PASSWORD,ALIYUN_SECRET_KEY`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripANSIEscapes(tt.input)
+			if string(result) != string(tt.expected) {
+				t.Errorf("AnsiEscape() = %v, want %v", string(result), string(tt.expected))
+			}
+			stringResult := StripANSIEscapesString(string(tt.input))
+			if stringResult != string(tt.expected) {
+				t.Errorf("AnsiEscape() = %v, want %v", string(result), string(tt.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
1. Fix terminal masking sensitive env leak.
2. Separate masking sensitive output from TerminalSecurity switch. (TERMINAL_MASKING (default: false))
3. Support TERMINAL_SENSITIVE_KEYWORDS (default: ""), TERMINAL_MASK_KEEP_FIRST_CHAR(default: false)


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   fix terminal masking sensitive env leak           |
| 🇨🇳 中文    |       修复控制台遮蔽敏感信息泄漏问题       |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
