### PR TITLE
feat(ai-proxy): Anthropic-Compatible Director support Thinking config

### DIFF
--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/anthropic_official/anthropic.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/anthropic_official/anthropic.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sashabaranov/go-openai"
 
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
-	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
 	"github.com/erda-project/erda/pkg/reverseproxy"
@@ -42,16 +42,16 @@ const (
 )
 
 type AnthropicRequest struct {
-	Model         string                    `json:"model"`
-	Messages      []common.AnthropicMessage `json:"messages"`
-	MaxTokens     int                       `json:"max_tokens"`
-	StopSequences []string                  `json:"stop_sequences,omitempty"`
-	Stream        bool                      `json:"stream"`
-	System        string                    `json:"system,omitempty"`
-	Temperature   float32                   `json:"temperature"`
-	ToolChoice    any                       `json:"tool_choice,omitempty"`
-	Tools         any                       `json:"tools,omitempty"`
-	TopP          float32                   `json:"top_p,omitempty"`
+	Model         string                               `json:"model"`
+	Messages      []message_converter.AnthropicMessage `json:"messages"`
+	MaxTokens     int                                  `json:"max_tokens"`
+	StopSequences []string                             `json:"stop_sequences,omitempty"`
+	Stream        bool                                 `json:"stream"`
+	System        string                               `json:"system,omitempty"`
+	Temperature   float32                              `json:"temperature"`
+	ToolChoice    any                                  `json:"tool_choice,omitempty"`
+	Tools         any                                  `json:"tools,omitempty"`
+	TopP          float32                              `json:"top_p,omitempty"`
 }
 
 type AnthropicResponse struct {
@@ -139,7 +139,7 @@ func (f *AnthropicDirector) OfficialDirector(ctx context.Context, infor reversep
 			case openai.ChatMessageRoleSystem:
 				systemPrompts = append(systemPrompts, msg.Content)
 			default:
-				bedrockMsg, err := common.ConvertOneOpenAIMessage(msg)
+				bedrockMsg, err := message_converter.ConvertOneOpenAIMessage(msg)
 				if err != nil {
 					panic(fmt.Errorf("failed to convert openai message to bedrock message: %v", err))
 				}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/aws_bedrock/bedrock.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/aws_bedrock/bedrock.go
@@ -31,12 +31,10 @@ import (
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/smithy-go/logging"
-	"github.com/sashabaranov/go-openai"
 
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended"
-	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
 	"github.com/erda-project/erda/pkg/reverseproxy"
@@ -45,62 +43,18 @@ import (
 const (
 	APIVendor api_style.APIVendor = "aws-bedrock"
 
-	defaultMaxTokens      = 10240
-	defaultTemperature    = 1.0
 	defaultBedrockVersion = "bedrock-2023-05-31"
 )
 
 type BedrockRequest struct {
-	System           string                               `json:"system,omitempty"`
-	Messages         []message_converter.AnthropicMessage `json:"messages"`
-	MaxTokens        int                                  `json:"max_tokens"`
-	Temperature      float32                              `json:"temperature"`
-	TopP             float32                              `json:"top_p,omitempty"`
-	Tools            any                                  `json:"tools,omitempty"`
-	ToolChoice       any                                  `json:"tool_choice,omitempty"`
-	StopSequences    []string                             `json:"stop_sequences,omitempty"`
-	AnthropicVersion string                               `json:"anthropic_version"`
-
-	*thinking.AnthropicThinking
-}
-
-type BedrockResponse struct {
-	ID      string           `json:"id"`
-	Type    string           `json:"type"` // always "message"
-	Role    string           `json:"role"` // always "assistant"
-	Content []map[string]any `json:"content"`
-}
-
-func (r BedrockResponse) ConvertToOpenAIFormat(modelID string) (openai.ChatCompletionResponse, error) {
-	openaiResp := openai.ChatCompletionResponse{
-		ID:      r.ID,
-		Object:  "chat.completions", // always
-		Created: time.Now().Unix(),
-		Model:   modelID,
-	}
-	// choices
-	var choices []openai.ChatCompletionChoice
-	for _, anthropicContentPart := range r.Content {
-		anthropicMsg := message_converter.AnthropicResponseMessage{
-			Role:    r.Role,
-			Content: anthropicContentPart,
-		}
-		openaiMsg, err := message_converter.ConvertAnthropicResponseMessageToOpenAIFormat(anthropicMsg)
-		if err != nil {
-			return openaiResp, fmt.Errorf("failed to convert anthropic response message to openai format: %v", err)
-		}
-		choices = append(choices, openai.ChatCompletionChoice{Message: openaiMsg})
-	}
-	openaiResp.Choices = choices
-	return openaiResp, nil
+	message_converter.BaseAnthropicRequest
+	AnthropicVersion string `json:"anthropic_version"`
 }
 
 type BedrockDirector struct {
 	*reverseproxy.DefaultResponseFilter
 
-	StreamMessageID    string
-	StreamMessageModel string
-	StreamMessageRole  string
+	StreamMessageInfo message_converter.AnthropicStreamMessageInfo
 }
 
 func NewDirector() *BedrockDirector {
@@ -119,45 +73,11 @@ func (f *BedrockDirector) AwsBedrockDirector(ctx context.Context, infor reversep
 			panic(fmt.Errorf("failed to decode request body as openai format, err: %v", err))
 		}
 		// convert to: anthropic format request
+		baseAnthropicReq := message_converter.ConvertOpenAIRequestToBaseAnthropicRequest(openaiReq)
 		bedrockReq := BedrockRequest{
-			MaxTokens:        openaiReq.MaxTokens,
-			Temperature:      openaiReq.Temperature,
-			TopP:             openaiReq.TopP,
-			StopSequences:    openaiReq.Stop,
-			AnthropicVersion: defaultBedrockVersion,
+			BaseAnthropicRequest: baseAnthropicReq,
+			AnthropicVersion:     defaultBedrockVersion,
 		}
-		if openaiReq.Temperature <= 0 {
-			bedrockReq.Temperature = defaultTemperature
-		}
-		if openaiReq.MaxTokens <= 1 {
-			bedrockReq.MaxTokens = defaultMaxTokens
-		}
-		// tool
-		if len(openaiReq.Tools) > 0 {
-			bedrockReq.Tools = openaiReq.Tools
-		}
-		if openaiReq.ToolChoice != nil {
-			bedrockReq.ToolChoice = openaiReq.ToolChoice
-		}
-		// split system prompt out, keep user / assistant messages
-		var systemPrompts []string
-		for _, msg := range openaiReq.Messages {
-			switch msg.Role {
-			case openai.ChatMessageRoleSystem:
-				systemPrompts = append(systemPrompts, msg.Content)
-			default:
-				bedrockMsg, err := message_converter.ConvertOneOpenAIMessage(msg)
-				if err != nil {
-					panic(fmt.Errorf("failed to convert openai message to bedrock message: %v", err))
-				}
-				bedrockReq.Messages = append(bedrockReq.Messages, *bedrockMsg)
-			}
-		}
-		if len(systemPrompts) > 0 {
-			bedrockReq.System = strings.Join(systemPrompts, "\n")
-		}
-		// thinking
-		bedrockReq.AnthropicThinking = thinking.UnifiedGetThinkingConfigs(openaiReq).ToAnthropicThinking()
 
 		anthropicReqBytes, err := json.Marshal(&bedrockReq)
 		if err != nil {
@@ -248,7 +168,7 @@ func (f *BedrockDirector) OnResponseEOF(ctx context.Context, infor reverseproxy.
 	// only stream style need append [DONE] chunk
 	if !ctxhelper.GetIsStream(ctx) {
 		// convert all at once
-		var bedrockResp BedrockResponse
+		var bedrockResp message_converter.AnthropicResponse
 		if err := json.Unmarshal(f.DefaultResponseFilter.Buffer.Bytes(), &bedrockResp); err != nil {
 			return fmt.Errorf("failed to unmarshal response body: %s, err: %v", string(chunk), err)
 		}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/aws_bedrock/bedrock_test.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/aws_bedrock/bedrock_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -96,4 +97,25 @@ func (t *DumpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	d := http.DefaultTransport
 	d.(*http.Transport).ForceAttemptHTTP2 = true
 	return d.RoundTrip(req)
+}
+
+func TestBedrockRequestThinkingUnmarshal(t *testing.T) {
+	payload := `{}`
+	var bedrockReq BedrockRequest
+	err := json.Unmarshal([]byte(payload), &bedrockReq)
+	assert.NoError(t, err)
+	assert.Nil(t, bedrockReq.AnthropicThinking)
+
+	payload = `{"thinking": {"type": "enabled", "budget_tokens": 1000}}`
+	err = json.Unmarshal([]byte(payload), &bedrockReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, bedrockReq.AnthropicThinking)
+	assert.Equal(t, "enabled", bedrockReq.AnthropicThinking.Thinking.Type)
+	assert.Equal(t, 1000, bedrockReq.AnthropicThinking.Thinking.BudgetTokens)
+
+	// payload = `{"thinking": {"type": "disabled"}}`
+	// err = json.Unmarshal([]byte(payload), &bedrockReq)
+	// assert.NoError(t, err)
+	// assert.NotNil(t, bedrockReq.AnthropicThinking)
+	// assert.Equal(t, "disabled", bedrockReq.AnthropicThinking.Thinking.Type)
 }

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/req.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/req.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package message_converter
 
 import (
 	"strings"
@@ -48,6 +48,7 @@ func ConvertOneOpenAIMessage(openaiMsg openai.ChatCompletionMessage) (*Anthropic
 			contentParts = append(contentParts, bedrockPart)
 		case openai.ChatMessagePartTypeImageURL:
 			// get media_type and base64 content from url
+			// url format: data:image/${media_type};base64,${base64_content}
 			ss := strings.SplitN(part.ImageURL.URL, ";", 2)
 			mediaType := strings.TrimPrefix(ss[0], "data:")
 			base64Content := strings.TrimPrefix(ss[1], "base64,")

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/req.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/req.go
@@ -18,10 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended"
-
 	"github.com/sashabaranov/go-openai"
 
+	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking"
 )
 

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
@@ -15,26 +15,107 @@
 package message_converter
 
 import (
+	"encoding/json"
+	"fmt"
+	"time"
+
 	"github.com/sashabaranov/go-openai"
 )
 
-// AnthropicResponseMessage is the message format of anthropic response.
-// see: https://docs.anthropic.com/en/api/messages#response-content
-type AnthropicResponseMessage struct {
-	Role    string         `json:"role"`
-	Content map[string]any `json:"content"`
+type AnthropicResponse struct {
+	ID      string                         `json:"id"`
+	Type    string                         `json:"type"` // always "message"
+	Role    string                         `json:"role"` // always "assistant"
+	Content []AnthropicResponseContentPart `json:"content"`
 }
 
-func ConvertAnthropicResponseMessageToOpenAIFormat(anthropicMsg AnthropicResponseMessage) (openai.ChatCompletionMessage, error) {
-	var openaiMsg openai.ChatCompletionMessage
-	openaiMsg.Role = anthropicMsg.Role
+func (r AnthropicResponse) ConvertToOpenAIFormat(modelID string) (openai.ChatCompletionResponse, error) {
+	openaiResp := openai.ChatCompletionResponse{
+		ID:      r.ID,
+		Object:  "chat.completions", // always
+		Created: time.Now().Unix(),
+		Model:   modelID,
+	}
+	// choices
+	var choices []openai.ChatCompletionChoice
+	for _, anthropicContentPart := range r.Content {
+		anthropicContentPart := anthropicContentPart
+		openaiMsg, err := ConvertAnthropicResponseMessageToOpenAIFormat(r.Role, anthropicContentPart)
+		if err != nil {
+			return openaiResp, fmt.Errorf("failed to convert anthropic response message to openai format: %v", err)
+		}
+		choices = append(choices, openai.ChatCompletionChoice{Message: openaiMsg})
+	}
+	openaiResp.Choices = choices
+	return openaiResp, nil
+}
 
-	switch anthropicMsg.Content["type"].(string) {
+// AnthropicResponseContentPart is the message format of anthropic response.
+// see: https://docs.anthropic.com/en/api/messages#response-content
+type AnthropicResponseContentPart map[string]any
+
+func ConvertAnthropicResponseMessageToOpenAIFormat(role string, anthropicContentPart AnthropicResponseContentPart) (openai.ChatCompletionMessage, error) {
+	var openaiMsg openai.ChatCompletionMessage
+	openaiMsg.Role = role
+
+	switch anthropicContentPart["type"].(string) {
 	case "text":
-		openaiMsg.Content = anthropicMsg.Content["text"].(string)
+		openaiMsg.Content = anthropicContentPart["text"].(string)
 	case "thinking": // https://docs.anthropic.com/en/api/messages#thinking
-		openaiMsg.ReasoningContent = anthropicMsg.Content["thinking"].(string)
+		openaiMsg.ReasoningContent = anthropicContentPart["thinking"].(string)
 	}
 
 	return openaiMsg, nil
+}
+
+type AnthropicStreamMessageInfo struct {
+	ID    string
+	Model string
+	Role  string
+}
+
+func ConvertStreamChunkDataToOpenAIChunk(anthropicDataRaw []byte, inputMsgInfo AnthropicStreamMessageInfo) (*AnthropicStreamMessageInfo, *openai.ChatCompletionStreamResponse, error) {
+	var rawObj map[string]any
+	if err := json.Unmarshal(anthropicDataRaw, &rawObj); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse raw, err: %v", err)
+	}
+
+	switch rawObj["type"].(string) {
+	case "message_start":
+		// get message id and model
+		var gotMsgInfo AnthropicStreamMessageInfo
+		gotMsgInfo.ID = rawObj["message"].(map[string]any)["id"].(string)
+		gotMsgInfo.Model = rawObj["message"].(map[string]any)["model"].(string)
+		gotMsgInfo.Role = rawObj["message"].(map[string]any)["role"].(string)
+		return &gotMsgInfo, nil, nil
+	case "content_block_delta":
+		openaiChunk := openai.ChatCompletionStreamResponse{
+			ID:      inputMsgInfo.ID,
+			Object:  "chat.completion.chunk", // fixed
+			Created: time.Now().Unix(),
+			Model:   inputMsgInfo.Model,
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionStreamChoiceDelta{
+						Role: inputMsgInfo.Role,
+					},
+				},
+			},
+		}
+		// get delta
+		deltaObj := rawObj["delta"].(map[string]any)
+		switch deltaObj["type"].(string) {
+		case "text_delta":
+			openaiChunk.Choices[0].Delta.Content = deltaObj["text"].(string)
+		case "thinking_delta":
+			openaiChunk.Choices[0].Delta.ReasoningContent = deltaObj["thinking"].(string)
+		default:
+			return nil, nil, nil
+		}
+		return nil, &openaiChunk, nil
+
+	default:
+		return nil, nil, nil
+	}
 }

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package message_converter
+
+import (
+	"github.com/sashabaranov/go-openai"
+)
+
+// AnthropicResponseMessage is the message format of anthropic response.
+// see: https://docs.anthropic.com/en/api/messages#response-content
+type AnthropicResponseMessage struct {
+	Role    string         `json:"role"`
+	Content map[string]any `json:"content"`
+}
+
+func ConvertAnthropicResponseMessageToOpenAIFormat(anthropicMsg AnthropicResponseMessage) (openai.ChatCompletionMessage, error) {
+	var openaiMsg openai.ChatCompletionMessage
+	openaiMsg.Role = anthropicMsg.Role
+
+	switch anthropicMsg.Content["type"].(string) {
+	case "text":
+		openaiMsg.Content = anthropicMsg.Content["text"].(string)
+	case "thinking": // https://docs.anthropic.com/en/api/messages#thinking
+		openaiMsg.ReasoningContent = anthropicMsg.Content["thinking"].(string)
+	}
+
+	return openaiMsg, nil
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/openai_extended.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/openai_extended.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openai_extended
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type OpenAIRequestExtended struct {
+	openai.ChatCompletionRequest
+
+	// ExtraFields is used to store extra fields that are not part of the original OpenAI request.
+	ExtraFields map[string]any `json:"extra_fields,omitempty"` // used to store extra fields that are not part of the original OpenAI request
+}
+
+func (m *OpenAIRequestExtended) UnmarshalJSON(data []byte) error {
+	type Alias OpenAIRequestExtended // avoid infinite recursion
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// decode to map, to extract extra fields
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// dynamically collect known fields from ChatCompletionRequest
+	known := make(map[string]struct{})
+	t := reflect.TypeOf(openai.ChatCompletionRequest{})
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("json")
+		if tag != "" {
+			name := strings.Split(tag, ",")[0]
+			if name != "" && name != "-" {
+				known[name] = struct{}{}
+			}
+		}
+	}
+
+	m.ExtraFields = make(map[string]any)
+	for k, v := range raw {
+		if _, ok := known[k]; !ok {
+			m.ExtraFields[k] = v
+		}
+	}
+
+	return nil
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thinking
+
+import (
+	"github.com/erda-project/erda-infra/providers/component-protocol/utils/cputil"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended"
+)
+
+// UnifiedGetThinkingConfigs get thinking configs from extra fields.
+// Currently, we support below styles:
+// - Anthropic Thinking
+// - Qwen
+func UnifiedGetThinkingConfigs(req openai_extended.OpenAIRequestExtended) *Thinking {
+	if len(req.ExtraFields) == 0 {
+		return nil
+	}
+
+	// get first non-nil thinking configs
+	getters := []ThinkingGetter{
+		getThinkingFromAnthropicStyle,
+		getThinkingFromQwenStyle,
+	}
+	for _, getter := range getters {
+		thinking := getter(req)
+		if thinking != nil {
+			return thinking
+		}
+	}
+	return nil
+}
+
+type ThinkingGetter func(req openai_extended.OpenAIRequestExtended) *Thinking
+
+var getThinkingFromAnthropicStyle = func(req openai_extended.OpenAIRequestExtended) *Thinking {
+	var anthropicThinking AnthropicThinking
+	cputil.MustObjJSONTransfer(req.ExtraFields, &anthropicThinking)
+	if anthropicThinking.Thinking == nil {
+		return nil
+	}
+	return &Thinking{Thinking: anthropicThinking.Thinking}
+}
+
+var getThinkingFromQwenStyle = func(req openai_extended.OpenAIRequestExtended) *Thinking {
+	var qwenThinking QwenThinking
+	cputil.MustObjJSONTransfer(req.ExtraFields, &qwenThinking)
+	if qwenThinking.EnableThinking == nil {
+		return nil
+	}
+	return &Thinking{Thinking: &AnthropicThinkingInternal{
+		Type: func() string {
+			if *qwenThinking.EnableThinking {
+				return "enabled"
+			}
+			return "disabled"
+		}(),
+		BudgetTokens: qwenThinking.ThinkingBudget,
+	}}
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter.go
@@ -23,7 +23,7 @@ import (
 // Currently, we support below styles:
 // - Anthropic Thinking
 // - Qwen
-func UnifiedGetThinkingConfigs(req openai_extended.OpenAIRequestExtended) *Thinking {
+func UnifiedGetThinkingConfigs(req openai_extended.OpenAIRequestExtended) *UnifiedThinking {
 	if len(req.ExtraFields) == 0 {
 		return nil
 	}
@@ -42,24 +42,24 @@ func UnifiedGetThinkingConfigs(req openai_extended.OpenAIRequestExtended) *Think
 	return nil
 }
 
-type ThinkingGetter func(req openai_extended.OpenAIRequestExtended) *Thinking
+type ThinkingGetter func(req openai_extended.OpenAIRequestExtended) *UnifiedThinking
 
-var getThinkingFromAnthropicStyle = func(req openai_extended.OpenAIRequestExtended) *Thinking {
+var getThinkingFromAnthropicStyle = func(req openai_extended.OpenAIRequestExtended) *UnifiedThinking {
 	var anthropicThinking AnthropicThinking
 	cputil.MustObjJSONTransfer(req.ExtraFields, &anthropicThinking)
 	if anthropicThinking.Thinking == nil {
 		return nil
 	}
-	return &Thinking{Thinking: anthropicThinking.Thinking}
+	return &UnifiedThinking{Thinking: anthropicThinking.Thinking}
 }
 
-var getThinkingFromQwenStyle = func(req openai_extended.OpenAIRequestExtended) *Thinking {
+var getThinkingFromQwenStyle = func(req openai_extended.OpenAIRequestExtended) *UnifiedThinking {
 	var qwenThinking QwenThinking
 	cputil.MustObjJSONTransfer(req.ExtraFields, &qwenThinking)
 	if qwenThinking.EnableThinking == nil {
 		return nil
 	}
-	return &Thinking{Thinking: &AnthropicThinkingInternal{
+	return &UnifiedThinking{Thinking: &AnthropicThinkingInternal{
 		Type: func() string {
 			if *qwenThinking.EnableThinking {
 				return "enabled"

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter_test.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thinking
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended"
+)
+
+func TestUnifiedGetThinkingConfigs(t *testing.T) {
+	type args struct {
+		req openai_extended.OpenAIRequestExtended
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Thinking
+	}{
+		{
+			name: "anthropic style: enabled",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: map[string]any{
+						"thinking": map[string]any{
+							"type":          "enabled",
+							"budget_tokens": 100,
+						},
+					},
+				},
+			},
+			want: &Thinking{
+				Thinking: &AnthropicThinkingInternal{
+					Type:         "enabled",
+					BudgetTokens: 100,
+				},
+			},
+		},
+		{
+			name: "anthropic style: disabled",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: map[string]any{
+						"thinking": map[string]any{
+							"type":          "disabled",
+							"budget_tokens": 100,
+						},
+					},
+				},
+			},
+			want: &Thinking{
+				Thinking: &AnthropicThinkingInternal{
+					Type:         "disabled",
+					BudgetTokens: 100,
+				},
+			},
+		},
+		{
+			name: "qwen style: enabled",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: map[string]any{
+						"enable_thinking": true,
+						"thinking_budget": 1000,
+					},
+				},
+			},
+			want: &Thinking{
+				Thinking: &AnthropicThinkingInternal{
+					Type:         "enabled",
+					BudgetTokens: 1000,
+				},
+			},
+		},
+		{
+			name: "qwen style: disabled",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: map[string]any{
+						"enable_thinking": false,
+						"thinking_budget": 1000,
+					},
+				},
+			},
+			want: &Thinking{
+				Thinking: &AnthropicThinkingInternal{
+					Type:         "disabled",
+					BudgetTokens: 1000,
+				},
+			},
+		},
+		{
+			name: "not set: extra fields is empty",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: map[string]any{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "not set: extra fields is nil",
+			args: args{
+				req: openai_extended.OpenAIRequestExtended{
+					ExtraFields: nil,
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UnifiedGetThinkingConfigs(tt.args.req); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UnifiedGetThinkingConfigs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter_test.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/getter_test.go
@@ -28,7 +28,7 @@ func TestUnifiedGetThinkingConfigs(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *Thinking
+		want *UnifiedThinking
 	}{
 		{
 			name: "anthropic style: enabled",
@@ -42,7 +42,7 @@ func TestUnifiedGetThinkingConfigs(t *testing.T) {
 					},
 				},
 			},
-			want: &Thinking{
+			want: &UnifiedThinking{
 				Thinking: &AnthropicThinkingInternal{
 					Type:         "enabled",
 					BudgetTokens: 100,
@@ -61,7 +61,7 @@ func TestUnifiedGetThinkingConfigs(t *testing.T) {
 					},
 				},
 			},
-			want: &Thinking{
+			want: &UnifiedThinking{
 				Thinking: &AnthropicThinkingInternal{
 					Type:         "disabled",
 					BudgetTokens: 100,
@@ -78,7 +78,7 @@ func TestUnifiedGetThinkingConfigs(t *testing.T) {
 					},
 				},
 			},
-			want: &Thinking{
+			want: &UnifiedThinking{
 				Thinking: &AnthropicThinkingInternal{
 					Type:         "enabled",
 					BudgetTokens: 1000,
@@ -95,7 +95,7 @@ func TestUnifiedGetThinkingConfigs(t *testing.T) {
 					},
 				},
 			},
-			want: &Thinking{
+			want: &UnifiedThinking{
 				Thinking: &AnthropicThinkingInternal{
 					Type:         "disabled",
 					BudgetTokens: 1000,

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
@@ -14,12 +14,27 @@
 
 package thinking
 
-// Thinking is the unified thinking configs.
+// UnifiedThinking is the unified thinking configs.
 // Distinguish:
 // - not-set
 // - enable
 // - disable
-type Thinking AnthropicThinking
+type UnifiedThinking AnthropicThinking
+
+func (t *UnifiedThinking) ToAnthropicThinking() *AnthropicThinking {
+	if t == nil || t.Thinking == nil {
+		return nil
+	}
+	return &AnthropicThinking{Thinking: t.Thinking}
+}
+
+func (t *UnifiedThinking) ToQwenThinking() *QwenThinking {
+	if t == nil || t.Thinking == nil {
+		return nil
+	}
+	enableThinking := t.Thinking.Type == "enabled"
+	return &QwenThinking{EnableThinking: &enableThinking, ThinkingBudget: t.Thinking.BudgetTokens}
+}
 
 type (
 	// Anthropic Thinking Style:
@@ -33,11 +48,11 @@ type (
 	//	  }
 	//	}
 	AnthropicThinking struct {
-		Thinking *AnthropicThinkingInternal `json:"thinking"`
+		Thinking *AnthropicThinkingInternal `json:"thinking,omitempty"`
 	}
 	AnthropicThinkingInternal struct {
-		Type         string `json:"type"`          // enabled | disabled
-		BudgetTokens int    `json:"budget_tokens"` // should be small than max_tokens
+		Type         string `json:"type,omitempty"`          // enabled | disabled
+		BudgetTokens int    `json:"budget_tokens,omitempty"` // should be small than max_tokens
 	}
 )
 
@@ -50,6 +65,6 @@ type (
 //	  "thinking_budget": 1000
 //	}
 type QwenThinking struct {
-	EnableThinking *bool `json:"enable_thinking"`
-	ThinkingBudget int   `json:"thinking_budget"`
+	EnableThinking *bool `json:"enable_thinking,omitempty"`
+	ThinkingBudget int   `json:"thinking_budget,omitempty"`
 }

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thinking
+
+// Thinking is the unified thinking configs.
+// Distinguish:
+// - not-set
+// - enable
+// - disable
+type Thinking AnthropicThinking
+
+type (
+	// Anthropic Thinking Style:
+	//
+	//	{
+	//	  ...
+	//	  "messages": ...,
+	//	  "thinking": {
+	//	    "type": "enabled",
+	//	    "budget_tokens": 1000
+	//	  }
+	//	}
+	AnthropicThinking struct {
+		Thinking *AnthropicThinkingInternal `json:"thinking"`
+	}
+	AnthropicThinkingInternal struct {
+		Type         string `json:"type"`          // enabled | disabled
+		BudgetTokens int    `json:"budget_tokens"` // should be small than max_tokens
+	}
+)
+
+// Qwen Thinking Style:
+//
+//	{
+//	  ...
+//	  "messages": ...,
+//	  "enable_thinking": true,
+//	  "thinking_budget": 1000
+//	}
+type QwenThinking struct {
+	EnableThinking *bool `json:"enable_thinking"`
+	ThinkingBudget int   `json:"thinking_budget"`
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking_test.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/openai_extended/thinking/thinking_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thinking
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestThinking_ToAnthropicThinking(t *testing.T) {
+	type fields struct {
+		UnifiedThinking *UnifiedThinking
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *AnthropicThinking
+	}{
+		{
+			name: "nil",
+			fields: fields{
+				UnifiedThinking: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "enabled",
+			fields: fields{
+				UnifiedThinking: &UnifiedThinking{
+					Thinking: &AnthropicThinkingInternal{Type: "enabled", BudgetTokens: 100},
+				},
+			},
+			want: &AnthropicThinking{
+				Thinking: &AnthropicThinkingInternal{Type: "enabled", BudgetTokens: 100},
+			},
+		},
+		{
+			name: "disabled",
+			fields: fields{
+				UnifiedThinking: &UnifiedThinking{
+					Thinking: &AnthropicThinkingInternal{Type: "disabled", BudgetTokens: 100},
+				},
+			},
+			want: &AnthropicThinking{
+				Thinking: &AnthropicThinkingInternal{Type: "disabled", BudgetTokens: 100},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.UnifiedThinking.ToAnthropicThinking(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Thinking.ToAnthropicThinking() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/filter.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/filter.go
@@ -94,6 +94,9 @@ func (f *AnthropicCompatibleDirector) OnRequest(ctx context.Context, w http.Resp
 }
 
 func (f *AnthropicCompatibleDirector) OnResponseChunk(ctx context.Context, infor reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) (signal reverseproxy.Signal, err error) {
+	if infor.StatusCode() != http.StatusOK {
+		return reverseproxy.Continue, nil
+	}
 	apiSegment := api_segment_getter.GetAPISegment(ctx)
 	switch strings.ToLower(string(apiSegment.APIVendor)) {
 	case strings.ToLower(string(aws_bedrock.APIVendor)):
@@ -106,6 +109,9 @@ func (f *AnthropicCompatibleDirector) OnResponseChunk(ctx context.Context, infor
 }
 
 func (f *AnthropicCompatibleDirector) OnResponseEOF(ctx context.Context, infor reverseproxy.HttpInfor, w reverseproxy.Writer, chunk []byte) error {
+	if infor.StatusCode() != http.StatusOK {
+		return nil
+	}
 	apiSegment := api_segment_getter.GetAPISegment(ctx)
 	switch strings.ToLower(string(apiSegment.APIVendor)) {
 	case strings.ToLower(string(aws_bedrock.APIVendor)):

--- a/internal/apps/ai-proxy/provider.go
+++ b/internal/apps/ai-proxy/provider.go
@@ -174,6 +174,9 @@ var modifyResponseFunc = func(response *http.Response) error {
 		response.Header.Del("Content-Length")
 		response.ContentLength = -1
 	}
+	// cors, set at outside, delete to avoid duplicated `Access-Control-Allow-Origin` header
+	response.Header.Del("Vary")
+	response.Header.Del("Access-Control-Allow-Origin")
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy Anthropic-Compatible Director support Thinking config:

- add OpenAIRequestExtended struct to store extra fields
- support Qwen & Anthropic two style thinking config
- abstract unified req&resp logic
- force avoid duplicated Access-Control-Allow-Origin header

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/terminus/dop/projects/190/issues/all?id=762963&iterationID=14782&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy Anthropic-Compatible Director support Thinking config           |
| 🇨🇳 中文    |    AI-Proxy Anthropic-Compatible Director 支持是否启用思考          |
