### PR TITLE
refactor(edas): update label keys for service name and group ID

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -626,8 +626,8 @@ func setLabels(svcSpec *types.ServiceSpec, sgID, serviceName string) error {
 	}
 
 	targetLabels := map[string]string{
-		"app":             serviceName,
-		"servicegroup-id": sgID,
+		types.LabelServiceName:    serviceName,
+		types.LabelServiceGroupID: sgID,
 	}
 
 	ret, err := json.Marshal(targetLabels)

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -41,8 +41,8 @@ func TestSetLabels(t *testing.T) {
 			sgID:        "test-sg-id",
 			serviceName: "test-service",
 			expected: map[string]string{
-				"app":             "test-service",
-				"servicegroup-id": "test-sg-id",
+				"core.erda.cloud/service-name":    "test-service",
+				"core.erda.cloud/servicegroup-id": "test-sg-id",
 			},
 			expectError: false,
 		},
@@ -61,8 +61,8 @@ func TestSetLabels(t *testing.T) {
 			sgID:        "",
 			serviceName: "test-service",
 			expected: map[string]string{
-				"app":             "test-service",
-				"servicegroup-id": "",
+				"core.erda.cloud/service-name":    "test-service",
+				"core.erda.cloud/servicegroup-id": "",
 			},
 			expectError: false,
 		},
@@ -74,8 +74,8 @@ func TestSetLabels(t *testing.T) {
 			sgID:        "test-sg-id",
 			serviceName: "",
 			expected: map[string]string{
-				"app":             "",
-				"servicegroup-id": "test-sg-id",
+				"core.erda.cloud/service-name":    "",
+				"core.erda.cloud/servicegroup-id": "test-sg-id",
 			},
 			expectError: false,
 		},
@@ -87,8 +87,8 @@ func TestSetLabels(t *testing.T) {
 			sgID:        "test-sg-id-with-dashes_and_underscores",
 			serviceName: "test-service-with-dashes",
 			expected: map[string]string{
-				"app":             "test-service-with-dashes",
-				"servicegroup-id": "test-sg-id-with-dashes_and_underscores",
+				"core.erda.cloud/service-name":    "test-service-with-dashes",
+				"core.erda.cloud/servicegroup-id": "test-sg-id-with-dashes_and_underscores",
 			},
 			expectError: false,
 		},
@@ -130,11 +130,11 @@ func TestSetLabels_JSONMarshaling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify specific labels are set
-	assert.Equal(t, "test-service", labels["app"])
-	assert.Equal(t, "test-sg-id", labels["servicegroup-id"])
+	assert.Equal(t, "test-service", labels["core.erda.cloud/service-name"])
+	assert.Equal(t, "test-sg-id", labels["core.erda.cloud/servicegroup-id"])
 
 	// Verify JSON structure
-	expectedJSON := `{"app":"test-service","servicegroup-id":"test-sg-id"}`
+	expectedJSON := `{"core.erda.cloud/service-name":"test-service","core.erda.cloud/servicegroup-id":"test-sg-id"}`
 	var expectedLabels map[string]string
 	err = json.Unmarshal([]byte(expectedJSON), &expectedLabels)
 	require.NoError(t, err)

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/types/types.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/types/types.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	// EDASAppIDLabel TODO: instead of EDAS API
-	EDASAppIDLabel = "edas.appid"
+	LabelServiceName    = "core.erda.cloud/service-name"
+	LabelServiceGroupID = "core.erda.cloud/servicegroup-id"
 )
 
 // ChangeOrderStatus change orderId status

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
@@ -137,8 +137,8 @@ func (e *wrapKubernetes) combineK8sService(appName, sgID, serviceName string, po
 		Spec: corev1.ServiceSpec{
 			// TODO: type?
 			Selector: map[string]string{
-				"app":             serviceName,
-				"servicegroup-id": sgID,
+				types.LabelServiceName:    serviceName,
+				types.LabelServiceGroupID: sgID,
 			},
 			Ports: servicePorts,
 		},

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
@@ -101,8 +101,8 @@ func TestCombineK8sService(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app":             serviceName,
-				"servicegroup-id": sgID,
+				"core.erda.cloud/service-name":    serviceName,
+				"core.erda.cloud/servicegroup-id": sgID,
 			},
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION

#### What this PR does / why we need it:

In certain scenarios, EDAS contains mixed labels, and the app label cannot be overridden. Therefore, the new label conventions of Erda are used instead.

- Replace EDASAppIDLabel with LabelServiceName and LabelServiceGroupID- Update label usage in service creation and tests
- Modify edas_app_flow and tests to use new label keys

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  update label keys for service name and group ID            |
| 🇨🇳 中文    |    edas 更新 service-name/ servicegroup-id 标签          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
