### PR TITLE
feat(ai-proxy): force convert image_url to base64 for bedrock anthropic

### DIFF
--- a/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/aws_bedrock/bedrock.go
+++ b/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/aws_bedrock/bedrock.go
@@ -72,6 +72,10 @@ func (f *BedrockDirector) AwsBedrockDirector(pr *httputil.ProxyRequest, apiStyle
 	if err := json.NewDecoder(pr.Out.Body).Decode(&openaiReq); err != nil {
 		panic(fmt.Errorf("failed to decode request body as openai format, err: %v", err))
 	}
+	// set options for bedrock
+	openaiReq.Options = openai_extended.Options{
+		ImageURLForceBase64: &[]bool{true}[0], // force convert http image url to base64
+	}
 	// convert to: anthropic format request
 	baseAnthropicReq := message_converter.ConvertOpenAIRequestToBaseAnthropicRequest(openaiReq)
 	bedrockReq := BedrockRequest{

--- a/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/openai_extended/openai_extended.go
+++ b/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/openai_extended/openai_extended.go
@@ -27,6 +27,18 @@ type OpenAIRequestExtended struct {
 
 	// ExtraFields is used to store extra fields that are not part of the original OpenAI request.
 	ExtraFields map[string]any `json:"extra_fields,omitempty"` // used to store extra fields that are not part of the original OpenAI request
+
+	// Options used to pass additional options dynamically.
+	// Like: image_url_force_base64: true
+	Options Options `json:"-"`
+}
+
+type Options struct {
+	ImageURLForceBase64 *bool // force convert http image url to base64
+}
+
+func (opt *Options) GetFlagImageURLForceBase64() bool {
+	return opt != nil && opt.ImageURLForceBase64 != nil && *opt.ImageURLForceBase64
 }
 
 func (m *OpenAIRequestExtended) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy force convert image_url to base64 for bedrock anthropic.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=780146&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy force convert image_url to base64 for bedrock anthropic           |
| 🇨🇳 中文    |   AI-Proxy 强制将 image_url 转换为 base64 以支持 bedrock anthropic           |
