### PR TITLE
fix(ai-proxy): `/v1/models` and context-find-model only use model.name or publisher/model.name

### DIFF
--- a/internal/apps/ai-proxy/route/filters/request/context-family/context/model.go
+++ b/internal/apps/ai-proxy/route/filters/request/context-family/context/model.go
@@ -112,19 +112,13 @@ func modelGetter(ctx context.Context, models []*modelpb.Model) *modelpb.Model {
 // getMapOfAvailableNameWithModels.
 // availableName rules: (priority: high -> low)
 // - ${publisher}/${model.name}
-// - ${publisher}/${model.metadata.public.model_id}
-// - ${publisher}/${model.metadata.public.model_name}
 // - ${model.name}
 func getMapOfAvailableNameWithModels(clientModels []*modelpb.Model) map[string][]*modelpb.Model {
 	modelsMap := make(map[string][]*modelpb.Model)
 	for _, model := range clientModels {
 		publisher := model.Metadata.Public["publisher"].GetStringValue()
-		modelIDInMetadata := model.Metadata.Public["model_id"].GetStringValue()
-		modelNameInMetadata := model.Metadata.Public["model_name"].GetStringValue()
 		keys := append([]string{},
 			fmt.Sprintf("%s/%s", publisher, model.Name),
-			fmt.Sprintf("%s/%s", publisher, modelIDInMetadata),
-			fmt.Sprintf("%s/%s", publisher, modelNameInMetadata),
 			model.Name,
 		)
 		for _, key := range keys {

--- a/internal/apps/ai-proxy/route/filters/request/openai-v1-models/model_name.go
+++ b/internal/apps/ai-proxy/route/filters/request/openai-v1-models/model_name.go
@@ -25,8 +25,7 @@ import (
 
 func GenerateModelNameWithPublisher(model *modelpb.Model) string {
 	publisher := GetModelPublisher(model)
-	modelID := GetModelID(model)
-	return fmt.Sprintf("%s/%s", publisher, modelID)
+	return fmt.Sprintf("%s/%s", publisher, model.Name)
 }
 
 func GetModelDisplayName(model *modelpb.Model) string {


### PR DESCRIPTION


#### What this PR does / why we need it:

AI-Proxy `/v1/models` and context-find-model only use model.name or publisher/model.name, no more `model.metadata.public.{model_name/model_id}`.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=778242&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy `/v1/models` and context-find-model only use model.name or publisher/model.name           |
| 🇨🇳 中文    |    AI-Proxy `/v1/models` 和 context-find-model 只使用 model.name 或 publisher/model.name          |
