### PR TITLE
build: support image build from git worktree

### DIFF
--- a/build/scripts/buildkit_image.sh
+++ b/build/scripts/buildkit_image.sh
@@ -2,7 +2,30 @@
 
 set -o errexit -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git_context.sh"
+
 cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(pwd)"
+CONTAINER_REPO_PATH="/go/src/github.com/erda-project/erda"
+BUILD_CONTEXT="${REPO_ROOT}"
+TEMP_BUILD_CONTEXT=""
+
+cleanup() {
+    if [[ -n "${TEMP_BUILD_CONTEXT}" && -d "${TEMP_BUILD_CONTEXT}" ]]; then
+        rm -rf "${TEMP_BUILD_CONTEXT}"
+    fi
+}
+trap cleanup EXIT
+
+prepare_build_context() {
+    if ! is_git_worktree "${REPO_ROOT}"; then
+        return
+    fi
+
+    TEMP_BUILD_CONTEXT="$(mktemp -d)"
+    prepare_git_build_context "${REPO_ROOT}" "${TEMP_BUILD_CONTEXT}" "${CONTAINER_REPO_PATH}"
+    BUILD_CONTEXT="${TEMP_BUILD_CONTEXT}"
+}
 
 BASE_DOCKER_IMAGE=registry.erda.cloud/erda/erda-base:20250812
 IMAGE_TAG="${IMAGE_TAG:-$(build/scripts/make-version.sh tag)}"
@@ -30,6 +53,8 @@ if [[ -n "$DOCKER_REGISTRY" ]]; then
     fi
 fi
 
+prepare_build_context
+
 buildctl \
     --addr tcp://buildkitd.default.svc.cluster.local:1234 \
     --tlscacert=/.buildkit/ca.pem \
@@ -37,8 +62,8 @@ buildctl \
     --tlskey=/.buildkit/key.pem \
      build \
     --frontend dockerfile.v0 \
-    --local context=. \
-    --local dockerfile="$DOCKERFILE" \
+    --local context="$BUILD_CONTEXT" \
+    --local dockerfile="$BUILD_CONTEXT/$DOCKERFILE" \
     --opt label:"branch=$(git rev-parse --abbrev-ref HEAD)" \
     --opt label:"commit=$(git rev-parse HEAD)" \
     --opt label:"build-time=$(date '+%Y-%m-%d %T%z')" \

--- a/build/scripts/docker_image.sh
+++ b/build/scripts/docker_image.sh
@@ -4,6 +4,8 @@
 
 set -o errexit -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/git_context.sh"
+
 echo "GO_BUILD_OPTIONS=${GO_BUILD_OPTIONS}"
 
 # check parameters and print usage if need
@@ -27,7 +29,28 @@ MODULE_PATH=$1
 ACTION=$2
 
 # cd to root directory
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(pwd)"
+CONTAINER_REPO_PATH="/go/src/github.com/erda-project/erda"
+BUILD_CONTEXT="${REPO_ROOT}"
+TEMP_BUILD_CONTEXT=""
+
+cleanup() {
+    if [[ -n "${TEMP_BUILD_CONTEXT}" && -d "${TEMP_BUILD_CONTEXT}" ]]; then
+        rm -rf "${TEMP_BUILD_CONTEXT}"
+    fi
+}
+trap cleanup EXIT
+
+prepare_build_context() {
+    if ! is_git_worktree "${REPO_ROOT}"; then
+        return
+    fi
+
+    TEMP_BUILD_CONTEXT="$(mktemp -d)"
+    prepare_git_build_context "${REPO_ROOT}" "${TEMP_BUILD_CONTEXT}" "${CONTAINER_REPO_PATH}"
+    BUILD_CONTEXT="${TEMP_BUILD_CONTEXT}"
+}
 
 # image version and url
 CURRENT_ARCH="$(go env GOARCH)"
@@ -89,6 +112,7 @@ print_details() {
     echo "Target Arch    : ${TARGET_ARCH}"
 }
 print_details
+prepare_build_context
 
 # login
 docker_login() {
@@ -137,7 +161,7 @@ build_image()  {
         --build-arg "MAKE_BUILD_CMD=${MAKE_BUILD_CMD}" \
         --build-arg "GO_BUILD_OPTIONS=${GO_BUILD_OPTIONS}" \
         --build-arg "GOPROXY=${GOPROXY}" \
-        -f "${DOCKERFILE}" . \
+        -f "${BUILD_CONTEXT}/${DOCKERFILE}" "${BUILD_CONTEXT}" \
         "${args[@]}"
     echo "action meta: image=${DOCKER_IMAGE}"
     echo "action meta: tag=${IMAGE_TAG}"

--- a/build/scripts/git_context.sh
+++ b/build/scripts/git_context.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail
+
+is_git_worktree() {
+    local repo_root="${1:?repo root is required}"
+    [[ -f "${repo_root}/.git" ]] && grep -q '^gitdir: ' "${repo_root}/.git"
+}
+
+prepare_git_build_context() {
+    local repo_root="${1:?repo root is required}"
+    local context_root="${2:?context root is required}"
+    local container_repo_path="${3:?container repo path is required}"
+
+    rm -rf "${context_root}"
+    mkdir -p "${context_root}"
+
+    rsync -a --delete --exclude '.git' "${repo_root}/" "${context_root}/"
+
+    if ! is_git_worktree "${repo_root}"; then
+        rsync -a "${repo_root}/.git/" "${context_root}/.git/"
+        return
+    fi
+
+    local worktree_git_dir common_git_dir
+    worktree_git_dir="$(git -C "${repo_root}" rev-parse --git-dir)"
+    common_git_dir="$(git -C "${repo_root}" rev-parse --git-common-dir)"
+
+    rsync -a "${common_git_dir}/" "${context_root}/.git-main/"
+    rsync -a "${worktree_git_dir}/" "${context_root}/.git-worktree/"
+
+    printf 'gitdir: .git-worktree\n' > "${context_root}/.git"
+    printf '../.git-main\n' > "${context_root}/.git-worktree/commondir"
+    printf '%s/.git\n' "${container_repo_path}" > "${context_root}/.git-worktree/gitdir"
+}

--- a/build/scripts/tests/git_context_test.sh
+++ b/build/scripts/tests/git_context_test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+source "${ROOT_DIR}/build/scripts/git_context.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+main_repo="${tmpdir}/main"
+repo_root="${tmpdir}/worktree"
+context_root="${tmpdir}/context"
+worktree_name=$(basename "${repo_root}")
+mkdir -p "${main_repo}"
+git -C "${tmpdir}" init main >/dev/null 2>&1
+git -C "${main_repo}" config user.name test
+git -C "${main_repo}" config user.email test@example.com
+git -C "${main_repo}" config commit.gpgSign false
+
+cat > "${main_repo}/README.md" <<'EOF_README'
+hello
+EOF_README
+mkdir -p "${main_repo}/src"
+cat > "${main_repo}/src/file.txt" <<'EOF_FILE'
+payload
+EOF_FILE
+
+git -C "${main_repo}" add README.md src/file.txt
+git -C "${main_repo}" commit -m "init" >/dev/null 2>&1
+git -C "${main_repo}" worktree add "${repo_root}" -b feature >/dev/null 2>&1
+
+prepare_git_build_context "${repo_root}" "${context_root}" "/go/src/github.com/erda-project/erda"
+
+test -f "${context_root}/README.md"
+test -f "${context_root}/src/file.txt"
+test -f "${context_root}/.git"
+test -f "${context_root}/.git-main/worktrees/${worktree_name}/HEAD"
+test -f "${context_root}/.git-worktree/HEAD"
+
+grep -qx 'gitdir: .git-worktree' "${context_root}/.git"
+grep -qx '../.git-main' "${context_root}/.git-worktree/commondir"
+grep -qx '/go/src/github.com/erda-project/erda/.git' "${context_root}/.git-worktree/gitdir"
+
+echo "git_context_test: PASS"


### PR DESCRIPTION
#### What this PR does / why we need it:

Build support image build from git worktree.


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | Build support image build from git worktree |
| 🇨🇳 中文    | Build 支持从 git worktree 构建镜像 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
