### PR TITLE
chore: separate maksing switch from terminal security

### DIFF
--- a/internal/tools/orchestrator/conf/conf.go
+++ b/internal/tools/orchestrator/conf/conf.go
@@ -57,6 +57,7 @@ type Conf struct {
 	TraceLogEnv           string `env:"TRACELOGENV" default:"TERMINUS_DEFINE_TAG"`
 	WsDiceRootDomain      string `env:"WS_DICE_ROOT_DOMAIN" default:"app.terminus.io,erda.cloud"`
 	TerminalSecurity      bool   `env:"TERMINAL_SECURITY" default:"false"`
+	TerminalMasking       bool   `env:"TERMINAL_MASKING" default:"false"`
 	ExecutorClientTimeout int    `env:"EXECUTOR_CLIENT_TIMEOUT" default:"10"`
 	CustomRegCredSecret   string `env:"CUSTOM_REGCRED_SECRET" default:"regcred"`
 	ErdaNamespace         string `env:"DICE_NAMESPACE" default:"default"`
@@ -196,6 +197,10 @@ func TraceLogEnv() string {
 // TerminalSecurity return cfg.TerminalSecurity
 func TerminalSecurity() bool {
 	return cfg.TerminalSecurity
+}
+
+func TerminalMasking() bool {
+	return cfg.TerminalMasking
 }
 
 func ExecutorClientTimeout() time.Duration {

--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/terminal.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/terminal.go
@@ -212,7 +212,7 @@ func (k *Kubernetes) Terminal(namespace, podname, containername string, upperCon
 				return
 			}
 			m[0] = Output
-			if conf.TerminalSecurity() {
+			if conf.TerminalSecurity() || conf.TerminalMasking() {
 				m = hidePassEnv(m)
 			}
 			if err := upperConn.WriteMessage(tp, m); err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
Separate maksing switch from terminal security.
A more robust solution is still under development, and there are no plans to advance it in the short term. [6498](https://github.com/erda-project/erda/pull/6498)

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | separate masking switch from terminal security             |
| 🇨🇳 中文    |    从安全控制台中拆分脱敏开关          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
