### PR TITLE
feat(ai-proxy): support set extra-body for some models

### DIFF
--- a/cmd/ai-proxy/conf/routes/routes.yml
+++ b/cmd/ai-proxy/conf/routes/routes.yml
@@ -42,6 +42,7 @@ routes:
       - name: bailian-director
       - name: dashscope-director
       - name: openai-director
+      - name: extra-body
       - name: audit-after-llm-director
       - name: finalize
   - path: /v1/embeddings

--- a/internal/apps/ai-proxy/dependent_filters.go
+++ b/internal/apps/ai-proxy/dependent_filters.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/context-responses"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/dashscope-director"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/erda-auth"
+	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/extra-body"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/finalize"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/initialize"
 	_ "github.com/erda-project/erda/internal/apps/ai-proxy/filters/log-http"

--- a/internal/apps/ai-proxy/filters/extra-body/filter.go
+++ b/internal/apps/ai-proxy/filters/extra-body/filter.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extra_body
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata"
+	"github.com/erda-project/erda/pkg/http/httputil"
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+const (
+	Name = "extra-body"
+)
+
+var (
+	_ reverseproxy.RequestFilter  = (*ExtraBody)(nil)
+	_ reverseproxy.ResponseFilter = (*ExtraBody)(nil)
+)
+
+func init() {
+	reverseproxy.RegisterFilterCreator(Name, New)
+}
+
+type ExtraBody struct {
+	*reverseproxy.DefaultResponseFilter
+}
+
+func (f *ExtraBody) Enable(ctx context.Context, req *http.Request) bool {
+	return true
+}
+
+func New(_ json.RawMessage) (reverseproxy.Filter, error) {
+	return &ExtraBody{DefaultResponseFilter: reverseproxy.NewDefaultResponseFilter()}, nil
+}
+
+func (f *ExtraBody) OnRequest(ctx context.Context, w http.ResponseWriter, infor reverseproxy.HttpInfor) (signal reverseproxy.Signal, err error) {
+	// handle json body
+	if strings.HasPrefix(infor.Header().Get(httputil.HeaderKeyContentType), string(httputil.ApplicationJson)) {
+		if err := f.setExtraJSONBody(ctx, infor); err != nil {
+			return reverseproxy.Intercept, fmt.Errorf("failed to set extra json body, err: %v", err)
+		}
+		return reverseproxy.Continue, nil
+	}
+
+	// handle other type of body, just pass through
+	return reverseproxy.Continue, nil
+}
+
+func (f *ExtraBody) setExtraJSONBody(ctx context.Context, infor reverseproxy.HttpInfor) error {
+	// handle extra json body
+	var jsonBody map[string]any
+	if err := json.NewDecoder(infor.Body()).Decode(&jsonBody); err != nil {
+		return fmt.Errorf("failed to decode request body, err: %v", err)
+	}
+	commonModelMeta := metadata.FromProtobuf(ctxhelper.MustGetModel(ctx).Metadata)
+	if err := FulfillExtraJSONBody(&commonModelMeta, ctxhelper.GetIsStream(ctx), jsonBody); err != nil {
+		return fmt.Errorf("failed to fulfill extra json body, err: %v", err)
+	}
+	b, err := json.Marshal(jsonBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body, err: %v", err)
+	}
+	infor.SetBody2(b)
+
+	return nil
+}

--- a/internal/apps/ai-proxy/filters/extra-body/json_body.go
+++ b/internal/apps/ai-proxy/filters/extra-body/json_body.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extra_body
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata"
+)
+
+const (
+	MetadataPublicKeyExtraJSONBodyForStream    = "extra_json_body_for_stream"
+	MetadataPublicKeyExtraJSONBodyForNonStream = "extra_json_body_for_non_stream"
+)
+
+// GetExtraJSONBody get extra json body from metadata.
+// For stream, field name is: "extra_json_body_for_stream"
+// For non-stream, field name is: "extra_json_body_for_non_stream"
+func GetExtraJSONBody(m *metadata.Metadata, isStream bool) (map[string]any, error) {
+	key := MetadataPublicKeyExtraJSONBodyForNonStream
+	if isStream {
+		key = MetadataPublicKeyExtraJSONBodyForStream
+	}
+	return unmarshalJSONFromString(m.Public[key])
+}
+
+func FulfillExtraJSONBody(m *metadata.Metadata, isStream bool, body map[string]any) error {
+	if body == nil {
+		return nil
+	}
+	extra_json_body, err := GetExtraJSONBody(m, isStream)
+	if err != nil {
+		return fmt.Errorf("failed to get extra json body, err: %v", err)
+	}
+	// iterate key in extra_json_body, only set key if key not exist in body
+	for k, v := range extra_json_body {
+		if _, ok := body[k]; !ok {
+			body[k] = v
+		}
+	}
+	return nil
+}
+
+// unmarshalJSONFromString unmarshal json string to map[string]any
+func unmarshalJSONFromString(s string) (map[string]any, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var jsonObj map[string]any
+	if err := json.Unmarshal([]byte(s), &jsonObj); err != nil {
+		return nil, err
+	}
+	return jsonObj, nil
+}

--- a/internal/apps/ai-proxy/filters/extra-body/json_body_test.go
+++ b/internal/apps/ai-proxy/filters/extra-body/json_body_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extra_body
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata"
+)
+
+func compare_map(got, want map[string]any) bool {
+	gotStr, err := json.Marshal(got)
+	if err != nil {
+		return false
+	}
+	wantStr, err := json.Marshal(want)
+	if err != nil {
+		return false
+	}
+	return string(gotStr) == string(wantStr)
+}
+
+func Test_unmarshalJSONFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "empty {}",
+			args: args{
+				s: `{}`,
+			},
+			want:    map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "extra json body for non-stream",
+			args: args{
+				s: `{"enable_thinking": true, "thinking_budget": 31334}`,
+			},
+			want:    map[string]any{"enable_thinking": true, "thinking_budget": 31334},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalJSONFromString(tt.args.s)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unmarshalJSONFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !compare_map(got, tt.want) {
+				t.Errorf("unmarshalJSONFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetExtraJSONBody(t *testing.T) {
+	type args struct {
+		m        *metadata.Metadata
+		isStream bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "extra json body for non-stream",
+			args: args{
+				m: &metadata.Metadata{
+					Public: map[string]string{
+						"extra_json_body_for_non_stream": `{"enable_thinking": false}`,
+					},
+				},
+				isStream: false,
+			},
+			want:    map[string]any{"enable_thinking": false},
+			wantErr: false,
+		},
+		{
+			name: "extra json body for stream",
+			args: args{
+				m: &metadata.Metadata{
+					Public: map[string]string{
+						"extra_json_body_for_stream": `{"enable_thinking": true, "thinking_budget": 31334}`,
+					},
+				},
+				isStream: true,
+			},
+			want:    map[string]any{"thinking_budget": 31334, "enable_thinking": true},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetExtraJSONBody(tt.args.m, tt.args.isStream)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetExtraJSONBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !compare_map(got, tt.want) {
+				t.Errorf("GetExtraJSONBody() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFulfillExtraJSONBody(t *testing.T) {
+	type args struct {
+		m        *metadata.Metadata
+		isStream bool
+		body     map[string]any
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "add new extra json body",
+			args: args{
+				m: &metadata.Metadata{
+					Public: map[string]string{
+						"extra_json_body_for_non_stream": `{"enable_thinking": false}`,
+					},
+				},
+				isStream: false,
+				body:     map[string]any{},
+			},
+			want:    map[string]any{"enable_thinking": false},
+			wantErr: false,
+		},
+		{
+			name: "override extra json body",
+			args: args{
+				m: &metadata.Metadata{
+					Public: map[string]string{
+						"extra_json_body_for_non_stream": `{"enable_thinking": false}`,
+					},
+				},
+				isStream: false,
+				body:     map[string]any{"enable_thinking": true},
+			},
+			want:    map[string]any{"enable_thinking": false},
+			wantErr: false,
+		},
+		{
+			name: "stream type mismatch",
+			args: args{
+				m: &metadata.Metadata{
+					Public: map[string]string{
+						"extra_json_body_for_non_stream": `{"enable_thinking": false}`,
+					},
+				},
+				isStream: true,
+				body:     map[string]any{"thinking_budget": 31334},
+			},
+			want:    map[string]any{"thinking_budget": 31334},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := FulfillExtraJSONBody(tt.args.m, tt.args.isStream, tt.args.body); (err != nil) != tt.wantErr {
+				t.Errorf("FulfillExtraJSONBody() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/filters/extra-body/json_body_test.go
+++ b/internal/apps/ai-proxy/filters/extra-body/json_body_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata"
 )
 
@@ -44,11 +46,19 @@ func Test_unmarshalJSONFromString(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "empty {}",
+			name: "{}",
 			args: args{
 				s: `{}`,
 			},
 			want:    map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "empty string",
+			args: args{
+				s: "",
+			},
+			want:    nil,
 			wantErr: false,
 		},
 		{
@@ -188,4 +198,12 @@ func TestFulfillExtraJSONBody(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRangeNilMap(t *testing.T) {
+	body := map[string]any{}
+	assert.Nil(t, body["not_exist"])
+
+	body = nil
+	assert.Nil(t, body["not_exist"])
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

ai-proxy support set extra-body for some models.

such as: qwen3-235b-a22b non-stream set unofficial `enable-thinking=false` as default.

default configs configured at model's public metadata:

<img width="526" alt="image" src="https://github.com/user-attachments/assets/99b1ce14-c932-4e87-ad78-c1e1403d061c" />


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=759363&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   ai-proxy  support set extra-body for some models          |
| 🇨🇳 中文    |    ai-proxy 支持为模型设置额外 request body          |
