### PR TITLE
fix(edas): reconcile service selectors for legacy envs and parallelize cyclic updates

### DIFF
--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas.go
@@ -205,7 +205,6 @@ func (e *EDAS) Create(ctx context.Context, specObj interface{}) (interface{}, er
 
 	select {
 	case err := <-errChan:
-		close(errChan)
 		return nil, err
 	case <-ctx.Done():
 	case <-time.After(5 * time.Second):

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas.go
@@ -48,7 +48,6 @@ const (
 	kind = "EDAS"
 	// edas k8s service namespace
 	defaultNamespace = metav1.NamespaceDefault
-	notFound         = "not found"
 )
 
 // EDAS plugin's configure

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	"github.com/erda-project/erda/apistructs"
@@ -146,69 +145,29 @@ func (e *EDAS) resolveServiceSelector(appName, appID, sgID, serviceName string) 
 		deployment = currentDeployment
 	}
 
-	var currentSvc *corev1.Service
-	if currentSvc, err := e.wrapClientSet.GetK8sService(appName); err == nil {
-		return resolveServiceSelectorFromResources(deployment, currentSvc, appID, sgID, serviceName)
-	}
-
-	return resolveServiceSelectorFromResources(deployment, currentSvc, appID, sgID, serviceName)
+	return resolveServiceSelectorFromDeployment(deployment, sgID, serviceName)
 }
 
-func selectorFromDeployment(deployment *appsv1.Deployment) map[string]string {
-	if deployment == nil || deployment.Spec.Selector == nil {
-		return nil
-	}
-	return preferredServiceSelector(deployment.Spec.Selector.MatchLabels)
-}
-
-func resolveServiceSelectorFromResources(deployment *appsv1.Deployment, currentSvc *corev1.Service, appID, sgID, serviceName string) map[string]string {
-	if selector := selectorFromDeployment(deployment); len(selector) > 0 {
-		return selector
-	}
-
-	if currentSvc != nil {
-		if selector := preferredServiceSelector(currentSvc.Spec.Selector); len(selector) > 0 {
-			return selector
+func resolveServiceSelectorFromDeployment(deployment *appsv1.Deployment, sgID, serviceName string) map[string]string {
+	if deployment != nil {
+		if labels := deployment.Spec.Template.Labels; len(labels) > 0 {
+			if labelServiceName, ok := labels[types.LabelServiceName]; ok && labelServiceName != "" {
+				if labelServiceGroupID, ok := labels[types.LabelServiceGroupID]; ok && labelServiceGroupID != "" {
+					return map[string]string{
+						types.LabelServiceName:    labelServiceName,
+						types.LabelServiceGroupID: labelServiceGroupID,
+					}
+				}
+			}
+			if labelEDASAppID, ok := labels[types.LabelEDASAppID]; ok && labelEDASAppID != "" {
+				return map[string]string{types.LabelEDASAppID: labelEDASAppID}
+			}
+		}
+		if deployment.Spec.Selector != nil && len(deployment.Spec.Selector.MatchLabels) > 0 {
+			return cloneStringMap(deployment.Spec.Selector.MatchLabels)
 		}
 	}
 
-	if appID != "" {
-		return map[string]string{types.LabelEDASAppID: appID}
-	}
-
-	return defaultServiceSelector(sgID, serviceName)
-}
-
-func preferredServiceSelector(selector map[string]string) map[string]string {
-	if len(selector) == 0 {
-		return nil
-	}
-
-	if serviceSelector := serviceIdentitySelector(selector); len(serviceSelector) > 0 {
-		return serviceSelector
-	}
-
-	if appID, ok := selector[types.LabelEDASAppID]; ok && appID != "" {
-		return map[string]string{types.LabelEDASAppID: appID}
-	}
-
-	return cloneStringMap(selector)
-}
-
-func serviceIdentitySelector(selector map[string]string) map[string]string {
-	serviceName, hasServiceName := selector[types.LabelServiceName]
-	serviceGroupID, hasServiceGroupID := selector[types.LabelServiceGroupID]
-	if !hasServiceName || !hasServiceGroupID || serviceName == "" || serviceGroupID == "" {
-		return nil
-	}
-
-	return map[string]string{
-		types.LabelServiceName:    serviceName,
-		types.LabelServiceGroupID: serviceGroupID,
-	}
-}
-
-func defaultServiceSelector(sgID, serviceName string) map[string]string {
 	return map[string]string{
 		types.LabelServiceName:    serviceName,
 		types.LabelServiceGroupID: sgID,

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -30,6 +30,7 @@ import (
 	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/edas/types"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/edas/utils"
+	wrappedas "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/edas"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/k8s/k8sapi"
 	executorutil "github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/util"
@@ -82,8 +83,8 @@ func (e *EDAS) createService(ctx context.Context, sg *apistructs.ServiceGroup, s
 
 	appName := utils.CombineEDASAppName(sg.Type, sg.ID, s.Name)
 
-	//create k8s service
-	if err = e.wrapClientSet.CreateK8sService(appName, sg.ID, s.Name, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
+	// Align k8s Service state even if a previous async flow already created it.
+	if err = e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, sg.ID, s.Name, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
 		l.Errorf("failed to create k8s service, appName: %s, error: %v", appName, err)
 		return errors.Wrap(err, "edas create k8s service")
 	}
@@ -98,7 +99,7 @@ func (e *EDAS) updateService(ctx context.Context, sg *apistructs.ServiceGroup, s
 
 	// Check whether the service exists, if it does not exist, create a new one; otherwise, update it
 	if appID, err := e.wrapEDASClient.GetAppID(appName); err != nil {
-		if err.Error() == notFound {
+		if errors.Is(err, wrappedas.ErrApplicationNotFound) {
 			l.Warningf("app(%s) is not found via edas api, will create it ", appName)
 			if err = e.createService(ctx, sg, s); err != nil {
 				l.Errorf("failed to create service(%s): %v", appName, err)

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -159,6 +159,9 @@ func (e *EDAS) removeService(ctx context.Context, group string, s *apistructs.Se
 func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *apistructs.ServiceGroup) error {
 	l := e.l.WithField("func", "cyclicUpdateService")
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	errChan := make(chan error, 1)
 	group := utils.CombineEDASAppGroup(newRuntime.Type, newRuntime.ID)
 
@@ -176,6 +179,10 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 		// 2. The service whose port has been modified
 		svcs := checkoutServicesToDelete(newRuntime, oldRuntime)
 		for _, svc := range *svcs {
+			if ctx.Err() != nil {
+				return
+			}
+
 			appName := utils.CombineEDASAppNameWithGroup(group, svc.Name)
 			l.Warningf("need to delete service(%s) because the user modified name or ports !!!", appName)
 
@@ -186,6 +193,10 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 
 		for _, batch := range flows {
 			for _, newSvc := range batch {
+				if ctx.Err() != nil {
+					return
+				}
+
 				var ok bool
 				var oldSvc *apistructs.Service
 
@@ -196,7 +207,7 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 					l.Infof("cyclicupdate to create service %s", svcName)
 					if err = e.createService(ctx, newRuntime, newSvc); err != nil {
 						l.Errorf("failed to create service: %s, error: %v", appName, err)
-						errChan <- err
+						reportAsyncError(ctx, errChan, err)
 						return
 					}
 					continue
@@ -206,7 +217,7 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 				// Does not include domain name updates
 				if err = e.updateService(ctx, newRuntime, newSvc); err != nil {
 					l.Errorf("failed to update service: %s, error: %v", appName, err)
-					errChan <- err
+					reportAsyncError(ctx, errChan, err)
 					return
 				}
 			}
@@ -217,13 +228,21 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 	// Prevent the upper layer from querying the status when the asynchronous has not been executed.
 	select {
 	case err := <-errChan:
-		close(errChan)
 		return err
 	case <-ctx.Done():
 	case <-time.After(5 * time.Second):
 	}
 
 	return nil
+}
+
+func reportAsyncError(ctx context.Context, errChan chan<- error, err error) bool {
+	select {
+	case errChan <- err:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // FIXME: Is 20 times reasonable?

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -21,11 +21,11 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/utils/pointer"
 
@@ -237,48 +237,29 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 		}
 
 		for _, batch := range flows {
-			var wg sync.WaitGroup
-			var batchErr error
-			var batchErrMu sync.Mutex
+			if err := runServiceBatch(ctx, batch, func(batchCtx context.Context, newSvc *apistructs.Service) error {
+				var runErr error
+				svcName := newSvc.Name
+				appName := utils.CombineEDASAppNameWithGroup(group, svcName)
 
-			for _, svc := range batch {
-				newSvc := svc
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-
-					var runErr error
-					svcName := newSvc.Name
-					appName := utils.CombineEDASAppNameWithGroup(group, svcName)
-
-					if ok, oldSvc := isServiceInRuntime(svcName, oldRuntime); !ok || oldSvc == nil {
-						l.Infof("cyclicupdate to create service %s", svcName)
-						runErr = e.createService(ctx, newRuntime, newSvc)
-						if runErr != nil {
-							l.Errorf("failed to create service: %s, error: %v", appName, runErr)
-						}
-					} else {
-						// update service
-						// Does not include domain name updates
-						runErr = e.updateService(ctx, newRuntime, newSvc)
-						if runErr != nil {
-							l.Errorf("failed to update service: %s, error: %v", appName, runErr)
-						}
-					}
-
+				if ok, oldSvc := isServiceInRuntime(svcName, oldRuntime); !ok || oldSvc == nil {
+					l.Infof("cyclicupdate to create service %s", svcName)
+					runErr = e.createService(batchCtx, newRuntime, newSvc)
 					if runErr != nil {
-						batchErrMu.Lock()
-						if batchErr == nil {
-							batchErr = runErr
-						}
-						batchErrMu.Unlock()
+						l.Errorf("failed to create service: %s, error: %v", appName, runErr)
 					}
-				}()
-			}
+				} else {
+					// update service
+					// Does not include domain name updates
+					runErr = e.updateService(batchCtx, newRuntime, newSvc)
+					if runErr != nil {
+						l.Errorf("failed to update service: %s, error: %v", appName, runErr)
+					}
+				}
 
-			wg.Wait()
-			if batchErr != nil {
-				trySendErr(errChan, batchErr)
+				return runErr
+			}); err != nil {
+				trySendErr(errChan, err)
 				return
 			}
 		}
@@ -294,6 +275,31 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 	}
 
 	return nil
+}
+
+func runServiceBatch(ctx context.Context, batch []*apistructs.Service, run func(context.Context, *apistructs.Service) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	g, batchCtx := errgroup.WithContext(ctx)
+	for _, svc := range batch {
+		svc := svc
+		g.Go(func() error {
+			select {
+			case <-batchCtx.Done():
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return nil
+			default:
+			}
+
+			return run(batchCtx, svc)
+		})
+	}
+
+	return g.Wait()
 }
 
 func trySendErr(errChan chan<- error, err error) {

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -159,9 +159,6 @@ func (e *EDAS) removeService(ctx context.Context, group string, s *apistructs.Se
 func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *apistructs.ServiceGroup) error {
 	l := e.l.WithField("func", "cyclicUpdateService")
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	errChan := make(chan error, 1)
 	group := utils.CombineEDASAppGroup(newRuntime.Type, newRuntime.ID)
 
@@ -179,10 +176,6 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 		// 2. The service whose port has been modified
 		svcs := checkoutServicesToDelete(newRuntime, oldRuntime)
 		for _, svc := range *svcs {
-			if ctx.Err() != nil {
-				return
-			}
-
 			appName := utils.CombineEDASAppNameWithGroup(group, svc.Name)
 			l.Warningf("need to delete service(%s) because the user modified name or ports !!!", appName)
 
@@ -193,10 +186,6 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 
 		for _, batch := range flows {
 			for _, newSvc := range batch {
-				if ctx.Err() != nil {
-					return
-				}
-
 				var ok bool
 				var oldSvc *apistructs.Service
 
@@ -207,7 +196,7 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 					l.Infof("cyclicupdate to create service %s", svcName)
 					if err = e.createService(ctx, newRuntime, newSvc); err != nil {
 						l.Errorf("failed to create service: %s, error: %v", appName, err)
-						reportAsyncError(ctx, errChan, err)
+						trySendErr(errChan, err)
 						return
 					}
 					continue
@@ -217,7 +206,7 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 				// Does not include domain name updates
 				if err = e.updateService(ctx, newRuntime, newSvc); err != nil {
 					l.Errorf("failed to update service: %s, error: %v", appName, err)
-					reportAsyncError(ctx, errChan, err)
+					trySendErr(errChan, err)
 					return
 				}
 			}
@@ -236,12 +225,10 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 	return nil
 }
 
-func reportAsyncError(ctx context.Context, errChan chan<- error, err error) bool {
+func trySendErr(errChan chan<- error, err error) {
 	select {
 	case errChan <- err:
-		return true
-	case <-ctx.Done():
-		return false
+	default:
 	}
 }
 

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 
 	"github.com/erda-project/erda/apistructs"
@@ -77,14 +79,16 @@ func (e *EDAS) createService(ctx context.Context, sg *apistructs.ServiceGroup, s
 	}
 
 	// Create application
-	if _, err = e.wrapEDASClient.InsertK8sApp(serviceSpec); err != nil {
+	appID, err := e.wrapEDASClient.InsertK8sApp(serviceSpec)
+	if err != nil {
 		return errors.Wrap(err, "edas create app")
 	}
 
 	appName := utils.CombineEDASAppName(sg.Type, sg.ID, s.Name)
+	selector := e.resolveServiceSelector(appName, appID, sg.ID, s.Name)
 
 	// Align k8s Service state even if a previous async flow already created it.
-	if err = e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, sg.ID, s.Name, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
+	if err = e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, selector, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
 		l.Errorf("failed to create k8s service, appName: %s, error: %v", appName, err)
 		return errors.Wrap(err, "edas create k8s service")
 	}
@@ -126,13 +130,101 @@ func (e *EDAS) updateService(ctx context.Context, sg *apistructs.ServiceGroup, s
 			return err
 		}
 
-		if err := e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, sg.ID, s.Name, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
+		selector := e.resolveServiceSelector(appName, appID, sg.ID, s.Name)
+		if err := e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, selector, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
 			l.Errorf("failed to update k8s service, appName: %s, error: %v", appName, err)
 			return errors.Wrap(err, "edas update k8s service")
 		}
 	}
 
 	return nil
+}
+
+func (e *EDAS) resolveServiceSelector(appName, appID, sgID, serviceName string) map[string]string {
+	var deployment *appsv1.Deployment
+	if currentDeployment, err := e.wrapEDASClient.GetAppDeployment(appName); err == nil {
+		deployment = currentDeployment
+	}
+
+	var currentSvc *corev1.Service
+	if currentSvc, err := e.wrapClientSet.GetK8sService(appName); err == nil {
+		return resolveServiceSelectorFromResources(deployment, currentSvc, appID, sgID, serviceName)
+	}
+
+	return resolveServiceSelectorFromResources(deployment, currentSvc, appID, sgID, serviceName)
+}
+
+func selectorFromDeployment(deployment *appsv1.Deployment) map[string]string {
+	if deployment == nil || deployment.Spec.Selector == nil {
+		return nil
+	}
+	return preferredServiceSelector(deployment.Spec.Selector.MatchLabels)
+}
+
+func resolveServiceSelectorFromResources(deployment *appsv1.Deployment, currentSvc *corev1.Service, appID, sgID, serviceName string) map[string]string {
+	if selector := selectorFromDeployment(deployment); len(selector) > 0 {
+		return selector
+	}
+
+	if currentSvc != nil {
+		if selector := preferredServiceSelector(currentSvc.Spec.Selector); len(selector) > 0 {
+			return selector
+		}
+	}
+
+	if appID != "" {
+		return map[string]string{types.LabelEDASAppID: appID}
+	}
+
+	return defaultServiceSelector(sgID, serviceName)
+}
+
+func preferredServiceSelector(selector map[string]string) map[string]string {
+	if len(selector) == 0 {
+		return nil
+	}
+
+	if serviceSelector := serviceIdentitySelector(selector); len(serviceSelector) > 0 {
+		return serviceSelector
+	}
+
+	if appID, ok := selector[types.LabelEDASAppID]; ok && appID != "" {
+		return map[string]string{types.LabelEDASAppID: appID}
+	}
+
+	return cloneStringMap(selector)
+}
+
+func serviceIdentitySelector(selector map[string]string) map[string]string {
+	serviceName, hasServiceName := selector[types.LabelServiceName]
+	serviceGroupID, hasServiceGroupID := selector[types.LabelServiceGroupID]
+	if !hasServiceName || !hasServiceGroupID || serviceName == "" || serviceGroupID == "" {
+		return nil
+	}
+
+	return map[string]string{
+		types.LabelServiceName:    serviceName,
+		types.LabelServiceGroupID: serviceGroupID,
+	}
+}
+
+func defaultServiceSelector(sgID, serviceName string) map[string]string {
+	return map[string]string{
+		types.LabelServiceName:    serviceName,
+		types.LabelServiceGroupID: sgID,
+	}
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(src))
+	for k, v := range src {
+		cloned[k] = v
+	}
+	return cloned
 }
 
 // TODO: how to handle the error

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -237,30 +238,49 @@ func (e *EDAS) cyclicUpdateService(ctx context.Context, newRuntime, oldRuntime *
 		}
 
 		for _, batch := range flows {
-			for _, newSvc := range batch {
-				var ok bool
-				var oldSvc *apistructs.Service
+			var wg sync.WaitGroup
+			var batchErr error
+			var batchErrMu sync.Mutex
 
-				svcName := newSvc.Name
-				appName := utils.CombineEDASAppNameWithGroup(group, svcName)
-				// add service
-				if ok, oldSvc = isServiceInRuntime(svcName, oldRuntime); !ok || oldSvc == nil {
-					l.Infof("cyclicupdate to create service %s", svcName)
-					if err = e.createService(ctx, newRuntime, newSvc); err != nil {
-						l.Errorf("failed to create service: %s, error: %v", appName, err)
-						trySendErr(errChan, err)
-						return
+			for _, svc := range batch {
+				newSvc := svc
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					var runErr error
+					svcName := newSvc.Name
+					appName := utils.CombineEDASAppNameWithGroup(group, svcName)
+
+					if ok, oldSvc := isServiceInRuntime(svcName, oldRuntime); !ok || oldSvc == nil {
+						l.Infof("cyclicupdate to create service %s", svcName)
+						runErr = e.createService(ctx, newRuntime, newSvc)
+						if runErr != nil {
+							l.Errorf("failed to create service: %s, error: %v", appName, runErr)
+						}
+					} else {
+						// update service
+						// Does not include domain name updates
+						runErr = e.updateService(ctx, newRuntime, newSvc)
+						if runErr != nil {
+							l.Errorf("failed to update service: %s, error: %v", appName, runErr)
+						}
 					}
-					continue
-				}
 
-				// update service
-				// Does not include domain name updates
-				if err = e.updateService(ctx, newRuntime, newSvc); err != nil {
-					l.Errorf("failed to update service: %s, error: %v", appName, err)
-					trySendErr(errChan, err)
-					return
-				}
+					if runErr != nil {
+						batchErrMu.Lock()
+						if batchErr == nil {
+							batchErr = runErr
+						}
+						batchErrMu.Unlock()
+					}
+				}()
+			}
+
+			wg.Wait()
+			if batchErr != nil {
+				trySendErr(errChan, batchErr)
+				return
 			}
 		}
 	}()

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow.go
@@ -79,13 +79,12 @@ func (e *EDAS) createService(ctx context.Context, sg *apistructs.ServiceGroup, s
 	}
 
 	// Create application
-	appID, err := e.wrapEDASClient.InsertK8sApp(serviceSpec)
-	if err != nil {
+	if _, err = e.wrapEDASClient.InsertK8sApp(serviceSpec); err != nil {
 		return errors.Wrap(err, "edas create app")
 	}
 
 	appName := utils.CombineEDASAppName(sg.Type, sg.ID, s.Name)
-	selector := e.resolveServiceSelector(appName, appID, sg.ID, s.Name)
+	selector := e.resolveServiceSelector(appName, sg.ID, s.Name)
 
 	// Align k8s Service state even if a previous async flow already created it.
 	if err = e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, selector, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
@@ -130,7 +129,7 @@ func (e *EDAS) updateService(ctx context.Context, sg *apistructs.ServiceGroup, s
 			return err
 		}
 
-		selector := e.resolveServiceSelector(appName, appID, sg.ID, s.Name)
+		selector := e.resolveServiceSelector(appName, sg.ID, s.Name)
 		if err := e.wrapClientSet.CreateOrUpdateK8sService(ctx, appName, selector, diceyml.ComposeIntPortsFromServicePorts(s.Ports)); err != nil {
 			l.Errorf("failed to update k8s service, appName: %s, error: %v", appName, err)
 			return errors.Wrap(err, "edas update k8s service")
@@ -140,7 +139,7 @@ func (e *EDAS) updateService(ctx context.Context, sg *apistructs.ServiceGroup, s
 	return nil
 }
 
-func (e *EDAS) resolveServiceSelector(appName, appID, sgID, serviceName string) map[string]string {
+func (e *EDAS) resolveServiceSelector(appName, sgID, serviceName string) map[string]string {
 	var deployment *appsv1.Deployment
 	if currentDeployment, err := e.wrapEDASClient.GetAppDeployment(appName); err == nil {
 		deployment = currentDeployment

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -160,52 +160,22 @@ func TestTrySendErrDoesNotBlockWhenChannelIsFull(t *testing.T) {
 	require.ErrorIs(t, <-errChan, assert.AnError)
 }
 
-func TestSelectorFromDeployment(t *testing.T) {
+func TestResolveServiceSelectorFromDeployment(t *testing.T) {
 	deployment := &appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					types.LabelServiceName:    "svc",
-					types.LabelServiceGroupID: "sg",
-					types.LabelEDASAppID:      "123",
-					"custom":                  "ignored",
+					"match": "deploy",
 				},
 			},
-		},
-	}
-
-	assert.Equal(t, map[string]string{
-		types.LabelServiceName:    "svc",
-		types.LabelServiceGroupID: "sg",
-	}, selectorFromDeployment(deployment))
-	assert.Nil(t, selectorFromDeployment(nil))
-}
-
-func TestDefaultServiceSelector(t *testing.T) {
-	assert.Equal(t, map[string]string{
-		types.LabelServiceName:    "test-service",
-		types.LabelServiceGroupID: "test-sg",
-	}, defaultServiceSelector("test-sg", "test-service"))
-}
-
-func TestResolveServiceSelectorFromResources(t *testing.T) {
-	deployment := &appsv1.Deployment{
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					types.LabelServiceName:    "deploy-service",
-					types.LabelServiceGroupID: "deploy-group",
-					types.LabelEDASAppID:      "deploy-app-id",
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						types.LabelServiceName:    "deploy-service",
+						types.LabelServiceGroupID: "deploy-group",
+						types.LabelEDASAppID:      "deploy-app-id",
+					},
 				},
-			},
-		},
-	}
-	currentSvc := &corev1.Service{
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				types.LabelServiceName:    "service-service",
-				types.LabelServiceGroupID: "service-group",
-				types.LabelEDASAppID:      "service-app-id",
 			},
 		},
 	}
@@ -214,19 +184,27 @@ func TestResolveServiceSelectorFromResources(t *testing.T) {
 		types.LabelServiceName:    "deploy-service",
 		types.LabelServiceGroupID: "deploy-group",
 	},
-		resolveServiceSelectorFromResources(deployment, currentSvc, "fallback-app-id", "test-sg", "test-service"))
-
-	assert.Equal(t, map[string]string{
-		types.LabelServiceName:    "service-service",
-		types.LabelServiceGroupID: "service-group",
-	},
-		resolveServiceSelectorFromResources(nil, currentSvc, "fallback-app-id", "test-sg", "test-service"))
-
-	assert.Equal(t, map[string]string{types.LabelEDASAppID: "fallback-app-id"},
-		resolveServiceSelectorFromResources(nil, nil, "fallback-app-id", "test-sg", "test-service"))
+		resolveServiceSelectorFromDeployment(deployment, "test-sg", "test-service"))
 
 	assert.Equal(t, map[string]string{
 		types.LabelServiceName:    "test-service",
 		types.LabelServiceGroupID: "test-sg",
-	}, resolveServiceSelectorFromResources(nil, nil, "", "test-sg", "test-service"))
+	}, resolveServiceSelectorFromDeployment(nil, "test-sg", "test-service"))
+
+	deployment.Spec.Template.Labels = map[string]string{
+		types.LabelEDASAppID: "deploy-app-id",
+	}
+	assert.Equal(t, map[string]string{
+		types.LabelEDASAppID: "deploy-app-id",
+	}, resolveServiceSelectorFromDeployment(deployment, "test-sg", "test-service"))
+
+	deployment.Spec.Template.Labels = map[string]string{
+		"custom": "deploy-value",
+	}
+	deployment.Spec.Selector.MatchLabels = map[string]string{
+		"match": "deploy",
+	}
+	assert.Equal(t, map[string]string{
+		"match": "deploy",
+	}, resolveServiceSelectorFromDeployment(deployment, "test-sg", "test-service"))
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -15,10 +15,8 @@
 package edas
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,32 +141,18 @@ func TestSetLabels_JSONMarshaling(t *testing.T) {
 	assert.Equal(t, expectedLabels, labels)
 }
 
-func TestReportAsyncErrorSendsWhenReceiverIsAvailable(t *testing.T) {
+func TestTrySendErrSendsWhenReceiverIsAvailable(t *testing.T) {
 	errChan := make(chan error, 1)
 	expectedErr := assert.AnError
 
-	sent := reportAsyncError(context.Background(), errChan, expectedErr)
-
-	require.True(t, sent)
+	trySendErr(errChan, expectedErr)
 	require.ErrorIs(t, <-errChan, expectedErr)
 }
 
-func TestReportAsyncErrorReturnsWhenContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+func TestTrySendErrDoesNotBlockWhenChannelIsFull(t *testing.T) {
 	errChan := make(chan error, 1)
 	errChan <- assert.AnError
-	cancel()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		sent := reportAsyncError(ctx, errChan, assert.AnError)
-		assert.False(t, sent)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("reportAsyncError blocked after context cancellation")
-	}
+	trySendErr(errChan, assert.AnError)
+	require.ErrorIs(t, <-errChan, assert.AnError)
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/edas/types"
 )
@@ -155,4 +158,75 @@ func TestTrySendErrDoesNotBlockWhenChannelIsFull(t *testing.T) {
 
 	trySendErr(errChan, assert.AnError)
 	require.ErrorIs(t, <-errChan, assert.AnError)
+}
+
+func TestSelectorFromDeployment(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					types.LabelServiceName:    "svc",
+					types.LabelServiceGroupID: "sg",
+					types.LabelEDASAppID:      "123",
+					"custom":                  "ignored",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, map[string]string{
+		types.LabelServiceName:    "svc",
+		types.LabelServiceGroupID: "sg",
+	}, selectorFromDeployment(deployment))
+	assert.Nil(t, selectorFromDeployment(nil))
+}
+
+func TestDefaultServiceSelector(t *testing.T) {
+	assert.Equal(t, map[string]string{
+		types.LabelServiceName:    "test-service",
+		types.LabelServiceGroupID: "test-sg",
+	}, defaultServiceSelector("test-sg", "test-service"))
+}
+
+func TestResolveServiceSelectorFromResources(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					types.LabelServiceName:    "deploy-service",
+					types.LabelServiceGroupID: "deploy-group",
+					types.LabelEDASAppID:      "deploy-app-id",
+				},
+			},
+		},
+	}
+	currentSvc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				types.LabelServiceName:    "service-service",
+				types.LabelServiceGroupID: "service-group",
+				types.LabelEDASAppID:      "service-app-id",
+			},
+		},
+	}
+
+	assert.Equal(t, map[string]string{
+		types.LabelServiceName:    "deploy-service",
+		types.LabelServiceGroupID: "deploy-group",
+	},
+		resolveServiceSelectorFromResources(deployment, currentSvc, "fallback-app-id", "test-sg", "test-service"))
+
+	assert.Equal(t, map[string]string{
+		types.LabelServiceName:    "service-service",
+		types.LabelServiceGroupID: "service-group",
+	},
+		resolveServiceSelectorFromResources(nil, currentSvc, "fallback-app-id", "test-sg", "test-service"))
+
+	assert.Equal(t, map[string]string{types.LabelEDASAppID: "fallback-app-id"},
+		resolveServiceSelectorFromResources(nil, nil, "fallback-app-id", "test-sg", "test-service"))
+
+	assert.Equal(t, map[string]string{
+		types.LabelServiceName:    "test-service",
+		types.LabelServiceGroupID: "test-sg",
+	}, resolveServiceSelectorFromResources(nil, nil, "", "test-sg", "test-service"))
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -15,8 +15,10 @@
 package edas
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,4 +141,34 @@ func TestSetLabels_JSONMarshaling(t *testing.T) {
 	err = json.Unmarshal([]byte(expectedJSON), &expectedLabels)
 	require.NoError(t, err)
 	assert.Equal(t, expectedLabels, labels)
+}
+
+func TestReportAsyncErrorSendsWhenReceiverIsAvailable(t *testing.T) {
+	errChan := make(chan error, 1)
+	expectedErr := assert.AnError
+
+	sent := reportAsyncError(context.Background(), errChan, expectedErr)
+
+	require.True(t, sent)
+	require.ErrorIs(t, <-errChan, expectedErr)
+}
+
+func TestReportAsyncErrorReturnsWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+	errChan <- assert.AnError
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sent := reportAsyncError(ctx, errChan, assert.AnError)
+		assert.False(t, sent)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("reportAsyncError blocked after context cancellation")
+	}
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/edas_app_flow_test.go
@@ -15,8 +15,10 @@
 package edas
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/erda-project/erda/apistructs"
 	"github.com/erda-project/erda/internal/tools/orchestrator/scheduler/executor/plugins/edas/types"
 )
 
@@ -158,6 +161,51 @@ func TestTrySendErrDoesNotBlockWhenChannelIsFull(t *testing.T) {
 
 	trySendErr(errChan, assert.AnError)
 	require.ErrorIs(t, <-errChan, assert.AnError)
+}
+
+func TestRunServiceBatchCancelsOnFirstError(t *testing.T) {
+	cancelableStarted := make(chan struct{})
+	cancelObserved := make(chan struct{})
+	batch := []*apistructs.Service{
+		{Name: "failed"},
+		{Name: "cancelable"},
+	}
+
+	err := runServiceBatch(context.Background(), batch, func(ctx context.Context, svc *apistructs.Service) error {
+		switch svc.Name {
+		case "failed":
+			<-cancelableStarted
+			return assert.AnError
+		case "cancelable":
+			close(cancelableStarted)
+			<-ctx.Done()
+			close(cancelObserved)
+			return nil
+		default:
+			return nil
+		}
+	})
+
+	require.ErrorIs(t, err, assert.AnError)
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("cancelable service did not observe cancellation")
+	}
+}
+
+func TestRunServiceBatchReturnsParentContextErrorWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	err := runServiceBatch(ctx, []*apistructs.Service{{Name: "svc"}}, func(ctx context.Context, svc *apistructs.Service) error {
+		called = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, called, "run should not be called when parent context is already canceled")
 }
 
 func TestResolveServiceSelectorFromDeployment(t *testing.T) {

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/types/types.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/types/types.go
@@ -30,6 +30,7 @@ const (
 )
 
 const (
+	LabelEDASAppID      = "edas.appid"
 	LabelServiceName    = "core.erda.cloud/service-name"
 	LabelServiceGroupID = "core.erda.cloud/servicegroup-id"
 )

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/edas/app.client.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/edas/app.client.go
@@ -59,7 +59,8 @@ func (c *wrapEDAS) GetAppID(appName string) (string, error) {
 	}
 
 	for _, app := range resp.ApplicationList.Application {
-		if app.Name == appName && app.ClusterId == c.clusterID {
+		if normalize(app.Name) == normalize(appName) &&
+			normalize(app.ClusterId) == normalize(c.clusterID) {
 			l.Infof("successfully to get app id: %s, name: %s", app.AppId, appName)
 			return app.AppId, nil
 		}
@@ -468,4 +469,8 @@ func (c *wrapEDAS) GetAppDeployment(appName string) (*appsv1.Deployment, error) 
 	l.Infof("app %s get deployment, name: %s, namespace: %s", appName, deployment.Name, deployment.Namespace)
 
 	return &deployment, nil
+}
+
+func normalize(s string) string {
+	return strings.ReplaceAll(strings.TrimSpace(s), " ", "")
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/provider.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/provider.go
@@ -30,8 +30,8 @@ import (
 type Interface interface {
 	GetK8sService(name string) (*corev1.Service, error)
 	GetK8sDeployList(group string, services *[]apistructs.Service) error
-	CreateK8sService(appName, sgID, serviceName string, ports []int) error
-	CreateOrUpdateK8sService(ctx context.Context, appName, sgID string, serviceName string, ports []int) error
+	CreateK8sService(appName string, selectors map[string]string, ports []int) error
+	CreateOrUpdateK8sService(ctx context.Context, appName string, selectors map[string]string, ports []int) error
 	DeleteK8sService(appName string) error
 }
 

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
@@ -90,8 +90,7 @@ func (e *wrapKubernetes) CreateOrUpdateK8sService(ctx context.Context, appName, 
 	l.Infof("start to update k8s svc, appname: %s", appName)
 	newSvc := e.combineK8sService(appName, sgID, serviceName, ports)
 
-	currentSvc.Spec = newSvc.Spec
-	currentSvc.Labels = newSvc.Labels
+	applyMutableServiceFields(currentSvc, newSvc)
 
 	if _, err := e.cs.CoreV1().Services(e.namespace).
 		Update(ctx, currentSvc, metav1.UpdateOptions{}); err != nil {
@@ -143,4 +142,10 @@ func (e *wrapKubernetes) combineK8sService(appName, sgID, serviceName string, po
 			Ports: servicePorts,
 		},
 	}
+}
+
+func applyMutableServiceFields(currentSvc, newSvc *corev1.Service) {
+	currentSvc.Spec.Selector = newSvc.Spec.Selector
+	currentSvc.Spec.Ports = newSvc.Spec.Ports
+	currentSvc.Labels = newSvc.Labels
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service.go
@@ -65,10 +65,10 @@ func (e *wrapKubernetes) GetK8sService(name string) (*corev1.Service, error) {
 
 // CreateK8sService create kubernetes service
 // TODO: Currently, it is injected by the controller; however, it is advisable to replace this with the 'CreateK8sService' interface provided by edas in the future.
-func (e *wrapKubernetes) CreateK8sService(appName, sgID, serviceName string, ports []int) error {
+func (e *wrapKubernetes) CreateK8sService(appName string, selectors map[string]string, ports []int) error {
 	l := e.l.WithField("func", "CreateK8sService")
 
-	k8sService := e.combineK8sService(appName, sgID, serviceName, ports)
+	k8sService := e.combineK8sService(appName, selectors, ports)
 
 	l.Infof("start to create k8s svc, appName: %s", appName)
 	_, err := e.cs.CoreV1().Services(e.namespace).Create(context.TODO(), k8sService, metav1.CreateOptions{})
@@ -76,19 +76,19 @@ func (e *wrapKubernetes) CreateK8sService(appName, sgID, serviceName string, por
 }
 
 // CreateOrUpdateK8sService create or update kubernetes service
-func (e *wrapKubernetes) CreateOrUpdateK8sService(ctx context.Context, appName, sgID, serviceName string, ports []int) error {
+func (e *wrapKubernetes) CreateOrUpdateK8sService(ctx context.Context, appName string, selectors map[string]string, ports []int) error {
 	l := e.l.WithField("func", "CreateOrUpdateK8sService")
 
 	currentSvc, err := e.cs.CoreV1().Services(e.namespace).Get(ctx, appName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return e.CreateK8sService(appName, sgID, serviceName, ports)
+			return e.CreateK8sService(appName, selectors, ports)
 		}
 		return err
 	}
 
 	l.Infof("start to update k8s svc, appname: %s", appName)
-	newSvc := e.combineK8sService(appName, sgID, serviceName, ports)
+	newSvc := e.combineK8sService(appName, selectors, ports)
 
 	applyMutableServiceFields(currentSvc, newSvc)
 
@@ -111,7 +111,7 @@ func (e *wrapKubernetes) DeleteK8sService(appName string) error {
 	return nil
 }
 
-func (e *wrapKubernetes) combineK8sService(appName, sgID, serviceName string, ports []int) *corev1.Service {
+func (e *wrapKubernetes) combineK8sService(appName string, selectors map[string]string, ports []int) *corev1.Service {
 	var (
 		// TODO：support more protocol
 		serviceNamePrefix = "tcp-"
@@ -135,11 +135,8 @@ func (e *wrapKubernetes) combineK8sService(appName, sgID, serviceName string, po
 		},
 		Spec: corev1.ServiceSpec{
 			// TODO: type?
-			Selector: map[string]string{
-				types.LabelServiceName:    serviceName,
-				types.LabelServiceGroupID: sgID,
-			},
-			Ports: servicePorts,
+			Selector: cloneSelector(selectors),
+			Ports:    servicePorts,
 		},
 	}
 }
@@ -148,4 +145,16 @@ func applyMutableServiceFields(currentSvc, newSvc *corev1.Service) {
 	currentSvc.Spec.Selector = newSvc.Spec.Selector
 	currentSvc.Spec.Ports = newSvc.Spec.Ports
 	currentSvc.Labels = newSvc.Labels
+}
+
+func cloneSelector(selectors map[string]string) map[string]string {
+	if len(selectors) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(selectors))
+	for k, v := range selectors {
+		cloned[k] = v
+	}
+	return cloned
 }

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
@@ -36,20 +36,17 @@ func TestCreateOrUpdateK8sService(t *testing.T) {
 	}
 
 	appName := "test-app"
-	sgID := "test-sg-id"
-	serviceName := "test-service"
+	selectors := map[string]string{"app": "test-app"}
 	ports := []int{80, 8080}
 
 	args := struct {
-		appName     string
-		sgID        string
-		serviceName string
-		ports       []int
+		appName   string
+		selectors map[string]string
+		ports     []int
 	}{
-		appName:     appName,
-		sgID:        sgID,
-		serviceName: serviceName,
-		ports:       ports,
+		appName:   appName,
+		selectors: selectors,
+		ports:     ports,
 	}
 
 	tests := []struct {
@@ -72,10 +69,10 @@ func TestCreateOrUpdateK8sService(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.existingSvc {
-				_ = kubernetesWrapper.CreateK8sService(appName, sgID, serviceName, ports)
+				_ = kubernetesWrapper.CreateK8sService(appName, selectors, ports)
 			}
 
-			err := kubernetesWrapper.CreateOrUpdateK8sService(context.Background(), args.appName, args.sgID, args.serviceName, args.ports)
+			err := kubernetesWrapper.CreateOrUpdateK8sService(context.Background(), args.appName, args.selectors, args.ports)
 
 			if test.expectedError && err == nil {
 				t.Error("Expected an error, but got nil.")
@@ -90,8 +87,10 @@ func TestCombineK8sService(t *testing.T) {
 	wrapCs := wrapKubernetes{}
 	// Test case 1
 	appName := "my-app"
-	sgID := "123"
-	serviceName := "test-service"
+	selectors := map[string]string{
+		"core.erda.cloud/service-name":    "test-service",
+		"core.erda.cloud/servicegroup-id": "123",
+	}
 	ports := []int{8080, 9090}
 
 	expectedService := &corev1.Service{
@@ -100,10 +99,7 @@ func TestCombineK8sService(t *testing.T) {
 			Labels: make(map[string]string),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"core.erda.cloud/service-name":    serviceName,
-				"core.erda.cloud/servicegroup-id": sgID,
-			},
+			Selector: selectors,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "tcp-0",
@@ -119,7 +115,7 @@ func TestCombineK8sService(t *testing.T) {
 		},
 	}
 
-	service := wrapCs.combineK8sService(appName, sgID, serviceName, ports)
+	service := wrapCs.combineK8sService(appName, selectors, ports)
 
 	// Compare the expected service with the actual service
 	if !reflect.DeepEqual(service, expectedService) {

--- a/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
+++ b/internal/tools/orchestrator/scheduler/executor/plugins/edas/wrapclient/kubernetes/service_test.go
@@ -127,3 +127,58 @@ func TestCombineK8sService(t *testing.T) {
 	}
 
 }
+
+func TestApplyMutableServiceFieldsPreservesClusterIP(t *testing.T) {
+	currentSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-app",
+			Labels: map[string]string{"old": "label"},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{"old": "selector"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "tcp-0",
+					Port:       80,
+					TargetPort: intstr.FromInt32(80),
+				},
+			},
+		},
+	}
+
+	newSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-app",
+			Labels: map[string]string{"new": "label"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"new": "selector"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "tcp-0",
+					Port:       8080,
+					TargetPort: intstr.FromInt32(8080),
+				},
+			},
+		},
+	}
+
+	applyMutableServiceFields(currentSvc, newSvc)
+
+	if currentSvc.Spec.ClusterIP != "10.0.0.1" {
+		t.Fatalf("expected clusterIP to be preserved, got %q", currentSvc.Spec.ClusterIP)
+	}
+
+	if !reflect.DeepEqual(currentSvc.Spec.Selector, newSvc.Spec.Selector) {
+		t.Fatalf("expected selector to be updated, got %+v", currentSvc.Spec.Selector)
+	}
+
+	if !reflect.DeepEqual(currentSvc.Spec.Ports, newSvc.Spec.Ports) {
+		t.Fatalf("expected ports to be updated, got %+v", currentSvc.Spec.Ports)
+	}
+
+	if !reflect.DeepEqual(currentSvc.Labels, newSvc.Labels) {
+		t.Fatalf("expected labels to be updated, got %+v", currentSvc.Labels)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
 1. Adjusted service selector compatibility logic
  - The primary source of selector resolution is now `Deployment.Spec.Template.Labels`
  - If both `core.erda.cloud/service-name` and `core.erda.cloud/servicegroup-id` exist in pod template labels, use them as the service selector
  - If they do not exist, fall back to `edas.appid`
  - If `edas.appid` is also absent, fall back to `Deployment.Spec.Selector.MatchLabels`
  - If none of the above is available, use the default selector as a final fallback

  2. Optimized `cyclicUpdateService`
  - Kept dependency batches in order
  - Changed service updates within the same batch to run concurrently
  - Preserved sequential execution across batches to avoid breaking dependency ordering
 
#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English | reconcile service selectors for legacy envs and parallelize cyclic updates          |
| 🇨🇳 中文    |   workflow 避免 channel 的 panic           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
