### PR TITLE
chore(pipeline): move dbgc config items from pipeline global into provider

### DIFF
--- a/internal/tools/pipeline/conf/conf.go
+++ b/internal/tools/pipeline/conf/conf.go
@@ -99,9 +99,6 @@ type Conf struct {
 	// cron interrupt compensate identification failure time second
 	CronFailureCreateIntervalCompensateTimeSecond int64 `env:"CRON_FAILURE_CREATE_INTERVAL_COMPENSATE_TIME_SECOND" default:"300"`
 
-	// database gc
-	AnalyzedPipelineDefaultDatabaseGCTTLSec uint64 `env:"ANALYZED_PIPELINE_DEFAULT_DATABASE_GC_TTL_SEC" default:"86400"`   // 60 * 60 * 24 analyzed pipeline db record default retains 1 day
-	FinishedPipelineDefaultDatabaseGCTTLSec uint64 `env:"FINISHED_PIPELINE_DEFAULT_DATABASE_GC_TTL_SEC" default:"5184000"` // 60 * 60 * 24 * 30 * 2 finished pipeline db record default retains 2 month
 	// resource gc
 	SuccessPipelineDefaultResourceGCTTLSec uint64 `env:"SUCCESS_PIPELINE_DEFAULT_RESOURCE_GC_TTL_SEC" default:"1800"` // 60 * 30 success pipeline resources default retains 30 min
 	FailedPipelineDefaultResourceGCTTLSec  uint64 `env:"FAILED_PIPELINE_DEFAULT_RESOURCE_GC_TTL_SEC" default:"1800"`  // 60 * 30 failed pipeline resources default retains 30 min
@@ -334,16 +331,6 @@ func CronCompensateConcurrentNumber() int64 {
 
 func CronFailureCreateIntervalCompensateTimeSecond() int64 {
 	return cfg.CronFailureCreateIntervalCompensateTimeSecond
-}
-
-// AnalyzedPipelineDefaultDatabaseGCTTLSec return default database gc ttl for analyzed pipeline record
-func AnalyzedPipelineDefaultDatabaseGCTTLSec() uint64 {
-	return cfg.AnalyzedPipelineDefaultDatabaseGCTTLSec
-}
-
-// FinishedPipelineDefaultDatabaseGCTTLSec return default database gc ttl for finished pipeline record
-func FinishedPipelineDefaultDatabaseGCTTLSec() uint64 {
-	return cfg.FinishedPipelineDefaultDatabaseGCTTLSec
 }
 
 // SuccessPipelineDefaultResourceGCTTLSec return default resource gc for success pipeline

--- a/internal/tools/pipeline/providers/dbgc/dbgc.go
+++ b/internal/tools/pipeline/providers/dbgc/dbgc.go
@@ -28,7 +28,6 @@ import (
 	basepb "github.com/erda-project/erda-proto-go/core/pipeline/base/pb"
 	"github.com/erda-project/erda-proto-go/core/pipeline/pipeline/pb"
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/internal/tools/pipeline/conf"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/db"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/reconciler/rutil"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
@@ -114,7 +113,7 @@ func (p *provider) doAnalyzedPipelineDatabaseGC(ctx context.Context, isSnippetPi
 	req.Status = []string{apistructs.PipelineStatusAnalyzed.String()}
 	req.IncludeSnippet = isSnippetPipeline
 	req.AscCols = []string{"id"}
-	req.EndTimeCreated = timestamppb.New(time.Now().Add(-time.Second * time.Duration(conf.AnalyzedPipelineDefaultDatabaseGCTTLSec())))
+	req.EndTimeCreated = timestamppb.New(time.Now().Add(-p.Cfg.AnalyzedPipelineDefaultDatabaseGCTTLDuration))
 	req.PageSize = 100
 	req.LargePageSize = true
 	req.PageNum = 1
@@ -136,7 +135,7 @@ func (p *provider) doNotAnalyzedPipelineDatabaseGC(ctx context.Context, isSnippe
 	req.NotStatus = []string{apistructs.PipelineStatusAnalyzed.String()}
 	req.IncludeSnippet = isSnippetPipeline
 	req.AscCols = []string{"id"}
-	req.EndTimeCreated = timestamppb.New(time.Now().Add(-time.Second * time.Duration(conf.FinishedPipelineDefaultDatabaseGCTTLSec())))
+	req.EndTimeCreated = timestamppb.New(time.Now().Add(-p.Cfg.FinishedPipelineDefaultDatabaseGCTTLDuration))
 	req.PageSize = 100
 	req.LargePageSize = true
 	req.PageNum = 1

--- a/internal/tools/pipeline/providers/dbgc/dbgc_test.go
+++ b/internal/tools/pipeline/providers/dbgc/dbgc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/db"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/dbgcconfig"
 	"github.com/erda-project/erda/internal/tools/pipeline/spec"
 )
 
@@ -174,7 +175,7 @@ func TestPipelineDatabaseGC(t *testing.T) {
 	})
 	defer pm1.Unpatch()
 	r.dbClient = &db.Client{Client: *DB}
-	r.Cfg = &config{
+	r.Cfg = &dbgcconfig.Config{
 		PipelineDBGCDuration: 3 * time.Second,
 	}
 	r.Log = logrusx.New()

--- a/internal/tools/pipeline/providers/dbgc/dbgcconfig/config.go
+++ b/internal/tools/pipeline/providers/dbgc/dbgcconfig/config.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbgcconfig
+
+import (
+	"time"
+
+	basepb "github.com/erda-project/erda-proto-go/core/pipeline/base/pb"
+)
+
+var (
+	Cfg = &Config{}
+)
+
+type Config struct {
+	// default 2h
+	PipelineDBGCDuration time.Duration `file:"pipeline_dbgc_duration" env:"PIPELINE_DBGC_DURATION" default:"2h"`
+	// default 1 day
+	AnalyzedPipelineArchiveDefaultRetainHour time.Duration `file:"analyzed_pipeline_archive_default_retain_hour" env:"ANALYZED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"24h"`
+	// default 30 day
+	FinishedPipelineArchiveDefaultRetainHour time.Duration `file:"finished_pipeline_archive_default_retain_hour" env:"FINISHED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"720h"`
+
+	// default database gc ttl for analyzed pipeline record: 1 day
+	AnalyzedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"analyzed_pipeline_default_database_gc_ttl_duration" env:"ANALYZED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"24h"`
+	// default database gc ttl for finished pipeline record: 60 day
+	FinishedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"finished_pipeline_default_database_gc_ttl_duration" env:"FINISHED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"1440h"`
+}
+
+func EnsureGCConfig(gc **basepb.PipelineDatabaseGC) {
+	if *gc == nil {
+		*gc = &basepb.PipelineDatabaseGC{}
+	}
+	// analyzed part
+	if (*gc).Analyzed == nil {
+		(*gc).Analyzed = &basepb.PipelineDBGCItem{}
+	}
+	if (*gc).Analyzed.NeedArchive == nil {
+		(*gc).Analyzed.NeedArchive = &[]bool{false}[0]
+	}
+	if (*gc).Analyzed.TTLSecond == nil {
+		(*gc).Analyzed.TTLSecond = &[]uint64{uint64(Cfg.AnalyzedPipelineDefaultDatabaseGCTTLDuration.Seconds())}[0]
+	}
+	// finished part
+	if (*gc).Finished == nil {
+		(*gc).Finished = &basepb.PipelineDBGCItem{}
+	}
+	if (*gc).Finished.NeedArchive == nil {
+		(*gc).Finished.NeedArchive = &[]bool{true}[0]
+	}
+	if (*gc).Finished.TTLSecond == nil {
+		(*gc).Finished.TTLSecond = &[]uint64{uint64(Cfg.FinishedPipelineDefaultDatabaseGCTTLDuration.Seconds())}[0]
+	}
+}

--- a/internal/tools/pipeline/providers/dbgc/dbgcconfig/config_test.go
+++ b/internal/tools/pipeline/providers/dbgc/dbgcconfig/config_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbgcconfig
+
+import (
+	"testing"
+	"time"
+
+	basepb "github.com/erda-project/erda-proto-go/core/pipeline/base/pb"
+)
+
+func TestEnsurePipelineRecordGCConfig(t *testing.T) {
+	Cfg = &Config{
+		AnalyzedPipelineDefaultDatabaseGCTTLDuration: 24 * time.Hour,
+		FinishedPipelineDefaultDatabaseGCTTLDuration: 720 * time.Hour,
+	}
+	cases := []struct {
+		name string
+		gc   *basepb.PipelineDatabaseGC
+	}{
+		{name: "nil", gc: nil},
+		{name: "empty", gc: &basepb.PipelineDatabaseGC{}},
+		{name: "analyzed", gc: &basepb.PipelineDatabaseGC{
+			Analyzed: &basepb.PipelineDBGCItem{
+				NeedArchive: &[]bool{false}[0],
+			},
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			EnsureGCConfig(&c.gc)
+			if c.gc.Analyzed.NeedArchive == nil {
+				t.Errorf("Analyzed.NeedArchive is nil")
+			}
+			if c.gc.Analyzed.TTLSecond == nil {
+				t.Errorf("Analyzed.TTLSecond is nil")
+			}
+			if c.gc.Finished.NeedArchive == nil {
+				t.Errorf("Finished.NeedArchive is nil")
+			}
+			if c.gc.Finished.TTLSecond == nil {
+				t.Errorf("Finished.TTLSecond is nil")
+			}
+		})
+	}
+}

--- a/internal/tools/pipeline/providers/dbgc/provider.go
+++ b/internal/tools/pipeline/providers/dbgc/provider.go
@@ -36,6 +36,11 @@ type config struct {
 	AnalyzedPipelineArchiveDefaultRetainHour time.Duration `file:"analyzed_pipeline_archive_default_retain_hour" env:"ANALYZED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"24h"`
 	// default 30 day
 	FinishedPipelineArchiveDefaultRetainHour time.Duration `file:"finished_pipeline_archive_default_retain_hour" env:"FINISHED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"720h"`
+
+	// default database gc ttl for analyzed pipeline record: 1 day
+	AnalyzedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"analyzed_pipeline_default_database_gc_ttl_duration" env:"ANALYZED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"24h"`
+	// default database gc ttl for finished pipeline record: 60 day
+	FinishedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"finished_pipeline_default_database_gc_ttl_duration" env:"FINISHED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"1440h"`
 }
 
 type provider struct {

--- a/internal/tools/pipeline/providers/dbgc/provider.go
+++ b/internal/tools/pipeline/providers/dbgc/provider.go
@@ -17,34 +17,20 @@ package dbgc
 import (
 	"context"
 	"reflect"
-	"time"
 
 	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda-infra/providers/mysqlxorm"
 	"github.com/erda-project/erda/internal/tools/pipeline/dbclient"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/db"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/dbgcconfig"
 	"github.com/erda-project/erda/internal/tools/pipeline/providers/leaderworker"
 	"github.com/erda-project/erda/pkg/jsonstore"
 	"github.com/erda-project/erda/pkg/jsonstore/etcd"
 )
 
-type config struct {
-	// default 2h
-	PipelineDBGCDuration time.Duration `file:"pipeline_dbgc_duration" env:"PIPELINE_DBGC_DURATION" default:"2h"`
-	// default 1 day
-	AnalyzedPipelineArchiveDefaultRetainHour time.Duration `file:"analyzed_pipeline_archive_default_retain_hour" env:"ANALYZED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"24h"`
-	// default 30 day
-	FinishedPipelineArchiveDefaultRetainHour time.Duration `file:"finished_pipeline_archive_default_retain_hour" env:"FINISHED_PIPELINE_ARCHIVE_RETAIN_HOUR" default:"720h"`
-
-	// default database gc ttl for analyzed pipeline record: 1 day
-	AnalyzedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"analyzed_pipeline_default_database_gc_ttl_duration" env:"ANALYZED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"24h"`
-	// default database gc ttl for finished pipeline record: 60 day
-	FinishedPipelineDefaultDatabaseGCTTLDuration time.Duration `file:"finished_pipeline_default_database_gc_ttl_duration" env:"FINISHED_PIPELINE_DEFAULT_DATABASE_GC_TTL_DURATION" default:"1440h"`
-}
-
 type provider struct {
-	Cfg      *config
+	Cfg      *dbgcconfig.Config
 	Log      logs.Logger
 	js       jsonstore.JsonStore
 	etcd     *etcd.Store
@@ -67,6 +53,9 @@ func (p *provider) Init(ctx servicehub.Context) error {
 	p.etcd = etcdStore
 
 	p.dbClient = &db.Client{Client: dbclient.Client{Engine: p.MySQL.DB()}}
+
+	p.Log.Debugf("dbgc config: %+v", p.Cfg)
+
 	return nil
 }
 
@@ -81,7 +70,7 @@ func init() {
 		Types:        []reflect.Type{reflect.TypeOf((*Interface)(nil)).Elem()},
 		Dependencies: nil,
 		Description:  "pipeline dbgc",
-		ConfigFunc:   func() interface{} { return &config{} },
+		ConfigFunc:   func() interface{} { return dbgcconfig.Cfg },
 		Creator:      func() servicehub.Provider { return &provider{} },
 	})
 }

--- a/internal/tools/pipeline/spec/pipeline.go
+++ b/internal/tools/pipeline/spec/pipeline.go
@@ -24,6 +24,7 @@ import (
 	"github.com/erda-project/erda-proto-go/core/pipeline/base/pb"
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/pipeline/conf"
+	"github.com/erda-project/erda/internal/tools/pipeline/providers/dbgc/dbgcconfig"
 	definitiondb "github.com/erda-project/erda/internal/tools/pipeline/providers/definition/db"
 	sourcedb "github.com/erda-project/erda/internal/tools/pipeline/providers/source/db"
 	"github.com/erda-project/erda/pkg/strutil"
@@ -262,12 +263,6 @@ func (p *Pipeline) GetConfigManageNamespaces() []string {
 // EnsureGC without nil field
 func (p *Pipeline) EnsureGC() {
 	gc := &p.Extra.GC
-	if gc.DatabaseGC == nil {
-		gc.DatabaseGC = &pb.PipelineDatabaseGC{
-			Analyzed: &pb.PipelineDBGCItem{},
-			Finished: &pb.PipelineDBGCItem{},
-		}
-	}
 	if gc.ResourceGC == nil {
 		gc.ResourceGC = &pb.PipelineResourceGC{}
 	}
@@ -279,18 +274,7 @@ func (p *Pipeline) EnsureGC() {
 		gc.ResourceGC.FailedTTLSecond = &[]uint64{conf.FailedPipelineDefaultResourceGCTTLSec()}[0]
 	}
 	// database
-	if gc.DatabaseGC.Analyzed.NeedArchive == nil {
-		gc.DatabaseGC.Analyzed.NeedArchive = &[]bool{false}[0]
-	}
-	if gc.DatabaseGC.Analyzed.TTLSecond == nil {
-		gc.DatabaseGC.Analyzed.TTLSecond = &[]uint64{conf.AnalyzedPipelineDefaultDatabaseGCTTLSec()}[0]
-	}
-	if gc.DatabaseGC.Finished.NeedArchive == nil {
-		gc.DatabaseGC.Finished.NeedArchive = &[]bool{true}[0]
-	}
-	if gc.DatabaseGC.Finished.TTLSecond == nil {
-		gc.DatabaseGC.Finished.TTLSecond = &[]uint64{conf.FinishedPipelineDefaultDatabaseGCTTLSec()}[0]
-	}
+	dbgcconfig.EnsureGCConfig(&gc.DatabaseGC)
 }
 
 func (p *Pipeline) GetResourceGCTTL() uint64 {


### PR DESCRIPTION
#### What this PR does / why we need it:

chore of pipeline:

- move dbgc config items from pipeline global into provider
- convert unit from sec to human-readable time.Duration


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=756918&iterationID=12783&tab=TASK&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    move pipeline dbgc config items from pipeline global into provider         |
| 🇨🇳 中文    |    将散落在 pipeline 全局配置里的 dbgc 配置项移动至 provider 内部          |

