### PR TITLE
fix(ai-proxy): ai-proxy ensure sse content-type to text/event-stream (such as aws-bedrock)

### DIFF
--- a/internal/apps/ai-proxy/provider.go
+++ b/internal/apps/ai-proxy/provider.go
@@ -191,6 +191,10 @@ var modifyResponseFunc = func(response *http.Response) error {
 	// cors, set at outside, delete to avoid duplicated `Access-Control-Allow-Origin` header
 	response.Header.Del("Vary")
 	response.Header.Del("Access-Control-Allow-Origin")
+	// ensure content-type to text/event-stream for stream response
+	if ctxhelper.GetIsStream(response.Request.Context()) {
+		response.Header.Set("Content-Type", "text/event-stream")
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy ensure sse content-type to `text/event-stream`, for aws-bedrock and others.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=772779&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    AI-Proxy ensure sse content-type to `text/event-stream`     |
| 🇨🇳 中文    |      AI-Proxy 确保 SSE Content-Type = `text/event-stream`     |
