### PR TITLE
fix(ai-proxy): fix concurrent map read and write for resp header

### DIFF
--- a/internal/apps/ai-proxy/route/reverse_proxy/response_header.go
+++ b/internal/apps/ai-proxy/route/reverse_proxy/response_header.go
@@ -30,6 +30,7 @@ func handleAIProxyHeader(resp *http.Response) {
 	_handleRequestBodyTransformHeaders(resp)
 	_handleRequestThinkingTransformHeaders(resp)
 	_handleEnsureContentType(resp)
+	_handleContentLength(resp)
 }
 
 // _handleModelHeaders handles model related header settings
@@ -92,4 +93,9 @@ func _handleEnsureContentType(resp *http.Response) {
 			resp.Header.Set("Content-Type", "text/event-stream")
 		}
 	}
+}
+
+func _handleContentLength(resp *http.Response) {
+	// force chunked transfer, worry-free
+	resp.Header.Del("Content-Length")
 }

--- a/internal/apps/ai-proxy/route/reverse_proxy/response_modify.go
+++ b/internal/apps/ai-proxy/route/reverse_proxy/response_modify.go
@@ -52,8 +52,6 @@ var MyResponseModify = func(w http.ResponseWriter, filters []filter_define.Filte
 				_err = fmt.Errorf("panic from response modify: %v", r)
 			}
 			if _err == nil {
-				// handle ai-proxy headers
-				handleAIProxyHeader(resp)
 				return
 			}
 			ctxhelper.PutReverseProxyResponseModifyError(resp.Request.Context(), &ctxhelper.ReverseProxyFilterError{
@@ -95,11 +93,8 @@ var MyResponseModify = func(w http.ResponseWriter, filters []filter_define.Filte
 		}
 		brokenFilterName = ""
 
-		// force chunked transfer, worry-free
-		resp.Header.Del("Content-Length")
-		if ctxhelper.MustGetIsStream(resp.Request.Context()) && resp.Header.Get("Content-Type") == "" {
-			resp.Header.Set("Content-Type", "text/event-stream; charset=utf-8")
-		}
+		// handle ai-proxy headers
+		handleAIProxyHeader(resp)
 
 		// ---------------------------------------------------------------------
 		// 3) write upstream Body-Splitter-Modifier chain results to Pipe, let ReverseProxy copy to client


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy fix concurrent map read and write for resp header.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=783125&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    AI-Proxy fix concurrent map read and write for resp header          |
| 🇨🇳 中文    |    AI-Proxy 修复响应头并发读写 map 的问题          |
