### PR TITLE
fix(ai-proxy): only check if body is nil for error-status-handler

### DIFF
--- a/internal/apps/ai-proxy/route/reverse_proxy/response_modify.go
+++ b/internal/apps/ai-proxy/route/reverse_proxy/response_modify.go
@@ -200,7 +200,8 @@ func errorStatusHandler(resp *http.Response) error {
 		"type": "llm-backend-error",
 	}
 
-	if resp.ContentLength > 0 && resp.Body != nil {
+	// Content-Length may be -1, so only check body
+	if resp.Body != nil {
 		respBodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			ctxhelper.MustGetLoggerBase(resp.Request.Context()).Warnf("failed to read resp body at error-status-handler: %v", err)


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy only check if body is nil for error-status-handler.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=785023&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    AI-Proxy only check if body is nil for error-status-handler          |
| 🇨🇳 中文    |    AI-Proxy 在 error-status-handler 里只校验响应体是否为空          |
