### PR TITLE
fix(ai-proxy): add packet stitching for AWS Bedrock EventStream chunks

### DIFF
--- a/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
+++ b/internal/apps/ai-proxy/filters/directors/anthropic-compatible-director/common/message_converter/resp.go
@@ -108,7 +108,7 @@ func ConvertAnthropicResponseMessageToOpenAIFormat(role string, anthropicContent
 		openaiMsg.ToolCalls = []openai.ToolCall{
 			{
 				ID:   anthropicContentPart["id"].(string),
-				Type: "tool_use", // always "tool_use" for anthropic tool use
+				Type: openai.ToolTypeFunction,
 				Function: openai.FunctionCall{
 					Name:      anthropicContentPart["name"].(string),
 					Arguments: string(inputJSON),


### PR DESCRIPTION
#### What this PR does / why we need it:

- add packet stitching for AWS Bedrock EventStream chunks
- fix logic of splitAnthropicMessages


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=775884&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy add packet stitching for AWS Bedrock EventStream chunks            |
| 🇨🇳 中文    |   AI-Proxy 为 AWS Bedrock 流式响应增加粘包处理           |
