### PR TITLE
fix(ai-proxy): use string content directly when converting openai tool_result to anthropic style

### DIFF
--- a/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/message_converter/req.go
+++ b/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/message_converter/req.go
@@ -143,20 +143,7 @@ func ConvertOneOpenAIToolMessage(openaiMsg openai.ChatCompletionMessage) (*Anthr
 		{
 			"type":        "tool_result",
 			"tool_use_id": openaiMsg.ToolCallID,
-			"content": []map[string]any{
-				func() map[string]any {
-					// try to unmarshal the tool_result content as JSON
-					var jsonObj map[string]any
-					if err := json.Unmarshal([]byte(openaiMsg.Content), &jsonObj); err != nil {
-						// if unmarshal fails, treat it as a string
-						return map[string]any{
-							"type": "text",
-							"text": openaiMsg.Content,
-						}
-					}
-					return jsonObj
-				}(),
-			},
+			"content":     openaiMsg.Content,
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy use string content directly when converting openai tool_result to anthropic style.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=780069&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy use string content directly when converting openai tool_result to anthropic style           |
| 🇨🇳 中文    |   AI-Proxy 在转换 tool_result 至 anthropic 风格时直接使用 string content           |
