### PR TITLE
fix(ai-proxy): set anthropic req.thinking.budget_tokens=req.max_tokens/2 if empty

### DIFF
--- a/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/message_converter/req.go
+++ b/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/message_converter/req.go
@@ -105,7 +105,7 @@ func ConvertOpenAIRequestToBaseAnthropicRequest(openaiReq openai_extended.OpenAI
 		baseAnthropicReq.System = strings.Join(systemPrompts, "\n")
 	}
 	// thinking
-	baseAnthropicReq.AnthropicThinking = thinking.UnifiedGetThinkingConfigs(openaiReq).ToAnthropicThinking()
+	baseAnthropicReq.AnthropicThinking = thinking.UnifiedGetThinkingConfigs(openaiReq).ToAnthropicThinking(baseAnthropicReq.MaxTokens)
 
 	// split anthropic messages
 	splitAnthropicMessages(&baseAnthropicReq)

--- a/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
+++ b/internal/apps/ai-proxy/route/filters/common/anthropic-compatible-director/common/openai_extended/thinking/thinking.go
@@ -21,9 +21,13 @@ package thinking
 // - disable
 type UnifiedThinking AnthropicThinking
 
-func (t *UnifiedThinking) ToAnthropicThinking() *AnthropicThinking {
+func (t *UnifiedThinking) ToAnthropicThinking(maxTokens int) *AnthropicThinking {
 	if t == nil || t.Thinking == nil {
 		return nil
+	}
+	// check budget_tokens
+	if t.Thinking.BudgetTokens <= 0 {
+		t.Thinking.BudgetTokens = maxTokens / 2
 	}
 	return &AnthropicThinking{Thinking: t.Thinking}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy set anthropic req.thinking.budget_tokens=req.max_tokens/2 if empty.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=779599&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   AI-Proxy set anthropic req.thinking.budget_tokens=req.max_tokens/2 if empty           |
| 🇨🇳 中文    |   AI-Proxy 在 req.thinking.budget_tokens 为空时设置其为 req.max_tokens/2           |
