### PR TITLE
fix(erda-server): using matched scope type&id when adding member by target-scope type&id

### DIFF
--- a/internal/core/legacy/services/member/member.go
+++ b/internal/core/legacy/services/member/member.go
@@ -222,7 +222,7 @@ func (m *Member) CreateOrUpdate(userID string, req apistructs.MemberAddRequest) 
 			parentIDMap[targetScopeID] = parentID
 			// 创建成员
 			if len(members) == 0 {
-				orgID, projectID, applicationID := m.getIDs(req, targetScopeID)
+				orgID, projectID, applicationID := m.getIDs(targetScopeType, targetScopeID)
 				// create PAT when user is invited to org.
 				// TODO: After we expose PAT management on UI, this can be removed.
 				if req.Scope.Type == apistructs.OrgScope {
@@ -239,7 +239,7 @@ func (m *Member) CreateOrUpdate(userID string, req apistructs.MemberAddRequest) 
 				member := &model.Member{
 					ScopeType:     targetScopeType,
 					ScopeID:       targetScopeID,
-					ScopeName:     m.db.GetScopeNameByScope(req.Scope.Type, targetScopeID),
+					ScopeName:     m.db.GetScopeNameByScope(targetScopeType, targetScopeID),
 					ParentID:      parentID,
 					UserID:        user.ID,
 					Email:         user.Email,
@@ -745,8 +745,8 @@ func (m *Member) CheckPermission(userID string, scopeType apistructs.ScopeType, 
 }
 
 // 获取orgID, projectID, applicationID
-func (m *Member) getIDs(req apistructs.MemberAddRequest, scopeID int64) (orgID, projectID, applicationID int64) {
-	switch req.Scope.Type {
+func (m *Member) getIDs(scopeType apistructs.ScopeType, scopeID int64) (orgID, projectID, applicationID int64) {
+	switch scopeType {
 	case apistructs.OrgScope:
 		orgID = scopeID
 	case apistructs.ProjectScope:


### PR DESCRIPTION
#### What this PR does / why we need it:

Erda-server: using matched scope type&id when adding member by target-scope type&id

#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=787092&iterationID=12783&type=BUG)


#### Specified Reviewers:

/assign @iutx 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |   Erda-server using matched scope type&id when adding member by target-scope type&id          |
| 🇨🇳 中文    |   当使用 target-scope type&id 添加成员时，Erda-server 使用匹配的 scope type&id           |
