### PR TITLE
feat(ai-proxy): add service provider thinking encoder

### DIFF
--- a/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_auto.json
+++ b/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_auto.json
@@ -9,6 +9,6 @@
     }
   ],
   "max_tokens": 1050,
-  "temperature": 0.7,
-  "stream": false
+  "temperature": 1,
+  "stream": true
 }

--- a/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_disabled.json
+++ b/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_disabled.json
@@ -9,6 +9,6 @@
     }
   ],
   "max_tokens": 100,
-  "temperature": 0.0,
-  "stream": false
+  "temperature": 1,
+  "stream": true
 }

--- a/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_enabled.json
+++ b/cmd/ai-proxy/integration-tests/curl_tests/thinking/chat_completions/bytedance_style_thinking_enabled.json
@@ -9,6 +9,6 @@
     }
   ],
   "max_tokens": 2000,
-  "temperature": 0.3,
-  "stream": false
+  "temperature": 1,
+  "stream": true
 }

--- a/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider.go
+++ b/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package common_types_util
 
-type ModelPublisher string
-
-var (
-	ModelPublisherOpenAI    ModelPublisher = "openai"
-	ModelPublisherAnthropic ModelPublisher = "anthropic"
-	ModelPublisherQwen      ModelPublisher = "qwen"
-	ModelPublisherBytedance ModelPublisher = "bytedance" // Doubao
+import (
+	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
 )
+
+const metaKeyServiceProviderType = "service_provider_type"
+
+func GetServiceProviderType(p *modelproviderpb.ModelProvider) string {
+	return p.GetMetadata().GetPublic()[metaKeyServiceProviderType].GetStringValue()
+}

--- a/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider_test.go
+++ b/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider_test.go
@@ -1,0 +1,67 @@
+package common_types_util
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	metadatapb "github.com/erda-project/erda-proto-go/apps/aiproxy/metadata/pb"
+	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
+)
+
+func TestGetServiceProviderType(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *modelproviderpb.ModelProvider
+		want     string
+	}{
+		{
+			name: "has service provider type",
+			provider: &modelproviderpb.ModelProvider{
+				Metadata: &metadatapb.Metadata{
+					Public: map[string]*structpb.Value{
+						metaKeyServiceProviderType: structpb.NewStringValue(common_types.ServiceProviderTypeVolcengineArk.String()),
+					},
+				},
+			},
+			want: common_types.ServiceProviderTypeVolcengineArk.String(),
+		},
+		{
+			name:     "nil provider",
+			provider: nil,
+			want:     "",
+		},
+		{
+			name:     "nil metadata",
+			provider: &modelproviderpb.ModelProvider{},
+			want:     "",
+		},
+		{
+			name: "nil public map",
+			provider: &modelproviderpb.ModelProvider{
+				Metadata: &metadatapb.Metadata{},
+			},
+			want: "",
+		},
+		{
+			name: "key missing",
+			provider: &modelproviderpb.ModelProvider{
+				Metadata: &metadatapb.Metadata{
+					Public: map[string]*structpb.Value{
+						"other": structpb.NewStringValue("value"),
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetServiceProviderType(tt.provider); got != tt.want {
+				t.Fatalf("GetServiceProviderType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider_test.go
+++ b/internal/apps/ai-proxy/common/common_types/common_types_util/service_provider_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common_types_util
 
 import (

--- a/internal/apps/ai-proxy/common/common_types/model_publisher.go
+++ b/internal/apps/ai-proxy/common/common_types/model_publisher.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_types
+
+type ModelPublisher string
+
+var (
+	ModelPublisherOpenAI    ModelPublisher = "openai"
+	ModelPublisherAnthropic ModelPublisher = "anthropic"
+	ModelPublisherQwen      ModelPublisher = "qwen"
+	ModelPublisherBytedance ModelPublisher = "bytedance" // Doubao
+)
+
+func (mp ModelPublisher) String() string { return string(mp) }

--- a/internal/apps/ai-proxy/common/common_types/service_provider.go
+++ b/internal/apps/ai-proxy/common/common_types/service_provider.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_types
+
+// ServiceProviderType defines the service provider that hosts the model runtime.
+type ServiceProviderType string
+
+const (
+	ServiceProviderTypeVolcengineArk  ServiceProviderType = "volcengine-ark"
+	ServiceProviderTypeAliyunBailian  ServiceProviderType = "aliyun-bailian"
+	ServiceProviderTypeAWSBedrock     ServiceProviderType = "aws-bedrock"
+	ServiceProviderTypeAzureAIFoundry ServiceProviderType = "azure-ai-foundry"
+	ServiceProviderTypeOpenAI         ServiceProviderType = "openai"
+	ServiceProviderTypeAnthropic      ServiceProviderType = "anthropic"
+)
+
+func (m ServiceProviderType) String() string { return string(m) }

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/anthropic_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/anthropic_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/bytedance.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/bytedance.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
@@ -28,7 +30,7 @@ type BytedanceThinkingEncoder struct{}
 
 func (e *BytedanceThinkingEncoder) CanEncode(ctx context.Context) bool {
 	model := ctxhelper.MustGetModel(ctx)
-	return strings.EqualFold(model.Publisher, string(types.ModelPublisherBytedance))
+	return strings.EqualFold(model.Publisher, string(common_types.ModelPublisherBytedance))
 }
 
 func (e *BytedanceThinkingEncoder) Encode(ctx context.Context, ct types.CommonThinking) (map[string]any, error) {
@@ -52,7 +54,7 @@ func (e *BytedanceThinkingEncoder) GetPriority() int {
 }
 
 func (e *BytedanceThinkingEncoder) GetName() string {
-	return "bytedance"
+	return fmt.Sprintf("model_publisher: %s", common_types.ModelPublisherBytedance)
 }
 
 var _ encoders.CommonThinkingEncoder = (*BytedanceThinkingEncoder)(nil)

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/bytedance_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/bytedance_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"
@@ -126,4 +126,3 @@ func TestBytedanceThinkingEncoder_Encode(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/openai_chat_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/openai_chat_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"
@@ -24,7 +24,7 @@ import (
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
 )
 
-func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
+func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.CommonThinking
@@ -51,10 +51,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMinimal),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMinimal,
-				},
+				types.FieldReasoningEffort: types.EffortMinimal,
 			},
 		},
 		{
@@ -64,10 +61,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortLow),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortLow,
-				},
+				types.FieldReasoningEffort: types.EffortLow,
 			},
 		},
 		{
@@ -77,10 +71,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMedium),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMedium,
-				},
+				types.FieldReasoningEffort: types.EffortMedium,
 			},
 		},
 		{
@@ -90,10 +81,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortHigh),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortHigh,
-				},
+				types.FieldReasoningEffort: types.EffortHigh,
 			},
 		},
 		{
@@ -103,10 +91,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(512),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMinimal,
-				},
+				types.FieldReasoningEffort: types.EffortMinimal,
 			},
 		},
 		{
@@ -116,10 +101,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(1500),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortLow,
-				},
+				types.FieldReasoningEffort: types.EffortLow,
 			},
 		},
 		{
@@ -129,10 +111,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(3000),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMedium,
-				},
+				types.FieldReasoningEffort: types.EffortMedium,
 			},
 		},
 		{
@@ -142,10 +121,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(8192),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortHigh,
-				},
+				types.FieldReasoningEffort: types.EffortHigh,
 			},
 		},
 		{
@@ -155,10 +131,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(0),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMedium,
-				},
+				types.FieldReasoningEffort: types.EffortMedium,
 			},
 		},
 		{
@@ -167,10 +140,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Mode: types.ModePtr(types.ModeOn),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortMedium,
-				},
+				types.FieldReasoningEffort: types.EffortMedium,
 			},
 		},
 		{
@@ -181,10 +151,7 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(8192), // would map to high, but effort should win
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortLow,
-				},
+				types.FieldReasoningEffort: types.EffortLow,
 			},
 		},
 		{
@@ -193,15 +160,12 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortHigh),
 			},
 			expected: map[string]any{
-				types.FieldReasoning: map[string]any{
-					"summary":         "auto",
-					types.FieldEffort: types.EffortHigh,
-				},
+				types.FieldReasoningEffort: types.EffortHigh,
 			},
 		},
 	}
 
-	encoder := &OpenAIResponsesThinkingEncoder{}
+	encoder := &OpenAIChatThinkingEncoder{}
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -212,4 +176,3 @@ func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/openai_responses_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/openai_responses_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"
@@ -24,7 +24,7 @@ import (
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
 )
 
-func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
+func TestOpenAIResponsesThinkingEncoder_Encode(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    types.CommonThinking
@@ -51,7 +51,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMinimal),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMinimal,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMinimal,
+				},
 			},
 		},
 		{
@@ -61,7 +64,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortLow),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortLow,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortLow,
+				},
 			},
 		},
 		{
@@ -71,7 +77,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMedium),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMedium,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMedium,
+				},
 			},
 		},
 		{
@@ -81,7 +90,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortHigh),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortHigh,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortHigh,
+				},
 			},
 		},
 		{
@@ -91,7 +103,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(512),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMinimal,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMinimal,
+				},
 			},
 		},
 		{
@@ -101,7 +116,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(1500),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortLow,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortLow,
+				},
 			},
 		},
 		{
@@ -111,7 +129,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(3000),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMedium,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMedium,
+				},
 			},
 		},
 		{
@@ -121,7 +142,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(8192),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortHigh,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortHigh,
+				},
 			},
 		},
 		{
@@ -131,7 +155,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(0),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMedium,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMedium,
+				},
 			},
 		},
 		{
@@ -140,7 +167,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Mode: types.ModePtr(types.ModeOn),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortMedium,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortMedium,
+				},
 			},
 		},
 		{
@@ -151,7 +181,10 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(8192), // would map to high, but effort should win
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortLow,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortLow,
+				},
 			},
 		},
 		{
@@ -160,12 +193,15 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortHigh),
 			},
 			expected: map[string]any{
-				types.FieldReasoningEffort: types.EffortHigh,
+				types.FieldReasoning: map[string]any{
+					"summary":         "auto",
+					types.FieldEffort: types.EffortHigh,
+				},
 			},
 		},
 	}
 
-	encoder := &OpenAIChatThinkingEncoder{}
+	encoder := &OpenAIResponsesThinkingEncoder{}
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -176,4 +212,3 @@ func TestOpenAIChatThinkingEncoder_Encode(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/qwen_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher/qwen_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package impl
+package model_publisher
 
 import (
 	"context"
@@ -51,7 +51,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(4096),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 4096,
 			},
 		},
@@ -62,7 +62,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(512),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 1024, // uses default minimum
 			},
 		},
@@ -73,7 +73,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMinimal),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 1024,
 			},
 		},
@@ -84,7 +84,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortLow),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 2048,
 			},
 		},
@@ -95,7 +95,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMedium),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 4096,
 			},
 		},
@@ -106,7 +106,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortHigh),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 8192,
 			},
 		},
@@ -116,7 +116,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Mode: types.ModePtr(types.ModeOn),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 1024,
 			},
 		},
@@ -128,7 +128,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(2048),                      // budget should win
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 2048,
 			},
 		},
@@ -138,7 +138,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				Effort: types.EffortPtr(types.EffortMedium),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 4096,
 			},
 		},
@@ -148,7 +148,7 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 				BudgetTokens: intPtr(3000),
 			},
 			expected: map[string]any{
-				types.FieldEnableThinking:  true,
+				types.FieldEnableThinking: true,
 				types.FieldThinkingBudget: 3000,
 			},
 		},
@@ -165,4 +165,3 @@ func TestQwenThinkingEncoder_Encode(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types/common_types_util"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders"
+	mp "github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
+)
+
+// BailianThinkingEncoder handles Aliyun Bailian (DashScope) provider-specific thinking payloads.
+type BailianThinkingEncoder struct {
+	delegate mp.QwenThinkingEncoder
+}
+
+func (e *BailianThinkingEncoder) CanEncode(ctx context.Context) bool {
+	provider := ctxhelper.MustGetModelProvider(ctx)
+	return strings.EqualFold(common_types_util.GetServiceProviderType(provider), common_types.ServiceProviderTypeAliyunBailian.String())
+}
+
+func (e *BailianThinkingEncoder) Encode(ctx context.Context, ct types.CommonThinking) (map[string]any, error) {
+	return e.delegate.Encode(ctx, ct)
+}
+
+func (e *BailianThinkingEncoder) GetPriority() int {
+	return 0 // ensure provider-specific logic wins over publisher-based defaults
+}
+
+func (e *BailianThinkingEncoder) GetName() string {
+	return fmt.Sprintf("service_provider: %s", common_types.ServiceProviderTypeAliyunBailian.String())
+}
+
+var _ encoders.CommonThinkingEncoder = (*BailianThinkingEncoder)(nil)

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"google.golang.org/protobuf/types/known/structpb"
 
 	metadatapb "github.com/erda-project/erda-proto-go/apps/aiproxy/metadata/pb"

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package service_provider
 
 import (
@@ -6,14 +20,28 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
+	metadatapb "github.com/erda-project/erda-proto-go/apps/aiproxy/metadata/pb"
 	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
 )
 
+func newProviderWithServiceType(t common_types.ServiceProviderType) *modelproviderpb.ModelProvider {
+	return &modelproviderpb.ModelProvider{
+		Metadata: &metadatapb.Metadata{
+			Public: map[string]*structpb.Value{
+				"service_provider_type": structpb.NewStringValue(t.String()),
+			},
+		},
+	}
+}
+
 func TestBailianThinkingEncoder(t *testing.T) {
 	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
-	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeAliyunDashScope.String()})
+	ctxhelper.PutModelProvider(ctx, newProviderWithServiceType(common_types.ServiceProviderTypeAliyunBailian))
 
 	encoder := &BailianThinkingEncoder{}
 
@@ -29,13 +57,13 @@ func TestBailianThinkingEncoder(t *testing.T) {
 
 func TestBailianThinkingEncoder_CanEncodeVariants(t *testing.T) {
 	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
-	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeAliyunBailian.String()})
+	ctxhelper.PutModelProvider(ctx, newProviderWithServiceType(common_types.ServiceProviderTypeAliyunBailian))
 
 	encoder := &BailianThinkingEncoder{}
 
 	assert.True(t, encoder.CanEncode(ctx))
 
 	ctx = ctxhelper.InitCtxMapIfNeed(context.Background())
-	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: "Unknown"})
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{})
 	assert.False(t, encoder.CanEncode(ctx))
 }

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/aliyun_bailian_test.go
@@ -1,0 +1,41 @@
+package service_provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
+)
+
+func TestBailianThinkingEncoder(t *testing.T) {
+	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeAliyunDashScope.String()})
+
+	encoder := &BailianThinkingEncoder{}
+
+	assert.True(t, encoder.CanEncode(ctx))
+
+	result, err := encoder.Encode(ctx, types.CommonThinking{Mode: types.ModePtr(types.ModeOn)})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		types.FieldEnableThinking: true,
+		types.FieldThinkingBudget: 1024,
+	}, result)
+}
+
+func TestBailianThinkingEncoder_CanEncodeVariants(t *testing.T) {
+	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeAliyunBailian.String()})
+
+	encoder := &BailianThinkingEncoder{}
+
+	assert.True(t, encoder.CanEncode(ctx))
+
+	ctx = ctxhelper.InitCtxMapIfNeed(context.Background())
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: "Unknown"})
+	assert.False(t, encoder.CanEncode(ctx))
+}

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types/common_types_util"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders"
+	mp "github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
+)
+
+// VolcengineThinkingEncoder handles Volcengine-specific thinking payloads. It primarily
+// exists to decouple provider-specific logic from publisher-specific implementations.
+type VolcengineThinkingEncoder struct {
+	delegate mp.BytedanceThinkingEncoder
+}
+
+func (e *VolcengineThinkingEncoder) CanEncode(ctx context.Context) bool {
+	provider := ctxhelper.MustGetModelProvider(ctx)
+	return strings.EqualFold(common_types_util.GetServiceProviderType(provider), common_types.ServiceProviderTypeVolcengineArk.String())
+}
+
+func (e *VolcengineThinkingEncoder) Encode(ctx context.Context, ct types.CommonThinking) (map[string]any, error) {
+	return e.delegate.Encode(ctx, ct)
+}
+
+func (e *VolcengineThinkingEncoder) GetPriority() int {
+	return 0 // highest priority to override publisher-based defaults when provider is Volcengine
+}
+
+func (e *VolcengineThinkingEncoder) GetName() string {
+	return fmt.Sprintf("service_provider: %s", common_types.ServiceProviderTypeAliyunBailian.String())
+}
+
+var _ encoders.CommonThinkingEncoder = (*VolcengineThinkingEncoder)(nil)

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"google.golang.org/protobuf/types/known/structpb"
 
 	metadatapb "github.com/erda-project/erda-proto-go/apps/aiproxy/metadata/pb"

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
@@ -1,0 +1,36 @@
+package service_provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
+)
+
+func TestVolcengineThinkingEncoder(t *testing.T) {
+	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeVolcengine.String()})
+
+	encoder := &VolcengineThinkingEncoder{}
+
+	assert.True(t, encoder.CanEncode(ctx))
+
+	result, err := encoder.Encode(ctx, types.CommonThinking{Mode: types.ModePtr(types.ModeOn)})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		types.FieldThinking: map[string]any{types.FieldType: "enabled"},
+	}, result)
+}
+
+func TestVolcengineThinkingEncoder_CanEncode_False(t *testing.T) {
+	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: "Unknown"})
+
+	encoder := &VolcengineThinkingEncoder{}
+
+	assert.False(t, encoder.CanEncode(ctx))
+}

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider/volcengine_ark_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package service_provider
 
 import (
@@ -6,14 +20,28 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
+	metadatapb "github.com/erda-project/erda-proto-go/apps/aiproxy/metadata/pb"
 	modelproviderpb "github.com/erda-project/erda-proto-go/apps/aiproxy/model_provider/pb"
+	"github.com/erda-project/erda/internal/apps/ai-proxy/common/common_types"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/common/ctxhelper"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
 )
 
+func newVolcengineProvider(serviceType common_types.ServiceProviderType) *modelproviderpb.ModelProvider {
+	return &modelproviderpb.ModelProvider{
+		Metadata: &metadatapb.Metadata{
+			Public: map[string]*structpb.Value{
+				"service_provider_type": structpb.NewStringValue(serviceType.String()),
+			},
+		},
+	}
+}
+
 func TestVolcengineThinkingEncoder(t *testing.T) {
 	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
-	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: types.ModelProviderTypeVolcengine.String()})
+	ctxhelper.PutModelProvider(ctx, newVolcengineProvider(common_types.ServiceProviderTypeVolcengineArk))
 
 	encoder := &VolcengineThinkingEncoder{}
 
@@ -28,7 +56,7 @@ func TestVolcengineThinkingEncoder(t *testing.T) {
 
 func TestVolcengineThinkingEncoder_CanEncode_False(t *testing.T) {
 	ctx := ctxhelper.InitCtxMapIfNeed(context.Background())
-	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{Type: "Unknown"})
+	ctxhelper.PutModelProvider(ctx, &modelproviderpb.ModelProvider{})
 
 	encoder := &VolcengineThinkingEncoder{}
 

--- a/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/registry/registry.go
+++ b/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/registry/registry.go
@@ -20,7 +20,8 @@ import (
 	"sort"
 
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders"
-	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl"
+	mp "github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/model-publisher"
+	sp "github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/encoders/impl/service-provider"
 	"github.com/erda-project/erda/internal/apps/ai-proxy/route/filters/request/thinking-handler/types"
 )
 
@@ -32,11 +33,15 @@ type Registry struct {
 // NewRegistry creates a new registry with default encoders
 func NewRegistry() *Registry {
 	encoderList := []encoders.CommonThinkingEncoder{
-		&impl.AnthropicThinkingEncoder{},
-		&impl.QwenThinkingEncoder{},
-		&impl.OpenAIChatThinkingEncoder{},
-		&impl.OpenAIResponsesThinkingEncoder{},
-		&impl.BytedanceThinkingEncoder{},
+		// service provider
+		&sp.VolcengineThinkingEncoder{},
+		&sp.BailianThinkingEncoder{},
+		// model publisher
+		&mp.AnthropicThinkingEncoder{},
+		&mp.QwenThinkingEncoder{},
+		&mp.OpenAIChatThinkingEncoder{},
+		&mp.OpenAIResponsesThinkingEncoder{},
+		&mp.BytedanceThinkingEncoder{},
 	}
 
 	// sort by priority (lower number = higher priority)


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy add service-provider thinking encoder.


#### Which issue(s) this PR fixes:

- [Erda Cloud Issue Link](https://erda.cloud/erda/dop/projects/387/issues/all?id=789300&iterationID=12783&type=TASK)


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    AI-Proxy add service-provider thinking encoder          |
| 🇨🇳 中文    |    AI-Proxy 增加 服务提供商 级别的思考配置编码器           |
