### PR TITLE
feat(ai-proxy): add support for OpenAI Responses API

### DIFF
--- a/cmd/ai-proxy/bootstrap.yml
+++ b/cmd/ai-proxy/bootstrap.yml
@@ -8,6 +8,7 @@ erda.app.ai-proxy:
   routes_refs:
     - conf/routes/routes.yml
     - conf/routes/assistant.yml
+    - conf/routes/responses.yml
     - conf/routes/file.yml
     - conf/routes/openai_format.yml
     - conf/routes/internal_apis.yml

--- a/cmd/ai-proxy/conf/routes/responses.yml
+++ b/cmd/ai-proxy/conf/routes/responses.yml
@@ -1,0 +1,62 @@
+routes:
+  - path: /v1/responses
+    method: POST
+    filters:
+      - name: initialize
+      - name: log-http
+      - name: rate-limit
+      - name: context
+      - name: context-responses
+      - name: audit-before-llm-director
+      - name: azure-director
+        config:
+          directors:
+            - TransAuthorization
+            - SetModelAPIVersionIfNotSpecified
+            - DefaultQueries("api-version=2025-03-01-preview")
+            - RewriteScheme
+            - RewriteHost
+            - RewritePath("/openai/responses")
+            - RewriteBodyModelName
+            - ResetContentLength
+      - name: audit-after-llm-director
+      - name: finalize
+
+  - path: /v1/responses/{response_id}
+    method: GET
+    filters:
+      - name: context
+      - name: azure-director
+        config:
+          directors:
+            - TransAuthorization
+            - DefaultQueries("api-version=2025-03-01-preview")
+            - RewriteScheme
+            - RewriteHost
+            - RewritePath("/openai/responses/${ path.response_id }")
+
+  - path: /v1/responses/{response_id}
+    method: DELETE
+    filters:
+      - name: context
+      - name: azure-director
+        config:
+          directors:
+            - TransAuthorization
+            - DefaultQueries("api-version=2025-03-01-preview")
+            - RewriteScheme
+            - RewriteHost
+            - RewritePath("/openai/responses/${ path.response_id }")
+
+  - path: /v1/responses/{response_id}/input_items
+    method: GET
+    filters:
+      - name: context
+      - name: azure-director
+        config:
+          directors:
+            - TransAuthorization
+            - DefaultQueries("api-version=2025-03-01-preview")
+            - RewriteScheme
+            - RewriteHost
+            - RewritePath("/openai/responses/${ path.response_id }/input_items")

--- a/internal/apps/ai-proxy/common/request_path.go
+++ b/internal/apps/ai-proxy/common/request_path.go
@@ -31,6 +31,7 @@ const (
 	RequestPathPrefixV1Files = "/v1/files"
 
 	RequestPathPrefixV1Assistants    = "/v1/assistants"
+	RequestPathPrefixV1Responses     = "/v1/responses"
 	RequestPathPrefixV1Threads       = "/v1/threads"
 	RequestPathV1ThreadCreateMessage = "/v1/threads/{thread_id}/messages"
 )

--- a/internal/apps/ai-proxy/dependent_filters.go
+++ b/internal/apps/ai-proxy/dependent_filters.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context-embedding"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context-file"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context-image"
+	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context-responses"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/dashscope-director"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/erda-auth"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/finalize"

--- a/internal/apps/ai-proxy/filters/azure-director/filter.go
+++ b/internal/apps/ai-proxy/filters/azure-director/filter.go
@@ -336,6 +336,14 @@ func (f *AzureDirector) RewriteBodyModelName(ctx context.Context) error {
 	return nil
 }
 
+func (f *AzureDirector) ResetContentLength(ctx context.Context) error {
+	reverseproxy.AppendDirectors(ctx, func(req *http.Request) {
+		req.Header.Del("Content-Length")
+		req.ContentLength = -1
+	})
+	return nil
+}
+
 func (f *AzureDirector) AllDirectors() map[string]func(ctx context.Context) error {
 	if len(f.funcs) > 0 {
 		return f.funcs

--- a/internal/apps/ai-proxy/filters/context-responses/filter.go
+++ b/internal/apps/ai-proxy/filters/context-responses/filter.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+// ContentType represents the type of content in the message
+type ContentType string
+
+const (
+	Name                             = "context-responses"
+	ContentTypeInputText ContentType = "input_text"
+)
+
+var (
+	_ reverseproxy.RequestFilter = (*Context)(nil)
+)
+
+func init() {
+	reverseproxy.RegisterFilterCreator(Name, New)
+}
+
+type (
+	// Message represents a message in the conversation
+	Message struct {
+		Role    string `json:"role"`
+		Content any    `json:"content"`
+	}
+	// ContentObject represents a content object in the message
+	ContentObject struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+)
+
+type Context struct {
+	Config *Config
+}
+
+type Config struct {
+}
+
+func New(configJSON json.RawMessage) (reverseproxy.Filter, error) {
+	var cfg Config
+	if err := yaml.Unmarshal(configJSON, &cfg); err != nil {
+		return nil, err
+	}
+	return &Context{Config: &cfg}, nil
+}
+
+func (f *Context) OnRequest(ctx context.Context, w http.ResponseWriter, infor reverseproxy.HttpInfor) (signal reverseproxy.Signal, err error) {
+	if common.GetRequestRoutePath(ctx) == common.RequestPathPrefixV1Responses && infor.Method() == http.MethodPost {
+		var req map[string]any
+		if err := json.NewDecoder(infor.BodyBuffer()).Decode(&req); err != nil {
+			return reverseproxy.Intercept, err
+		}
+
+		prompts := make([]string, 0)
+
+		if instructions, ok := req["instructions"].(string); ok && strings.TrimSpace(instructions) != "" {
+			prompts = append(prompts, instructions)
+		}
+
+		// Handle OpenAI Responses API input structure
+		if input, ok := req["input"]; ok {
+			prompts = append(prompts, FindUserPrompts(input)...)
+		}
+
+		ctxhelper.PutUserPrompt(ctx, strings.Join(prompts, "\n"))
+		infor.SetBody2(req)
+	}
+
+	return reverseproxy.Continue, nil
+}
+
+// FindUserPrompts recursively extracts user prompts from OpenAI Responses API structure
+func FindUserPrompts(obj any) []string {
+	if obj == nil {
+		return nil
+	}
+
+	prompts := make([]string, 0)
+	switch v := obj.(type) {
+	case string:
+		if strings.TrimSpace(v) != "" {
+			prompts = append(prompts, v)
+		}
+	case []any:
+		for _, item := range v {
+			if msg, ok := item.(map[string]any); ok {
+				if role, ok := msg["role"].(string); ok && role == "user" {
+					if content, ok := msg["content"]; ok {
+						prompts = append(prompts, extractPromptsFromContent(content)...)
+					}
+				}
+			}
+		}
+	}
+
+	return prompts
+}
+
+// extractPromptsFromContent extracts prompts from content of different types
+func extractPromptsFromContent(content any) []string {
+	prompts := make([]string, 0)
+
+	switch c := content.(type) {
+	case string:
+		if strings.TrimSpace(c) != "" {
+			prompts = append(prompts, c)
+		}
+	case []any:
+		for _, cc := range c {
+			if contentObj, ok := cc.(map[string]any); ok {
+				if contentType, ok := contentObj["type"].(string); ok && ContentType(contentType) == ContentTypeInputText {
+					if text, ok := contentObj["text"].(string); ok && text != "" {
+						prompts = append(prompts, text)
+					}
+				}
+			}
+		}
+	}
+
+	return prompts
+}

--- a/internal/apps/ai-proxy/filters/context-responses/filter_test.go
+++ b/internal/apps/ai-proxy/filters/context-responses/filter_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFindUserPrompts(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "string input",
+			input:    `"hello"`,
+			expected: []string{"hello"},
+		},
+		{
+			name: "array of user messages",
+			input: `[
+				{
+					"role": "user",
+					"content": "hello"
+				},
+				{
+					"role": "assistant",
+					"content": "hi"
+				},
+				{
+					"role": "user",
+					"content": "how are you"
+				}
+			]`,
+			expected: []string{"hello", "how are you"},
+		},
+		{
+			name: "array with mixed content types",
+			input: `[
+				{
+					"role": "user",
+					"content": [
+						{
+							"type": "input_text",
+							"text": "text"
+						},
+						{
+							"type": "input_image",
+ 							"image_url": "https://www.erda.cloud/_next/image?url=%2Fimages%2Flogo-new.png&w=256&q=75"
+						},
+						{
+							"type": "input_text",
+							"text": "more text"
+						}
+					]
+				}
+			]`,
+			expected: []string{"text", "more text"},
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: []string{},
+		},
+		{
+			name:     "null input",
+			input:    `null`,
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var input interface{}
+			if err := json.Unmarshal([]byte(tc.input), &input); err != nil {
+				t.Fatalf("failed to unmarshal input: %v", err)
+			}
+			result := FindUserPrompts(input)
+			if len(result) != len(tc.expected) {
+				t.Errorf("expected %d prompts, got %d", len(tc.expected), len(result))
+				return
+			}
+			for i, prompt := range result {
+				if prompt != tc.expected[i] {
+					t.Errorf("prompt %d: expected %q, got %q", i, tc.expected[i], prompt)
+				}
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/filters/context/filter.go
+++ b/internal/apps/ai-proxy/filters/context/filter.go
@@ -68,14 +68,6 @@ func (f *Context) OnRequest(ctx context.Context, w http.ResponseWriter, infor re
 		m = ctx.Value(reverseproxy.CtxKeyMap{}).(*sync.Map)
 	)
 
-	// check body
-	body := infor.BodyBuffer()
-	if body == nil {
-		err = fmt.Errorf("missing body")
-		l.Error(err)
-		return reverseproxy.Intercept, err
-	}
-
 	// find client
 	var client *clientpb.Client
 	ak := vars.TrimBearer(infor.Header().Get(httputil.HeaderKeyAuthorization))
@@ -144,6 +136,14 @@ func (f *Context) OnRequest(ctx context.Context, w http.ResponseWriter, infor re
 		type Model struct {
 			ModelID string `json:"model"`
 		}
+		// check body
+		body := infor.BodyBuffer()
+		if body == nil {
+			err = fmt.Errorf("missing body")
+			l.Error(err)
+			return reverseproxy.Intercept, err
+		}
+
 		var m Model
 		if err := json.NewDecoder(body).Decode(&m); err == nil {
 			if m.ModelID != "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
- Fix Missing body, will cause method like GET or DELETE.. error.
- Add new route and filters for handling Responses API requests- Implement context filter to extract user prompts from API input
- Update request path constants to include new Responses API endpoint- Add unit tests for new context filter functionality

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=749255&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   add support for OpenAI Responses API           |
| 🇨🇳 中文    |   支持 OpenAI Responses API           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
