### PR TITLE
fix(pipeline): get cms configs in req.Namespaces order

### DIFF
--- a/internal/tools/pipeline/providers/cms/pipeline_cms.go
+++ b/internal/tools/pipeline/providers/cms/pipeline_cms.go
@@ -352,19 +352,19 @@ func (c *pipelineCm) BatchGetConfigs(ctx context.Context, req *pb.CmsNsConfigsBa
 		}(config)
 	}
 	wait.Wait()
-	orderedConfigs := getOrderedCmsConfigs(newConfigs, cmsNsList)
+	orderedConfigs := getOrderedCmsConfigs(newConfigs, req.Namespaces)
 	return orderedConfigs, nil
 }
 
 // getOrderedCmsConfigs Sort by namespace
 // the final results are sorted by namespace
 // every namespace config list sort by creation time
-func getOrderedCmsConfigs(configs []*pb.PipelineCmsConfig, cmsNsList []db.PipelineCmsNs) []*pb.PipelineCmsConfig {
+func getOrderedCmsConfigs(configs []*pb.PipelineCmsConfig, orderedNamespaces []string) []*pb.PipelineCmsConfig {
 	var orderedConfigs []*pb.PipelineCmsConfig
-	for _, ns := range cmsNsList {
+	for _, ns := range orderedNamespaces {
 		var tmpConfigs []*pb.PipelineCmsConfig
 		for _, config := range configs {
-			if config.Ns.Ns == ns.Ns {
+			if config.Ns.Ns == ns {
 				tmpConfigs = append(tmpConfigs, config)
 			}
 		}

--- a/internal/tools/pipeline/providers/cms/pipeline_cms_test.go
+++ b/internal/tools/pipeline/providers/cms/pipeline_cms_test.go
@@ -79,3 +79,228 @@ func TestBatchGetConfigs(t *testing.T) {
 	assert.Equal(t, "key-ns-0", configs[0].Key)
 	assert.Equal(t, "value-ns-2", configs[2].Value)
 }
+
+func TestBatchGetConfigs_RealDataWithMultipleKeys(t *testing.T) {
+	// test constants
+	const (
+		nsUser    = "user-1-org-1"
+		nsDevelop = "pipeline-secrets-app-2-develop"
+		nsDefault = "pipeline-secrets-app-2-default"
+
+		keyBuildProfile = "BUILD_PROFILE"
+		keyUserToken    = "USER_TOKEN"
+		keyOrgName      = "ORG_NAME"
+		keyEnvType      = "ENV_TYPE"
+		keyApiHost      = "API_HOST"
+		keyDatabaseURL  = "DATABASE_URL"
+		keyRedisURL     = "REDIS_URL"
+
+		valueBuildProfileDev  = "dev"
+		valueBuildProfileTest = "test"
+		valueUserToken        = "abc123"
+		valueOrgName          = "terminus"
+		valueEnvTypeDevelop   = "develop"
+		valueEnvTypeDefault   = "default"
+		valueApiHost          = "dev.api.com"
+		valueDatabaseURL      = "mysql://default.db"
+		valueRedisURL         = "redis://default.cache"
+	)
+
+	dbClient := &db.Client{}
+
+	// real namespace data based on database screenshot
+	realNsData := map[uint64]string{
+		1: nsUser,
+		2: nsDevelop,
+		3: nsDefault,
+	}
+
+	// mock BatchGetCmsNamespaces to return in database order (by ID), not request order
+	pm1 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "BatchGetCmsNamespaces", func(_ *db.Client, pipelineSource string, namespaces []string, ops ...mysqlxorm.SessionOption) ([]db.PipelineCmsNs, error) {
+		// return in database order [1,2,3], not request order [3,2,1]
+		res := make([]db.PipelineCmsNs, 0)
+		for id := uint64(1); id <= 3; id++ {
+			if ns, exists := realNsData[id]; exists {
+				// check if this namespace is in the request
+				for _, reqNs := range namespaces {
+					if reqNs == ns {
+						res = append(res, db.PipelineCmsNs{
+							ID:             id,
+							PipelineSource: apistructs.PipelineSource(pipelineSource),
+							Ns:             ns,
+						})
+						break
+					}
+				}
+			}
+		}
+		return res, nil
+	})
+	defer pm1.Unpatch()
+
+	// mock BatchGetCmsNsConfigs to return configs in mixed order
+	pm2 := monkey.PatchInstanceMethod(reflect.TypeOf(dbClient), "BatchGetCmsNsConfigs", func(_ *db.Client, cmsNsIDs []uint64, ops ...mysqlxorm.SessionOption) ([]db.PipelineCmsConfig, error) {
+		res := make([]db.PipelineCmsConfig, 0)
+
+		// ns 1: user-1-org-1 configs
+		if contains(cmsNsIDs, 1) {
+			res = append(res,
+				db.PipelineCmsConfig{
+					ID:      10,
+					NsID:    1,
+					Key:     keyUserToken,
+					Value:   valueUserToken,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      11,
+					NsID:    1,
+					Key:     keyOrgName,
+					Value:   valueOrgName,
+					Encrypt: &[]bool{false}[0],
+				},
+			)
+		}
+
+		// ns 2: pipeline-secrets-app-2-develop configs
+		if contains(cmsNsIDs, 2) {
+			res = append(res,
+				db.PipelineCmsConfig{
+					ID:      20,
+					NsID:    2,
+					Key:     keyBuildProfile,
+					Value:   valueBuildProfileTest,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      21,
+					NsID:    2,
+					Key:     keyEnvType,
+					Value:   valueEnvTypeDevelop,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      22,
+					NsID:    2,
+					Key:     keyApiHost,
+					Value:   valueApiHost,
+					Encrypt: &[]bool{false}[0],
+				},
+			)
+		}
+
+		// ns 3: pipeline-secrets-app-2-default configs
+		if contains(cmsNsIDs, 3) {
+			res = append(res,
+				db.PipelineCmsConfig{
+					ID:      30,
+					NsID:    3,
+					Key:     keyBuildProfile,
+					Value:   valueBuildProfileDev,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      31,
+					NsID:    3,
+					Key:     keyEnvType,
+					Value:   valueEnvTypeDefault,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      32,
+					NsID:    3,
+					Key:     keyDatabaseURL,
+					Value:   valueDatabaseURL,
+					Encrypt: &[]bool{false}[0],
+				},
+				db.PipelineCmsConfig{
+					ID:      33,
+					NsID:    3,
+					Key:     keyRedisURL,
+					Value:   valueRedisURL,
+					Encrypt: &[]bool{false}[0],
+				},
+			)
+		}
+
+		return res, nil
+	})
+	defer pm2.Unpatch()
+
+	cm := pipelineCm{
+		dbClient: dbClient,
+	}
+
+	// request order: [3,2,1] (default, develop, user)
+	configs, err := cm.BatchGetConfigs(context.Background(), &pb.CmsNsConfigsBatchGetRequest{
+		PipelineSource: "dice",
+		Namespaces: []string{
+			nsDefault, // id 3
+			nsDevelop, // id 2
+			nsUser,    // id 1
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 9, len(configs)) // 4 + 3 + 2 = 9 configs total
+
+	// verify order: should be [3,2,1] namespace order
+	// first 4 configs should be from ns 3 (pipeline-secrets-app-2-default)
+	assert.Equal(t, nsDefault, configs[0].Ns.Ns)
+	assert.Equal(t, nsDefault, configs[1].Ns.Ns)
+	assert.Equal(t, nsDefault, configs[2].Ns.Ns)
+	assert.Equal(t, nsDefault, configs[3].Ns.Ns)
+
+	// next 3 configs should be from ns 2 (pipeline-secrets-app-2-develop)
+	assert.Equal(t, nsDevelop, configs[4].Ns.Ns)
+	assert.Equal(t, nsDevelop, configs[5].Ns.Ns)
+	assert.Equal(t, nsDevelop, configs[6].Ns.Ns)
+
+	// last 2 configs should be from ns 1 (user-1-org-1)
+	assert.Equal(t, nsUser, configs[7].Ns.Ns)
+	assert.Equal(t, nsUser, configs[8].Ns.Ns)
+
+	// verify specific key values in correct positions
+	buildProfileConfigs := make([]string, 0)
+	for _, config := range configs {
+		if config.Key == keyBuildProfile {
+			buildProfileConfigs = append(buildProfileConfigs, config.Value)
+		}
+	}
+	// BUILD_PROFILE should appear in order: ["dev", "test"]
+	// (dev from ns 3 first, then test from ns 2)
+	assert.Equal(t, []string{valueBuildProfileDev, valueBuildProfileTest}, buildProfileConfigs)
+
+	// verify unique keys appear in correct namespaces
+	var foundUserToken, foundDatabaseURL, foundApiHost bool
+	for _, config := range configs {
+		if config.Key == keyUserToken {
+			assert.Equal(t, nsUser, config.Ns.Ns)
+			assert.Equal(t, valueUserToken, config.Value)
+			foundUserToken = true
+		}
+		if config.Key == keyDatabaseURL {
+			assert.Equal(t, nsDefault, config.Ns.Ns)
+			assert.Equal(t, valueDatabaseURL, config.Value)
+			foundDatabaseURL = true
+		}
+		if config.Key == keyApiHost {
+			assert.Equal(t, nsDevelop, config.Ns.Ns)
+			assert.Equal(t, valueApiHost, config.Value)
+			foundApiHost = true
+		}
+	}
+	assert.True(t, foundUserToken, "USER_TOKEN should be found in user-1-org-1")
+	assert.True(t, foundDatabaseURL, "DATABASE_URL should be found in pipeline-secrets-app-2-default")
+	assert.True(t, foundApiHost, "API_HOST should be found in pipeline-secrets-app-2-develop")
+}
+
+// helper function to check if slice contains value
+func contains(slice []uint64, val uint64) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Pipeline get cms configs in req.Namespaces order.

`cmsNsList` is returned by db, so order not guaranteed.

Related issue: #5227 

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=784347&iterationID=12783&type=BUG)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    Pipeline get cms configs in req.Namespaces order          |
| 🇨🇳 中文    |   Pipeline 以请求里的 Namespaces 顺序获取 cms 配置           |
