### PR TITLE
feat(release 2.1): openapi settings provider and configurable session expiration time in redis

### DIFF
--- a/cmd/erda/main.go
+++ b/cmd/erda/main.go
@@ -21,6 +21,7 @@ import (
 	// providers and modules
 	_ "github.com/erda-project/erda-infra/providers"
 	_ "github.com/erda-project/erda/modules/openapi"
+	_ "github.com/erda-project/erda/modules/openapi/settings"
 	_ "github.com/erda-project/erda/modules/orchestrator"
 	_ "github.com/erda-project/erda/modules/pipeline"
 )

--- a/cmd/erda/main.go
+++ b/cmd/erda/main.go
@@ -21,7 +21,6 @@ import (
 	// providers and modules
 	_ "github.com/erda-project/erda-infra/providers"
 	_ "github.com/erda-project/erda/modules/openapi"
-	_ "github.com/erda-project/erda/modules/openapi/settings"
 	_ "github.com/erda-project/erda/modules/orchestrator"
 	_ "github.com/erda-project/erda/modules/pipeline"
 )

--- a/cmd/openapi/main.go
+++ b/cmd/openapi/main.go
@@ -42,6 +42,7 @@ import (
 	_ "github.com/erda-project/erda/modules/core/openapi-ng/routes/openapi-v1"
 	_ "github.com/erda-project/erda/modules/core/openapi-ng/routes/proto"
 	_ "github.com/erda-project/erda/modules/openapi"
+	_ "github.com/erda-project/erda/modules/openapi/settings"
 	_ "github.com/erda-project/erda/providers/audit"
 	_ "github.com/erda-project/erda/providers/service-discover/erda-discover"
 	_ "github.com/erda-project/erda/providers/service-discover/fixed-discover"

--- a/conf/erda/erda.yaml
+++ b/conf/erda/erda.yaml
@@ -2,9 +2,6 @@ http-server:
     addr: ":8080"
 health:
 
-openapi-settings:
-    session_expire: "${OPENAPI_SESSION_EXPIRE:120m}"
-
 i18n:
     files:
         - ${CONFIG_PATH}/i18n/apis.yml

--- a/conf/erda/erda.yaml
+++ b/conf/erda/erda.yaml
@@ -2,6 +2,9 @@ http-server:
     addr: ":8080"
 health:
 
+openapi-settings:
+    session_expire: "${OPENAPI_SESSION_EXPIRE:30m}"
+
 i18n:
     files:
         - ${CONFIG_PATH}/i18n/apis.yml

--- a/conf/erda/erda.yaml
+++ b/conf/erda/erda.yaml
@@ -3,7 +3,7 @@ http-server:
 health:
 
 openapi-settings:
-    session_expire: "${OPENAPI_SESSION_EXPIRE:30m}"
+    session_expire: "${OPENAPI_SESSION_EXPIRE:120m}"
 
 i18n:
     files:

--- a/conf/openapi/openapi.yaml
+++ b/conf/openapi/openapi.yaml
@@ -11,6 +11,9 @@ redis:
   master_name: "${REDIS_MASTER_NAME}"
   sentinels_addr: "${REDIS_SENTINELS_ADDR}"
 
+openapi-settings:
+  session_expire: "${OPENAPI_SESSION_EXPIRE:30m}"
+
 openapi-ng:
 
 openapi-interceptor-dump:

--- a/conf/openapi/openapi.yaml
+++ b/conf/openapi/openapi.yaml
@@ -12,7 +12,7 @@ redis:
   sentinels_addr: "${REDIS_SENTINELS_ADDR}"
 
 openapi-settings:
-  session_expire: "${OPENAPI_SESSION_EXPIRE:30m}"
+  session_expire: "${OPENAPI_SESSION_EXPIRE:120h}"
 
 openapi-ng:
 

--- a/modules/core/openapi-ng/auth/password/check.go
+++ b/modules/core/openapi-ng/auth/password/check.go
@@ -47,8 +47,8 @@ func (p *provider) Check(r *http.Request, data interface{}, opts openapiauth.Opt
 	if len(parts) != 2 || len(parts[0]) <= 0 || len(parts[1]) <= 0 {
 		return false, r, fmt.Errorf("miss username or password")
 	}
-	user := auth.NewUser(p.Redis)
-	_, err = user.PwdLogin(parts[0], parts[1])
+	user := auth.NewUser(p.Redis, p.Settings.GetSessionExpire())
+	_, err = user.PwdLogin(parts[0], parts[1], p.Settings.GetSessionExpire())
 	if err != nil {
 		return false, r, nil
 	}

--- a/modules/core/openapi-ng/auth/password/provider.go
+++ b/modules/core/openapi-ng/auth/password/provider.go
@@ -28,6 +28,7 @@ import (
 	openapiauth "github.com/erda-project/erda/modules/core/openapi-ng/auth"
 	"github.com/erda-project/erda/modules/core/openapi-ng/common"
 	"github.com/erda-project/erda/modules/openapi/auth"
+	"github.com/erda-project/erda/modules/openapi/settings"
 	"github.com/erda-project/erda/pkg/ucauth"
 )
 
@@ -37,10 +38,11 @@ type config struct {
 
 // +provider
 type provider struct {
-	Cfg    *config
-	Log    logs.Logger
-	Router openapi.Interface `autowired:"openapi-router"`
-	Redis  *redis.Client     `autowired:"redis-client"`
+	Cfg      *config
+	Log      logs.Logger
+	Router   openapi.Interface        `autowired:"openapi-router"`
+	Redis    *redis.Client            `autowired:"redis-client"`
+	Settings settings.OpenapiSettings `autowired:"openapi-settings"`
 }
 
 func (p *provider) Init(ctx servicehub.Context) (err error) {
@@ -71,8 +73,8 @@ func (p *provider) Login(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user := auth.NewUser(p.Redis)
-	sessionID, err := user.PwdLogin(params.Username, params.Password)
+	user := auth.NewUser(p.Redis, p.Settings.GetSessionExpire())
+	sessionID, err := user.PwdLogin(params.Username, params.Password, p.Settings.GetSessionExpire())
 	if err != nil {
 		err := fmt.Errorf("failed to PwdLogin: %v", err)
 		p.Log.Error(err)

--- a/modules/core/openapi-ng/auth/uc-session/check.go
+++ b/modules/core/openapi-ng/auth/uc-session/check.go
@@ -42,7 +42,7 @@ func (a *loginChecker) Match(r *http.Request, opts openapiauth.Options) (bool, i
 }
 
 func (a *loginChecker) Check(r *http.Request, data interface{}, opts openapiauth.Options) (bool, *http.Request, error) {
-	user := auth.NewUser(a.p.Redis)
+	user := auth.NewUser(a.p.Redis, a.p.Settings.GetSessionExpire())
 	r = r.WithContext(context.WithValue(r.Context(), "session", data.(string)))
 	result := user.IsLogin(r)
 	if result.Code != auth.AuthSucc {
@@ -93,7 +93,7 @@ func (a *tryLoginChecker) Match(r *http.Request, opts openapiauth.Options) (bool
 }
 
 func (a *tryLoginChecker) Check(r *http.Request, data interface{}, opts openapiauth.Options) (bool, *http.Request, error) {
-	user := auth.NewUser(a.p.Redis)
+	user := auth.NewUser(a.p.Redis, a.p.Settings.GetSessionExpire())
 	r = r.WithContext(context.WithValue(r.Context(), "session", data.(string)))
 	result := user.IsLogin(r)
 	if result.Code == auth.AuthSucc {

--- a/modules/core/openapi-ng/auth/uc-session/login.go
+++ b/modules/core/openapi-ng/auth/uc-session/login.go
@@ -58,8 +58,8 @@ func (p *provider) LoginCallback(rw http.ResponseWriter, r *http.Request) {
 	scheme := p.getScheme(r)
 	redirectURI := fmt.Sprintf("%s://%s/logincb?referer=%s", scheme, p.getUCRedirectHost(referer, r.URL.Host), url.QueryEscape(referer))
 
-	user := auth.NewUser(p.Redis)
-	sessionID, _, err := user.Login(code, redirectURI)
+	user := auth.NewUser(p.Redis, p.Settings.GetSessionExpire())
+	sessionID, _, err := user.Login(code, redirectURI, p.Settings.GetSessionExpire())
 	if err != nil {
 		p.Log.Errorf("failed to login: %v", err)
 		http.Error(rw, err.Error(), http.StatusUnauthorized)
@@ -90,7 +90,7 @@ func (p *provider) Logout(rw http.ResponseWriter, r *http.Request) {
 	session := p.getSession(r)
 	if len(session) > 0 {
 		r = r.WithContext(context.WithValue(r.Context(), "session", session))
-		if err := auth.NewUser(p.Redis).Logout(r); err != nil {
+		if err := auth.NewUser(p.Redis, p.Settings.GetSessionExpire()).Logout(r); err != nil {
 			err := fmt.Errorf("logout: %v", err)
 			p.Log.Error(err)
 			http.Error(rw, err.Error(), http.StatusBadGateway)

--- a/modules/core/openapi-ng/auth/uc-session/provider.go
+++ b/modules/core/openapi-ng/auth/uc-session/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/erda-project/erda-infra/base/servicehub"
 	"github.com/erda-project/erda/modules/core/openapi-ng"
 	openapiauth "github.com/erda-project/erda/modules/core/openapi-ng/auth"
+	"github.com/erda-project/erda/modules/openapi/settings"
 )
 
 type config struct {
@@ -42,10 +43,11 @@ type config struct {
 
 // +provider
 type provider struct {
-	Cfg    *config
-	Log    logs.Logger
-	Router openapi.Interface `autowired:"openapi-router"`
-	Redis  *redis.Client     `autowired:"redis-client"`
+	Cfg      *config
+	Log      logs.Logger
+	Router   openapi.Interface        `autowired:"openapi-router"`
+	Redis    *redis.Client            `autowired:"redis-client"`
+	Settings settings.OpenapiSettings `autowired:"openapi-settings"`
 }
 
 func (p *provider) Init(ctx servicehub.Context) (err error) {

--- a/modules/core/openapi-ng/auth/uc-session/user.go
+++ b/modules/core/openapi-ng/auth/uc-session/user.go
@@ -33,7 +33,7 @@ func (p *provider) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 	if len(session) > 0 {
 		r = r.WithContext(context.WithValue(r.Context(), "session", session))
 	}
-	user := auth.NewUser(p.Redis)
+	user := auth.NewUser(p.Redis, p.Settings.GetSessionExpire())
 	info, authr := user.GetInfo(r)
 	if authr.Code != auth.AuthSucc {
 		http.Error(rw, authr.Detail, authr.Code)

--- a/modules/core/openapi-ng/routes/openapi-v1/provider.go
+++ b/modules/core/openapi-ng/routes/openapi-v1/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/erda-project/erda/modules/openapi/component-protocol/types"
 	"github.com/erda-project/erda/modules/openapi/conf"
 	"github.com/erda-project/erda/modules/openapi/hooks"
+	"github.com/erda-project/erda/modules/openapi/settings"
 	discover "github.com/erda-project/erda/providers/service-discover"
 )
 
@@ -43,6 +44,7 @@ type provider struct {
 	Router   openapi.Interface  `autowired:"openapi-router"`
 	proxy    proxy.Proxy
 	handler  http.Handler
+	Settings settings.OpenapiSettings `autowired:"openapi-settings"`
 }
 
 func (p *provider) Init(ctx servicehub.Context) (err error) {
@@ -50,7 +52,7 @@ func (p *provider) Init(ctx servicehub.Context) (err error) {
 	p.proxy.Discover = p.Discover
 	hooks.Enable = false
 	conf.Load()
-	srv, err := openapiv1.NewServer()
+	srv, err := openapiv1.NewServer(p.Settings)
 	if err != nil {
 		return err
 	}

--- a/modules/openapi/auth/user.go
+++ b/modules/openapi/auth/user.go
@@ -64,26 +64,27 @@ type ScopeInfo struct {
 }
 
 type User struct {
-	sessionID  string
-	token      ucauth.OAuthToken
-	info       ucauth.UserInfo
-	scopeInfo  ScopeInfo
-	state      GetUserState
-	redisCli   *redis.Client
-	ucUserAuth *ucauth.UCUserAuth
+	sessionID     string
+	token         ucauth.OAuthToken
+	info          ucauth.UserInfo
+	scopeInfo     ScopeInfo
+	state         GetUserState
+	redisCli      *redis.Client
+	ucUserAuth    *ucauth.UCUserAuth
+	sessionExpire time.Duration
 
 	bundle *bundle.Bundle
 }
 
 var client = bundle.New(bundle.WithCoreServices(), bundle.WithDOP())
 
-func NewUser(redisCli *redis.Client) *User {
+func NewUser(redisCli *redis.Client, expire time.Duration) *User {
 	ucUserAuth := ucauth.NewUCUserAuth(conf.UCAddrFront(), discover.UC(), "http://"+conf.UCRedirectHost()+"/logincb", conf.UCClientID(), conf.UCClientSecret())
 	if conf.OryEnabled() {
 		ucUserAuth.ClientID = conf.OryCompatibleClientID()
 		ucUserAuth.UCHost = conf.OryKratosAddr()
 	}
-	return &User{state: GetInit, redisCli: redisCli, ucUserAuth: ucUserAuth, bundle: client}
+	return &User{state: GetInit, redisCli: redisCli, ucUserAuth: ucUserAuth, bundle: client, sessionExpire: expire}
 }
 
 func (u *User) get(req *http.Request, state GetUserState) (interface{}, AuthResult) {
@@ -182,6 +183,10 @@ func (u *User) get(req *http.Request, state GetUserState) (interface{}, AuthResu
 		fallthrough
 	case GotScopeInfo:
 		if state == GotScopeInfo {
+			// if sessionExpire is less than or equal to zero, it means no need to renew session in Redis
+			if u.sessionExpire > 0 {
+				u.redisCli.Expire(MkSessionKey(u.sessionID), u.sessionExpire)
+			}
 			return u.scopeInfo, AuthResult{AuthSucc, ""}
 		}
 	}
@@ -212,29 +217,30 @@ func (u *User) GetScopeInfo(req *http.Request) (ScopeInfo, AuthResult) {
 }
 
 // return (token, expiredays, err)
-func (u *User) Login(uccode string, redirectURI string) (string, int, error) {
+func (u *User) Login(uccode string, redirectURI string, expiration time.Duration) (string, int, error) {
 	u.ucUserAuth.RedirectURI = redirectURI
 	otoken, err := u.ucUserAuth.Login(uccode)
+	expireDays := int(expiration / (time.Hour * 24))
 	if err != nil {
 		logrus.Error(err)
-		return "", SessionExpireDays, err
+		return "", expireDays, err
 	}
 	u.token = otoken
 	userInfo, err := u.ucUserAuth.GetUserInfo(u.token)
 	if err != nil {
-		return "", SessionExpireDays, err
+		return "", expireDays, err
 	}
 	u.info = userInfo
 	u.state = GotInfo
-	if err := u.storeSession(otoken.AccessToken); err != nil {
+	if err := u.storeSession(otoken.AccessToken, expiration); err != nil {
 		err_ := errors.Wrap(err, "login: storeSession fail")
 		logrus.Error(err_)
-		return "", SessionExpireDays, err_
+		return "", expireDays, err_
 	}
-	return u.sessionID, SessionExpireDays, nil
+	return u.sessionID, expireDays, nil
 }
 
-func (u *User) PwdLogin(username, password string) (string, error) {
+func (u *User) PwdLogin(username, password string, expire time.Duration) (string, error) {
 	otoken, err := u.ucUserAuth.PwdAuth(username, password)
 	if err != nil {
 		logrus.Error(err)
@@ -247,7 +253,7 @@ func (u *User) PwdLogin(username, password string) (string, error) {
 	}
 	u.info = userInfo
 	u.state = GotInfo
-	if err := u.storeSession(otoken.AccessToken); err != nil {
+	if err := u.storeSession(otoken.AccessToken, expire); err != nil {
 		err_ := errors.Wrap(err, "pwdlogin: storeSession fail")
 		logrus.Error(err_)
 		return "", err_
@@ -255,9 +261,9 @@ func (u *User) PwdLogin(username, password string) (string, error) {
 	return u.sessionID, nil
 }
 
-func (u *User) storeSession(token string) error {
+func (u *User) storeSession(token string, expire time.Duration) error {
 	u.sessionID = genSessionID()
-	_, err := u.redisCli.Set(MkSessionKey(u.sessionID), token, SessionExpireDays*24*time.Hour).Result()
+	_, err := u.redisCli.Set(MkSessionKey(u.sessionID), token, expire).Result()
 	if err != nil {
 		err_ := errors.Wrap(err, "storeSession: store redis fail")
 		return err_

--- a/modules/openapi/provider.go
+++ b/modules/openapi/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/erda-project/erda-infra/base/version"
 	"github.com/erda-project/erda/modules/openapi/component-protocol/types"
 	"github.com/erda-project/erda/modules/openapi/conf"
+	"github.com/erda-project/erda/modules/openapi/settings"
 )
 
 type config struct {
@@ -30,14 +31,15 @@ type config struct {
 }
 
 type provider struct {
-	Cfg *config
+	Cfg      *config
+	Settings settings.OpenapiSettings `autowired:"openapi-settings"`
 }
 
 func (p *provider) Run(ctx context.Context) error {
 	logrus.Infof(version.String())
 	logrus.Errorf("[alert] openapi instance start")
 	conf.Load()
-	srv, err := NewServer()
+	srv, err := NewServer(p.Settings)
 	if err != nil {
 		return err
 	}

--- a/modules/openapi/server.go
+++ b/modules/openapi/server.go
@@ -21,10 +21,11 @@ import (
 	"time"
 
 	"github.com/erda-project/erda/modules/openapi/conf"
+	"github.com/erda-project/erda/modules/openapi/settings"
 )
 
-func NewServer() (*http.Server, error) {
-	s, err := NewLoginServer()
+func NewServer(settings settings.OpenapiSettings) (*http.Server, error) {
+	s, err := NewLoginServer(settings)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/openapi/settings/provider.go
+++ b/modules/openapi/settings/provider.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package settings
+
+import (
+	"errors"
+	"time"
+
+	"github.com/erda-project/erda-infra/base/servicehub"
+)
+
+type OpenapiSettings interface {
+	GetSessionExpire() time.Duration
+}
+
+type config struct {
+	SessionExpire time.Duration `file:"session_expire" default:"24h"`
+}
+type provider struct {
+	Cfg *config
+}
+
+func (p *provider) GetSessionExpire() time.Duration {
+	return p.Cfg.SessionExpire
+}
+
+func (p *provider) Init(ctx servicehub.Context) (err error) {
+	if p.Cfg.SessionExpire < 0 {
+		return errors.New("session_expire must be greater than or equal to 0")
+	}
+	return nil
+}
+
+func init() {
+	servicehub.Register("openapi-settings", &servicehub.Spec{
+		Description: "Openapi global settings",
+		Services:    []string{"openapi-settings"},
+		ConfigFunc: func() interface{} {
+			return &config{}
+		},
+		Creator: func() servicehub.Provider {
+			return &provider{}
+		},
+	})
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
openapi settings provider and configurable session expiration time in redis

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=760957&iterationID=-1&type=BUG)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |       openapi settings provider and configurable session expiration time in redis       |
| 🇨🇳 中文    |      可配置的Session过期时间        |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
