### PR TITLE
feat(ai-proxy): model add publisher; support specify normal model name at request body

### DIFF
--- a/api/proto/apps/aiproxy/model/model.proto
+++ b/api/proto/apps/aiproxy/model/model.proto
@@ -53,6 +53,7 @@ message Model {
     string providerId = 8;
     string apiKey = 9;
     metadata.Metadata metadata = 10;
+    string publisher = 11; // set at metadata.public.publisher; promoted to first-level when display
 }
 
 enum ModelType {

--- a/api/proto/apps/aiproxy/model/model.proto
+++ b/api/proto/apps/aiproxy/model/model.proto
@@ -102,6 +102,7 @@ message ModelPagingRequest {
     string providerId = 5 [(validate.rules).string = {ignore_empty: true, len: 36}];
     repeated string ids = 6 [(validate.rules).repeated.items.string = {len: 36}];
     repeated string orderBys = 7 [(validate.rules).repeated.items.string = {ignore_empty: true, min_len: 2, max_len: 32}];
+    string nameFull = 8 [(validate.rules).string = {ignore_empty: true, min_len: 2, max_len: 191}];
 }
 
 message ModelPagingResponse {

--- a/internal/apps/ai-proxy/filters/context/model.go
+++ b/internal/apps/ai-proxy/filters/context/model.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	clientpb "github.com/erda-project/erda-proto-go/apps/aiproxy/client/pb"
+	clientmodelrelationpb "github.com/erda-project/erda-proto-go/apps/aiproxy/client_model_relation/pb"
+	modelpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model/pb"
+	openai_v1_models "github.com/erda-project/erda/internal/apps/ai-proxy/filters/openai-v1-models"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/providers/dao"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
+	"github.com/erda-project/erda/pkg/http/httputil"
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+type RequestForModel struct {
+	Model string `json:"model"`
+}
+
+func findModel(ctx context.Context, infor reverseproxy.HttpInfor, client *clientpb.Client) (*modelpb.Model, error) {
+	r := infor.Request()
+	q := ctx.Value(vars.CtxKeyDAO{}).(dao.DAO)
+
+	// find model uuid, get exactly by model uuid;
+	modelID, err := findModelID(infor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model id, err: %v", err)
+	}
+	// if concrete uuid specified, no need to check client model relation
+	if modelID != "" {
+		model, err := q.ModelClient().Get(ctx, &modelpb.ModelGetRequest{Id: modelID})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get model by uuid: %s", modelID)
+		}
+		return model, nil
+	}
+
+	// find by model name + optional publisher
+	var reqForModelName RequestForModel
+	bodyCopy := infor.BodyBuffer(true)
+	if err := json.NewDecoder(bodyCopy).Decode(&reqForModelName); err != nil {
+		return nil, fmt.Errorf("failed to decode request body: %v", err)
+	}
+	if reqForModelName.Model == "" {
+		return nil, fmt.Errorf("missing required model field in request body")
+	}
+	requiredModelPublisher := r.Header.Get(vars.XAIProxyModelPublisher)
+	clientMatchedModels, err := getClientModelsByNameAndPublisher(ctx, client.Id, reqForModelName.Model, requiredModelPublisher)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client models by name and publisher: %v", err)
+	}
+	// if there are multiple, take the first one, default is sorted by updated_at desc
+	if len(clientMatchedModels) > 0 {
+		return clientMatchedModels[0], nil
+	}
+	// model not found, construct friendly error
+	return nil, constructFriendlyError(ctx, reqForModelName.Model, requiredModelPublisher)
+}
+
+func findModelID(infor reverseproxy.HttpInfor) (string, error) {
+	r := infor.Request()
+	// header preferred
+	headerModelId := r.Header.Get(vars.XAIProxyModelId)
+	if headerModelId != "" {
+		return headerModelId, nil
+	}
+	// get from body
+	// support json body
+	if r.Header.Get(httputil.HeaderKeyContentType) == string(httputil.ApplicationJson) {
+		snapshotBody := infor.BodyBuffer(true)
+		var reqForModelID RequestForModel
+		if err := json.NewDecoder(snapshotBody).Decode(&reqForModelID); err != nil {
+			return "", fmt.Errorf("failed to decode request body, err: %v", err)
+		}
+		if reqForModelID.Model != "" {
+			// parse truly model uuid, which is generated at api `/v1/models`/, see: internal/apps/ai-proxy/filters/openai-v1-models/filter.go#generateModelDisplayName
+			uuid := openai_v1_models.ParseModelUUIDFromDisplayName(reqForModelID.Model)
+			if uuid != "" {
+				return uuid, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func getClientModelsByNameAndPublisher(ctx context.Context, clientID string, modelName string, publisher string) ([]*modelpb.Model, error) {
+	q := ctx.Value(vars.CtxKeyDAO{}).(dao.DAO)
+	clientModelsResp, err := q.ClientModelRelationClient().ListClientModels(ctx, &clientmodelrelationpb.ListClientModelsRequest{
+		ClientId: clientID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(clientModelsResp.ModelIds) == 0 {
+		return nil, nil
+	}
+	// list models by name & ids
+	pagingModelResp, err := q.ModelClient().Paging(ctx, &modelpb.ModelPagingRequest{
+		PageNum:  1,
+		PageSize: 999,
+		NameFull: modelName,
+		Ids:      clientModelsResp.ModelIds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to paging models by name and modelIDs, name: %s, err: %v", modelName, err)
+	}
+	// filter by publisher
+	return filterModelsByPublisher(pagingModelResp.List, publisher), nil
+}
+
+func filterModelsByPublisher(in []*modelpb.Model, publisher string) (out []*modelpb.Model) {
+	if publisher == "" {
+		return in
+	}
+	for _, model := range in {
+		modelPublisher := model.Metadata.Public["publisher"].GetStringValue()
+		if modelPublisher == publisher {
+			out = append(out, model)
+		}
+	}
+	return
+}
+
+func getModelsByNameAndPublisher(ctx context.Context, modelName string, requiredModelPublisher string) ([]*modelpb.Model, error) {
+	q := ctx.Value(vars.CtxKeyDAO{}).(dao.DAO)
+	sameNameModelsResp, err := q.ModelClient().Paging(ctx, &modelpb.ModelPagingRequest{
+		PageNum:  1,
+		PageSize: 999,
+		NameFull: modelName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get models by model name: %s, err: %v", modelName, err)
+	}
+	// filter by publisher
+	return filterModelsByPublisher(sameNameModelsResp.List, requiredModelPublisher), nil
+}
+
+func constructFriendlyError(ctx context.Context, modelName string, requiredModelPublisher string) error {
+	models, _ := getModelsByNameAndPublisher(ctx, modelName, requiredModelPublisher)
+	var errMsg string
+	if len(models) == 0 {
+		errMsg = fmt.Sprintf("model not exist: %s", modelName)
+	} else {
+		errMsg = fmt.Sprintf("you don't have permission to access the model: %s", modelName)
+	}
+	if requiredModelPublisher != "" {
+		errMsg += fmt.Sprintf(", publisher: %s", requiredModelPublisher)
+	}
+	return fmt.Errorf(errMsg)
+}

--- a/internal/apps/ai-proxy/filters/context/model_test.go
+++ b/internal/apps/ai-proxy/filters/context/model_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/vars"
+	"github.com/erda-project/erda/pkg/reverseproxy"
+)
+
+func Test_findModelID(t *testing.T) {
+	type args struct {
+		infor reverseproxy.HttpInfor
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "model id in header only",
+			args: args{
+				infor: reverseproxy.NewInfor(context.Background(), &http.Request{
+					Header: http.Header{
+						textproto.CanonicalMIMEHeaderKey(vars.XAIProxyModelId): []string{"model-id-in-header"},
+					},
+				}),
+			},
+			want:    "model-id-in-header",
+			wantErr: false,
+		},
+		{
+			name: "model id in body only",
+			args: args{
+				infor: reverseproxy.NewInfor(context.Background(), &http.Request{
+					Header: http.Header{
+						textproto.CanonicalMIMEHeaderKey("Content-Type"): []string{"application/json"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"model": "[ID:model-id-in-body]"}`)),
+				}),
+			},
+			want:    "model-id-in-body",
+			wantErr: false,
+		},
+		{
+			name: "model id both in header and body, header is preferred",
+			args: args{
+				infor: reverseproxy.NewInfor(context.Background(), &http.Request{
+					Header: http.Header{
+						textproto.CanonicalMIMEHeaderKey("Content-Type"):       []string{"application/json"},
+						textproto.CanonicalMIMEHeaderKey(vars.XAIProxyModelId): []string{"model-id-in-header"},
+					},
+					Body: io.NopCloser(strings.NewReader(`{"model": "[ID:model-id-in-body]"}`)),
+				}),
+			},
+			want:    "model-id-in-header",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findModelID(tt.args.infor)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findModelID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("findModelID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/models/client_model_relation/dbclient.go
+++ b/internal/apps/ai-proxy/models/client_model_relation/dbclient.go
@@ -107,8 +107,8 @@ func (dbClient *DBClient) ListClientModels(ctx context.Context, req *pb.ListClie
 }
 
 func (dbClient *DBClient) Paging(ctx context.Context, req *pb.PagingRequest) (*pb.PagingResponse, error) {
-	relationTableName := (&ClientModelRelation{}).TableName()
-	sql := dbClient.DB.Table(relationTableName)
+	c := &ClientModelRelations{}
+	sql := dbClient.DB.Model(c)
 	if len(req.ClientIds) > 0 {
 		sql = sql.Where("client_id in (?)", req.ClientIds)
 	}

--- a/internal/apps/ai-proxy/models/model/dbclient.go
+++ b/internal/apps/ai-proxy/models/model/dbclient.go
@@ -88,6 +88,9 @@ func (dbClient *DBClient) Paging(ctx context.Context, req *pb.ModelPagingRequest
 	if req.Name != "" {
 		sql = sql.Where("name LIKE ?", "%"+req.Name+"%")
 	}
+	if req.NameFull != "" {
+		c.Name = req.NameFull
+	}
 	if req.Type != pb.ModelType_MODEL_TYPE_UNSPECIFIED {
 		c.Type = model_type.GetModelTypeFromProtobuf(req.Type)
 	}

--- a/internal/apps/ai-proxy/models/model/table.go
+++ b/internal/apps/ai-proxy/models/model/table.go
@@ -36,6 +36,7 @@ type Model struct {
 func (*Model) TableName() string { return "ai_proxy_model" }
 
 func (m *Model) ToProtobuf() *pb.Model {
+	pbMetadata := m.Metadata.ToProtobuf()
 	return &pb.Model{
 		Id:         m.ID.String,
 		CreatedAt:  timestamppb.New(m.CreatedAt),
@@ -46,16 +47,17 @@ func (m *Model) ToProtobuf() *pb.Model {
 		Type:       pb.ModelType(pb.ModelType_value[string(m.Type)]),
 		ProviderId: m.ProviderID,
 		ApiKey:     m.APIKey,
-		Metadata:   m.Metadata.ToProtobuf(),
+		Metadata:   pbMetadata,
+		Publisher:  pbMetadata.Public["publisher"].GetStringValue(),
 	}
 }
 
 type Models []*Model
 
 func (models Models) ToProtobuf() []*pb.Model {
-	var pbClients []*pb.Model
+	var pbModels []*pb.Model
 	for _, c := range models {
-		pbClients = append(pbClients, c.ToProtobuf())
+		pbModels = append(pbModels, c.ToProtobuf())
 	}
-	return pbClients
+	return pbModels
 }

--- a/internal/apps/ai-proxy/vars/consts.go
+++ b/internal/apps/ai-proxy/vars/consts.go
@@ -34,9 +34,11 @@ const (
 	XAiProxyErdaOpenapiSession = "X-Ai-Proxy-Erda-Openapi-Session"
 	XRequestId                 = "X-Request-Id"
 
-	XAIProxyModelId   = "X-AI-Proxy-Model-Id"
-	XAIProxySessionId = "X-AI-Proxy-Session-Id"
-	XAIProxyPromptId  = "X-AI-Proxy-Prompt-Id"
+	XAIProxyModelId        = "X-AI-Proxy-Model-Id"
+	XAIProxySessionId      = "X-AI-Proxy-Session-Id"
+	XAIProxyPromptId       = "X-AI-Proxy-Prompt-Id"
+	XAIProxyModelName      = "X-AI-Proxy-Model-Name"
+	XAIProxyModelPublisher = "X-AI-Proxy-Model-Publisher"
 
 	UIValueUndefined = "undefined"
 )


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy:

- model add publisher field at metadata.public.publisher, like: openai / anthropic / deepseek
- support specify normal model name at request body, like: deepseek-r1 / gpt-4o


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/terminus/dop/projects/190/issues/all?id=763422&iterationID=14782&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy model add publisher; support specify normal model name at request body           |
| 🇨🇳 中文    |    AI-Proxy 模型增加发布商字段；支持在请求体中使用模型名          |
