### PR TITLE
feat(ai-proxy): support request body transform

### DIFF
--- a/internal/apps/ai-proxy/common/ctxhelper/keys.go
+++ b/internal/apps/ai-proxy/common/ctxhelper/keys.go
@@ -73,6 +73,8 @@ type (
 	mapKeyClientId          struct{ string }
 	mapKeyAccessLang        struct{ string }
 	mapKeyRichClientHandler struct{ any }
+
+	mapKeyRequestBodyTransformChanges struct{ any }
 )
 
 // KeysWithCustomMustGet defines keys with custom MustGet implementations (should not generate default MustGet)

--- a/internal/apps/ai-proxy/models/metadata/api_segment/merge.go
+++ b/internal/apps/ai-proxy/models/metadata/api_segment/merge.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_segment
+
+import (
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
+)
+
+// MergeAPIStyleConfig merges multiple API segments by priority (later segments override earlier ones).
+// It first uses api.GetAPIStyleConfigByMethodAndPathMatcher to find the corresponding APIStyleConfig,
+// then merges them field by field, where non-empty fields from later configs override earlier ones.
+func MergeAPIStyleConfig(method string, pathMatcher string, apiSegments ...*API) *api_style.APIStyleConfig {
+	if len(apiSegments) == 0 {
+		return nil
+	}
+
+	var result *api_style.APIStyleConfig
+
+	// process each API segment in order (later ones have higher priority)
+	for _, apiSeg := range apiSegments {
+		if apiSeg == nil {
+			continue
+		}
+
+		config := apiSeg.GetAPIStyleConfigByMethodAndPathMatcher(method, pathMatcher)
+		if config == nil {
+			continue
+		}
+
+		if result == nil {
+			result = config
+			continue
+		}
+
+		mergeAPIStyleConfigFields(result, config)
+	}
+
+	return result
+}
+
+// mergeAPIStyleConfigFields merges non-empty fields from high priority config into low priority config
+func mergeAPIStyleConfigFields(low, high *api_style.APIStyleConfig) {
+	if high == nil {
+		return
+	}
+
+	if high.Method != "" {
+		low.Method = high.Method
+	}
+	if high.Scheme != "" {
+		low.Scheme = high.Scheme
+	}
+	if high.Host != "" {
+		low.Host = high.Host
+	}
+	if high.Path != nil {
+		low.Path = high.Path
+	}
+	if len(high.PathOp) > 0 {
+		// replace the entire PathOp
+		low.PathOp = high.PathOp
+	}
+
+	// merge map fields
+	if len(high.QueryParams) > 0 {
+		if low.QueryParams == nil {
+			low.QueryParams = make(map[string][]string)
+		}
+		for key, value := range high.QueryParams {
+			if len(value) > 0 {
+				// replace the entire value for this key
+				low.QueryParams[key] = value
+			}
+		}
+	}
+
+	if len(high.Headers) > 0 {
+		if low.Headers == nil {
+			low.Headers = make(map[string][]string)
+		}
+		for key, value := range high.Headers {
+			if len(value) > 0 {
+				// replace the entire value for this key
+				low.Headers[key] = value
+			}
+		}
+	}
+
+	// merge body field
+	if high.Body != nil {
+		// replace the entire Body field
+		low.Body = high.Body
+	}
+}

--- a/internal/apps/ai-proxy/models/metadata/api_segment/merge_test.go
+++ b/internal/apps/ai-proxy/models/metadata/api_segment/merge_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_segment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
+)
+
+func TestMergeAPIStyleConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		pathMatcher string
+		apiSegments []*API
+		expected    *api_style.APIStyleConfig
+	}{
+		{
+			name:        "single provider config",
+			method:      "POST",
+			pathMatcher: "/v1/chat/completions",
+			apiSegments: []*API{
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Host:   "api.openai.com",
+							Scheme: "https",
+							Headers: map[string][]string{
+								"Authorization": {"set", "Bearer ${@provider.apiKey}"},
+							},
+						},
+					},
+				},
+			},
+			expected: &api_style.APIStyleConfig{
+				Host:   "api.openai.com",
+				Scheme: "https",
+				Headers: map[string][]string{
+					"Authorization": {"set", "Bearer ${@provider.apiKey}"},
+				},
+			},
+		},
+		{
+			name:        "provider and model config merge",
+			method:      "POST",
+			pathMatcher: "/v1/chat/completions",
+			apiSegments: []*API{
+				// Provider level (lower priority)
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Host:   "api.openai.com",
+							Scheme: "https",
+							Headers: map[string][]string{
+								"Authorization": {"set", "Bearer ${@provider.apiKey}"},
+								"User-Agent":    {"set", "erda-ai-proxy"},
+							},
+						},
+					},
+				},
+				// Model level (higher priority)
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Host: "api.openai.com/v2", // Override host
+							Body: &api_style.BodyTransform{
+								Rename: map[string]string{
+									"max_tokens": "max_completion_tokens",
+								},
+							},
+							Headers: map[string][]string{
+								"X-Model": {"set", "gpt-5"}, // Add new header
+							},
+						},
+					},
+				},
+			},
+			expected: &api_style.APIStyleConfig{
+				Host:   "api.openai.com/v2", // Overridden by model
+				Scheme: "https",             // From provider
+				Headers: map[string][]string{
+					"Authorization": {"set", "Bearer ${@provider.apiKey}"}, // From provider
+					"User-Agent":    {"set", "erda-ai-proxy"},              // From provider
+					"X-Model":       {"set", "gpt-5"},                      // From model
+				},
+				Body: &api_style.BodyTransform{
+					Rename: map[string]string{
+						"max_tokens": "max_completion_tokens",
+					},
+				},
+			},
+		},
+		{
+			name:        "body transformation replace",
+			method:      "POST",
+			pathMatcher: "/v1/chat/completions",
+			apiSegments: []*API{
+				// Provider level
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Body: &api_style.BodyTransform{
+								Drop: []string{
+									"top_p",
+								},
+								Default: map[string]any{
+									"temperature": 1.0,
+								},
+							},
+						},
+					},
+				},
+				// Model level
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Body: &api_style.BodyTransform{
+								Rename: map[string]string{
+									"max_tokens": "max_completion_tokens",
+								},
+								Drop: []string{
+									"frequency_penalty",
+								},
+								Clamp: map[string]api_style.NumericClamp{
+									"max_completion_tokens": {
+										Min: func() *float64 { v := 1.0; return &v }(),
+										Max: func() *float64 { v := 8192.0; return &v }(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &api_style.APIStyleConfig{
+				Body: &api_style.BodyTransform{
+					Rename: map[string]string{
+						"max_tokens": "max_completion_tokens",
+					},
+					Drop: []string{
+						"frequency_penalty", // From model
+					},
+					Clamp: map[string]api_style.NumericClamp{
+						"max_completion_tokens": {
+							Min: func() *float64 { v := 1.0; return &v }(),
+							Max: func() *float64 { v := 8192.0; return &v }(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "no matching config",
+			method:      "GET",
+			pathMatcher: "/v1/models",
+			apiSegments: []*API{
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Host: "api.openai.com",
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:        "empty api segments",
+			method:      "POST",
+			pathMatcher: "/v1/chat/completions",
+			apiSegments: []*API{},
+			expected:    nil,
+		},
+		{
+			name:        "GPT-5 specific case",
+			method:      "POST",
+			pathMatcher: "/v1/chat/completions",
+			apiSegments: []*API{
+				// Provider level - OpenAI base config
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"POST:/v1/chat/completions": {
+							Host:   "api.openai.com",
+							Scheme: "https",
+							Headers: map[string][]string{
+								"Authorization": {"set", "Bearer ${@provider.apiKey}"},
+								"Content-Type":  {"set", "application/json"},
+							},
+						},
+					},
+				},
+				// Model level - GPT-5 specific transformations
+				{
+					APIStyleConfigs: map[string]api_style.APIStyleConfig{
+						"*:*": {
+							Body: &api_style.BodyTransform{
+								Rename: map[string]string{
+									"max_tokens": "max_completion_tokens",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &api_style.APIStyleConfig{
+				Host:   "api.openai.com",
+				Scheme: "https",
+				Headers: map[string][]string{
+					"Authorization": {"set", "Bearer ${@provider.apiKey}"},
+					"Content-Type":  {"set", "application/json"},
+				},
+				Body: &api_style.BodyTransform{
+					Rename: map[string]string{
+						"max_tokens": "max_completion_tokens",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeAPIStyleConfig(tt.method, tt.pathMatcher, tt.apiSegments...)
+
+			if tt.expected == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expected.Host, result.Host)
+			assert.Equal(t, tt.expected.Scheme, result.Scheme)
+			assert.Equal(t, tt.expected.Method, result.Method)
+			assert.Equal(t, tt.expected.Headers, result.Headers)
+
+			// Compare Body transformation
+			if tt.expected.Body == nil {
+				assert.Nil(t, result.Body)
+			} else {
+				assert.NotNil(t, result.Body)
+				if tt.expected.Body == nil {
+					assert.Nil(t, result.Body)
+				} else {
+					assert.NotNil(t, result.Body)
+					assert.Equal(t, tt.expected.Body.Rename, result.Body.Rename)
+					assert.Equal(t, tt.expected.Body.Drop, result.Body.Drop)
+					assert.Equal(t, tt.expected.Body.Default, result.Body.Default)
+					assert.Equal(t, tt.expected.Body.Clamp, result.Body.Clamp)
+				}
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/route/filters/common/custom-http-director/body.go
+++ b/internal/apps/ai-proxy/route/filters/common/custom-http-director/body.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package custom_http_director
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/body_util"
+)
+
+// BodyTransformChange records a single body transformation operation
+type BodyTransformChange struct {
+	Op    string `json:"op"`              // rename, drop, default, clamp, force
+	Key   string `json:"key,omitempty"`   // parameter name
+	From  any    `json:"from,omitempty"`  // original value (for rename, clamp)
+	To    any    `json:"to,omitempty"`    // new value (for rename, clamp)
+	Value any    `json:"value,omitempty"` // set value (for default, force)
+}
+
+// BodyTransformer defines the interface for transforming request bodies based on content type
+type BodyTransformer interface {
+	CanHandle(contentType string) bool
+	Transform(r *http.Request, config *api_style.BodyTransform) error
+}
+
+// getBodyTransformerByContentType selects appropriate body rewriter based on Content-Type
+func getBodyTransformerByContentType(contentType string) BodyTransformer {
+	transformers := []BodyTransformer{
+		&JSONBodyTransformer{},
+	}
+	for _, rewriter := range transformers {
+		if rewriter.CanHandle(contentType) {
+			return rewriter
+		}
+	}
+	return nil
+}
+
+// JSONBodyTransformer handles JSON body transformations
+type JSONBodyTransformer struct{}
+
+func (jbt *JSONBodyTransformer) CanHandle(contentType string) bool {
+	return strings.HasPrefix(contentType, "application/json")
+}
+
+func (jbt *JSONBodyTransformer) Transform(r *http.Request, config *api_style.BodyTransform) error {
+	if config == nil {
+		return nil
+	}
+	return jbt.transformBody(r, config)
+}
+
+func (jbt *JSONBodyTransformer) transformBody(r *http.Request, config *api_style.BodyTransform) error {
+	if config == nil {
+		return nil
+	}
+
+	var jsonBody map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&jsonBody); err != nil {
+		return fmt.Errorf("failed to decode request body: %v", err)
+	}
+
+	// Apply transformations
+	var changes []BodyTransformChange
+	if err := jbt.applyTransformations(jsonBody, config, &changes); err != nil {
+		return fmt.Errorf("failed to apply transformations: %v", err)
+	}
+
+	// reset body
+	b, err := json.Marshal(jsonBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal transformed body: %v", err)
+	}
+	if err := body_util.SetBody(r, b); err != nil {
+		return fmt.Errorf("failed to set transformed body: %w", err)
+	}
+
+	// store changes in context
+	if len(changes) > 0 {
+		ctxhelper.PutRequestBodyTransformChanges(r.Context(), &changes)
+	}
+
+	return nil
+}
+
+// applyTransformations applies all transformation rules in the fixed order
+func (jbt *JSONBodyTransformer) applyTransformations(
+	jsonBody map[string]any,
+	config *api_style.BodyTransform,
+	changes *[]BodyTransformChange,
+) error {
+	// 1. rename parameters
+	if err := jbt.applyRename(jsonBody, config.Rename, changes); err != nil {
+		return fmt.Errorf("failed to apply rename: %v", err)
+	}
+
+	// 2. set default values
+	if err := jbt.applyDefault(jsonBody, config.Default, changes); err != nil {
+		return fmt.Errorf("failed to apply default: %v", err)
+	}
+
+	// 3. force set values
+	if err := jbt.applyForce(jsonBody, config.Force, changes); err != nil {
+		return fmt.Errorf("failed to apply force: %v", err)
+	}
+
+	// 4. drop explicitly specified parameters
+	if err := jbt.applyDrop(jsonBody, config.Drop, changes); err != nil {
+		return fmt.Errorf("failed to apply drop: %v", err)
+	}
+
+	// 5. apply numeric clamping
+	if err := jbt.applyClamp(jsonBody, config.Clamp, changes); err != nil {
+		return fmt.Errorf("failed to apply clamp: %v", err)
+	}
+
+	return nil
+}
+
+// applyRename renames parameters according to the rename map
+func (jbt *JSONBodyTransformer) applyRename(jsonBody map[string]any, renameMap map[string]string, changes *[]BodyTransformChange) error {
+	for oldKey, newKey := range renameMap {
+		if oldValue, hasOld := jsonBody[oldKey]; hasOld {
+			// if new key already exists, skip
+			if _, hasNew := jsonBody[newKey]; hasNew {
+				continue
+			}
+			// rename old to new
+			jsonBody[newKey] = oldValue
+			delete(jsonBody, oldKey)
+			*changes = append(*changes, BodyTransformChange{
+				Op:   "rename",
+				From: oldKey,
+				To:   newKey,
+			})
+		}
+	}
+	return nil
+}
+
+// applyDefault sets default values for missing keys
+func (jbt *JSONBodyTransformer) applyDefault(jsonBody map[string]any, defaultMap map[string]any, changes *[]BodyTransformChange) error {
+	for key, defaultValue := range defaultMap {
+		if _, exists := jsonBody[key]; !exists {
+			jsonBody[key] = defaultValue
+			*changes = append(*changes, BodyTransformChange{
+				Op:    "default",
+				Key:   key,
+				Value: defaultValue,
+			})
+		}
+	}
+	return nil
+}
+
+// applyForce sets values, overriding existing ones
+func (jbt *JSONBodyTransformer) applyForce(jsonBody map[string]any, forceMap map[string]any, changes *[]BodyTransformChange) error {
+	for key, forceValue := range forceMap {
+		oldValue := jsonBody[key]
+		jsonBody[key] = forceValue
+		*changes = append(*changes, BodyTransformChange{
+			Op:    "force",
+			Key:   key,
+			From:  oldValue,
+			Value: forceValue,
+		})
+	}
+	return nil
+}
+
+// applyDrop removes explicitly specified parameters
+func (jbt *JSONBodyTransformer) applyDrop(jsonBody map[string]any, dropList []string, changes *[]BodyTransformChange) error {
+	for _, key := range dropList {
+		if oldValue, exists := jsonBody[key]; exists {
+			delete(jsonBody, key)
+			*changes = append(*changes, BodyTransformChange{
+				Op:   "drop",
+				Key:  key,
+				From: oldValue,
+			})
+		}
+	}
+	return nil
+}
+
+// applyClamp applies numeric constraints to values
+func (jbt *JSONBodyTransformer) applyClamp(jsonBody map[string]any, clampMap map[string]api_style.NumericClamp, changes *[]BodyTransformChange) error {
+	for key, clamp := range clampMap {
+		if value, exists := jsonBody[key]; exists {
+			// JSON numbers decode to float64 in map[string]any
+			numValue, ok := value.(float64)
+			if !ok {
+				// not a number in JSON body; skip
+				continue
+			}
+
+			originalValue := numValue
+			clamped := false
+
+			// apply min constraint
+			if clamp.Min != nil && numValue < *clamp.Min {
+				numValue = *clamp.Min
+				clamped = true
+			}
+
+			// apply max constraint
+			if clamp.Max != nil && numValue > *clamp.Max {
+				numValue = *clamp.Max
+				clamped = true
+			}
+
+			if clamped {
+				// keep as float64; JSON encoder handles integral values naturally
+				jsonBody[key] = numValue
+
+				*changes = append(*changes, BodyTransformChange{
+					Op:   "clamp",
+					Key:  key,
+					From: originalValue,
+					To:   numValue,
+				})
+			}
+		}
+	}
+	return nil
+}

--- a/internal/apps/ai-proxy/route/filters/common/custom-http-director/body_test.go
+++ b/internal/apps/ai-proxy/route/filters/common/custom-http-director/body_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package custom_http_director
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	modelpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model/pb"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/models/metadata/api_segment/api_style"
+)
+
+func TestJSONBodyTransformer(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestBody     map[string]any
+		bodyTransform   *api_style.BodyTransform
+		expectedBody    map[string]any
+		expectedChanges []BodyTransformChange
+	}{
+		{
+			name: "GPT-5 max_tokens transformation",
+			requestBody: map[string]any{
+				"model": "gpt-5",
+				"messages": []any{
+					map[string]any{"role": "user", "content": "Hello"},
+				},
+				"max_tokens":  150,
+				"top_p":       0.9,
+				"temperature": 0.8,
+			},
+			bodyTransform: &api_style.BodyTransform{
+				Rename: map[string]string{
+					"max_tokens": "max_completion_tokens",
+				},
+				Drop: []string{"top_p"},
+				Default: map[string]any{
+					"temperature": 1.0, // Should not override existing 0.8
+				},
+				Clamp: map[string]api_style.NumericClamp{
+					"max_completion_tokens": {
+						Min: func() *float64 { v := 1.0; return &v }(),
+						Max: func() *float64 { v := 8192.0; return &v }(),
+					},
+				},
+			},
+			expectedBody: map[string]any{
+				"model": "gpt-5",
+				"messages": []any{
+					map[string]any{"role": "user", "content": "Hello"},
+				},
+				"max_completion_tokens": int64(150), // Renamed from max_tokens
+				"temperature":           0.8,        // Original value kept (not defaulted)
+				// top_p should be dropped
+			},
+			expectedChanges: []BodyTransformChange{
+				{Op: "rename", Key: "max_tokens", From: 150, To: "max_completion_tokens"},
+				{Op: "drop", Key: "top_p", From: 0.9},
+			},
+		},
+		{
+			name: "clamping test",
+			requestBody: map[string]any{
+				"max_tokens": 50000, // Should be clamped to 8192
+			},
+			bodyTransform: &api_style.BodyTransform{
+				Rename: map[string]string{
+					"max_tokens": "max_completion_tokens",
+				},
+				Clamp: map[string]api_style.NumericClamp{
+					"max_completion_tokens": {
+						Min: func() *float64 { v := 1.0; return &v }(),
+						Max: func() *float64 { v := 8192.0; return &v }(),
+					},
+				},
+			},
+			expectedBody: map[string]any{
+				"max_completion_tokens": int64(8192), // Clamped from 50000
+			},
+			expectedChanges: []BodyTransformChange{
+				{Op: "rename", Key: "max_tokens", From: 50000, To: "max_completion_tokens"},
+				{Op: "clamp", Key: "max_completion_tokens", From: 50000.0, To: 8192.0},
+			},
+		},
+		{
+			name: "force set values",
+			requestBody: map[string]any{
+				"temperature": 0.8,
+			},
+			bodyTransform: &api_style.BodyTransform{
+				Force: map[string]any{
+					"temperature": 1.0,
+					"stream":      false,
+				},
+			},
+			expectedBody: map[string]any{
+				"temperature": 1.0,
+				"stream":      false,
+			},
+			expectedChanges: []BodyTransformChange{
+				{Op: "force", Key: "temperature", From: 0.8, Value: 1.0},
+				{Op: "force", Key: "stream", From: nil, Value: false},
+			},
+		},
+		{
+			name: "default values only for missing keys",
+			requestBody: map[string]any{
+				"temperature": 0.8, // Should not be overridden
+			},
+			bodyTransform: &api_style.BodyTransform{
+				Default: map[string]any{
+					"temperature": 1.0,   // Should not override existing
+					"stream":      false, // Should be added
+				},
+			},
+			expectedBody: map[string]any{
+				"temperature": 0.8,
+				"stream":      false,
+			},
+			expectedChanges: []BodyTransformChange{
+				{Op: "default", Key: "stream", Value: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Prepare request body
+			bodyBytes, err := json.Marshal(tt.requestBody)
+			assert.NoError(t, err)
+
+			// Create HTTP request with context containing model
+			req, err := http.NewRequest("POST", "/v1/chat/completions", bytes.NewReader(bodyBytes))
+			assert.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			// Add model to context (required by transformBody)
+			ctx := ctxhelper.InitCtxMapIfNeed(req.Context())
+			ctxhelper.PutModel(ctx, &modelpb.Model{Name: "test-model"})
+			req = req.WithContext(ctx)
+
+			// Create transformer
+			transformer := &JSONBodyTransformer{}
+
+			// Apply transformation
+			err = transformer.Transform(req, tt.bodyTransform)
+			assert.NoError(t, err)
+
+			// Read and verify the transformed body
+			bodyBytes, err = io.ReadAll(req.Body)
+			assert.NoError(t, err)
+
+			var actualBody map[string]any
+			err = json.Unmarshal(bodyBytes, &actualBody)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectedBody, actualBody)
+
+			// Verify changes were stored in context
+			if len(tt.expectedChanges) > 0 {
+				transformResult, ok := ctxhelper.GetBodyTransformChanges(ctx)
+				assert.True(t, ok)
+				assert.NotNil(t, transformResult)
+
+				actualChanges := *transformResult.(*[]BodyTransformChange)
+				assert.Len(t, actualChanges, len(tt.expectedChanges))
+
+				for i, expected := range tt.expectedChanges {
+					assert.Equal(t, expected.Op, actualChanges[i].Op)
+					assert.Equal(t, expected.Key, actualChanges[i].Key)
+					if expected.From != nil {
+						assert.Equal(t, expected.From, actualChanges[i].From)
+					}
+					if expected.To != nil {
+						assert.Equal(t, expected.To, actualChanges[i].To)
+					}
+					if expected.Value != nil {
+						assert.Equal(t, expected.Value, actualChanges[i].Value)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBodyDirectorIntegration(t *testing.T) {
+	t.Run("no transformation when no body config", func(t *testing.T) {
+		requestBody := map[string]any{
+			"max_tokens": 150,
+		}
+
+		bodyBytes, err := json.Marshal(requestBody)
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest("POST", "/v1/chat/completions", bytes.NewReader(bodyBytes))
+		assert.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		apiStyleConfig := api_style.APIStyleConfig{
+			// No Body configuration
+		}
+
+		err = bodyDirector(req, apiStyleConfig)
+		assert.NoError(t, err)
+
+		// Read body and verify it's unchanged
+		bodyBytes, err = io.ReadAll(req.Body)
+		assert.NoError(t, err)
+
+		var actualBody map[string]any
+		err = json.Unmarshal(bodyBytes, &actualBody)
+		assert.NoError(t, err)
+
+		expectedBody := map[string]any{
+			"max_tokens": 150.0, // JSON unmarshaling converts numbers to float64
+		}
+		assert.Equal(t, expectedBody, actualBody)
+	})
+
+	t.Run("non-JSON content type ignored", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/v1/chat/completions", bytes.NewReader([]byte("plain text")))
+		assert.NoError(t, err)
+		req.Header.Set("Content-Type", "text/plain")
+
+		apiStyleConfig := api_style.APIStyleConfig{
+			Body: &api_style.BodyTransform{
+				Rename: map[string]string{
+					"max_tokens": "max_completion_tokens",
+				},
+			},
+		}
+
+		err = bodyDirector(req, apiStyleConfig)
+		assert.NoError(t, err)
+
+		// Body should remain unchanged
+		bodyBytes, err := io.ReadAll(req.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "plain text", string(bodyBytes))
+	})
+}
+
+func TestJSONBodyTransformerCanHandle(t *testing.T) {
+	transformer := &JSONBodyTransformer{}
+
+	tests := []struct {
+		contentType string
+		expected    bool
+	}{
+		{"application/json", true},
+		{"application/json; charset=utf-8", true},
+		{"application/vnd.api+json", false}, // Only exact prefix match
+		{"text/plain", false},
+		{"application/xml", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			assert.Equal(t, tt.expected, transformer.CanHandle(tt.contentType))
+		})
+	}
+}
+
+func TestGetBodyTransformerByContentType(t *testing.T) {
+	tests := []struct {
+		contentType         string
+		expectedTransformer bool
+	}{
+		{"application/json", true},
+		{"application/json; charset=utf-8", true},
+		{"text/plain", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.contentType, func(t *testing.T) {
+			transformer := getBodyTransformerByContentType(tt.contentType)
+			if tt.expectedTransformer {
+				assert.NotNil(t, transformer)
+				assert.IsType(t, &JSONBodyTransformer{}, transformer)
+			} else {
+				assert.Nil(t, transformer)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/vars/consts.go
+++ b/internal/apps/ai-proxy/vars/consts.go
@@ -43,6 +43,8 @@ const (
 	XAIProxyModelName      = "X-AI-Proxy-Model-Name"
 	XAIProxyModelPublisher = "X-AI-Proxy-Model-Publisher"
 
+	XAIProxyRequestBodyTransform = "X-AI-Proxy-Request-Body-Transform"
+
 	UIValueUndefined = "undefined"
 )
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy support transform request body.

To fix: 

- OpenAI gpt-5 does not support `max_tokens` as param
- OpenAI gpt-5 `temperature` - Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=779300&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    AI-Proxy support transform request body          |
| 🇨🇳 中文    |    AI-Proxy 支持转换请求体          |
