### PR TITLE
feat(openapi): allow UCAddr in referer validation

### DIFF
--- a/internal/core/openapi/openapi-ng/auth/uc-session/refer.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/refer.go
@@ -31,6 +31,7 @@ func (p *provider) buildReferMatcher() *referMatcher {
 		allowedSuffixes: make([]string, 0),
 		exactDomains: map[string]struct{}{
 			p.Cfg.PlatformDomain: {},
+			p.Cfg.UCAddr:         {},
 		},
 	}
 	for _, refer := range p.Cfg.AllowedReferrers {

--- a/internal/core/openapi/openapi-ng/auth/uc-session/refer_test.go
+++ b/internal/core/openapi/openapi-ng/auth/uc-session/refer_test.go
@@ -20,6 +20,7 @@ func TestReferValidate(t *testing.T) {
 	p := provider{
 		Cfg: &config{
 			PlatformDomain: "erda.cloud",
+			UCAddr:         "uc.erda.cloud",
 		},
 	}
 
@@ -29,6 +30,11 @@ func TestReferValidate(t *testing.T) {
 		allowList  []string
 		wantResult bool
 	}{
+		{
+			name:       "Matching referer from uc",
+			refer:      "https://uc.erda.cloud/login",
+			wantResult: true,
+		},
 		{
 			name:       "Matching referer with allowList",
 			refer:      "https://sub.erda.cloud/login",


### PR DESCRIPTION
#### What this PR does / why we need it:
In some cases, the browser jump source will be changed to uc.
ChangeLog:
- Add UCAddr to exactDomains map in refer.go
- Update refer_test.go to include test case for UCAddr

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  allow UCAddr in referer validation            |
| 🇨🇳 中文    |    允许 UC 地址作为跳转来源          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
