### PR TITLE
fix(ai-proxy): avoid reserved key column in setting query

### DIFF
--- a/internal/apps/ai-proxy/models/setting/dbclient.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient.go
@@ -69,7 +69,7 @@ func (dbClient *DBClient) GetByNamespaceKeys(ctx context.Context, namespace stri
 
 	var items []*Setting
 	if err := dbClient.DB.WithContext(ctx).
-		Where("namespace = ? AND `key` IN ?", namespace, keys).
+		Where("namespace = ? AND `key` IN (?)", namespace, keys).
 		Find(&items).Error; err != nil {
 		return nil, err
 	}

--- a/internal/apps/ai-proxy/models/setting/dbclient.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	"github.com/erda-project/erda-proto-go/apps/aiproxy/setting/pb"
 	commonpb "github.com/erda-project/erda-proto-go/common/pb"
@@ -70,8 +69,7 @@ func (dbClient *DBClient) GetByNamespaceKeys(ctx context.Context, namespace stri
 
 	var items []*Setting
 	if err := dbClient.DB.WithContext(ctx).
-		Where(&Setting{Namespace: namespace}).
-		Where(clause.IN{Column: clause.Column{Name: "key"}, Values: stringSliceToAnySlice(keys)}).
+		Where("namespace = ? AND `key` IN ?", namespace, keys).
 		Find(&items).Error; err != nil {
 		return nil, err
 	}
@@ -81,14 +79,6 @@ func (dbClient *DBClient) GetByNamespaceKeys(ctx context.Context, namespace stri
 		result[item.Key] = item
 	}
 	return result, nil
-}
-
-func stringSliceToAnySlice(values []string) []any {
-	items := make([]any, 0, len(values))
-	for _, value := range values {
-		items = append(items, value)
-	}
-	return items
 }
 
 func (dbClient *DBClient) Create(ctx context.Context, req *pb.SettingCreateRequest) (*pb.Setting, error) {

--- a/internal/apps/ai-proxy/models/setting/dbclient.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/erda-project/erda-proto-go/apps/aiproxy/setting/pb"
 	commonpb "github.com/erda-project/erda-proto-go/common/pb"
@@ -36,7 +37,7 @@ func (dbClient *DBClient) CreateOrUpdate(ctx context.Context, item *Setting) err
 
 	var existing Setting
 	err := dbClient.DB.WithContext(ctx).
-		Where("namespace = ? AND key = ?", item.Namespace, item.Key).
+		Where(&Setting{Namespace: item.Namespace, Key: item.Key}).
 		First(&existing).Error
 	if err == nil {
 		existing.Value = item.Value
@@ -54,7 +55,7 @@ func (dbClient *DBClient) CreateOrUpdate(ctx context.Context, item *Setting) err
 func (dbClient *DBClient) GetByNamespaceKey(ctx context.Context, namespace, key string) (*Setting, error) {
 	var item Setting
 	err := dbClient.DB.WithContext(ctx).
-		Where("namespace = ? AND key = ?", namespace, key).
+		Where(&Setting{Namespace: namespace, Key: key}).
 		First(&item).Error
 	if err != nil {
 		return nil, err
@@ -69,7 +70,8 @@ func (dbClient *DBClient) GetByNamespaceKeys(ctx context.Context, namespace stri
 
 	var items []*Setting
 	if err := dbClient.DB.WithContext(ctx).
-		Where("namespace = ? AND key IN ?", namespace, keys).
+		Where(&Setting{Namespace: namespace}).
+		Where(clause.IN{Column: clause.Column{Name: "key"}, Values: stringSliceToAnySlice(keys)}).
 		Find(&items).Error; err != nil {
 		return nil, err
 	}
@@ -79,6 +81,14 @@ func (dbClient *DBClient) GetByNamespaceKeys(ctx context.Context, namespace stri
 		result[item.Key] = item
 	}
 	return result, nil
+}
+
+func stringSliceToAnySlice(values []string) []any {
+	items := make([]any, 0, len(values))
+	for _, value := range values {
+		items = append(items, value)
+	}
+	return items
 }
 
 func (dbClient *DBClient) Create(ctx context.Context, req *pb.SettingCreateRequest) (*pb.Setting, error) {

--- a/internal/apps/ai-proxy/models/setting/dbclient_test.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient_test.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -118,6 +120,30 @@ func TestDBClient_CreateConflict(t *testing.T) {
 	got, err := client.GetByNamespaceKey(ctx, "blacklist_user_agent", "general.prompts")
 	require.NoError(t, err)
 	require.Equal(t, "claude;;;codex", got.Value)
+}
+
+func TestDBClient_GetByNamespaceKeys_QuotesReservedKeyColumn(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() {
+		_ = sqlDB.Close()
+	}()
+
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{})
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT \\* FROM `ai_proxy_setting` WHERE \\(namespace = \\? AND `key` IN \\(\\?,\\?\\)\\) AND \\(`ai_proxy_setting`\\.`deleted_at` <= \\? OR `ai_proxy_setting`\\.`deleted_at` IS NULL\\)").
+		WithArgs("blacklist_user_agent", "general.headers", "general.prompts", sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "deleted_at", "namespace", "key", "value"}))
+
+	client := &DBClient{DB: db}
+	got, err := client.GetByNamespaceKeys(context.Background(), "blacklist_user_agent", "general.headers", "general.prompts")
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func prepareSQLiteSettingTable(db *gorm.DB) error {

--- a/internal/apps/ai-proxy/models/setting/dbclient_test.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient_test.go
@@ -135,7 +135,7 @@ func TestDBClient_GetByNamespaceKeys_QuotesReservedKeyColumn(t *testing.T) {
 	}), &gorm.Config{})
 	require.NoError(t, err)
 
-	mock.ExpectQuery("SELECT \\* FROM `ai_proxy_setting` WHERE \\(namespace = \\? AND `key` IN \\(\\?,\\?\\)\\) AND \\(`ai_proxy_setting`\\.`deleted_at` <= \\? OR `ai_proxy_setting`\\.`deleted_at` IS NULL\\)").
+	mock.ExpectQuery("`key` IN").
 		WithArgs("blacklist_user_agent", "general.headers", "general.prompts", sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at", "deleted_at", "namespace", "key", "value"}))
 

--- a/internal/apps/ai-proxy/models/setting/dbclient_test.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient_test.go
@@ -120,10 +120,6 @@ func TestDBClient_CreateConflict(t *testing.T) {
 	require.Equal(t, "claude;;;codex", got.Value)
 }
 
-func TestDBClient_UseQuotedKeyColumnInWhereClauses(t *testing.T) {
-	require.Equal(t, []any{"a", "b"}, stringSliceToAnySlice([]string{"a", "b"}))
-}
-
 func prepareSQLiteSettingTable(db *gorm.DB) error {
 	return db.Exec(`
 CREATE TABLE ai_proxy_setting (

--- a/internal/apps/ai-proxy/models/setting/dbclient_test.go
+++ b/internal/apps/ai-proxy/models/setting/dbclient_test.go
@@ -120,6 +120,10 @@ func TestDBClient_CreateConflict(t *testing.T) {
 	require.Equal(t, "claude;;;codex", got.Value)
 }
 
+func TestDBClient_UseQuotedKeyColumnInWhereClauses(t *testing.T) {
+	require.Equal(t, []any{"a", "b"}, stringSliceToAnySlice([]string{"a", "b"}))
+}
+
 func prepareSQLiteSettingTable(db *gorm.DB) error {
 	return db.Exec(`
 CREATE TABLE ai_proxy_setting (


### PR DESCRIPTION
#### What this PR does / why we need it:

AI-Proxy avoid MySQL reserved key column issue in setting query.


#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](https://erda.cloud/terminus/dop/projects/190/issues/all?id=823836&iterationID=-1&tab=ALL&type=TASK)


#### Specified Reviewers:


#### ChangeLog

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | AI-Proxy avoid reserved key column issue in setting query |
| 🇨🇳 中文    | AI-Proxy 修复 setting 查询中 key 保留字导致的 SQL 问题 |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.
