### PR TITLE
fix(ai-proxy): convert anthropic response with `finish_reason` and `usage` for stream and non-stream

### DIFF
--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
@@ -22,11 +22,19 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+// AnthropicResponse is non-stream response body.
+// See: https://docs.anthropic.com/en/api/messages#response-id
 type AnthropicResponse struct {
 	ID      string                         `json:"id"`
 	Type    string                         `json:"type"` // always "message"
 	Role    string                         `json:"role"` // always "assistant"
 	Content []AnthropicResponseContentPart `json:"content"`
+	Usage   AnthropicResponseUsage         `json:"usage"`
+}
+
+type AnthropicResponseUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
 }
 
 func (r AnthropicResponse) ConvertToOpenAIFormat(modelID string) (openai.ChatCompletionResponse, error) {
@@ -38,15 +46,26 @@ func (r AnthropicResponse) ConvertToOpenAIFormat(modelID string) (openai.ChatCom
 	}
 	// choices
 	var choices []openai.ChatCompletionChoice
-	for _, anthropicContentPart := range r.Content {
+	for i, anthropicContentPart := range r.Content {
 		anthropicContentPart := anthropicContentPart
 		openaiMsg, err := ConvertAnthropicResponseMessageToOpenAIFormat(r.Role, anthropicContentPart)
 		if err != nil {
 			return openaiResp, fmt.Errorf("failed to convert anthropic response message to openai format: %v", err)
 		}
 		choices = append(choices, openai.ChatCompletionChoice{Message: openaiMsg})
+		// Set finish reason for the last message
+		if i == len(r.Content)-1 {
+			choices[i].FinishReason = "stop"
+		}
 	}
 	openaiResp.Choices = choices
+	openaiResp.Usage = openai.Usage{
+		PromptTokens:            r.Usage.InputTokens,
+		CompletionTokens:        r.Usage.OutputTokens,
+		TotalTokens:             r.Usage.InputTokens + r.Usage.OutputTokens,
+		PromptTokensDetails:     nil,
+		CompletionTokensDetails: nil,
+	}
 	return openaiResp, nil
 }
 
@@ -72,8 +91,12 @@ type AnthropicStreamMessageInfo struct {
 	ID    string
 	Model string
 	Role  string
+
+	Usage AnthropicResponseUsage
 }
 
+// ConvertStreamChunkDataToOpenAIChunk .
+// See: https://docs.anthropic.com/en/docs/build-with-claude/streaming
 func ConvertStreamChunkDataToOpenAIChunk(anthropicDataRaw []byte, inputMsgInfo AnthropicStreamMessageInfo) (*AnthropicStreamMessageInfo, *openai.ChatCompletionStreamResponse, error) {
 	var rawObj map[string]any
 	if err := json.Unmarshal(anthropicDataRaw, &rawObj); err != nil {
@@ -82,11 +105,16 @@ func ConvertStreamChunkDataToOpenAIChunk(anthropicDataRaw []byte, inputMsgInfo A
 
 	switch rawObj["type"].(string) {
 	case "message_start":
+		// Example:
+		// event: message_start
+		// data: {"type": "message_start", "message": {"id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-4-20250514", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}
+
 		// get message id and model
 		var gotMsgInfo AnthropicStreamMessageInfo
 		gotMsgInfo.ID = rawObj["message"].(map[string]any)["id"].(string)
 		gotMsgInfo.Model = rawObj["message"].(map[string]any)["model"].(string)
 		gotMsgInfo.Role = rawObj["message"].(map[string]any)["role"].(string)
+		gotMsgInfo.Usage.InputTokens = int(rawObj["message"].(map[string]any)["usage"].(map[string]any)["input_tokens"].(float64))
 		return &gotMsgInfo, nil, nil
 	case "content_block_delta":
 		openaiChunk := openai.ChatCompletionStreamResponse{
@@ -112,6 +140,50 @@ func ConvertStreamChunkDataToOpenAIChunk(anthropicDataRaw []byte, inputMsgInfo A
 			openaiChunk.Choices[0].Delta.ReasoningContent = deltaObj["thinking"].(string)
 		default:
 			return nil, nil, nil
+		}
+		return nil, &openaiChunk, nil
+	case "message_delta":
+		// Example:
+		// event: message_delta
+		// data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage": {"output_tokens": 15}}
+
+		// Only send `finish_reason`; `usage` is handled in `message_stop`.
+
+		outputTokens := int(rawObj["usage"].(map[string]any)["output_tokens"].(float64))
+		inputMsgInfo.Usage.OutputTokens = outputTokens
+
+		openaiChunk := openai.ChatCompletionStreamResponse{
+			ID:      inputMsgInfo.ID,
+			Object:  "chat.completion.chunk",
+			Created: time.Now().Unix(),
+			Model:   inputMsgInfo.Model,
+			Choices: []openai.ChatCompletionStreamChoice{
+				{
+					Index:        0,
+					Delta:        openai.ChatCompletionStreamChoiceDelta{},
+					FinishReason: "stop", // always stop
+				},
+			},
+		}
+		return &inputMsgInfo, &openaiChunk, nil
+	case "message_stop":
+		// Example:
+		// event: message_stop
+		// data: {"type": "message_stop"}
+
+		openaiChunk := openai.ChatCompletionStreamResponse{
+			ID:      inputMsgInfo.ID,
+			Object:  "chat.completion.chunk",
+			Created: time.Now().Unix(),
+			Model:   inputMsgInfo.Model,
+			Choices: []openai.ChatCompletionStreamChoice{},
+			Usage: &openai.Usage{
+				PromptTokens:            inputMsgInfo.Usage.InputTokens,
+				CompletionTokens:        inputMsgInfo.Usage.OutputTokens,
+				TotalTokens:             inputMsgInfo.Usage.InputTokens + inputMsgInfo.Usage.OutputTokens,
+				PromptTokensDetails:     nil,
+				CompletionTokensDetails: nil,
+			},
 		}
 		return nil, &openaiChunk, nil
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy convert anthropic response with `finish_reason` and `usage` for stream and non-stream.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=773212&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy convert anthropic response with `finish_reason` and `usage` for stream and non-stream           |
| 🇨🇳 中文    |      AI-Proxy 转换 Anthropic 响应时新增 `finish_reaon` 和 `usage` 字段，同时支持流式和非流式模式        |
