### PR TITLE
fix(orchestrator): sourcecov overcommit nil

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/sourcecov/sourcecov.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/k8s/addon/sourcecov/sourcecov.go
@@ -39,7 +39,6 @@ import (
 type SourcecovOperator struct {
 	k8s        addon.K8SUtil
 	client     *httpclient.HTTPClient
-	oc         addon.OverCommitUtil
 	ns         addon.NamespaceUtil
 	overcommit addon.OverCommitUtil
 }
@@ -284,11 +283,11 @@ func (s *SourcecovOperator) Update(i interface{}) error {
 	return nil
 }
 
-func New(k8s addon.K8SUtil, client *httpclient.HTTPClient, oc addon.OverCommitUtil, ns addon.NamespaceUtil) *SourcecovOperator {
+func New(k8s addon.K8SUtil, client *httpclient.HTTPClient, overcommit addon.OverCommitUtil, ns addon.NamespaceUtil) *SourcecovOperator {
 	return &SourcecovOperator{
-		k8s:    k8s,
-		client: client,
-		oc:     oc,
-		ns:     ns,
+		k8s:        k8s,
+		client:     client,
+		overcommit: overcommit,
+		ns:         ns,
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
- Fix sourcecov overcommit nil
- Remove unused 'oc' field from SourcecovOperator struct
- Rename 'overcommit' field to match constructor parameter
- Update New function to use 'overcommit' parameter


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @sfwn 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |  sourcecov overcommit nil            |
| 🇨🇳 中文    |    sourcecov overcommit 空指针          |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
