### PR TITLE
feat(auth): add referer validation for UC login direct

### DIFF
--- a/cmd/erda-server/bootstrap.yaml
+++ b/cmd/erda-server/bootstrap.yaml
@@ -165,6 +165,8 @@ openapi-auth-uc:
   platform_protocol: "${DICE_PROTOCOL:https}"
   weight: 100
   redirect_after_login: "${UI_PUBLIC_ADDR}"
+  platform_domain: "${UI_PUBLIC_ADDR}"
+  allowed_referrers: "${ALLOWED_REFERRERS}"
   client_id: "${UC_CLIENT_ID:dice}"
   uc_addr: "${UC_PUBLIC_ADDR}"
   uc_redirect_addrs: "${SELF_PUBLIC_ADDR}"
@@ -178,7 +180,7 @@ openapi-auth-password:
 openapi-over-permission-org-name:
   _enable: ${AUTH_OVER_PERMISSION:true}
   weight: 30
-  default_match_org: ["query:scope","query:scopeId"]
+  default_match_org: [ "query:scope","query:scopeId" ]
 openapi-over-permission-org-id:
   _enable: ${AUTH_OVER_PERMISSION:true}
 openapi-auth-token:

--- a/internal/core/openapi/openapi-ng/auth/uc-session/login.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/login.go
@@ -78,6 +78,11 @@ func (p *provider) LoginCallback(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(rw, cookie)
+	if !p.referMatcher.Match(referer) {
+		http.Error(rw, "invalid referer", http.StatusBadRequest)
+		return
+	}
+
 	http.Redirect(rw, r, referer, http.StatusFound)
 }
 

--- a/internal/core/openapi/openapi-ng/auth/uc-session/refer.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/refer.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucoauth
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type referMatcher struct {
+	allowedSuffixes []string
+	exactDomains    map[string]struct{}
+}
+
+func (p *provider) buildReferMatcher() *referMatcher {
+	r := referMatcher{
+		allowedSuffixes: make([]string, 0),
+		exactDomains: map[string]struct{}{
+			p.Cfg.PlatformDomain: {},
+		},
+	}
+	for _, refer := range p.Cfg.AllowedReferrers {
+		refer = strings.ToLower(strings.TrimSpace(refer))
+		if strings.HasPrefix(refer, "*.") {
+			// wildcard match: "*.test.com" => ".test.com"
+			r.allowedSuffixes = append(r.allowedSuffixes, refer[1:]) // keep `.test.com`
+		} else {
+			r.exactDomains[refer] = struct{}{}
+		}
+	}
+
+	logrus.Infof("allowed referrers: %v, %v", r.allowedSuffixes, r.exactDomains)
+	return &r
+}
+
+func (r *referMatcher) Match(refer string) bool {
+	if refer == "" {
+		return true
+	}
+
+	u, err := url.Parse(refer)
+	if err != nil {
+		logrus.Warnf("illegal referer format %s, %v", refer, err)
+		return false
+	}
+
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+
+	// exact match
+	if _, ok := r.exactDomains[host]; ok {
+		return true
+	}
+
+	// suffix match
+	for _, suffix := range r.allowedSuffixes {
+		if !strings.HasSuffix(host, suffix) || len(host) == len(suffix) {
+			continue
+		}
+		i := len(host) - len(suffix)
+		if i >= 0 && host[i] == '.' {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/core/openapi/openapi-ng/auth/uc-session/refer_test.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/refer_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ucoauth
+
+import "testing"
+
+func TestReferValidate(t *testing.T) {
+	p := provider{
+		Cfg: &config{
+			PlatformDomain: "erda.cloud",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		refer      string
+		allowList  []string
+		wantResult bool
+	}{
+		{
+			name:       "Matching referer with allowList",
+			refer:      "https://sub.erda.cloud/login",
+			allowList:  []string{"sub.erda.cloud"},
+			wantResult: true,
+		},
+		{
+			name:       "Matching platform domain",
+			refer:      "https://erda.cloud/login",
+			wantResult: true,
+		},
+		{
+			name:       "Matching all sub domains",
+			refer:      "https://sub.erda.cloud/login",
+			allowList:  []string{"*.erda.cloud"},
+			wantResult: true,
+		},
+		{
+			name:       "Matching all sub domains list",
+			refer:      "https://b.test.com/login",
+			allowList:  []string{"*.erda.cloud", "*.test.com"},
+			wantResult: true,
+		},
+		{
+			name:       "Missmatch case",
+			refer:      "https://btest.com/login",
+			allowList:  []string{"*.erda.cloud", "*.test.com"},
+			wantResult: false,
+		},
+		{
+			name:       "Non-matching referer with allowList",
+			refer:      "https://test.erda.cloud/login",
+			wantResult: false,
+		},
+		{
+			name:       "Empty referer",
+			refer:      "",
+			wantResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p.Cfg.AllowedReferrers = tt.allowList
+			p.referMatcher = p.buildReferMatcher()
+			got := p.referMatcher.Match(tt.refer)
+			if got != tt.wantResult {
+				t.Errorf("referValidate() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add referMatcher struct and buildReferMatcher method to validate referer
- Implement Match method in referMatcher to check if referer is allowed
- Add refer validation logic in UC login handler
- Update bootstrap.yaml to include platform_domain and allowed_referrers config

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=757954&iterationID=12783&type=TASK)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   add referer validation for UC login direct           |
| 🇨🇳 中文    |     增加 uc 登录跳转后 referer 认证         |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
