### PR TITLE
fix(ai-proxy): set XFF correctly; fix json-body-model-finder

### DIFF
--- a/cmd/ai-proxy/integration-tests/responses_test.go
+++ b/cmd/ai-proxy/integration-tests/responses_test.go
@@ -396,6 +396,12 @@ func createNonStreamResponse(t *testing.T, client *common.Client, ctx context.Co
 		t.Fatalf("✗ Create non-stream response failed with status %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
+	}
+
 	// Parse response
 	var responseData map[string]any
 	if err := resp.GetJSON(&responseData); err != nil {
@@ -451,6 +457,12 @@ func createChainedNonStreamResponse(t *testing.T, client *common.Client, ctx con
 		t.Fatalf("✗ Create chained non-stream response failed with status %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
+	}
+
 	// Parse response
 	var responseData map[string]any
 	if err := resp.GetJSON(&responseData); err != nil {
@@ -502,6 +514,12 @@ func createResponse(t *testing.T, client *common.Client, ctx context.Context, mo
 
 	if !resp.IsSuccess() {
 		t.Fatalf("✗ Create response failed with status %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
 	}
 
 	// Parse response
@@ -558,6 +576,12 @@ func createChainedResponse(t *testing.T, client *common.Client, ctx context.Cont
 		t.Fatalf("✗ Create chained response failed with status %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
+	}
+
 	// Parse response
 	var responseData map[string]any
 	if err := resp.GetJSON(&responseData); err != nil {
@@ -604,6 +628,12 @@ func getResponse(t *testing.T, client *common.Client, ctx context.Context, respo
 
 	if !resp.IsSuccess() {
 		t.Fatalf("✗ Get response failed with status %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
 	}
 
 	var responseData map[string]any
@@ -659,6 +689,12 @@ func getResponseInputItems(t *testing.T, client *common.Client, ctx context.Cont
 		t.Fatalf("✗ Get response input items failed with status %d: %s", resp.StatusCode, string(resp.Body))
 	}
 
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
+	}
+
 	var inputItemsData map[string]any
 	if err := resp.GetJSON(&inputItemsData); err != nil {
 		t.Fatalf("✗ Failed to parse input items response: %v", err)
@@ -710,6 +746,12 @@ func deleteResponse(t *testing.T, client *common.Client, ctx context.Context, re
 
 	if !resp.IsSuccess() {
 		t.Fatalf("✗ Delete response failed with status %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	// Check if response header contains application/json
+	contentType := resp.Headers.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("✗ Expected Content-Type to contain 'application/json', got: %s", contentType)
 	}
 
 	var deleteResult map[string]any

--- a/internal/apps/ai-proxy/reverse_proxy.go
+++ b/internal/apps/ai-proxy/reverse_proxy.go
@@ -113,7 +113,10 @@ func (p *provider) HandleReverseProxyAPI() http.HandlerFunc {
 		proxy := httputil.ReverseProxy{
 			Rewrite: myRewrite(w, filters),
 			Transport: &transports.RequestFilterGeneratedResponseTransport{
-				Inner: &transports.CurlPrinterTransport{}},
+				Inner: &transports.CurlPrinterTransport{
+					Inner: &transports.TimerTransport{},
+				},
+			},
 			FlushInterval:  -1,
 			ErrorLog:       nil,
 			BufferPool:     nil,
@@ -259,14 +262,6 @@ var myResponseModify = func(w http.ResponseWriter, filters []FilterWithName) fun
 
 		go func() {
 			defer upstream.Close()
-
-			//// 3.1 If there's Content-Encoding:gzip/deflate... decompress first
-			//reader, derr := reverseproxy.NewBodyDecompressor(resp.Header, upstream)
-			//if derr != nil {
-			//	pw.CloseWithError(derr)
-			//	return
-			//}
-			//defer reader.(io.Closer).Close()
 
 			if len(filters) == 0 {
 				// If no Modifiers, directly write upstream content to downstream as-is

--- a/internal/apps/ai-proxy/route/filters/common/custom-http-director/filter.go
+++ b/internal/apps/ai-proxy/route/filters/common/custom-http-director/filter.go
@@ -117,7 +117,6 @@ func hostDirector(r *http.Request, apiStyleConfig api_style.APIStyleConfig) erro
 	r.Host = host
 	r.URL.Host = host
 	r.Header.Set("Host", host)
-	r.Header.Set("X-Forwarded-Host", host)
 	return nil
 }
 

--- a/internal/apps/ai-proxy/route/filters/request/context-family/context/model_finder.go
+++ b/internal/apps/ai-proxy/route/filters/request/context-family/context/model_finder.go
@@ -53,7 +53,7 @@ type BodyModelFinder interface {
 type JSONBodyFinder struct{}
 
 func (f *JSONBodyFinder) FindModelName(req *http.Request, fieldKey string) (string, error) {
-	if req.Header.Get(httperrorutil.HeaderKeyContentType) != string(httperrorutil.ApplicationJson) {
+	if !strings.HasPrefix(req.Header.Get(httperrorutil.HeaderKeyContentType), string(httperrorutil.ApplicationJson)) {
 		return "", nil
 	}
 

--- a/internal/apps/ai-proxy/route/filters/request/directors/anthropic-compatible-director/filter.go
+++ b/internal/apps/ai-proxy/route/filters/request/directors/anthropic-compatible-director/filter.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http/httputil"
+	"os"
 	"strings"
 
 	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_segment_getter"
@@ -81,5 +82,11 @@ func (f *AnthropicCompatibleDirectorRequest) OnProxyRequest(pr *httputil.ProxyRe
 	default:
 		return fmt.Errorf("unsupported anthropic-compatible api vendor: %s", apiSegment.APIVendor)
 	}
+
+	// force set internal pod ip as xff for anthropic region restriction
+	if podIP := os.Getenv("POD_IP"); podIP != "" {
+		pr.Out.Header.Set("X-Forwarded-For", podIP)
+	}
+
 	return nil
 }

--- a/internal/apps/ai-proxy/route/filters/request/directors/openai-compatible-director/filter.go
+++ b/internal/apps/ai-proxy/route/filters/request/directors/openai-compatible-director/filter.go
@@ -48,5 +48,8 @@ func (f *OpenaiCompatibleDirector) Enable(pr *httputil.ProxyRequest) bool {
 }
 
 func (f *OpenaiCompatibleDirector) OnProxyRequest(pr *httputil.ProxyRequest) error {
+	if !f.Enable(pr) {
+		return nil
+	}
 	return f.CustomHTTPDirector.OnProxyRequest(pr)
 }

--- a/internal/apps/ai-proxy/route/transports/transport.go
+++ b/internal/apps/ai-proxy/route/transports/transport.go
@@ -29,7 +29,6 @@ import (
 
 	"golang.org/x/net/http/httpproxy"
 
-	"github.com/erda-project/erda-infra/base/logs"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/body_util"
 	"github.com/erda-project/erda/pkg/http/httputil"
@@ -66,8 +65,7 @@ func (d *DoNothingTransport) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 type TimerTransport struct {
-	Logger logs.Logger
-	Inner  http.RoundTripper
+	Inner http.RoundTripper
 }
 
 func (t *TimerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -76,8 +74,8 @@ func (t *TimerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.Inner = BaseTransport
 	}
 	res, err := t.Inner.RoundTrip(req)
-	t.Logger.Sub(reflect.TypeOf(t).String()).
-		Debugf("RoundTrip costs: %s", time.Now().Sub(start).String())
+	ctxhelper.MustGetLogger(req.Context()).Sub(reflect.TypeOf(t).String()).
+		Infof("RoundTrip costs: %s", time.Now().Sub(start).String())
 	return res, err
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy:

- set XFF correctly
- fix json-body-model-finder, support `application/json; charset=utf-8`


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=778242&iterationID=12783&type=TASK)


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Bugfix(AI-Proxy): Fix XFF header handling and JSON body model finder |
| 🇨🇳 中文    | 修复(AI-Proxy)：修复了 AI Proxy 平台的 XFF 头处理和 JSON body model finder |
