### PR TITLE
feat(cli): add issue and iteration commands with workspace-aware host

### DIFF
--- a/internal/apps/dop/providers/issue/core/service.go
+++ b/internal/apps/dop/providers/issue/core/service.go
@@ -16,12 +16,12 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -113,6 +113,9 @@ func (i *IssueService) CreateIssue(ctx context.Context, req *pb.IssueCreateReque
 		req.IdentityInfo.UserID = req.Creator
 	}
 	planStartedAt, planFinishedAt := common.ToIssueTime(req.PlanStartedAt), common.ToIssueTime(req.PlanFinishedAt)
+	if err := i.validateIssueCreateRequest(req, planStartedAt, planFinishedAt); err != nil {
+		return nil, err
+	}
 	// 初始状态为排序级最高的状态
 	initState, err := i.db.GetIssuesStatesByProjectID(req.ProjectID, req.Type.String())
 	if err != nil {
@@ -192,17 +195,6 @@ func (i *IssueService) CreateIssue(ctx context.Context, req *pb.IssueCreateReque
 		return nil, err
 	}
 
-	u := &query.IssueUpdated{
-		Id:             create.ID,
-		IterationID:    req.IterationID,
-		PlanStartedAt:  planStartedAt,
-		PlanFinishedAt: planFinishedAt,
-	}
-
-	if err := i.query.AfterIssueUpdate(u); err != nil {
-		return nil, fmt.Errorf("after issue update failed when issue id: %v create, err: %v", issueID, err)
-	}
-
 	go func() {
 		if err := i.stream.CreateIssueEvent(&streamReq); err != nil {
 			logrus.Errorf("create issue %d event err: %v", streamReq.IssueID, err)
@@ -256,6 +248,27 @@ func (i *IssueService) CreateIssue(ctx context.Context, req *pb.IssueCreateReque
 	return &pb.IssueCreateResponse{
 		Data: create.ID,
 	}, nil
+}
+
+func (i *IssueService) validateIssueCreateRequest(req *pb.IssueCreateRequest, planStartedAt, planFinishedAt *time.Time) error {
+	if planStartedAt != nil && planFinishedAt != nil && planStartedAt.After(*planFinishedAt) {
+		return apierrors.ErrCreateIssue.InvalidParameter("planStartedAt must be earlier than or equal to planFinishedAt")
+	}
+	if req.IterationID <= 0 {
+		return nil
+	}
+
+	iteration, err := i.db.GetIteration(uint64(req.IterationID))
+	if err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return apierrors.ErrCreateIssue.InvalidParameter("iterationID does not exist")
+		}
+		return apierrors.ErrCreateIssue.InternalError(err)
+	}
+	if iteration.ProjectID != req.ProjectID {
+		return apierrors.ErrCreateIssue.InvalidParameter("iterationID does not belong to current project")
+	}
+	return nil
 }
 
 func getStage(req *pb.IssueCreateRequest) string {

--- a/internal/apps/dop/providers/issue/core/service.go
+++ b/internal/apps/dop/providers/issue/core/service.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -193,6 +194,16 @@ func (i *IssueService) CreateIssue(ctx context.Context, req *pb.IssueCreateReque
 		Creator:   create.Creator,
 	}); err != nil {
 		return nil, err
+	}
+
+	u := &query.IssueUpdated{
+		Id:             create.ID,
+		IterationID:    req.IterationID,
+		PlanStartedAt:  planStartedAt,
+		PlanFinishedAt: planFinishedAt,
+	}
+	if err := i.query.AfterIssueUpdate(u); err != nil {
+		return nil, fmt.Errorf("after issue update failed when issue id: %v create, err: %w", issueID, err)
 	}
 
 	go func() {

--- a/internal/apps/dop/providers/issue/core/service_test.go
+++ b/internal/apps/dop/providers/issue/core/service_test.go
@@ -15,11 +15,14 @@
 package core
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"bou.ke/monkey"
 	"github.com/alecthomas/assert"
+	"github.com/jinzhu/gorm"
 
 	"github.com/erda-project/erda-proto-go/dop/issue/core/pb"
 	"github.com/erda-project/erda/apistructs"
@@ -131,4 +134,75 @@ func TestIssueService_DBClient(t *testing.T) {
 	db := &dao.DBClient{}
 	i := IssueService{db: db}
 	assert.Equal(t, db, i.DBClient())
+}
+
+func TestIssueService_validateIssueCreateRequest_TimeOrder(t *testing.T) {
+	svc := &IssueService{}
+	start := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	finish := time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC)
+
+	err := svc.validateIssueCreateRequest(&pb.IssueCreateRequest{
+		ProjectID:   2,
+		IterationID: -1,
+	}, &start, &finish)
+	if err == nil {
+		t.Fatal("expected validation error when planStartedAt > planFinishedAt")
+	}
+}
+
+func TestIssueService_validateIssueCreateRequest_IterationNotFound(t *testing.T) {
+	var db *dao.DBClient
+	patch := monkey.PatchInstanceMethod(reflect.TypeOf(db), "GetIteration",
+		func(_ *dao.DBClient, _ uint64) (*dao.Iteration, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	)
+	defer patch.Unpatch()
+
+	svc := &IssueService{db: db}
+	err := svc.validateIssueCreateRequest(&pb.IssueCreateRequest{
+		ProjectID:   2,
+		IterationID: 999999,
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected validation error for non-existing iteration")
+	}
+}
+
+func TestIssueService_validateIssueCreateRequest_IterationProjectMismatch(t *testing.T) {
+	var db *dao.DBClient
+	patch := monkey.PatchInstanceMethod(reflect.TypeOf(db), "GetIteration",
+		func(_ *dao.DBClient, _ uint64) (*dao.Iteration, error) {
+			return &dao.Iteration{ProjectID: 3}, nil
+		},
+	)
+	defer patch.Unpatch()
+
+	svc := &IssueService{db: db}
+	err := svc.validateIssueCreateRequest(&pb.IssueCreateRequest{
+		ProjectID:   2,
+		IterationID: 3,
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected validation error for mismatched project iteration")
+	}
+}
+
+func TestIssueService_validateIssueCreateRequest_IterationDBError(t *testing.T) {
+	var db *dao.DBClient
+	patch := monkey.PatchInstanceMethod(reflect.TypeOf(db), "GetIteration",
+		func(_ *dao.DBClient, _ uint64) (*dao.Iteration, error) {
+			return nil, errors.New("db unavailable")
+		},
+	)
+	defer patch.Unpatch()
+
+	svc := &IssueService{db: db}
+	err := svc.validateIssueCreateRequest(&pb.IssueCreateRequest{
+		ProjectID:   2,
+		IterationID: 3,
+	}, nil, nil)
+	if err == nil {
+		t.Fatal("expected internal error when iteration query fails")
+	}
 }

--- a/tools/cli/cmd/build.go
+++ b/tools/cli/cmd/build.go
@@ -25,16 +25,18 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/command"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 
 var PIPELINERUN = command.Command{
-	ParentName: "PIPELINE",
-	Name:       "run",
-	ShortHelp:  "create a pipeline and run it",
-	LongHelp:   `With global -V (--verbose): prints the JSON body sent to POST /api/cicds and the full HTTP response body when the call fails or returns success=false, in addition to the HTTP client debug log.`,
-	Example:    "$ erda-cli pipeline run <path-to/pipeline.yml>\n$ erda-cli -V pipeline run <path-to/pipeline.yml>",
+	ParentName:          "PIPELINE",
+	Name:                "run",
+	ShortHelp:           "create a pipeline and run it",
+	PreferWorkspaceHost: true,
+	LongHelp:            `With global -V (--verbose): prints the JSON body sent to POST /api/cicds and the full HTTP response body when the call fails or returns success=false, in addition to the HTTP client debug log.`,
+	Example:             "$ erda-cli pipeline run <path-to/pipeline.yml>\n$ erda-cli -V pipeline run <path-to/pipeline.yml>",
 	Args: []command.Arg{
 		command.StringArg{}.Name("filename"),
 	},
@@ -130,7 +132,7 @@ func PipelineRun(ctx *command.Context, filename, branch string, watch bool) erro
 	}
 
 	// fetch appID
-	info, err := getWorkspaceInfo(".", command.Remote)
+	info, err := getScopedWorkspaceInfo()
 	if err != nil {
 		return err
 	}
@@ -140,7 +142,7 @@ func PipelineRun(ctx *command.Context, filename, branch string, watch bool) erro
 		return err
 	}
 
-	_, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Project, info.Application)
+	_, applicationID, err := common.ResolveWorkspaceApplication(ctx, org.ID, info.Org, info.Project, info.Application)
 	if err != nil {
 		return err
 	}

--- a/tools/cli/cmd/build.go
+++ b/tools/cli/cmd/build.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/erda-project/erda/apistructs"
-	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 

--- a/tools/cli/cmd/history.go
+++ b/tools/cli/cmd/history.go
@@ -57,7 +57,7 @@ func PipelineHistory(ctx *command.Context, branch string, page int, pageSize int
 		branch = b
 	}
 
-	info, err := getWorkspaceInfo(".", command.Remote)
+	info, err := getScopedWorkspaceInfo()
 	if err != nil {
 		return errors.Wrap(err, "failed to get  workspace info")
 	}
@@ -67,7 +67,7 @@ func PipelineHistory(ctx *command.Context, branch string, page int, pageSize int
 		return err
 	}
 
-	_, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Project, info.Application)
+	_, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Org, info.Project, info.Application)
 	if err != nil {
 		return errors.Wrapf(err, "orgID: %v, projectName: %s, appName: %s", org.ID, info.Project, info.Application)
 	}

--- a/tools/cli/cmd/history_test.go
+++ b/tools/cli/cmd/history_test.go
@@ -75,7 +75,7 @@ func TestPipelineHistoryPassesQueryFilters(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 

--- a/tools/cli/cmd/issue.go
+++ b/tools/cli/cmd/issue.go
@@ -29,10 +29,13 @@ import (
 )
 
 var ISSUE = command.Command{
-	Name:      "issue",
-	ShortHelp: "list issue already started to handle",
-	Example:   "$ erda-cli issue",
+	Name:                "issue",
+	ShortHelp:           "list issue already started to handle",
+	PreferWorkspaceHost: true,
+	Example:             "$ erda-cli issue",
 	Flags: []command.Flag{
+		command.StringFlag{Short: "", Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Short: "", Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
 		command.BoolFlag{Short: "", Name: "no-headers", Doc: "if true, don't print headers (default print headers)", DefaultValue: false},
 		command.BoolFlag{Short: "", Name: "requirement", Doc: "if true, list requirements", DefaultValue: false},
 		command.BoolFlag{Short: "", Name: "task", Doc: "if true, list tasks", DefaultValue: false},
@@ -42,9 +45,9 @@ var ISSUE = command.Command{
 	Run: MyIssueList,
 }
 
-func MyIssueList(ctx *command.Context, noHeaders, requirement, task, bug bool, pageSize int) error {
+func MyIssueList(ctx *command.Context, org, project string, noHeaders, requirement, task, bug bool, pageSize int) error {
 
-	req, states, err := makeRequest(ctx, requirement, task, bug)
+	req, states, err := makeRequest(ctx, org, project, requirement, task, bug)
 	if err != nil {
 		return err
 	}
@@ -71,16 +74,13 @@ func MyIssueList(ctx *command.Context, noHeaders, requirement, task, bug bool, p
 	return nil
 }
 
-func makeRequest(ctx *command.Context, requirement, task, bug bool) (*apistructs.IssuePagingRequest, []apistructs.IssueStateRelation, error) {
-	var org, project string
-	org, orgID, err := common.GetOrgID(ctx, org)
+func makeRequest(ctx *command.Context, org, project string, requirement, task, bug bool) (*apistructs.IssuePagingRequest, []apistructs.IssueStateRelation, error) {
+	org, orgID, err := resolveIssueScope(ctx, org, project, common.GetOrgID, common.GetProjectID)
 	if err != nil {
 		return nil, nil, err
 	}
-	project, projectID, err := common.GetProjectID(ctx, orgID, project)
-	if err != nil {
-		return nil, nil, err
-	}
+	project = ctx.CurrentProject.Project
+	projectID := ctx.CurrentProject.ProjectID
 	userID := ctx.GetUserID()
 	if userID == "" {
 		return nil, nil, errors.New("Invalid user")
@@ -99,10 +99,12 @@ func makeRequest(ctx *command.Context, requirement, task, bug bool) (*apistructs
 	}
 
 	var req apistructs.IssuePagingRequest
+	req.OrgID = int64(orgID)
 	req.Assignees = []string{userID}
 	req.State = todoStateIds
 	req.OrderBy = "planFinishedAt"
 	req.ProjectID = projectID
+	req.ProjectIDs = []uint64{projectID}
 	if requirement {
 		req.Type = append(req.Type, "REQUIREMENT")
 	}
@@ -166,7 +168,7 @@ func IssueCompletion(ctx *cobra.Command, args []string, toComplete string, issue
 	}
 
 	c := command.GetContext()
-	req, _, err := makeRequest(c, true, true, true)
+	req, _, err := makeRequest(c, "", "", true, true, true)
 	if err != nil {
 		return comps
 	}

--- a/tools/cli/cmd/issue_bind.go
+++ b/tools/cli/cmd/issue_bind.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ISSUEBIND = command.Command{
+	ParentName: "ISSUE",
+	Name:       "bind",
+	ShortHelp:  "bind child issues to a parent issue",
+	Example:    "$ erda-cli issue bind --parent 18 --children 101,102",
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.IntFlag{Name: "parent", Doc: "parent issue id, usually a requirement", DefaultValue: 0},
+		command.StringFlag{Name: "children", Doc: "child issue ids, comma-separated", DefaultValue: ""},
+		command.StringFlag{Name: "type", Doc: "relation type: inclusion or connection", DefaultValue: apistructs.IssueRelationInclusion},
+	},
+	Run: IssueBind,
+}
+
+var (
+	getIssueBindOrgID               = common.GetOrgID
+	getIssueBindProjectID           = common.GetProjectID
+	bindIssueRelation               = common.CreateIssueRelation
+	issueBindStdout       io.Writer = os.Stdout
+)
+
+type issueBindOutput struct {
+	ParentID uint64   `json:"parentID"`
+	Children []uint64 `json:"children"`
+	Type     string   `json:"type"`
+}
+
+func IssueBind(ctx *command.Context, org string, project string, parent int, children string, relationType string) error {
+	if parent <= 0 {
+		return fmt.Errorf("--parent must be greater than 0")
+	}
+	childIDs, err := parseIssueBindChildren(children)
+	if err != nil {
+		return err
+	}
+	if relationType == "" {
+		relationType = apistructs.IssueRelationInclusion
+	}
+	if relationType != apistructs.IssueRelationInclusion && relationType != apistructs.IssueRelationConnection {
+		return fmt.Errorf("invalid --type %q, supported values: inclusion, connection", relationType)
+	}
+
+	_, orgID, err := resolveIssueScope(ctx, org, project, getIssueBindOrgID, getIssueBindProjectID)
+	if err != nil {
+		return err
+	}
+	projectID := ctx.CurrentProject.ProjectID
+
+	parentID := uint64(parent)
+	err = bindIssueRelation(ctx, orgID, parentID, &apistructs.IssueRelationCreateRequest{
+		IssueID:      parentID,
+		RelatedIssue: childIDs,
+		ProjectID:    int64(projectID),
+		Type:         relationType,
+	})
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(issueBindStdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(issueBindOutput{ParentID: parentID, Children: childIDs, Type: relationType})
+}
+
+func parseIssueBindChildren(children string) ([]uint64, error) {
+	parts := splitIssueListCSV(children)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("--children is required")
+	}
+	result := make([]uint64, 0, len(parts))
+	for _, part := range parts {
+		childID, err := parsePositiveUint64(part, "--children")
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, childID)
+	}
+	return result, nil
+}
+
+func parsePositiveUint64(raw string, flagName string) (uint64, error) {
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value %q", flagName, raw)
+	}
+	if value == 0 {
+		return 0, fmt.Errorf("%s value must be greater than 0", flagName)
+	}
+	return value, nil
+}

--- a/tools/cli/cmd/issue_bind_test.go
+++ b/tools/cli/cmd/issue_bind_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestIssueBindCreatesInclusionRelation(t *testing.T) {
+	restoreIssueBindStubs(t)
+
+	getIssueBindOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueBindProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+
+	var parentID uint64
+	var created *apistructs.IssueRelationCreateRequest
+	bindIssueRelation = func(_ *command.Context, _ uint64, p uint64, req *apistructs.IssueRelationCreateRequest) error {
+		parentID = p
+		created = req
+		return nil
+	}
+
+	var out bytes.Buffer
+	issueBindStdout = &out
+
+	if err := IssueBind(&command.Context{}, "", "", 18, "101,102", ""); err != nil {
+		t.Fatalf("IssueBind() error = %v", err)
+	}
+	if parentID != 18 {
+		t.Fatalf("parentID = %d, want 18", parentID)
+	}
+	if created == nil || created.IssueID != 18 || created.ProjectID != 2001 || created.Type != apistructs.IssueRelationInclusion {
+		t.Fatalf("created = %+v, want inclusion relation for parent 18/project 2001", created)
+	}
+	if len(created.RelatedIssue) != 2 || created.RelatedIssue[0] != 101 || created.RelatedIssue[1] != 102 {
+		t.Fatalf("children = %+v, want 101,102", created.RelatedIssue)
+	}
+
+	var output issueBindOutput
+	if err := json.Unmarshal(out.Bytes(), &output); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if output.ParentID != 18 || len(output.Children) != 2 || output.Type != apistructs.IssueRelationInclusion {
+		t.Fatalf("output = %+v, want parent/children/type", output)
+	}
+}
+
+func TestIssueBindCommandShape(t *testing.T) {
+	if ISSUEBIND.ParentName != "ISSUE" {
+		t.Fatalf("issue bind parent = %q, want ISSUE", ISSUEBIND.ParentName)
+	}
+	if ISSUEBIND.Name != "bind" {
+		t.Fatalf("issue bind name = %q, want bind", ISSUEBIND.Name)
+	}
+	for _, flag := range []string{"parent", "children", "type"} {
+		if !hasCommandFlag(ISSUEBIND.Flags, flag) {
+			t.Fatalf("issue bind missing --%s", flag)
+		}
+	}
+}
+
+func restoreIssueBindStubs(t *testing.T) {
+	origGetOrgID := getIssueBindOrgID
+	origGetProjectID := getIssueBindProjectID
+	origBindIssueRelation := bindIssueRelation
+	origStdout := issueBindStdout
+	t.Cleanup(func() {
+		getIssueBindOrgID = origGetOrgID
+		getIssueBindProjectID = origGetProjectID
+		bindIssueRelation = origBindIssueRelation
+		issueBindStdout = origStdout
+	})
+}

--- a/tools/cli/cmd/issue_close.go
+++ b/tools/cli/cmd/issue_close.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -35,17 +36,19 @@ var ISSUECLOSE = command.Command{
 		command.IntArg{}.Name("issue-id"),
 	},
 	Flags: []command.Flag{
+		command.StringFlag{Short: "", Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Short: "", Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
 		command.StringFlag{Short: "", Name: "man-hour", Doc: "time for work, in format of 2m/2h/2d/2w", DefaultValue: ""},
 	},
 	ValidArgsFunction: CloseIssueCompletion,
 	Run:               IssueClose,
 }
 
-func CloseIssueCompletion(ctx *cobra.Command, args []string, toComplete string, issueID int, manHour string) []string {
+func CloseIssueCompletion(ctx *cobra.Command, args []string, toComplete string, issueID int, org string, project string, manHour string) []string {
 	return IssueCompletion(ctx, args, toComplete, issueID)
 }
 
-func IssueClose(ctx *command.Context, issueID int, manHour string) error {
+func IssueClose(ctx *command.Context, issueID int, org string, project string, manHour string) error {
 	l := len(manHour)
 	if l == 0 {
 		return errors.Errorf("man-hour not set.")
@@ -71,37 +74,38 @@ func IssueClose(ctx *command.Context, issueID int, manHour string) error {
 		return errors.Errorf("Parse man-hour %s failed, not end with m/h/d/w", manHour)
 	}
 
-	issue, err := common.GetIssue(ctx, ctx.CurrentOrg.ID, ctx.CurrentProject.ProjectID, uint64(issueID))
+	_, orgID, err := resolveIssueScope(ctx, org, project, common.GetOrgID, common.GetProjectID)
 	if err != nil {
 		return err
 	}
+	projectID := ctx.CurrentProject.ProjectID
 
-	var reqState apistructs.IssueStateRelationGetRequest
-	reqState.ProjectID = ctx.CurrentProject.ProjectID
-	states, err := common.ListState(ctx, ctx.CurrentOrg.ID, reqState)
+	issue, err := common.GetIssue(ctx, orgID, projectID, uint64(issueID))
 	if err != nil {
 		return err
 	}
-	var state *apistructs.IssueStateRelation
-	stateMap := map[int64]*apistructs.IssueStateRelation{}
-	for i, s := range states {
-		if s.StateID == issue.State {
-			state = &states[i]
-		}
-		stateMap[s.StateID] = &states[i]
-	}
-	if state == nil {
-		return errors.Errorf("Issue state %d not found in erda", issue.State)
-	}
-	nextStateId, err := getDoneState(state, stateMap)
+	stateMap, err := loadIssueStateMap(ctx, projectID, issue.Type)
 	if err != nil {
 		return err
+	}
+	current := stateMap[issue.State]
+	if current == nil {
+		return fmt.Errorf("current issue state %d not found in project workflow", issue.State)
+	}
+	var target *apistructs.IssueStateRelation
+	switch issue.Type {
+	case apistructs.IssueTypeBug:
+		target = findTransitionByStateBelong(current, stateMap, apistructs.IssueStateBelongResolved)
+	default:
+		target = findTransitionByStateBelong(current, stateMap, apistructs.IssueStateBelongDone)
+	}
+	if target == nil {
+		return buildInvalidTransitionError(current, stateMap, "close target")
 	}
 
 	req := &apistructs.IssueUpdateRequest{}
 	req.ID = uint64(issue.ID)
-	req.State = &nextStateId
-	req.IterationID = &issue.IterationID
+	req.State = &target.StateID
 
 	issue.ManHour.ThisElapsedTime = manHourInMinutes
 	if issue.ManHour.EstimateTime == 0 {
@@ -116,58 +120,11 @@ func IssueClose(ctx *command.Context, issueID int, manHour string) error {
 
 	req.ManHour = &issue.ManHour
 
-	err = common.UpdateIssue(ctx, ctx.CurrentOrg.ID, req)
+	err = common.UpdateIssue(ctx, orgID, req)
 	if err != nil {
 		return err
 	}
 
+	ctx.Succ("Issue %d state updated: %s -> %s", issue.ID, formatStateDebug(current), formatStateDebug(target))
 	return nil
-}
-
-func getDoneState(state *apistructs.IssueStateRelation, stateMap map[int64]*apistructs.IssueStateRelation) (int64, error) {
-	var nextStateId int64
-	var done bool
-	switch state.IssueType {
-	case apistructs.IssueTypeRequirement:
-		if state.StateBelong == apistructs.IssueStateBelongWorking {
-			for _, next := range state.StateRelation {
-				if n, ok := stateMap[next]; ok {
-					if n.StateBelong == apistructs.IssueStateBelongDone {
-						nextStateId = n.StateID
-						done = true
-					}
-				}
-			}
-		}
-	case apistructs.IssueTypeBug:
-		if state.StateBelong == apistructs.IssueStateBelongOpen ||
-			state.StateBelong == apistructs.IssueStateBelongReopen {
-			for _, next := range state.StateRelation {
-				if n, ok := stateMap[next]; ok {
-					if n.StateBelong == apistructs.IssueStateBelongResolved {
-						nextStateId = n.StateID
-						done = true
-					}
-				}
-			}
-		}
-	case apistructs.IssueTypeTask:
-		if state.StateBelong == apistructs.IssueStateBelongWorking {
-			for _, next := range state.StateRelation {
-				if n, ok := stateMap[next]; ok {
-					if n.StateBelong == apistructs.IssueStateBelongDone {
-						nextStateId = n.StateID
-						done = true
-					}
-				}
-			}
-		}
-	}
-
-	if !done {
-		return 0, errors.Errorf("Issue type is %s, state is %s, could not change to done",
-			state.IssueType.String(), state.StateName)
-	}
-
-	return nextStateId, nil
 }

--- a/tools/cli/cmd/issue_create.go
+++ b/tools/cli/cmd/issue_create.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ISSUECREATE = command.Command{
+	ParentName: "ISSUE",
+	Name:       "create",
+	ShortHelp:  "create an issue from JSON file",
+	Example:    "$ erda-cli issue create --file issue.json",
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "file", Doc: "issue JSON file generated from issue schema", DefaultValue: ""},
+		command.StringFlag{Name: "json", Doc: "inline issue JSON, mutually exclusive with --file", DefaultValue: ""},
+	},
+	Run: IssueCreate,
+}
+
+var (
+	getIssueCreateOrgID                   = common.GetOrgID
+	getIssueCreateProjectID               = common.GetProjectID
+	listIssueCreateProperties             = common.ListIssueProperties
+	listIssueCreateStages                 = common.ListIssueStages
+	createIssue                           = common.CreateIssue
+	createIssuePropertyInstance           = common.CreateIssuePropertyInstance
+	createIssueRelation                   = common.CreateIssueRelation
+	issueCreateStdout           io.Writer = os.Stdout
+)
+
+type issueCreateFile struct {
+	apistructs.IssueCreateRequest
+	CustomFields map[string]json.RawMessage `json:"customFields"`
+	ParentID     uint64                     `json:"parentID"`
+	RelationType string                     `json:"relationType"`
+}
+
+type issueCreateOutput struct {
+	ID uint64 `json:"id"`
+}
+
+func IssueCreate(ctx *command.Context, org string, project string, file string, inlineJSON string) error {
+	if (file == "") == (inlineJSON == "") {
+		return fmt.Errorf("exactly one of --file or --json is required")
+	}
+
+	createFile, err := readIssueCreateInput(file, inlineJSON)
+	if err != nil {
+		return err
+	}
+
+	_, orgID, err := resolveIssueScope(ctx, org, project, getIssueCreateOrgID, getIssueCreateProjectID)
+	if err != nil {
+		return err
+	}
+	projectID := ctx.CurrentProject.ProjectID
+
+	req := createFile.IssueCreateRequest
+	req.ProjectID = projectID
+
+	properties, err := listIssueCreateProperties(ctx, orgID, projectID, req.Type)
+	if err != nil {
+		return err
+	}
+	stages, err := listIssueCreateStages(ctx, orgID, req.Type)
+	if err != nil {
+		return err
+	}
+	if err := normalizeIssueStage(&req, stages); err != nil {
+		return err
+	}
+	propertyInstances, err := buildIssuePropertyInstances(orgID, projectID, req.Type, properties, createFile.CustomFields)
+	if err != nil {
+		return err
+	}
+
+	issueID, err := createIssue(ctx, orgID, &req)
+	if err != nil {
+		return err
+	}
+
+	if len(propertyInstances) > 0 {
+		err = createIssuePropertyInstance(ctx, &common.IssuePropertyInstanceCreateRequest{
+			OrgID:     int64(orgID),
+			ProjectID: int64(projectID),
+			IssueID:   int64(issueID),
+			Property:  propertyInstances,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if createFile.ParentID != 0 {
+		relationType := createFile.RelationType
+		if relationType == "" {
+			relationType = apistructs.IssueRelationInclusion
+		}
+		err = createIssueRelation(ctx, orgID, createFile.ParentID, &apistructs.IssueRelationCreateRequest{
+			IssueID:      createFile.ParentID,
+			RelatedIssue: []uint64{issueID},
+			ProjectID:    int64(projectID),
+			Type:         relationType,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	encoder := json.NewEncoder(issueCreateStdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(issueCreateOutput{ID: issueID})
+}
+
+func readIssueCreateInput(file string, inlineJSON string) (*issueCreateFile, error) {
+	content := []byte(inlineJSON)
+	if file != "" {
+		fileContent, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		content = fileContent
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+
+	var createFile issueCreateFile
+	if err := decoder.Decode(&createFile); err != nil {
+		return nil, err
+	}
+	if createFile.Type == "" {
+		return nil, fmt.Errorf("type is required")
+	}
+	types, err := parseIssueSchemaTypes(string(createFile.Type))
+	if err != nil {
+		return nil, err
+	}
+	createFile.Type = types[0]
+	if createFile.Title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	if createFile.IterationID == 0 {
+		return nil, fmt.Errorf("iterationID is required, use -1 when the issue does not belong to any iteration")
+	}
+	if createFile.Assignee == "" && createFile.Type != apistructs.IssueTypeTicket {
+		return nil, fmt.Errorf("assignee is required")
+	}
+	if err := validateIssueCreateUserIDs(&createFile); err != nil {
+		return nil, err
+	}
+	return &createFile, nil
+}
+
+func validateIssueCreateUserIDs(createFile *issueCreateFile) error {
+	userFields := map[string]string{
+		"assignee": createFile.Assignee,
+		"creator":  createFile.Creator,
+		"owner":    createFile.Owner,
+	}
+	for field, value := range userFields {
+		if err := validateIssueCreateUserID(field, value); err != nil {
+			return err
+		}
+	}
+	for i, subscriber := range createFile.Subscribers {
+		if err := validateIssueCreateUserID(fmt.Sprintf("subscribers[%d]", i), subscriber); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIssueCreateUserID(field string, value string) error {
+	if value == "" {
+		return nil
+	}
+	if _, err := strconv.ParseUint(value, 10, 64); err != nil {
+		return fmt.Errorf("%s must be a numeric Erda user ID, got %q; use erda-cli whoami to get current UserID", field, value)
+	}
+	return nil
+}
+
+func normalizeIssueStage(req *apistructs.IssueCreateRequest, stages []apistructs.IssueStage) error {
+	switch req.Type {
+	case apistructs.IssueTypeTask:
+		if req.TaskType == "" {
+			return nil
+		}
+		value, err := normalizeIssueStageValue(stages, req.TaskType, "taskType")
+		if err != nil {
+			return err
+		}
+		req.TaskType = value
+	case apistructs.IssueTypeBug:
+		if req.BugStage == "" {
+			return nil
+		}
+		value, err := normalizeIssueStageValue(stages, req.BugStage, "bugStage")
+		if err != nil {
+			return err
+		}
+		req.BugStage = value
+	}
+	return nil
+}
+
+func normalizeIssueStageValue(stages []apistructs.IssueStage, input string, fieldName string) (string, error) {
+	for _, stage := range stages {
+		if stage.Value == "" {
+			stage.Value = stage.Name
+		}
+		if input == stage.Value || input == stage.Name {
+			return stage.Value, nil
+		}
+	}
+	return "", fmt.Errorf("invalid %s %q, use one of current project stage values or names", fieldName, input)
+}
+
+func buildIssuePropertyInstances(orgID, projectID uint64, issueType apistructs.IssueType, properties []apistructs.IssuePropertyIndex, customFields map[string]json.RawMessage) ([]common.IssuePropertyInstance, error) {
+	propertiesByName := make(map[string]apistructs.IssuePropertyIndex, len(properties))
+	for _, property := range properties {
+		if property.PropertyIssueType != "" && property.PropertyIssueType != issuePropertyType(issueType) {
+			continue
+		}
+		propertiesByName[property.PropertyName] = property
+	}
+
+	for _, property := range propertiesByName {
+		if property.Required && !hasCustomFieldValue(customFields, property.PropertyName) {
+			return nil, fmt.Errorf("custom field %q is required", property.PropertyName)
+		}
+	}
+
+	instances := make([]common.IssuePropertyInstance, 0, len(customFields))
+	for name, value := range customFields {
+		property, ok := propertiesByName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown custom field %q", name)
+		}
+		instance, err := buildIssuePropertyInstance(orgID, projectID, property, value)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, instance)
+	}
+	return instances, nil
+}
+
+func hasCustomFieldValue(customFields map[string]json.RawMessage, name string) bool {
+	value, ok := customFields[name]
+	if !ok {
+		return false
+	}
+	trimmed := bytes.TrimSpace(value)
+	if len(trimmed) == 0 || string(trimmed) == "null" || string(trimmed) == `""` || string(trimmed) == "[]" {
+		return false
+	}
+	return true
+}
+
+func buildIssuePropertyInstance(orgID, projectID uint64, property apistructs.IssuePropertyIndex, value json.RawMessage) (common.IssuePropertyInstance, error) {
+	instance := common.IssuePropertyInstance{
+		PropertyID:        property.PropertyID,
+		ScopeID:           property.ScopeID,
+		ScopeType:         property.ScopeType,
+		OrgID:             int64(orgID),
+		PropertyName:      property.PropertyName,
+		DisplayName:       property.DisplayName,
+		PropertyType:      property.PropertyType,
+		Required:          property.Required,
+		PropertyIssueType: property.PropertyIssueType,
+		Relation:          property.Relation,
+		Index:             property.Index,
+		EnumeratedValues:  property.EnumeratedValues,
+	}
+	if instance.ScopeID == 0 {
+		instance.ScopeID = int64(projectID)
+	}
+	if instance.ScopeType == "" {
+		instance.ScopeType = apistructs.ProjectScope
+	}
+
+	if property.PropertyType.IsOptions() {
+		values, err := issuePropertyOptionValues(property, value)
+		if err != nil {
+			return common.IssuePropertyInstance{}, err
+		}
+		instance.Values = values
+		return instance, nil
+	}
+
+	arbitraryValue, err := issuePropertyArbitraryValue(value)
+	if err != nil {
+		return common.IssuePropertyInstance{}, err
+	}
+	if property.PropertyType == apistructs.PropertyTypePerson {
+		userID, ok := arbitraryValue.(string)
+		if !ok {
+			return common.IssuePropertyInstance{}, fmt.Errorf("custom field %q must be a numeric Erda user ID string", property.PropertyName)
+		}
+		if err := validateIssueCreateUserID(fmt.Sprintf("customFields.%s", property.PropertyName), userID); err != nil {
+			return common.IssuePropertyInstance{}, err
+		}
+	}
+	instance.ArbitraryValue = arbitraryValue
+	return instance, nil
+}
+
+func issuePropertyOptionValues(property apistructs.IssuePropertyIndex, value json.RawMessage) ([]int64, error) {
+	var rawValues []json.RawMessage
+	if bytes.HasPrefix(bytes.TrimSpace(value), []byte("[")) {
+		if err := json.Unmarshal(value, &rawValues); err != nil {
+			return nil, err
+		}
+	} else {
+		rawValues = []json.RawMessage{value}
+	}
+
+	values := make([]int64, 0, len(rawValues))
+	for _, rawValue := range rawValues {
+		valueID, err := issuePropertyOptionID(property, rawValue)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, valueID)
+	}
+	return values, nil
+}
+
+func issuePropertyOptionID(property apistructs.IssuePropertyIndex, value json.RawMessage) (int64, error) {
+	var name string
+	if err := json.Unmarshal(value, &name); err == nil {
+		for _, option := range property.EnumeratedValues {
+			if option.Name == name {
+				return option.ID, nil
+			}
+		}
+		return 0, fmt.Errorf("invalid value %q for custom field %q", name, property.PropertyName)
+	}
+
+	var id int64
+	if err := json.Unmarshal(value, &id); err == nil {
+		for _, option := range property.EnumeratedValues {
+			if option.ID == id {
+				return id, nil
+			}
+		}
+		return 0, fmt.Errorf("invalid value %d for custom field %q", id, property.PropertyName)
+	}
+	return 0, fmt.Errorf("invalid option value for custom field %q", property.PropertyName)
+}
+
+func issuePropertyArbitraryValue(value json.RawMessage) (interface{}, error) {
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.UseNumber()
+
+	var arbitraryValue interface{}
+	if err := decoder.Decode(&arbitraryValue); err != nil {
+		return nil, err
+	}
+	return arbitraryValue, nil
+}
+
+func issuePropertyType(issueType apistructs.IssueType) apistructs.PropertyIssueType {
+	switch issueType {
+	case apistructs.IssueTypeRequirement:
+		return apistructs.PropertyIssueTypeRequirement
+	case apistructs.IssueTypeTask:
+		return apistructs.PropertyIssueTypeTask
+	case apistructs.IssueTypeBug:
+		return apistructs.PropertyIssueTypeBug
+	case apistructs.IssueTypeEpic:
+		return apistructs.PropertyIssueTypeEpic
+	default:
+		return apistructs.PropertyIssueType(issueType)
+	}
+}

--- a/tools/cli/cmd/issue_create_test.go
+++ b/tools/cli/cmd/issue_create_test.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+func TestIssueCreateFromFileCreatesIssueAndCustomFields(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	getIssueCreateOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueCreateProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueCreateProperties = func(_ *command.Context, _ uint64, _ uint64, issueType apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		if issueType != apistructs.IssueTypeBug {
+			t.Fatalf("issueType = %s, want BUG", issueType)
+		}
+		return []apistructs.IssuePropertyIndex{
+			{
+				PropertyID:        41,
+				ScopeID:           2001,
+				ScopeType:         apistructs.ProjectScope,
+				OrgID:             1001,
+				PropertyName:      "rootCause",
+				DisplayName:       "Root Cause",
+				PropertyType:      apistructs.PropertyTypeSelect,
+				Required:          true,
+				PropertyIssueType: apistructs.PropertyIssueTypeBug,
+				EnumeratedValues:  []apistructs.Enumerate{{ID: 7, Name: "code"}},
+			},
+		}, nil
+	}
+	listIssueCreateStages = func(*command.Context, uint64, apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		return []apistructs.IssueStage{{Name: "开发", Value: "dev"}}, nil
+	}
+
+	var created apistructs.IssueCreateRequest
+	createIssue = func(_ *command.Context, _ uint64, req *apistructs.IssueCreateRequest) (uint64, error) {
+		created = *req
+		return 3001, nil
+	}
+	var propertyReq common.IssuePropertyInstanceCreateRequest
+	createIssuePropertyInstance = func(_ *command.Context, req *common.IssuePropertyInstanceCreateRequest) error {
+		propertyReq = *req
+		return nil
+	}
+	var relationReq *apistructs.IssueRelationCreateRequest
+	createIssueRelation = func(_ *command.Context, _ uint64, parentID uint64, req *apistructs.IssueRelationCreateRequest) error {
+		relationReq = req
+		if parentID != 18 {
+			t.Fatalf("parentID = %d, want 18", parentID)
+		}
+		return nil
+	}
+
+	path := writeIssueCreateFile(t, `{
+		"type": "BUG",
+		"title": "login failed",
+		"content": "reproduce steps",
+		"assignee": "1001055",
+		"iterationID": -1,
+		"priority": "HIGH",
+		"severity": "SERIOUS",
+		"parentID": 18,
+		"relationType": "inclusion",
+		"labels": ["cli"],
+		"customFields": {
+			"rootCause": "code"
+		}
+	}`)
+
+	var out bytes.Buffer
+	issueCreateStdout = &out
+
+	if err := IssueCreate(&command.Context{}, "", "", path, ""); err != nil {
+		t.Fatalf("IssueCreate() error = %v", err)
+	}
+
+	if created.ProjectID != 2001 || created.Type != apistructs.IssueTypeBug || created.Title != "login failed" {
+		t.Fatalf("created request = %+v, want project/type/title populated", created)
+	}
+	if created.IterationID != -1 || created.Assignee != "1001055" || created.Priority != apistructs.IssuePriorityHigh {
+		t.Fatalf("created request = %+v, want iteration/assignee/priority populated", created)
+	}
+	if propertyReq.IssueID != 3001 || len(propertyReq.Property) != 1 {
+		t.Fatalf("property request = %+v, want one property for issue 3001", propertyReq)
+	}
+	property := propertyReq.Property[0]
+	if property.PropertyID != 41 || len(property.Values) != 1 || property.Values[0] != 7 {
+		t.Fatalf("property = %+v, want rootCause value id 7", property)
+	}
+	if relationReq == nil || relationReq.Type != apistructs.IssueRelationInclusion || len(relationReq.RelatedIssue) != 1 || relationReq.RelatedIssue[0] != 3001 {
+		t.Fatalf("relation request = %+v, want parent inclusion relation to issue 3001", relationReq)
+	}
+
+	var resp issueCreateOutput
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if resp.ID != 3001 {
+		t.Fatalf("output id = %d, want 3001", resp.ID)
+	}
+}
+
+func TestIssueCreateFromInlineJSON(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	getIssueCreateOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueCreateProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueCreateProperties = func(*command.Context, uint64, uint64, apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		return nil, nil
+	}
+	listIssueCreateStages = func(*command.Context, uint64, apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		return []apistructs.IssueStage{{Name: "开发", Value: "dev"}}, nil
+	}
+
+	var created apistructs.IssueCreateRequest
+	createIssue = func(_ *command.Context, _ uint64, req *apistructs.IssueCreateRequest) (uint64, error) {
+		created = *req
+		return 3002, nil
+	}
+
+	var out bytes.Buffer
+	issueCreateStdout = &out
+
+	inlineJSON := `{"type":"bug","title":"inline issue","assignee":"1001055","iterationID":-1}`
+	if err := IssueCreate(&command.Context{}, "", "", "", inlineJSON); err != nil {
+		t.Fatalf("IssueCreate() error = %v", err)
+	}
+	if created.ProjectID != 2001 || created.Type != apistructs.IssueTypeBug || created.Title != "inline issue" {
+		t.Fatalf("created request = %+v, want inline JSON request", created)
+	}
+
+	var resp issueCreateOutput
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if resp.ID != 3002 {
+		t.Fatalf("output id = %d, want 3002", resp.ID)
+	}
+}
+
+func TestIssueCreateConvertsTaskTypeFromStageName(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	getIssueCreateOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueCreateProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueCreateProperties = func(*command.Context, uint64, uint64, apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		return nil, nil
+	}
+	listIssueCreateStages = func(*command.Context, uint64, apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		return []apistructs.IssueStage{{Name: "开发", Value: "dev"}}, nil
+	}
+
+	var created apistructs.IssueCreateRequest
+	createIssue = func(_ *command.Context, _ uint64, req *apistructs.IssueCreateRequest) (uint64, error) {
+		created = *req
+		return 3003, nil
+	}
+
+	inlineJSON := `{"type":"TASK","title":"task issue","assignee":"1001055","iterationID":-1,"taskType":"开发"}`
+	if err := IssueCreate(&command.Context{}, "", "", "", inlineJSON); err != nil {
+		t.Fatalf("IssueCreate() error = %v", err)
+	}
+	if created.TaskType != "dev" {
+		t.Fatalf("created taskType = %q, want dev", created.TaskType)
+	}
+}
+
+func TestIssueCreateRejectsUnknownTaskType(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	getIssueCreateOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueCreateProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueCreateProperties = func(*command.Context, uint64, uint64, apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		return nil, nil
+	}
+	listIssueCreateStages = func(*command.Context, uint64, apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		return []apistructs.IssueStage{{Name: "开发", Value: "dev"}}, nil
+	}
+	createIssue = func(*command.Context, uint64, *apistructs.IssueCreateRequest) (uint64, error) {
+		t.Fatal("CreateIssue should not be called when taskType is unknown")
+		return 0, nil
+	}
+
+	inlineJSON := `{"type":"TASK","title":"task issue","assignee":"1001055","iterationID":-1,"taskType":"development"}`
+	if err := IssueCreate(&command.Context{}, "", "", "", inlineJSON); err == nil {
+		t.Fatal("IssueCreate() error = nil, want unknown taskType error")
+	}
+}
+
+func TestIssueCreateRejectsNonNumericUserIDs(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	createIssue = func(*command.Context, uint64, *apistructs.IssueCreateRequest) (uint64, error) {
+		t.Fatal("CreateIssue should not be called when assignee is not a user ID")
+		return 0, nil
+	}
+
+	inlineJSON := `{"type":"TASK","title":"task issue","assignee":"ash","iterationID":-1}`
+	if err := IssueCreate(&command.Context{}, "", "", "", inlineJSON); err == nil {
+		t.Fatal("IssueCreate() error = nil, want non-numeric assignee error")
+	}
+}
+
+func TestIssueCreateRejectsNonNumericPersonCustomField(t *testing.T) {
+	property := apistructs.IssuePropertyIndex{
+		PropertyID:        41,
+		ScopeID:           2001,
+		ScopeType:         apistructs.ProjectScope,
+		OrgID:             1001,
+		PropertyName:      "reviewer",
+		DisplayName:       "Reviewer",
+		PropertyType:      apistructs.PropertyTypePerson,
+		PropertyIssueType: apistructs.PropertyIssueTypeTask,
+	}
+
+	_, err := buildIssuePropertyInstance(1001, 2001, property, json.RawMessage(`"ash"`))
+	if err == nil {
+		t.Fatal("buildIssuePropertyInstance() error = nil, want non-numeric person custom field error")
+	}
+}
+
+func TestIssueCreateRejectsAmbiguousInput(t *testing.T) {
+	path := writeIssueCreateFile(t, `{"type":"BUG","title":"x","assignee":"1001055","iterationID":-1}`)
+	if err := IssueCreate(&command.Context{}, "", "", path, `{"type":"BUG"}`); err == nil {
+		t.Fatal("IssueCreate() error = nil, want file/json mutual exclusion error")
+	}
+	if err := IssueCreate(&command.Context{}, "", "", "", ""); err == nil {
+		t.Fatal("IssueCreate() error = nil, want missing input error")
+	}
+}
+
+func TestIssueCreateRejectsMissingRequiredCustomField(t *testing.T) {
+	restoreIssueCreateStubs(t)
+
+	getIssueCreateOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueCreateProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueCreateProperties = func(*command.Context, uint64, uint64, apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		return []apistructs.IssuePropertyIndex{
+			{PropertyName: "rootCause", DisplayName: "Root Cause", PropertyType: apistructs.PropertyTypeText, Required: true},
+		}, nil
+	}
+	listIssueCreateStages = func(*command.Context, uint64, apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		return nil, nil
+	}
+	createIssue = func(*command.Context, uint64, *apistructs.IssueCreateRequest) (uint64, error) {
+		t.Fatal("CreateIssue should not be called when required custom field is missing")
+		return 0, nil
+	}
+
+	path := writeIssueCreateFile(t, `{
+		"type": "BUG",
+		"title": "login failed",
+		"assignee": "1001055",
+		"iterationID": -1
+	}`)
+
+	if err := IssueCreate(&command.Context{}, "", "", path, ""); err == nil {
+		t.Fatal("IssueCreate() error = nil, want missing required custom field error")
+	}
+}
+
+func TestIssueCreateCommandShape(t *testing.T) {
+	if ISSUECREATE.ParentName != "ISSUE" {
+		t.Fatalf("issue create parent = %q, want ISSUE", ISSUECREATE.ParentName)
+	}
+	if ISSUECREATE.Name != "create" {
+		t.Fatalf("issue create name = %q, want create", ISSUECREATE.Name)
+	}
+	if !hasCommandFlag(ISSUECREATE.Flags, "file") {
+		t.Fatal("issue create missing --file")
+	}
+	if !hasCommandFlag(ISSUECREATE.Flags, "json") {
+		t.Fatal("issue create missing --json")
+	}
+}
+
+func writeIssueCreateFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "issue.json")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func restoreIssueCreateStubs(t *testing.T) {
+	origGetOrgID := getIssueCreateOrgID
+	origGetProjectID := getIssueCreateProjectID
+	origListProperties := listIssueCreateProperties
+	origListStages := listIssueCreateStages
+	origCreateIssue := createIssue
+	origCreateIssuePropertyInstance := createIssuePropertyInstance
+	origCreateIssueRelation := createIssueRelation
+	origStdout := issueCreateStdout
+	t.Cleanup(func() {
+		getIssueCreateOrgID = origGetOrgID
+		getIssueCreateProjectID = origGetProjectID
+		listIssueCreateProperties = origListProperties
+		listIssueCreateStages = origListStages
+		createIssue = origCreateIssue
+		createIssuePropertyInstance = origCreateIssuePropertyInstance
+		createIssueRelation = origCreateIssueRelation
+		issueCreateStdout = origStdout
+	})
+}

--- a/tools/cli/cmd/issue_list.go
+++ b/tools/cli/cmd/issue_list.go
@@ -55,13 +55,13 @@ var ISSUELIST = command.Command{
 }
 
 var (
-	getIssueListOrgID               = common.GetOrgID
-	getIssueListProjectID           = common.GetProjectID
-	listIssueResponse               = common.ListMyIssueResponse
-	getIssueListStates              = common.ListState
-	getIssueListUsersByIDs          = queryIssueListUsersByIDs
-	getIssueListIterationByID       = queryIssueListIterationByID
-	issueListStdout       io.Writer = os.Stdout
+	getIssueListOrgID                   = common.GetOrgID
+	getIssueListProjectID               = common.GetProjectID
+	listIssueResponse                   = common.ListMyIssueResponse
+	getIssueListStates                  = common.ListState
+	getIssueListUsersByIDs              = queryIssueListUsersByIDs
+	getIssueListIterationByID           = queryIssueListIterationByID
+	issueListStdout           io.Writer = os.Stdout
 )
 
 type issueListOutput struct {
@@ -167,7 +167,7 @@ func resolveIssueListDisplayNames(ctx *command.Context, orgID uint64, list []api
 			}
 		}
 		if needLookup {
-		if users, err := getIssueListUsersByIDs(ctx, userIDs); err == nil {
+			if users, err := getIssueListUsersByIDs(ctx, userIDs); err == nil {
 				for id, name := range users {
 					if strings.TrimSpace(name) != "" {
 						userNames[id] = name

--- a/tools/cli/cmd/issue_list.go
+++ b/tools/cli/cmd/issue_list.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ISSUELIST = command.Command{
+	ParentName: "ISSUE",
+	Name:       "list",
+	ShortHelp:  "list current project issues",
+	Example:    "$ erda-cli issue list --type bug --iteration -1 --assignee 1001055",
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "type", Doc: "issue types, comma-separated: requirement, task, bug", DefaultValue: ""},
+		command.BoolFlag{Name: "requirement", Doc: "if true, include requirement issues", DefaultValue: false},
+		command.BoolFlag{Name: "task", Doc: "if true, include task issues", DefaultValue: false},
+		command.BoolFlag{Name: "bug", Doc: "if true, include bug issues", DefaultValue: false},
+		command.IntFlag{Name: "iteration", Doc: "iteration id; -1 means no iteration", DefaultValue: 0},
+		command.StringFlag{Name: "state", Doc: "state ids, comma-separated", DefaultValue: ""},
+		command.StringFlag{Name: "assignee", Doc: "assignee user ids, comma-separated", DefaultValue: ""},
+		command.StringFlag{Name: "creator", Doc: "creator user ids, comma-separated", DefaultValue: ""},
+		command.StringFlag{Name: "owner", Doc: "owner user ids, comma-separated", DefaultValue: ""},
+		command.IntFlag{Name: "page", Doc: "page number", DefaultValue: 1},
+		command.IntFlag{Name: "page-size", Doc: "page size", DefaultValue: 20},
+		command.BoolFlag{Name: "wide", Doc: "if true, show name with IDs", DefaultValue: false},
+		command.BoolFlag{Name: "json", Doc: "if true, output JSON", DefaultValue: false},
+	},
+	Run: IssueList,
+}
+
+var (
+	getIssueListOrgID               = common.GetOrgID
+	getIssueListProjectID           = common.GetProjectID
+	listIssueResponse               = common.ListMyIssueResponse
+	getIssueListStates              = common.ListState
+	getIssueListUsersByIDs          = queryIssueListUsersByIDs
+	getIssueListIterationByID       = queryIssueListIterationByID
+	issueListStdout       io.Writer = os.Stdout
+)
+
+type issueListOutput struct {
+	Total uint64             `json:"total"`
+	List  []apistructs.Issue `json:"list"`
+}
+
+func IssueList(ctx *command.Context, org string, project string, issueTypes string, requirement bool, task bool, bug bool, iteration int, states string, assignees string, creators string, owners string, page int, pageSize int, wide bool, jsonOutput bool) error {
+	_, orgID, err := resolveIssueScope(ctx, org, project, getIssueListOrgID, getIssueListProjectID)
+	if err != nil {
+		return err
+	}
+	projectID := ctx.CurrentProject.ProjectID
+
+	req, err := buildIssueListRequest(orgID, projectID, issueTypes, requirement, task, bug, iteration, states, assignees, creators, owners, page, pageSize)
+	if err != nil {
+		return err
+	}
+	resp, err := listIssueResponse(ctx, req)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		resp = &apistructs.IssuePagingResponse{}
+	}
+	if resp.Data == nil {
+		resp.Data = &apistructs.IssuePagingResponseData{}
+	}
+
+	if !jsonOutput {
+		userNames, stateNames, iterationNames := resolveIssueListDisplayNames(ctx, orgID, resp.Data.List, resp.UserInfo)
+		return writeIssueListTable(issueListStdout, resp.Data.List, resp.Data.Total, page, pageSize, userNames, stateNames, iterationNames, wide)
+	}
+
+	encoder := json.NewEncoder(issueListStdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(issueListOutput{Total: resp.Data.Total, List: resp.Data.List})
+}
+
+func writeIssueListTable(w io.Writer, list []apistructs.Issue, total uint64, page int, pageSize int, userNames map[string]string, stateNames map[int64]string, iterationNames map[int64]string, wide bool) error {
+	_, _ = fmt.Fprintf(w, "issues (total=%d, page=%d, pageSize=%d)\n", total, page, pageSize)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ID\tTITLE\tTYPE\tSTATE\tASSIGNEE\tITERATION")
+	for _, item := range list {
+		_, _ = fmt.Fprintf(
+			tw,
+			"%d\t%s\t%s\t%s\t%s\t%s\n",
+			item.ID,
+			item.Title,
+			item.Type,
+			formatIssueListState(item.State, stateNames, wide),
+			formatIssueListAssignee(item.Assignee, userNames, wide),
+			formatIssueListIteration(item.IterationID, iterationNames, wide),
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(list) == 0 {
+		_, _ = fmt.Fprintln(w, "No issues found.")
+	}
+	return nil
+}
+
+func resolveIssueListDisplayNames(ctx *command.Context, orgID uint64, list []apistructs.Issue, userInfo map[string]apistructs.UserInfo) (map[string]string, map[int64]string, map[int64]string) {
+	userIDs := make([]string, 0, len(list))
+	userSeen := make(map[string]struct{}, len(list))
+	iterationIDs := make([]int64, 0, len(list))
+	iterationSeen := make(map[int64]struct{}, len(list))
+	for _, item := range list {
+		if item.Assignee != "" {
+			if _, ok := userSeen[item.Assignee]; !ok {
+				userSeen[item.Assignee] = struct{}{}
+				userIDs = append(userIDs, item.Assignee)
+			}
+		}
+		if item.IterationID > 0 {
+			if _, ok := iterationSeen[item.IterationID]; !ok {
+				iterationSeen[item.IterationID] = struct{}{}
+				iterationIDs = append(iterationIDs, item.IterationID)
+			}
+		}
+	}
+
+	userNames := make(map[string]string)
+	for id, info := range userInfo {
+		name := strings.TrimSpace(info.Nick)
+		if name == "" {
+			name = strings.TrimSpace(info.Name)
+		}
+		if name != "" {
+			userNames[id] = name
+		}
+	}
+	if len(userIDs) > 0 {
+		needLookup := false
+		for _, id := range userIDs {
+			if userNames[id] == "" {
+				needLookup = true
+				break
+			}
+		}
+		if needLookup {
+		if users, err := getIssueListUsersByIDs(ctx, userIDs); err == nil {
+				for id, name := range users {
+					if strings.TrimSpace(name) != "" {
+						userNames[id] = name
+					}
+				}
+			}
+		}
+	}
+
+	iterationNames := make(map[int64]string)
+	for _, id := range iterationIDs {
+		iteration, err := getIssueListIterationByID(ctx, orgID, id)
+		if err != nil || iteration == nil {
+			continue
+		}
+		if iteration.Title != "" {
+			iterationNames[id] = iteration.Title
+		}
+	}
+
+	stateNames := make(map[int64]string)
+	states, err := getIssueListStates(ctx, orgID, apistructs.IssueStateRelationGetRequest{
+		ProjectID: ctx.CurrentProject.ProjectID,
+	})
+	if err == nil {
+		for _, state := range states {
+			if strings.TrimSpace(state.StateName) != "" {
+				stateNames[state.StateID] = state.StateName
+			}
+		}
+	}
+	return userNames, stateNames, iterationNames
+}
+
+func resolveIssueScope(ctx *command.Context, org string, project string, getOrgID func(*command.Context, string) (string, uint64, error), getProjectID func(*command.Context, uint64, string) (string, uint64, error)) (string, uint64, error) {
+	org = strings.TrimSpace(org)
+	project = strings.TrimSpace(project)
+	if project != "" && org == "" && ctx.CurrentOrg.ID == 0 && strings.TrimSpace(ctx.CurrentOrg.Name) == "" {
+		return "", 0, fmt.Errorf("--project requires --org when no workspace context is available")
+	}
+	orgName := ctx.CurrentOrg.Name
+	orgID := ctx.CurrentOrg.ID
+	if org != "" || (orgID == 0 && strings.TrimSpace(orgName) == "") {
+		var err error
+		orgName, orgID, err = getOrgID(ctx, org)
+		if err != nil {
+			return "", 0, err
+		}
+	}
+
+	projectName := ctx.CurrentProject.Project
+	projectID := ctx.CurrentProject.ProjectID
+	if project != "" || (projectID == 0 && strings.TrimSpace(projectName) == "") {
+		var err error
+		projectName, projectID, err = getProjectID(ctx, orgID, project)
+		if err != nil {
+			return "", 0, err
+		}
+	}
+	ctx.CurrentOrg.Name = orgName
+	ctx.CurrentOrg.ID = orgID
+	ctx.CurrentProject.Project = projectName
+	ctx.CurrentProject.ProjectID = projectID
+	return orgName, orgID, nil
+}
+
+func queryIssueListUsersByIDs(ctx *command.Context, userIDs []string) (map[string]string, error) {
+	var resp apistructs.UserListResponse
+	values := url.Values{"userID": userIDs}
+	_, err := ctx.Get().
+		Path("/core/api/users").
+		Param("plaintext", "true").
+		Params(values).
+		Do().JSON(&resp)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("failed to query users: %s", resp.Error.Msg)
+	}
+	result := make(map[string]string, len(resp.Data.Users))
+	for _, user := range resp.Data.Users {
+		if user.ID == "" {
+			continue
+		}
+		name := strings.TrimSpace(user.Nick)
+		if name == "" {
+			name = strings.TrimSpace(user.Name)
+		}
+		if name != "" {
+			result[user.ID] = name
+		}
+	}
+	return result, nil
+}
+
+func queryIssueListIterationByID(ctx *command.Context, orgID uint64, iterationID int64) (*apistructs.Iteration, error) {
+	var resp apistructs.IterationGetResponse
+	_, err := ctx.Get().
+		Path(fmt.Sprintf("/api/iterations/%d", iterationID)).
+		Header("org", strconv.FormatUint(orgID, 10)).
+		Do().JSON(&resp)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("failed to query iteration %d: %s", iterationID, resp.Error.Msg)
+	}
+	return &resp.Data, nil
+}
+
+func formatIssueListAssignee(userID string, userNames map[string]string, wide bool) string {
+	if userID == "" {
+		return "-"
+	}
+	name := strings.TrimSpace(userNames[userID])
+	if name == "" {
+		return fmt.Sprintf("unknown(%s)", userID)
+	}
+	if !wide {
+		return name
+	}
+	return fmt.Sprintf("%s(%s)", name, userID)
+}
+
+func formatIssueListIteration(iterationID int64, iterationNames map[int64]string, wide bool) string {
+	if iterationID == -1 {
+		if wide {
+			return "UNASSIGNED(-1)"
+		}
+		return "UNASSIGNED"
+	}
+	if iterationID == 0 {
+		return "-"
+	}
+	name := strings.TrimSpace(iterationNames[iterationID])
+	if name == "" {
+		return strconv.FormatInt(iterationID, 10)
+	}
+	if !wide {
+		return name
+	}
+	return fmt.Sprintf("%s(%d)", name, iterationID)
+}
+
+func formatIssueListState(stateID int64, stateNames map[int64]string, wide bool) string {
+	name := strings.TrimSpace(stateNames[stateID])
+	if name == "" {
+		return strconv.FormatInt(stateID, 10)
+	}
+	if !wide {
+		return name
+	}
+	return fmt.Sprintf("%s(%d)", name, stateID)
+}
+
+func buildIssueListRequest(orgID, projectID uint64, issueTypes string, requirement bool, task bool, bug bool, iteration int, states string, assignees string, creators string, owners string, page int, pageSize int) (*apistructs.IssuePagingRequest, error) {
+	if page <= 0 {
+		return nil, fmt.Errorf("--page must be greater than 0")
+	}
+	if pageSize <= 0 {
+		return nil, fmt.Errorf("--page-size must be greater than 0")
+	}
+
+	types, err := parseIssueListTypes(issueTypes, requirement, task, bug)
+	if err != nil {
+		return nil, err
+	}
+	stateIDs, err := parseIssueListInt64s(states, "--state")
+	if err != nil {
+		return nil, err
+	}
+
+	return &apistructs.IssuePagingRequest{
+		PageNo:     uint64(page),
+		PageSize:   uint64(pageSize),
+		OrgID:      int64(orgID),
+		ProjectIDs: []uint64{projectID},
+		IssueListRequest: apistructs.IssueListRequest{
+			ProjectID:   projectID,
+			IterationID: int64(iteration),
+			Type:        types,
+			State:       stateIDs,
+			Assignees:   splitIssueListCSV(assignees),
+			Creators:    splitIssueListCSV(creators),
+			Owner:       splitIssueListCSV(owners),
+		},
+	}, nil
+}
+
+func parseIssueListTypes(raw string, requirement bool, task bool, bug bool) ([]apistructs.IssueType, error) {
+	if raw == "" {
+		var types []apistructs.IssueType
+		if requirement {
+			types = append(types, apistructs.IssueTypeRequirement)
+		}
+		if task {
+			types = append(types, apistructs.IssueTypeTask)
+		}
+		if bug {
+			types = append(types, apistructs.IssueTypeBug)
+		}
+		return types, nil
+	}
+	parts := splitIssueListCSV(raw)
+	types := make([]apistructs.IssueType, 0, len(parts))
+	for _, part := range parts {
+		parsed, err := parseIssueSchemaTypes(part)
+		if err != nil {
+			return nil, err
+		}
+		types = append(types, parsed[0])
+	}
+	return types, nil
+}
+
+func parseIssueListInt64s(raw string, flagName string) ([]int64, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := splitIssueListCSV(raw)
+	values := make([]int64, 0, len(parts))
+	for _, part := range parts {
+		value, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s value %q", flagName, part)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func splitIssueListCSV(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}

--- a/tools/cli/cmd/issue_list_test.go
+++ b/tools/cli/cmd/issue_list_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestIssueListOutputsTableByDefault(t *testing.T) {
+	restoreIssueListStubs(t)
+
+	getIssueListOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueListProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+
+	var requested *apistructs.IssuePagingRequest
+	listIssueResponse = func(_ *command.Context, req *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponse, error) {
+		copied := *req
+		requested = &copied
+		return &apistructs.IssuePagingResponse{
+			Data: &apistructs.IssuePagingResponseData{
+				Total: 1,
+				List: []apistructs.Issue{
+					{ID: 3001, ProjectID: 2001, IterationID: -1, Type: apistructs.IssueTypeBug, Title: "login failed", State: 1, Assignee: "1001055"},
+				},
+			},
+			UserInfoHeader: apistructs.UserInfoHeader{
+				UserInfo: map[string]apistructs.UserInfo{
+					"1001055": {ID: "1001055", Nick: "ash"},
+				},
+			},
+		}, nil
+	}
+	getIssueListStates = func(*command.Context, uint64, apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		return []apistructs.IssueStateRelation{
+			{IssueStatus: apistructs.IssueStatus{StateID: 0, StateName: "Unknown"}},
+			{IssueStatus: apistructs.IssueStatus{StateID: 1, StateName: "Open"}},
+		}, nil
+	}
+	getIssueListUsersByIDs = func(*command.Context, []string) (map[string]string, error) { return nil, nil }
+	getIssueListIterationByID = func(*command.Context, uint64, int64) (*apistructs.Iteration, error) {
+		return &apistructs.Iteration{Title: "Sprint 1"}, nil
+	}
+
+	var out bytes.Buffer
+	issueListStdout = &out
+
+	if err := IssueList(&command.Context{}, "", "", "bug", false, false, false, -1, "", "1001055", "", "", 1, 20, false, false); err != nil {
+		t.Fatalf("IssueList() error = %v", err)
+	}
+	if requested == nil {
+		t.Fatal("ListIssues was not called")
+	}
+	if requested.ProjectID != 2001 || requested.PageNo != 1 || requested.PageSize != 20 {
+		t.Fatalf("request = %+v, want project/page populated", requested)
+	}
+	if len(requested.Type) != 1 || requested.Type[0] != apistructs.IssueTypeBug {
+		t.Fatalf("request types = %+v, want BUG", requested.Type)
+	}
+	if requested.IterationID != -1 {
+		t.Fatalf("iterationID = %d, want -1", requested.IterationID)
+	}
+	if len(requested.Assignees) != 1 || requested.Assignees[0] != "1001055" {
+		t.Fatalf("assignees = %+v, want 1001055", requested.Assignees)
+	}
+
+	got := out.String()
+	for _, expected := range []string{"issues (total=1, page=1, pageSize=20)", "ID", "login failed", "BUG", "Open", "ash", "UNASSIGNED"} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("table output missing %q:\n%s", expected, got)
+		}
+	}
+}
+
+func TestIssueListOutputsJSONWithFlag(t *testing.T) {
+	restoreIssueListStubs(t)
+
+	getIssueListOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueListProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueResponse = func(_ *command.Context, _ *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponse, error) {
+		return &apistructs.IssuePagingResponse{
+			Data: &apistructs.IssuePagingResponseData{
+				Total: 1,
+				List: []apistructs.Issue{
+					{ID: 3001, ProjectID: 2001, IterationID: -1, Type: apistructs.IssueTypeBug, Title: "login failed", State: 1, Assignee: "1001055"},
+				},
+			},
+		}, nil
+	}
+	getIssueListStates = func(*command.Context, uint64, apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		t.Fatal("state lookup should not happen in json mode")
+		return nil, nil
+	}
+	getIssueListUsersByIDs = func(*command.Context, []string) (map[string]string, error) {
+		t.Fatal("user lookup should not happen in json mode")
+		return nil, nil
+	}
+	getIssueListIterationByID = func(*command.Context, uint64, int64) (*apistructs.Iteration, error) {
+		t.Fatal("iteration lookup should not happen in json mode")
+		return nil, nil
+	}
+
+	var out bytes.Buffer
+	issueListStdout = &out
+
+	if err := IssueList(&command.Context{}, "", "", "bug", false, false, false, -1, "", "1001055", "", "", 1, 20, false, true); err != nil {
+		t.Fatalf("IssueList() error = %v", err)
+	}
+
+	var output issueListOutput
+	if err := json.Unmarshal(out.Bytes(), &output); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if output.Total != 1 || len(output.List) != 1 || output.List[0].Title != "login failed" {
+		t.Fatalf("output = %+v, want one issue", output)
+	}
+}
+
+func TestIssueListShowsUnknownAssigneeWhenNameLookupMisses(t *testing.T) {
+	restoreIssueListStubs(t)
+
+	getIssueListOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueListProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueResponse = func(_ *command.Context, _ *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponse, error) {
+		return &apistructs.IssuePagingResponse{
+			Data: &apistructs.IssuePagingResponseData{
+				Total: 1,
+				List: []apistructs.Issue{
+					{ID: 3001, ProjectID: 2001, IterationID: -1, Type: apistructs.IssueTypeBug, Title: "login failed", State: 1, Assignee: "1001055"},
+				},
+			},
+		}, nil
+	}
+	getIssueListStates = func(*command.Context, uint64, apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		return nil, nil
+	}
+	getIssueListUsersByIDs = func(*command.Context, []string) (map[string]string, error) {
+		return map[string]string{}, nil
+	}
+	getIssueListIterationByID = func(*command.Context, uint64, int64) (*apistructs.Iteration, error) {
+		return nil, nil
+	}
+
+	var out bytes.Buffer
+	issueListStdout = &out
+
+	if err := IssueList(&command.Context{}, "", "", "bug", false, false, false, -1, "", "1001055", "", "", 1, 20, false, false); err != nil {
+		t.Fatalf("IssueList() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "unknown(1001055)") {
+		t.Fatalf("table output should contain unknown assignee marker:\n%s", out.String())
+	}
+}
+
+func TestIssueListWideShowsNameWithIDs(t *testing.T) {
+	restoreIssueListStubs(t)
+
+	getIssueListOrgID = func(*command.Context, string) (string, uint64, error) { return "erda", 1001, nil }
+	getIssueListProjectID = func(*command.Context, uint64, string) (string, uint64, error) { return "erda-project", 2001, nil }
+	listIssueResponse = func(_ *command.Context, _ *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponse, error) {
+		return &apistructs.IssuePagingResponse{
+			Data: &apistructs.IssuePagingResponseData{
+				Total: 1,
+				List:  []apistructs.Issue{{ID: 3001, ProjectID: 2001, IterationID: 3, Type: apistructs.IssueTypeBug, Title: "login failed", State: 1, Assignee: "1001055"}},
+			},
+		}, nil
+	}
+	getIssueListStates = func(*command.Context, uint64, apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		return []apistructs.IssueStateRelation{{IssueStatus: apistructs.IssueStatus{StateID: 1, StateName: "Open"}}}, nil
+	}
+	getIssueListUsersByIDs = func(*command.Context, []string) (map[string]string, error) {
+		return map[string]string{"1001055": "ash"}, nil
+	}
+	getIssueListIterationByID = func(*command.Context, uint64, int64) (*apistructs.Iteration, error) {
+		return &apistructs.Iteration{Title: "Sprint 3"}, nil
+	}
+
+	var out bytes.Buffer
+	issueListStdout = &out
+	if err := IssueList(&command.Context{}, "", "", "bug", false, false, false, 3, "", "1001055", "", "", 1, 20, true, false); err != nil {
+		t.Fatalf("IssueList() error = %v", err)
+	}
+	got := out.String()
+	for _, expected := range []string{"Open(1)", "ash(1001055)", "Sprint 3(3)"} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("wide output missing %q:\n%s", expected, got)
+		}
+	}
+}
+
+func TestIssueListCommandShape(t *testing.T) {
+	if ISSUELIST.ParentName != "ISSUE" {
+		t.Fatalf("issue list parent = %q, want ISSUE", ISSUELIST.ParentName)
+	}
+	if ISSUELIST.Name != "list" {
+		t.Fatalf("issue list name = %q, want list", ISSUELIST.Name)
+	}
+	for _, flag := range []string{"type", "requirement", "task", "bug", "iteration", "state", "assignee", "creator", "owner", "page", "page-size", "wide", "json"} {
+		if !hasCommandFlag(ISSUELIST.Flags, flag) {
+			t.Fatalf("issue list missing --%s", flag)
+		}
+	}
+}
+
+func TestParseIssueListTypesSupportsLegacyBooleanFilters(t *testing.T) {
+	types, err := parseIssueListTypes("", true, true, false)
+	if err != nil {
+		t.Fatalf("parseIssueListTypes() error = %v", err)
+	}
+	if len(types) != 2 || types[0] != apistructs.IssueTypeRequirement || types[1] != apistructs.IssueTypeTask {
+		t.Fatalf("types = %+v, want requirement/task", types)
+	}
+}
+
+func restoreIssueListStubs(t *testing.T) {
+	origGetOrgID := getIssueListOrgID
+	origGetProjectID := getIssueListProjectID
+	origListIssues := listIssueResponse
+	origGetStates := getIssueListStates
+	origGetUsers := getIssueListUsersByIDs
+	origGetIteration := getIssueListIterationByID
+	origStdout := issueListStdout
+	t.Cleanup(func() {
+		getIssueListOrgID = origGetOrgID
+		getIssueListProjectID = origGetProjectID
+		listIssueResponse = origListIssues
+		getIssueListStates = origGetStates
+		getIssueListUsersByIDs = origGetUsers
+		getIssueListIterationByID = origGetIteration
+		issueListStdout = origStdout
+	})
+}

--- a/tools/cli/cmd/issue_schema.go
+++ b/tools/cli/cmd/issue_schema.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ISSUESCHEMA = command.Command{
+	ParentName: "ISSUE",
+	Name:       "schema",
+	ShortHelp:  "show current project issue schema as JSON",
+	Example:    "$ erda-cli issue schema --type bug",
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "type", Doc: "issue type: requirement, task, bug; empty means all supported types", DefaultValue: ""},
+	},
+	Run: IssueSchema,
+}
+
+var (
+	getIssueSchemaOrgID                 = common.GetOrgID
+	getIssueSchemaProjectID             = common.GetProjectID
+	listIssueSchemaStates               = common.ListState
+	listIssueSchemaLabels               = common.ListIssueLabels
+	listIssueSchemaProperties           = common.ListIssueProperties
+	listIssueSchemaStages               = common.ListIssueStages
+	issueSchemaStdout         io.Writer = os.Stdout
+)
+
+type issueSchemaDocument struct {
+	Project    issueSchemaProject `json:"project"`
+	IssueTypes []issueTypeSchema  `json:"issueTypes"`
+	Labels     []issueSchemaLabel `json:"labels"`
+}
+
+type issueSchemaProject struct {
+	ID   uint64 `json:"id"`
+	Name string `json:"name"`
+}
+
+type issueTypeSchema struct {
+	Type           string             `json:"type"`
+	DisplayName    string             `json:"displayName"`
+	RequiredFields []string           `json:"requiredFields"`
+	Fields         []issueSchemaField `json:"fields"`
+	States         []issueSchemaState `json:"states"`
+}
+
+type issueSchemaField struct {
+	Name        string              `json:"name"`
+	DisplayName string              `json:"displayName"`
+	ValueType   string              `json:"valueType"`
+	Description string              `json:"description,omitempty"`
+	Required    bool                `json:"required"`
+	Source      string              `json:"source"`
+	Options     []issueSchemaOption `json:"options,omitempty"`
+}
+
+type issueSchemaOption struct {
+	ID          int64  `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Value       string `json:"value,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Index       int64  `json:"index,omitempty"`
+}
+
+type issueSchemaState struct {
+	ID          int64                 `json:"id"`
+	Name        string                `json:"name"`
+	Belong      string                `json:"belong"`
+	Transitions []issueSchemaStateRef `json:"transitions"`
+}
+
+type issueSchemaStateRef struct {
+	ID     int64  `json:"id"`
+	Name   string `json:"name"`
+	Belong string `json:"belong"`
+}
+
+type issueSchemaLabel struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	Color     string `json:"color"`
+	Type      string `json:"type"`
+	ProjectID uint64 `json:"projectID"`
+}
+
+func IssueSchema(ctx *command.Context, org string, project string, issueType string) error {
+	_, orgID, err := resolveIssueScope(ctx, org, project, getIssueSchemaOrgID, getIssueSchemaProjectID)
+	if err != nil {
+		return err
+	}
+	projectName := ctx.CurrentProject.Project
+	projectID := ctx.CurrentProject.ProjectID
+
+	types, err := parseIssueSchemaTypes(issueType)
+	if err != nil {
+		return err
+	}
+
+	doc := issueSchemaDocument{
+		Project: issueSchemaProject{ID: projectID, Name: projectName},
+	}
+	for _, typ := range types {
+		schema, err := buildIssueTypeSchema(ctx, orgID, projectID, typ)
+		if err != nil {
+			return err
+		}
+		doc.IssueTypes = append(doc.IssueTypes, schema)
+	}
+
+	labels, err := listIssueSchemaLabels(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	doc.Labels = toIssueSchemaLabels(labels)
+
+	encoder := json.NewEncoder(issueSchemaStdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(doc)
+}
+
+func parseIssueSchemaTypes(issueType string) ([]apistructs.IssueType, error) {
+	if issueType == "" {
+		return []apistructs.IssueType{apistructs.IssueTypeRequirement, apistructs.IssueTypeTask, apistructs.IssueTypeBug}, nil
+	}
+
+	switch strings.ToLower(issueType) {
+	case "requirement":
+		return []apistructs.IssueType{apistructs.IssueTypeRequirement}, nil
+	case "task":
+		return []apistructs.IssueType{apistructs.IssueTypeTask}, nil
+	case "bug":
+		return []apistructs.IssueType{apistructs.IssueTypeBug}, nil
+	default:
+		return nil, fmt.Errorf("invalid issue type %q, supported values: requirement, task, bug", issueType)
+	}
+}
+
+func buildIssueTypeSchema(ctx *command.Context, orgID, projectID uint64, issueType apistructs.IssueType) (issueTypeSchema, error) {
+	states, err := listIssueSchemaStates(ctx, orgID, apistructs.IssueStateRelationGetRequest{
+		ProjectID: projectID,
+		IssueType: issueType,
+	})
+	if err != nil {
+		return issueTypeSchema{}, err
+	}
+	properties, err := listIssueSchemaProperties(ctx, orgID, projectID, issueType)
+	if err != nil {
+		return issueTypeSchema{}, err
+	}
+	stages, err := listIssueSchemaStages(ctx, orgID, issueType)
+	if err != nil {
+		return issueTypeSchema{}, err
+	}
+
+	fields := append(baseIssueSchemaFields(issueType, stages), customIssueSchemaFields(properties)...)
+	return issueTypeSchema{
+		Type:           string(issueType),
+		DisplayName:    issueType.GetZhName(),
+		RequiredFields: requiredIssueSchemaFields(fields),
+		Fields:         fields,
+		States:         toIssueSchemaStates(states),
+	}, nil
+}
+
+func baseIssueSchemaFields(issueType apistructs.IssueType, stages []apistructs.IssueStage) []issueSchemaField {
+	fields := []issueSchemaField{
+		requiredBaseField("type", "类型", "string"),
+		requiredBaseField("title", "标题", "string"),
+		userBaseField("assignee", "处理人", true),
+		requiredBaseField("iterationID", "迭代", "uint64"),
+		optionalBaseField("content", "内容", "string"),
+		optionalBaseField("priority", "优先级", "enum", priorityOptions()),
+		optionalBaseField("labels", "标签", "string[]"),
+		optionalBaseField("planStartedAt", "计划开始时间", "datetime"),
+		optionalBaseField("planFinishedAt", "计划完成时间", "datetime"),
+		userBaseField("owner", "负责人", false),
+	}
+
+	switch issueType {
+	case apistructs.IssueTypeRequirement:
+		fields = append(fields, optionalBaseField("complexity", "复杂度", "enum", complexityOptions()))
+	case apistructs.IssueTypeTask:
+		fields = append(fields,
+			optionalBaseField("taskType", "任务类型", "enum", stageOptions(stages)),
+			optionalBaseField("manHour", "工时", "object"),
+		)
+	case apistructs.IssueTypeBug:
+		fields = append(fields,
+			optionalBaseField("severity", "严重程度", "enum", severityOptions()),
+			optionalBaseField("bugStage", "缺陷阶段", "enum", stageOptions(stages)),
+			optionalBaseField("manHour", "工时", "object"),
+		)
+	}
+	return fields
+}
+
+func requiredBaseField(name, displayName, valueType string) issueSchemaField {
+	return issueSchemaField{Name: name, DisplayName: displayName, ValueType: valueType, Required: true, Source: "base"}
+}
+
+func optionalBaseField(name, displayName, valueType string, options ...[]issueSchemaOption) issueSchemaField {
+	field := issueSchemaField{Name: name, DisplayName: displayName, ValueType: valueType, Source: "base"}
+	if len(options) > 0 {
+		field.Options = options[0]
+	}
+	return field
+}
+
+func userBaseField(name, displayName string, required bool) issueSchemaField {
+	return issueSchemaField{
+		Name:        name,
+		DisplayName: displayName,
+		ValueType:   "user",
+		Description: "numeric Erda user ID string, not username or nickname; use `erda-cli whoami` for current UserID",
+		Required:    required,
+		Source:      "base",
+	}
+}
+
+func customIssueSchemaFields(properties []apistructs.IssuePropertyIndex) []issueSchemaField {
+	fields := make([]issueSchemaField, 0, len(properties))
+	for _, property := range properties {
+		name := property.PropertyName
+		if name == "" {
+			continue
+		}
+		displayName := property.DisplayName
+		if displayName == "" {
+			displayName = name
+		}
+		fields = append(fields, issueSchemaField{
+			Name:        name,
+			DisplayName: displayName,
+			ValueType:   string(property.PropertyType),
+			Required:    property.Required,
+			Source:      "custom",
+			Options:     propertyOptions(property.EnumeratedValues),
+		})
+	}
+	return fields
+}
+
+func requiredIssueSchemaFields(fields []issueSchemaField) []string {
+	required := make([]string, 0)
+	for _, field := range fields {
+		if field.Required {
+			required = append(required, field.Name)
+		}
+	}
+	return required
+}
+
+func toIssueSchemaStates(states []apistructs.IssueStateRelation) []issueSchemaState {
+	stateRefs := make(map[int64]issueSchemaStateRef, len(states))
+	for _, state := range states {
+		stateRefs[state.StateID] = issueSchemaStateRef{
+			ID:     state.StateID,
+			Name:   state.StateName,
+			Belong: string(state.StateBelong),
+		}
+	}
+
+	result := make([]issueSchemaState, 0, len(states))
+	for _, state := range states {
+		transitions := make([]issueSchemaStateRef, 0, len(state.StateRelation))
+		for _, targetID := range state.StateRelation {
+			if target, ok := stateRefs[targetID]; ok {
+				transitions = append(transitions, target)
+			}
+		}
+		result = append(result, issueSchemaState{
+			ID:          state.StateID,
+			Name:        state.StateName,
+			Belong:      string(state.StateBelong),
+			Transitions: transitions,
+		})
+	}
+	return result
+}
+
+func toIssueSchemaLabels(labels []apistructs.ProjectLabel) []issueSchemaLabel {
+	result := make([]issueSchemaLabel, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, issueSchemaLabel{
+			ID:        label.ID,
+			Name:      label.Name,
+			Color:     label.Color,
+			Type:      string(label.Type),
+			ProjectID: label.ProjectID,
+		})
+	}
+	return result
+}
+
+func propertyOptions(values []apistructs.Enumerate) []issueSchemaOption {
+	options := make([]issueSchemaOption, 0, len(values))
+	for _, value := range values {
+		options = append(options, issueSchemaOption{
+			ID:          value.ID,
+			Name:        value.Name,
+			Value:       value.Name,
+			DisplayName: value.Name,
+			Index:       value.Index,
+		})
+	}
+	sort.SliceStable(options, func(i, j int) bool {
+		return options[i].Index < options[j].Index
+	})
+	return options
+}
+
+func priorityOptions() []issueSchemaOption {
+	options := make([]issueSchemaOption, 0, len(apistructs.IssuePriorityList))
+	for _, priority := range apistructs.IssuePriorityList {
+		options = append(options, enumOption(string(priority), priority.GetZhName()))
+	}
+	return options
+}
+
+func complexityOptions() []issueSchemaOption {
+	complexities := []apistructs.IssueComplexity{
+		apistructs.IssueComplexityHard,
+		apistructs.IssueComplexityNormal,
+		apistructs.IssueComplexityEasy,
+	}
+	options := make([]issueSchemaOption, 0, len(complexities))
+	for _, complexity := range complexities {
+		options = append(options, enumOption(string(complexity), complexity.GetZhName()))
+	}
+	return options
+}
+
+func severityOptions() []issueSchemaOption {
+	options := make([]issueSchemaOption, 0, len(apistructs.IssueSeveritys))
+	for _, severity := range apistructs.IssueSeveritys {
+		options = append(options, enumOption(string(severity), severity.GetZhName()))
+	}
+	return options
+}
+
+func stageOptions(stages []apistructs.IssueStage) []issueSchemaOption {
+	options := make([]issueSchemaOption, 0, len(stages))
+	for _, stage := range stages {
+		value := stage.Value
+		if value == "" {
+			value = stage.Name
+		}
+		options = append(options, issueSchemaOption{
+			ID:          stage.ID,
+			Name:        stage.Name,
+			Value:       value,
+			DisplayName: stage.Name,
+		})
+	}
+	return options
+}
+
+func enumOption(value, displayName string) issueSchemaOption {
+	return issueSchemaOption{Name: value, Value: value, DisplayName: displayName}
+}

--- a/tools/cli/cmd/issue_schema_test.go
+++ b/tools/cli/cmd/issue_schema_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestIssueSchemaOutputsProjectIssueMetadataAsJSON(t *testing.T) {
+	restoreIssueSchemaStubs(t)
+
+	getIssueSchemaOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIssueSchemaProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listIssueSchemaStates = func(_ *command.Context, _ uint64, req apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		if req.IssueType != apistructs.IssueTypeBug {
+			return nil, nil
+		}
+		return []apistructs.IssueStateRelation{
+			{
+				IssueStatus: apistructs.IssueStatus{
+					StateID:     11,
+					StateName:   "Open",
+					StateBelong: apistructs.IssueStateBelongOpen,
+					IssueType:   apistructs.IssueTypeBug,
+				},
+				StateRelation: []int64{12},
+			},
+			{
+				IssueStatus: apistructs.IssueStatus{
+					StateID:     12,
+					StateName:   "Resolved",
+					StateBelong: apistructs.IssueStateBelongResolved,
+					IssueType:   apistructs.IssueTypeBug,
+				},
+			},
+		}, nil
+	}
+	listIssueSchemaLabels = func(*command.Context, uint64) ([]apistructs.ProjectLabel, error) {
+		return []apistructs.ProjectLabel{
+			{ID: 31, Name: "cli", Color: "green", Type: apistructs.LabelTypeIssue, ProjectID: 2001, CreatedAt: time.Unix(0, 0), UpdatedAt: time.Unix(0, 0)},
+		}, nil
+	}
+	listIssueSchemaProperties = func(_ *command.Context, _ uint64, _ uint64, issueType apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+		if issueType != apistructs.IssueTypeBug {
+			return nil, nil
+		}
+		return []apistructs.IssuePropertyIndex{
+			{
+				PropertyID:        41,
+				PropertyName:      "rootCause",
+				DisplayName:       "Root Cause",
+				PropertyType:      apistructs.PropertyTypeSelect,
+				Required:          true,
+				PropertyIssueType: apistructs.PropertyIssueTypeBug,
+				EnumeratedValues:  []apistructs.Enumerate{{ID: 1, Name: "code", Index: 1}},
+			},
+		}, nil
+	}
+	listIssueSchemaStages = func(_ *command.Context, _ uint64, issueType apistructs.IssueType) ([]apistructs.IssueStage, error) {
+		if issueType != apistructs.IssueTypeBug {
+			return nil, nil
+		}
+		return []apistructs.IssueStage{{Name: "代码开发", Value: "dev"}}, nil
+	}
+
+	var out bytes.Buffer
+	issueSchemaStdout = &out
+
+	if err := IssueSchema(&command.Context{}, "", "", "bug"); err != nil {
+		t.Fatalf("IssueSchema() error = %v", err)
+	}
+
+	var schema issueSchemaDocument
+	if err := json.Unmarshal(out.Bytes(), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v\n%s", err, out.String())
+	}
+	if schema.Project.ID != 2001 || schema.Project.Name != "erda-project" {
+		t.Fatalf("project = %+v, want id=2001 name=erda-project", schema.Project)
+	}
+	if len(schema.IssueTypes) != 1 || schema.IssueTypes[0].Type != string(apistructs.IssueTypeBug) {
+		t.Fatalf("issueTypes = %+v, want only BUG", schema.IssueTypes)
+	}
+
+	bugSchema := schema.IssueTypes[0]
+	if !containsString(bugSchema.RequiredFields, "title") || !containsString(bugSchema.RequiredFields, "rootCause") {
+		t.Fatalf("requiredFields = %+v, want title and custom rootCause", bugSchema.RequiredFields)
+	}
+	if len(bugSchema.States) != 2 {
+		t.Fatalf("states len = %d, want 2", len(bugSchema.States))
+	}
+	if len(bugSchema.States[0].Transitions) != 1 || bugSchema.States[0].Transitions[0].Name != "Resolved" {
+		t.Fatalf("transitions = %+v, want transition to Resolved", bugSchema.States[0].Transitions)
+	}
+	if len(schema.Labels) != 1 || schema.Labels[0].Name != "cli" {
+		t.Fatalf("labels = %+v, want cli label", schema.Labels)
+	}
+	if !fieldHasOption(bugSchema.Fields, "bugStage", "dev") {
+		t.Fatalf("fields = %+v, want bugStage stage option dev", bugSchema.Fields)
+	}
+}
+
+func TestIssueSchemaCommandShape(t *testing.T) {
+	if ISSUESCHEMA.ParentName != "ISSUE" {
+		t.Fatalf("issue schema parent = %q, want ISSUE", ISSUESCHEMA.ParentName)
+	}
+	if ISSUESCHEMA.Name != "schema" {
+		t.Fatalf("issue schema name = %q, want schema", ISSUESCHEMA.Name)
+	}
+	if !hasCommandFlag(ISSUESCHEMA.Flags, "type") {
+		t.Fatal("issue schema missing --type")
+	}
+}
+
+func restoreIssueSchemaStubs(t *testing.T) {
+	origGetOrgID := getIssueSchemaOrgID
+	origGetProjectID := getIssueSchemaProjectID
+	origListStates := listIssueSchemaStates
+	origListLabels := listIssueSchemaLabels
+	origListProperties := listIssueSchemaProperties
+	origListStages := listIssueSchemaStages
+	origStdout := issueSchemaStdout
+	t.Cleanup(func() {
+		getIssueSchemaOrgID = origGetOrgID
+		getIssueSchemaProjectID = origGetProjectID
+		listIssueSchemaStates = origListStates
+		listIssueSchemaLabels = origListLabels
+		listIssueSchemaProperties = origListProperties
+		listIssueSchemaStages = origListStages
+		issueSchemaStdout = origStdout
+	})
+}
+
+func containsString(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
+func fieldHasOption(fields []issueSchemaField, fieldName string, value string) bool {
+	for _, field := range fields {
+		if field.Name != fieldName {
+			continue
+		}
+		for _, option := range field.Options {
+			if option.Value == value {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tools/cli/cmd/issue_update.go
+++ b/tools/cli/cmd/issue_update.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ISSUEUPDATE = command.Command{
+	Name:       "update",
+	ParentName: "ISSUE",
+	ShortHelp:  "update issue fields such as state",
+	Example:    "$ erda-cli issue update <issue-id> --state 进行中",
+	Args: []command.Arg{
+		command.IntArg{}.Name("issue-id"),
+	},
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "state", Doc: "target state name", DefaultValue: ""},
+		command.IntFlag{Name: "state-id", Doc: "target state ID", DefaultValue: 0},
+	},
+	ValidArgsFunction: UpdateIssueCompletion,
+	Run:               IssueUpdate,
+}
+
+var (
+	getIssueUpdateIssue  = common.GetIssue
+	getIssueUpdateStates = common.ListState
+	updateIssueState     = common.UpdateIssue
+)
+
+func UpdateIssueCompletion(ctx *cobra.Command, args []string, toComplete string, issueID int, org string, project string, state string, stateID int) []string {
+	return IssueCompletion(ctx, args, toComplete, issueID)
+}
+
+func IssueUpdate(ctx *command.Context, issueID int, org string, project string, state string, stateID int) error {
+	if issueID <= 0 {
+		return fmt.Errorf("issue-id must be greater than 0")
+	}
+	if (state == "") == (stateID == 0) {
+		return fmt.Errorf("exactly one of --state or --state-id is required")
+	}
+
+	_, orgID, err := resolveIssueScope(ctx, org, project, common.GetOrgID, common.GetProjectID)
+	if err != nil {
+		return err
+	}
+	projectID := ctx.CurrentProject.ProjectID
+
+	issue, err := getIssueUpdateIssue(ctx, orgID, projectID, uint64(issueID))
+	if err != nil {
+		return err
+	}
+	stateMap, err := loadIssueStateMap(ctx, projectID, issue.Type)
+	if err != nil {
+		return err
+	}
+
+	current, ok := stateMap[issue.State]
+	if !ok {
+		return fmt.Errorf("current issue state %d not found in project workflow", issue.State)
+	}
+
+	var target *apistructs.IssueStateRelation
+	if stateID > 0 {
+		target = stateMap[int64(stateID)]
+		if target == nil {
+			return fmt.Errorf("target state-id %d not found in project workflow", stateID)
+		}
+	} else {
+		target = findTransitionStateByName(current, stateMap, state)
+		if target == nil {
+			return buildInvalidTransitionError(current, stateMap, fmt.Sprintf("state %q", state))
+		}
+	}
+
+	if !isReachableState(current, target.StateID) {
+		return buildInvalidTransitionError(current, stateMap, fmt.Sprintf("state %q (%d)", target.StateName, target.StateID))
+	}
+
+	req := &apistructs.IssueUpdateRequest{
+		ID:    uint64(issue.ID),
+		State: &target.StateID,
+	}
+	if err := updateIssueState(ctx, orgID, req); err != nil {
+		return err
+	}
+
+	ctx.Succ("Issue %d state updated: %s(%d) -> %s(%d)", issue.ID, current.StateName, current.StateID, target.StateName, target.StateID)
+	return nil
+}
+
+func loadIssueStateMap(ctx *command.Context, projectID uint64, issueType apistructs.IssueType) (map[int64]*apistructs.IssueStateRelation, error) {
+	states, err := getIssueUpdateStates(ctx, ctx.CurrentOrg.ID, apistructs.IssueStateRelationGetRequest{
+		ProjectID: projectID,
+		IssueType: issueType,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	stateMap := make(map[int64]*apistructs.IssueStateRelation, len(states))
+	for i := range states {
+		stateMap[states[i].StateID] = &states[i]
+	}
+	return stateMap, nil
+}
+
+func isReachableState(current *apistructs.IssueStateRelation, targetStateID int64) bool {
+	if current == nil {
+		return false
+	}
+	for _, nextID := range current.StateRelation {
+		if nextID == targetStateID {
+			return true
+		}
+	}
+	return false
+}
+
+func findTransitionStateByName(current *apistructs.IssueStateRelation, stateMap map[int64]*apistructs.IssueStateRelation, wanted string) *apistructs.IssueStateRelation {
+	name := strings.ToLower(strings.TrimSpace(wanted))
+	for _, nextID := range current.StateRelation {
+		next := stateMap[nextID]
+		if next == nil {
+			continue
+		}
+		if strings.ToLower(next.StateName) == name {
+			return next
+		}
+	}
+	return nil
+}
+
+func buildInvalidTransitionError(current *apistructs.IssueStateRelation, stateMap map[int64]*apistructs.IssueStateRelation, target string) error {
+	allowed := make([]string, 0, len(current.StateRelation))
+	for _, nextID := range current.StateRelation {
+		if next, ok := stateMap[nextID]; ok {
+			allowed = append(allowed, fmt.Sprintf("%s(%d)", next.StateName, next.StateID))
+		}
+	}
+	return fmt.Errorf(
+		"invalid transition from %s(%d) to %s, allowed targets: %s",
+		current.StateName,
+		current.StateID,
+		target,
+		strings.Join(allowed, ", "),
+	)
+}
+
+func findTransitionByStateBelong(current *apistructs.IssueStateRelation, stateMap map[int64]*apistructs.IssueStateRelation, belong apistructs.IssueStateBelong) *apistructs.IssueStateRelation {
+	for _, nextID := range current.StateRelation {
+		next := stateMap[nextID]
+		if next != nil && next.StateBelong == belong {
+			return next
+		}
+	}
+	return nil
+}
+
+func formatStateDebug(state *apistructs.IssueStateRelation) string {
+	return state.StateName + "(" + strconv.FormatInt(state.StateID, 10) + ")"
+}

--- a/tools/cli/cmd/issue_update_test.go
+++ b/tools/cli/cmd/issue_update_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestIssueUpdateCommandShape(t *testing.T) {
+	if ISSUEUPDATE.ParentName != "ISSUE" {
+		t.Fatalf("issue update parent = %q, want ISSUE", ISSUEUPDATE.ParentName)
+	}
+	if ISSUEUPDATE.Name != "update" {
+		t.Fatalf("issue update name = %q, want update", ISSUEUPDATE.Name)
+	}
+	for _, flag := range []string{"state", "state-id"} {
+		if !hasCommandFlag(ISSUEUPDATE.Flags, flag) {
+			t.Fatalf("issue update missing --%s", flag)
+		}
+	}
+}
+
+func TestIssueUpdateRequiresExactlyOneStateFlag(t *testing.T) {
+	restoreIssueUpdateStubs(t)
+	ctx := &command.Context{}
+
+	if err := IssueUpdate(ctx, 1001, "", "", "", 0); err == nil {
+		t.Fatal("expected error when both --state and --state-id are missing")
+	}
+	if err := IssueUpdate(ctx, 1001, "", "", "done", 10); err == nil {
+		t.Fatal("expected error when both --state and --state-id are set")
+	}
+}
+
+func TestIssueUpdateByStateName(t *testing.T) {
+	restoreIssueUpdateStubs(t)
+	ctx := &command.Context{}
+	ctx.CurrentOrg.ID = 1001
+	ctx.CurrentProject.ProjectID = 2001
+
+	getIssueUpdateIssue = func(*command.Context, uint64, uint64, uint64) (*apistructs.Issue, error) {
+		return &apistructs.Issue{
+			ID:          3001,
+			Type:        apistructs.IssueTypeRequirement,
+			State:       1,
+			IterationID: 2,
+		}, nil
+	}
+	getIssueUpdateStates = func(*command.Context, uint64, apistructs.IssueStateRelationGetRequest) ([]apistructs.IssueStateRelation, error) {
+		return []apistructs.IssueStateRelation{
+			{IssueStatus: apistructs.IssueStatus{StateID: 1, StateName: "Open"}, StateRelation: []int64{2}},
+			{IssueStatus: apistructs.IssueStatus{StateID: 2, StateName: "In Progress"}},
+		}, nil
+	}
+
+	called := false
+	updateIssueState = func(_ *command.Context, _ uint64, req *apistructs.IssueUpdateRequest) error {
+		called = true
+		if req.State == nil || *req.State != 2 {
+			t.Fatalf("state = %v, want 2", req.State)
+		}
+		if req.IterationID != nil {
+			t.Fatalf("iteration id should be nil for state-only update, got %v", *req.IterationID)
+		}
+		return nil
+	}
+
+	if err := IssueUpdate(ctx, 3001, "", "", "in progress", 0); err != nil {
+		t.Fatalf("IssueUpdate() error = %v", err)
+	}
+	if !called {
+		t.Fatal("UpdateIssue was not called")
+	}
+}
+
+func restoreIssueUpdateStubs(t *testing.T) {
+	origGetIssue := getIssueUpdateIssue
+	origGetStates := getIssueUpdateStates
+	origUpdate := updateIssueState
+	t.Cleanup(func() {
+		getIssueUpdateIssue = origGetIssue
+		getIssueUpdateStates = origGetStates
+		updateIssueState = origUpdate
+	})
+}

--- a/tools/cli/cmd/iteration.go
+++ b/tools/cli/cmd/iteration.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/erda-project/erda/tools/cli/command"
+
+var ITERATION = command.Command{
+	Name:                "iteration",
+	ShortHelp:           "iteration management commands",
+	PreferWorkspaceHost: true,
+	Example:             "$ erda-cli iteration list",
+}

--- a/tools/cli/cmd/iteration_list.go
+++ b/tools/cli/cmd/iteration_list.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/common"
+)
+
+var ITERATIONLIST = command.Command{
+	ParentName: "ITERATION",
+	Name:       "list",
+	ShortHelp:  "list current project iterations",
+	Example:    "$ erda-cli iteration list",
+	Flags: []command.Flag{
+		command.StringFlag{Name: "org", Doc: "organization name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "project", Doc: "project name; defaults to current workspace context", DefaultValue: ""},
+		command.StringFlag{Name: "state", Doc: "iteration state, FILED or UNFILED", DefaultValue: ""},
+		command.IntFlag{Name: "page", Doc: "page number", DefaultValue: 1},
+		command.IntFlag{Name: "page-size", Doc: "page size", DefaultValue: 20},
+		command.BoolFlag{Name: "json", Doc: "if true, output JSON", DefaultValue: false},
+	},
+	Run: IterationList,
+}
+
+var (
+	getIterationListOrgID     = common.GetOrgID
+	getIterationListProjectID = common.GetProjectID
+	listProjectIterations     = queryProjectIterations
+	iterationListStdout       io.Writer = os.Stdout
+)
+
+type iterationListOutput struct {
+	Total uint64                 `json:"total"`
+	List  []apistructs.Iteration `json:"list"`
+}
+
+func IterationList(ctx *command.Context, org string, project string, state string, page int, pageSize int, jsonOutput bool) error {
+	_, orgID, err := resolveIssueScope(ctx, org, project, getIterationListOrgID, getIterationListProjectID)
+	if err != nil {
+		return err
+	}
+	projectID := ctx.CurrentProject.ProjectID
+
+	req, err := buildIterationListRequest(orgID, projectID, state, page, pageSize)
+	if err != nil {
+		return err
+	}
+	resp, err := listProjectIterations(ctx, req, strconv.FormatUint(orgID, 10))
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		resp = &apistructs.IterationPagingResponseData{}
+	}
+
+	if !jsonOutput {
+		return writeIterationListTable(iterationListStdout, resp.List, resp.Total, page, pageSize)
+	}
+
+	encoder := json.NewEncoder(iterationListStdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(iterationListOutput{Total: resp.Total, List: resp.List})
+}
+
+func writeIterationListTable(w io.Writer, list []apistructs.Iteration, total uint64, page int, pageSize int) error {
+	_, _ = fmt.Fprintf(w, "iterations (total=%d, page=%d, pageSize=%d)\n", total, page, pageSize)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "ID\tTITLE\tSTATE\tSTARTED AT\tFINISHED AT")
+	for _, item := range list {
+		_, _ = fmt.Fprintf(
+			tw,
+			"%d\t%s\t%s\t%s\t%s\n",
+			item.ID,
+			item.Title,
+			item.State,
+			formatIterationTime(item.StartedAt),
+			formatIterationTime(item.FinishedAt),
+		)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(list) == 0 {
+		_, _ = fmt.Fprintln(w, "No iterations found.")
+	}
+	return nil
+}
+
+func formatIterationTime(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func buildIterationListRequest(orgID, projectID uint64, state string, page int, pageSize int) (*apistructs.IterationPagingRequest, error) {
+	if page <= 0 {
+		return nil, fmt.Errorf("--page must be greater than 0")
+	}
+	if pageSize <= 0 {
+		return nil, fmt.Errorf("--page-size must be greater than 0")
+	}
+
+	var iterationState apistructs.IterationState
+	if state != "" {
+		iterationState = apistructs.IterationState(state)
+	}
+
+	return &apistructs.IterationPagingRequest{
+		PageNo:              uint64(page),
+		PageSize:            uint64(pageSize),
+		ProjectID:           projectID,
+		State:               iterationState,
+		WithoutIssueSummary: false,
+	}, nil
+}
+
+// queryProjectIterations queries project iterations.
+func queryProjectIterations(ctx *command.Context, req *apistructs.IterationPagingRequest, orgID string) (*apistructs.IterationPagingResponseData, error) {
+	var listResp apistructs.IterationPagingResponse
+	resp, err := ctx.Get().
+		Path("/api/iterations").
+		Param("projectID", strconv.FormatUint(req.ProjectID, 10)).
+		Param("pageNo", strconv.FormatUint(req.PageNo, 10)).
+		Param("pageSize", strconv.FormatUint(req.PageSize, 10)).
+		Param("withoutIssueSummary", strconv.FormatBool(req.WithoutIssueSummary)).
+		Param("state", string(req.State)).
+		Header("org", orgID).
+		Do().JSON(&listResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list iterations: %w", err)
+	}
+	if !resp.IsOK() || !listResp.Success {
+		return nil, fmt.Errorf("failed to list iterations: %s", listResp.Error.Msg)
+	}
+
+	return listResp.Data, nil
+}

--- a/tools/cli/cmd/iteration_list.go
+++ b/tools/cli/cmd/iteration_list.go
@@ -45,9 +45,9 @@ var ITERATIONLIST = command.Command{
 }
 
 var (
-	getIterationListOrgID     = common.GetOrgID
-	getIterationListProjectID = common.GetProjectID
-	listProjectIterations     = queryProjectIterations
+	getIterationListOrgID               = common.GetOrgID
+	getIterationListProjectID           = common.GetProjectID
+	listProjectIterations               = queryProjectIterations
 	iterationListStdout       io.Writer = os.Stdout
 )
 

--- a/tools/cli/cmd/iteration_list_test.go
+++ b/tools/cli/cmd/iteration_list_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/command"
+)
+
+func TestIterationListOutputsTableByDefault(t *testing.T) {
+	restoreIterationListStubs(t)
+
+	getIterationListOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIterationListProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	listProjectIterations = func(_ *command.Context, req *apistructs.IterationPagingRequest, orgID string) (*apistructs.IterationPagingResponseData, error) {
+		if req.ProjectID != 2001 || orgID != "1001" {
+			t.Fatalf("unexpected request project/org: %+v %s", req, orgID)
+		}
+		return &apistructs.IterationPagingResponseData{
+			Total: 1,
+			List: []apistructs.Iteration{
+				{ID: 3001, Title: "Sprint 1", State: apistructs.IterationStateUnfiled, StartedAt: &now, FinishedAt: &now},
+			},
+		}, nil
+	}
+
+	var out bytes.Buffer
+	iterationListStdout = &out
+
+	if err := IterationList(&command.Context{}, "", "", "", 1, 20, false); err != nil {
+		t.Fatalf("IterationList() error = %v", err)
+	}
+
+	got := out.String()
+	for _, expected := range []string{"iterations (total=1, page=1, pageSize=20)", "ID", "Sprint 1", "UNFILED"} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("table output missing %q:\n%s", expected, got)
+		}
+	}
+}
+
+func TestIterationListOutputsJSONWithFlag(t *testing.T) {
+	restoreIterationListStubs(t)
+
+	getIterationListOrgID = func(*command.Context, string) (string, uint64, error) {
+		return "erda", 1001, nil
+	}
+	getIterationListProjectID = func(*command.Context, uint64, string) (string, uint64, error) {
+		return "erda-project", 2001, nil
+	}
+	listProjectIterations = func(_ *command.Context, _ *apistructs.IterationPagingRequest, _ string) (*apistructs.IterationPagingResponseData, error) {
+		return &apistructs.IterationPagingResponseData{
+			Total: 1,
+			List: []apistructs.Iteration{
+				{ID: 3001, Title: "Sprint 1", State: apistructs.IterationStateUnfiled},
+			},
+		}, nil
+	}
+
+	var out bytes.Buffer
+	iterationListStdout = &out
+
+	if err := IterationList(&command.Context{}, "", "", "", 1, 20, true); err != nil {
+		t.Fatalf("IterationList() error = %v", err)
+	}
+
+	var output iterationListOutput
+	if err := json.Unmarshal(out.Bytes(), &output); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, out.String())
+	}
+	if output.Total != 1 || len(output.List) != 1 || output.List[0].Title != "Sprint 1" {
+		t.Fatalf("output = %+v, want one iteration", output)
+	}
+}
+
+func TestIterationListCommandShape(t *testing.T) {
+	if ITERATIONLIST.ParentName != "ITERATION" {
+		t.Fatalf("iteration list parent = %q, want ITERATION", ITERATIONLIST.ParentName)
+	}
+	if ITERATIONLIST.Name != "list" {
+		t.Fatalf("iteration list name = %q, want list", ITERATIONLIST.Name)
+	}
+	for _, flag := range []string{"state", "page", "page-size", "json"} {
+		if !hasCommandFlag(ITERATIONLIST.Flags, flag) {
+			t.Fatalf("iteration list missing --%s", flag)
+		}
+	}
+}
+
+func restoreIterationListStubs(t *testing.T) {
+	origGetOrgID := getIterationListOrgID
+	origGetProjectID := getIterationListProjectID
+	origList := listProjectIterations
+	origStdout := iterationListStdout
+	t.Cleanup(func() {
+		getIterationListOrgID = origGetOrgID
+		getIterationListProjectID = origGetProjectID
+		listProjectIterations = origList
+		iterationListStdout = origStdout
+	})
+}

--- a/tools/cli/cmd/logs.go
+++ b/tools/cli/cmd/logs.go
@@ -230,7 +230,7 @@ func resolvePipelineIDForLogs(ctx *command.Context, pipelineID uint64) (uint64, 
 	if err != nil {
 		return 0, err
 	}
-	info, err := getWorkspaceInfo(".", command.Remote)
+	info, err := getScopedWorkspaceInfo()
 	if err != nil {
 		return 0, err
 	}
@@ -238,7 +238,7 @@ func resolvePipelineIDForLogs(ctx *command.Context, pipelineID uint64) (uint64, 
 	if err != nil {
 		return 0, err
 	}
-	_, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Project, info.Application)
+	_, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Org, info.Project, info.Application)
 	if err != nil {
 		return 0, err
 	}

--- a/tools/cli/cmd/logs_test.go
+++ b/tools/cli/cmd/logs_test.go
@@ -538,7 +538,7 @@ func TestResolvePipelineIDForLogsUsesLatestWorkspacePipeline(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	getLatestPipelineID = func(*command.Context, uint64, string) (uint64, error) {
@@ -602,7 +602,7 @@ func TestPipelineLogsResolvesMissingPipelineID(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	getLatestPipelineID = func(*command.Context, uint64, string) (uint64, error) {

--- a/tools/cli/cmd/pipeline.go
+++ b/tools/cli/cmd/pipeline.go
@@ -15,15 +15,18 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/erda-project/erda/tools/cli/command"
 	"github.com/erda-project/erda/tools/cli/common"
 	"github.com/erda-project/erda/tools/cli/utils"
 )
 
 var PIPELINE = command.Command{
-	Name:      "pipeline",
-	ShortHelp: "Pipeline operations",
-	Example:   `erda-cli pipeline logs -i <pipelineID>`,
+	Name:                "pipeline",
+	ShortHelp:           "Pipeline operations",
+	PreferWorkspaceHost: true,
+	Example:             `erda-cli pipeline logs -i <pipelineID>`,
 }
 
 var (
@@ -34,3 +37,17 @@ var (
 	getLatestPipelineID         = common.GetLatestPipelineID
 	listPipelinesCICD           = common.ListPipelinesCICD
 )
+
+func getScopedWorkspaceInfo() (utils.GitterURLInfo, error) {
+	info, err := getWorkspaceInfo(".", command.Remote)
+	if err != nil {
+		return utils.GitterURLInfo{}, err
+	}
+	if strings.TrimSpace(command.OrgName) != "" {
+		info.Org = strings.TrimSpace(command.OrgName)
+	}
+	if strings.TrimSpace(command.ProjectName) != "" {
+		info.Project = strings.TrimSpace(command.ProjectName)
+	}
+	return info, nil
+}

--- a/tools/cli/cmd/runtime.go
+++ b/tools/cli/cmd/runtime.go
@@ -32,9 +32,10 @@ import (
 )
 
 var RUNTIME = command.Command{
-	Name:      "runtime",
-	ShortHelp: "Runtime operations",
-	Example:   `erda-cli runtime status`,
+	Name:                "runtime",
+	ShortHelp:           "Runtime operations",
+	PreferWorkspaceHost: true,
+	Example:             `erda-cli runtime status`,
 }
 
 type resolvedRuntimeContext struct {
@@ -91,7 +92,7 @@ func RuntimeStatus(ctx *command.Context, workspace string, runtimeID uint64) err
 }
 
 func resolveRuntimeContext(ctx *command.Context, workspace string, runtimeID uint64, requireRuntimeID bool) (*resolvedRuntimeContext, error) {
-	info, err := getWorkspaceInfo(".", command.Remote)
+	info, err := getScopedWorkspaceInfo()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get workspace info")
 	}
@@ -101,7 +102,7 @@ func resolveRuntimeContext(ctx *command.Context, workspace string, runtimeID uin
 		return nil, err
 	}
 
-	projectID, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Project, info.Application)
+	projectID, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Org, info.Project, info.Application)
 	if err != nil {
 		return nil, errors.Wrapf(err, "orgID: %v, projectName: %s, appName: %s", org.ID, info.Project, info.Application)
 	}

--- a/tools/cli/cmd/runtime_test.go
+++ b/tools/cli/cmd/runtime_test.go
@@ -118,7 +118,7 @@ func TestRuntimeListUsesResolvedWorkspace(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	getCurrentBranchWorkspace = func(*command.Context, uint64, string) (string, error) {
@@ -209,7 +209,7 @@ func TestRuntimeStatusResolvesLatestRuntimeInWorkspace(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	getCurrentBranchWorkspace = func(*command.Context, uint64, string) (string, error) {
@@ -295,7 +295,7 @@ func TestRuntimeInstanceListUsesRuntimeServices(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	inspectRuntime = func(_ *command.Context, orgID uint64, runtimeID uint64, applicationID uint64, workspace string) (apistructs.RuntimeInspectDTO, error) {
@@ -379,7 +379,7 @@ func TestRuntimeInstanceListAllIncludesStoppedInstances(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	inspectRuntime = func(_ *command.Context, orgID uint64, runtimeID uint64, applicationID uint64, workspace string) (apistructs.RuntimeInspectDTO, error) {
@@ -476,7 +476,7 @@ func TestRuntimeLogsFiltersByServiceAndInstance(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	listRuntimeServicePodsForLogs = func(_ *command.Context, orgID uint64, runtimeID int64, service string) (apistructs.Pods, error) {
@@ -563,7 +563,7 @@ func TestRuntimeLogsFallsBackToStoppedInstance(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	listRuntimeServicePodsForLogs = func(_ *command.Context, orgID uint64, runtimeID int64, service string) (apistructs.Pods, error) {
@@ -665,7 +665,7 @@ func TestRuntimeLogsWatchPrintsOnlyUnseenLines(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	listRuntimeServicePodsForLogs = func(_ *command.Context, orgID uint64, runtimeID int64, service string) (apistructs.Pods, error) {
@@ -763,7 +763,7 @@ func TestRuntimeLogsWatchStopsCleanlyWhenRequested(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	listRuntimeServicePodsForLogs = func(_ *command.Context, orgID uint64, runtimeID int64, service string) (apistructs.Pods, error) {
@@ -836,7 +836,7 @@ func TestRuntimeLogsWatchPagesBeyondTailWindow(t *testing.T) {
 	getOrgDetail = func(*command.Context, string) (apistructs.OrgDTO, error) {
 		return apistructs.OrgDTO{ID: 1001}, nil
 	}
-	resolveWorkspaceApplication = func(*command.Context, uint64, string, string) (uint64, int64, error) {
+	resolveWorkspaceApplication = func(*command.Context, uint64, string, string, string) (uint64, int64, error) {
 		return 2001, 3001, nil
 	}
 	listRuntimeServicePodsForLogs = func(_ *command.Context, orgID uint64, runtimeID int64, service string) (apistructs.Pods, error) {

--- a/tools/cli/cmd/self_update.go
+++ b/tools/cli/cmd/self_update.go
@@ -445,6 +445,9 @@ func UpdateSetDefault(ctx *command.Context, channel string) error {
 		}
 		globalConfig = &command.GlobalConfig{Version: command.ConfigVersion}
 	}
+	if globalConfig == nil {
+		globalConfig = &command.GlobalConfig{Version: command.ConfigVersion}
+	}
 	if globalConfig.Version == "" {
 		globalConfig.Version = command.ConfigVersion
 	}

--- a/tools/cli/cmd/status.go
+++ b/tools/cli/cmd/status.go
@@ -58,7 +58,7 @@ func PipelineStatus(ctx *command.Context, branch string, pipelineID uint64, watc
 		branch = b
 	}
 
-	info, err := getWorkspaceInfo(".", command.Remote)
+	info, err := getScopedWorkspaceInfo()
 	if err != nil {
 		return errors.Wrap(err, "failed to get  workspace info")
 	}
@@ -68,7 +68,7 @@ func PipelineStatus(ctx *command.Context, branch string, pipelineID uint64, watc
 		return err
 	}
 
-	projectID, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Project, info.Application)
+	projectID, applicationID, err := resolveWorkspaceApplication(ctx, org.ID, info.Org, info.Project, info.Application)
 	if err != nil {
 		return errors.Wrapf(err, "orgID: %v, projectName: %s, appName: %s", org.ID, info.Project, info.Application)
 	}

--- a/tools/cli/cmd/whoami.go
+++ b/tools/cli/cmd/whoami.go
@@ -24,8 +24,9 @@ import (
 )
 
 var WHOAMI = command.Command{
-	Name:      "whoami",
-	ShortHelp: "show current erda authentication info",
+	Name:                "whoami",
+	ShortHelp:           "show current erda authentication info",
+	PreferWorkspaceHost: true,
 	Example: `
 $ erda-cli whoami
 $ ERDA_HOST=https://erda.cloud erda-cli whoami
@@ -34,9 +35,6 @@ $ ERDA_HOST=https://erda.cloud erda-cli whoami
 }
 
 func RunWhoami(ctx *command.Context) error {
-	command.SetPreferWorkspaceHost(true)
-	defer command.SetPreferWorkspaceHost(false)
-
 	if err := command.LoadAuthState(); err != nil {
 		return err
 	}

--- a/tools/cli/command/command.go
+++ b/tools/cli/command/command.go
@@ -24,6 +24,8 @@ type Command struct {
 	// dont show up in list of cmds
 	Hidden         bool
 	DontHideCursor bool
+	// If true, host resolution prefers workspace git remote host.
+	PreferWorkspaceHost bool
 	/* args:
 	        []Arg {
 		       IPArg{},

--- a/tools/cli/command/generate/generate.go
+++ b/tools/cli/command/generate/generate.go
@@ -97,6 +97,7 @@ func genTemplateArg(cmd command.Command, cmdname string) templateArg {
 		Example:                    cmd.Example,
 		Hidden:                     cmd.Hidden,
 		DontHideCursor:             cmd.DontHideCursor,
+		PreferWorkspaceHost:        cmd.PreferWorkspaceHost,
 		Args:                       cmd.Args,
 		ArgsNumMin:                 argmin,
 		ArgsNumMax:                 argmax,
@@ -188,6 +189,7 @@ type templateArg struct {
 	Usage                      string
 	Hidden                     bool
 	DontHideCursor             bool
+	PreferWorkspaceHost        bool
 	ShortHelp                  string
 	LongHelp                   string
 	Example                    string
@@ -241,6 +243,11 @@ var {{.Name}}Cmd = &cobra.Command{
 	Long: ` + "`{{.LongHelp}}`" + `,
 	{{- end}}
 	Example: ` + "`{{.Example}}`" + `,
+	{{- if .PreferWorkspaceHost}}
+	Annotations: map[string]string{
+		command.PreferWorkspaceHostAnnotationKey: "true",
+	},
+	{{- end}}
 	{{- if .RunCMD}}
 	Args:  cobra.RangeArgs({{$.ArgsNumMin}}, {{$.ArgsNumMax}}),
 	Hidden: {{.Hidden}},

--- a/tools/cli/command/root_cmd.go
+++ b/tools/cli/command/root_cmd.go
@@ -43,6 +43,10 @@ import (
 var (
 	host         string // erda host, format: http[s]://<domain> eg: https://erda.cloud
 	Remote       string // git remote name for erda repo
+	OrgName      string // preferred org name override
+	ProjectName  string // preferred project name override
+	OrgID        uint64 // preferred org id override
+	ProjectID    uint64 // preferred project id override
 	username     string
 	password     string
 	debugMode    bool
@@ -66,12 +70,14 @@ var (
 var loginAndStoreSession = loginAndStoreSessionWithPassword
 
 var preferWorkspaceHost bool
+const PreferWorkspaceHostAnnotationKey = "erda.prefer_workspace_host"
 
 var (
 	commandErrorOutput  io.Writer = os.Stdout
 	commandErrorPrinted bool
 	cursorStateMu       sync.Mutex
 	cursorHidden        bool
+	exitWithCode        = os.Exit
 )
 
 // Default portal origin (same host family as git clone URLs, e.g. https://erda.cloud/org/dop/...).
@@ -182,7 +188,7 @@ func PrepareCtx(cmd *cobra.Command, args []string) error {
 		err = fmt.Errorf("%s", color_str.Red("✗ ")+err.Error())
 		return err
 	}
-	preferWorkspaceHost = commandPrefersWorkspaceHost(u)
+	preferWorkspaceHost = lookupPreferWorkspaceHost(cmd)
 
 	// For completion zsh etc.
 	if strings.HasPrefix(u, "completion ") || strings.HasPrefix(u, "__complete") {
@@ -423,28 +429,15 @@ func resolveBaseHost() (string, error) {
 	return resolveGlobalHost()
 }
 
-// commandPrefersWorkspaceHost returns true when the command should resolve the
-// API host from the git remote URL rather than the global config. This ensures
-// that workspace commands (pipeline, runtime, build, whoami) talk to the same
-// Erda instance that owns the repository, even when the global config points
-// elsewhere. Non-workspace commands (login, update, project list, etc.) fall
-// through to the global config host first.
-func commandPrefersWorkspaceHost(fullUse string) bool {
-	switch {
-	case fullUse == "whoami":
-		return true
-	case strings.HasPrefix(fullUse, "pipeline "):
-		return true
-	case strings.HasPrefix(fullUse, "runtime "):
-		return true
-	case strings.HasPrefix(fullUse, "build "):
-		return true
+// lookupPreferWorkspaceHost returns true when the active command or an ancestor
+// was generated with PreferWorkspaceHost (workspace git remote drives API host).
+func lookupPreferWorkspaceHost(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations[PreferWorkspaceHostAnnotationKey] == "true" {
+			return true
+		}
 	}
 	return false
-}
-
-func SetPreferWorkspaceHost(v bool) {
-	preferWorkspaceHost = v
 }
 
 func loadWorkspaceInfo() (utils.GitterURLInfo, bool, error) {
@@ -494,6 +487,18 @@ func parseCtx() error {
 			}
 			ctx.Applications = append(ctx.Applications, a2)
 		}
+	}
+	if OrgID > 0 {
+		ctx.CurrentOrg.ID = OrgID
+	}
+	if ProjectID > 0 {
+		ctx.CurrentProject.ProjectID = ProjectID
+	}
+	if strings.TrimSpace(OrgName) != "" {
+		ctx.CurrentOrg.Name = strings.TrimSpace(OrgName)
+	}
+	if strings.TrimSpace(ProjectName) != "" {
+		ctx.CurrentProject.Project = strings.TrimSpace(ProjectName)
 	}
 
 	workspaceInfo, hasWorkspaceInfo, err := loadWorkspaceInfo()
@@ -692,6 +697,10 @@ func hasUsableAuth(s status.StatusInfo) bool {
 func Execute() {
 	RootCmd.PersistentFlags().StringVar(&host, "host", "", "Erda portal base URL (default: https://erda.cloud, same as git remote host; use your OpenAPI URL only if the deployment exposes API without portal; overrides ERDA_HOST and ~/.erda.d/config)")
 	RootCmd.PersistentFlags().StringVarP(&Remote, "remote", "", "origin", "the remote for Erda repo")
+	RootCmd.PersistentFlags().StringVar(&OrgName, "org", "", "organization name override for commands using workspace context")
+	RootCmd.PersistentFlags().StringVar(&ProjectName, "project", "", "project name override for commands using workspace context")
+	RootCmd.PersistentFlags().Uint64Var(&OrgID, "org-id", 0, "organization ID override for commands using workspace context")
+	RootCmd.PersistentFlags().Uint64Var(&ProjectID, "project-id", 0, "project ID override for commands using workspace context")
 	RootCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "Erda username to authenticate")
 	RootCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Erda password to authenticate")
 	RootCmd.PersistentFlags().BoolVarP(&debugMode, "verbose", "V", false, "if true, enable verbose mode")
@@ -705,7 +714,9 @@ func Execute() {
 		restoreCursorIfHidden(tput)
 	})
 
-	_ = executeRootCommand(RootCmd)
+	if err := executeRootCommand(RootCmd); err != nil {
+		exitWithCode(1)
+	}
 }
 
 func MarkCommandErrorPrinted() {
@@ -717,7 +728,18 @@ func executeRootCommand(root *cobra.Command) error {
 	err := root.Execute()
 	if err != nil && !IsCompletion && !commandErrorPrinted {
 		MarkCommandErrorPrinted()
-		_, _ = fmt.Fprintln(commandErrorOutput, err)
+		_, _ = fmt.Fprintln(commandErrorOutput, formatCommandError(err))
+	}
+	return err
+}
+
+func formatCommandError(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := err.Error()
+	if strings.Contains(message, "accepts between 0 and 0 arg(s), received 1") {
+		return fmt.Errorf("unknown subcommand or unexpected argument; run \"erda-cli --help\" or \"erda-cli <command> --help\"")
 	}
 	return err
 }

--- a/tools/cli/command/root_cmd_test.go
+++ b/tools/cli/command/root_cmd_test.go
@@ -489,15 +489,23 @@ func TestResolveBaseHostReturnsEmptyWithoutConfiguredSources(t *testing.T) {
 	require.Empty(t, resolved)
 }
 
-func TestCommandPrefersWorkspaceHost(t *testing.T) {
-	require.True(t, commandPrefersWorkspaceHost("whoami"))
-	require.True(t, commandPrefersWorkspaceHost("pipeline history"))
-	require.True(t, commandPrefersWorkspaceHost("runtime logs"))
-	require.True(t, commandPrefersWorkspaceHost("build list"))
+func TestLookupPreferWorkspaceHost(t *testing.T) {
+	root := &cobra.Command{Use: "erda-cli"}
+	pipeline := &cobra.Command{
+		Use: "pipeline",
+		Annotations: map[string]string{
+			PreferWorkspaceHostAnnotationKey: "true",
+		},
+	}
+	history := &cobra.Command{Use: "history"}
+	login := &cobra.Command{Use: "login"}
+	root.AddCommand(pipeline)
+	pipeline.AddCommand(history)
+	root.AddCommand(login)
 
-	require.False(t, commandPrefersWorkspaceHost("login"))
-	require.False(t, commandPrefersWorkspaceHost("update check"))
-	require.False(t, commandPrefersWorkspaceHost("project list"))
+	require.True(t, lookupPreferWorkspaceHost(pipeline))
+	require.True(t, lookupPreferWorkspaceHost(history))
+	require.False(t, lookupPreferWorkspaceHost(login))
 }
 
 func TestResolveHostFromFlagOrEnvPrefersFlag(t *testing.T) {
@@ -600,6 +608,63 @@ func TestExecuteRootCommandDoesNotDuplicateReportedError(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 1, strings.Count(output.String(), "already printed"))
 	require.NotContains(t, output.String(), "boom")
+}
+
+func TestExecuteRootCommandRewritesUnexpectedArgumentError(t *testing.T) {
+	origOutput := commandErrorOutput
+	origPrinted := commandErrorPrinted
+	t.Cleanup(func() {
+		commandErrorOutput = origOutput
+		commandErrorPrinted = origPrinted
+	})
+
+	var output bytes.Buffer
+	commandErrorOutput = &output
+	commandErrorPrinted = false
+
+	root := &cobra.Command{Use: "erda-cli", SilenceUsage: true}
+	issue := &cobra.Command{
+		Use:   "issue",
+		Short: "issue command",
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("accepts between 0 and 0 arg(s), received 1")
+			}
+			return nil
+		},
+	}
+	root.AddCommand(issue)
+	root.SetArgs([]string{"issue", "iteration"})
+
+	err := executeRootCommand(root)
+	require.Error(t, err)
+	require.Contains(t, output.String(), "unknown subcommand or unexpected argument")
+	require.NotContains(t, output.String(), "accepts between 0 and 0 arg(s)")
+}
+
+func TestExecuteExitsNonZeroWhenRootCommandFails(t *testing.T) {
+	origRoot := RootCmd
+	origExit := exitWithCode
+	t.Cleanup(func() {
+		RootCmd = origRoot
+		exitWithCode = origExit
+	})
+
+	RootCmd = &cobra.Command{
+		Use: "erda-cli",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return errors.New("boom")
+		},
+	}
+	RootCmd.SetArgs([]string{})
+
+	exitCode := 0
+	exitWithCode = func(code int) {
+		exitCode = code
+	}
+
+	Execute()
+	require.Equal(t, 1, exitCode)
 }
 
 func TestHandleInterruptSignalsExits(t *testing.T) {

--- a/tools/cli/common/application.go
+++ b/tools/cli/common/application.go
@@ -46,10 +46,7 @@ func GetApplicationDetail(ctx *command.Context, orgID, projectID, applicationID 
 	}
 
 	if !response.IsOK() {
-		return apistructs.ApplicationDTO{}, fmt.Errorf("%s", utils.FormatErrMsg("get application detail",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.ApplicationDTO{}, formatHTTPFailureFromResponse("get application detail", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -132,10 +129,7 @@ func GetPagingApplications(ctx *command.Context, orgID, projectID uint64, pageNo
 	}
 
 	if !response.IsOK() {
-		return apistructs.ApplicationListResponseData{}, fmt.Errorf("%s", utils.FormatErrMsg("list",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.ApplicationListResponseData{}, formatHTTPFailureFromResponse("list", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -171,10 +165,7 @@ func GetPagingMyApplications(ctx *command.Context, orgID, projectID uint64, page
 	}
 
 	if !response.IsOK() {
-		return apistructs.ApplicationListResponseData{}, fmt.Errorf("%s", utils.FormatErrMsg("list",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.ApplicationListResponseData{}, formatHTTPFailureFromResponse("list", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -207,10 +198,7 @@ func DeleteApplication(ctx *command.Context, applicationID uint64) error {
 	}
 
 	if !response.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("delete",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return formatHTTPFailureFromResponse("delete", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -256,10 +244,7 @@ func CreateApplication(ctx *command.Context, orgID, projectID uint64, applicatio
 	}
 
 	if !resp.IsOK() {
-		return apistructs.ApplicationDTO{}, fmt.Errorf("%s", utils.FormatErrMsg("create",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				resp.StatusCode(), resp.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.ApplicationDTO{}, formatHTTPFailureFromResponse("create", resp, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &response); err != nil {

--- a/tools/cli/common/config.go
+++ b/tools/cli/common/config.go
@@ -103,10 +103,7 @@ func UpdateProjectWorkspaceConfigs(ctx *command.Context, feature, org, project, 
 	}
 
 	if !response.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("config update",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), string(response.Body())), false))
-
+		return formatHTTPFailureFromResponse("config update", response, response.Body())
 	}
 
 	if !resp.Success {
@@ -144,10 +141,7 @@ func GetProjectWorkspaceConfigs(ctx *command.Context, org, project, workspace st
 	}
 
 	if !response.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("config get",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return formatHTTPFailureFromResponse("config get", response, b.Bytes())
 	}
 
 	if err = json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -196,10 +190,7 @@ func DelelteProjectWorkspaceConfigs(ctx *command.Context, org, project, workspac
 	}
 
 	if !response.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("config delete",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return formatHTTPFailureFromResponse("config delete", response, b.Bytes())
 	}
 
 	if err = json.Unmarshal(b.Bytes(), &resp); err != nil {

--- a/tools/cli/common/http_error.go
+++ b/tools/cli/common/http_error.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/tools/cli/utils"
+)
+
+type httpFailureResponse interface {
+	StatusCode() int
+	ResponseHeader(string) string
+}
+
+func formatHTTPFailureFromResponse(action string, resp httpFailureResponse, body []byte) error {
+	if resp == nil {
+		return formatHTTPFailure(action, 0, "", body, "")
+	}
+	return formatHTTPFailure(
+		action,
+		resp.StatusCode(),
+		resp.ResponseHeader("Content-Type"),
+		body,
+		requestIDFromHeaders(resp.ResponseHeader),
+	)
+}
+
+func formatHTTPFailure(action string, statusCode int, contentType string, body []byte, requestID string) error {
+	if parsed, ok := decodeStandardErrorBody(body); ok {
+		details := fmt.Sprintf("status=%d, code=%s", statusCode, parsed.Error.Code)
+		if requestID != "" {
+			details = fmt.Sprintf("%s, request-id=%s", details, requestID)
+		}
+		return fmt.Errorf("%s", utils.FormatErrMsg(action,
+			fmt.Sprintf("%s\ndetails: %s", parsed.Error.Msg, details), false))
+	}
+
+	requestIDSuffix := ""
+	if requestID != "" {
+		requestIDSuffix = fmt.Sprintf(", request-id=%s", requestID)
+	}
+	return fmt.Errorf("%s", utils.FormatErrMsg(action,
+		fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s%s",
+			statusCode, contentType, string(body), requestIDSuffix), false))
+}
+
+func requestIDFromHeaders(getHeader func(string) string) string {
+	candidates := []string{
+		"Request-Id",
+		"Request-ID",
+		"X-Request-Id",
+		"X-Request-ID",
+		"X-Erda-Request-Id",
+		"X-Erda-Request-ID",
+		"X-B3-TraceId",
+		"X-Trace-Id",
+	}
+	for _, header := range candidates {
+		if value := getHeader(header); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func decodeStandardErrorBody(body []byte) (*apistructs.Header, bool) {
+	var parsed apistructs.Header
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, false
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, false
+	}
+	if parsed.Error.Code == "" && parsed.Error.Msg == "" {
+		return nil, false
+	}
+	return &parsed, true
+}

--- a/tools/cli/common/issue.go
+++ b/tools/cli/common/issue.go
@@ -42,10 +42,7 @@ func GetIssue(ctx *command.Context, orgID, projectID, issueID uint64) (*apistruc
 	}
 
 	if !response.IsOK() {
-		return nil, fmt.Errorf("%s", utils.FormatErrMsg("get issue",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return nil, formatHTTPFailureFromResponse("get issue", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -64,7 +61,37 @@ func GetIssue(ctx *command.Context, orgID, projectID, issueID uint64) (*apistruc
 	return resp.Data, nil
 }
 
-func ListMyIssue(ctx *command.Context, req *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponseData, error) {
+func CreateIssue(ctx *command.Context, orgID uint64, request *apistructs.IssueCreateRequest) (uint64, error) {
+	var resp apistructs.IssueCreateResponse
+	var b bytes.Buffer
+
+	response, err := ctx.Post().Path("/api/issues").JSONBody(request).
+		Header("org", strconv.FormatUint(orgID, 10)).
+		Do().Body(&b)
+	if err != nil {
+		return 0, fmt.Errorf("%s", utils.FormatErrMsg(
+			"create issue", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return 0, formatHTTPFailureFromResponse("create issue", response, b.Bytes())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return 0, fmt.Errorf("%s", utils.FormatErrMsg("create issue",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return 0, fmt.Errorf("%s", utils.FormatErrMsg("create issue",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return resp.Data, nil
+}
+
+func ListMyIssueResponse(ctx *command.Context, req *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponse, error) {
 	var resp apistructs.IssuePagingResponse
 	var b bytes.Buffer
 
@@ -80,6 +107,8 @@ func ListMyIssue(ctx *command.Context, req *apistructs.IssuePagingRequest) (*api
 	}
 
 	response, err := ctx.Get().Path("/api/issues").
+		Header("org", strconv.FormatInt(req.OrgID, 10)).
+		Header("Org-ID", strconv.FormatInt(req.OrgID, 10)).
 		Param("pageNo", strconv.FormatUint(req.PageNo, 10)).
 		Param("pageSize", strconv.FormatUint(req.PageSize, 10)).
 		Param("orgID", strconv.FormatInt(req.OrgID, 10)).
@@ -93,10 +122,7 @@ func ListMyIssue(ctx *command.Context, req *apistructs.IssuePagingRequest) (*api
 	}
 
 	if !response.IsOK() {
-		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return nil, formatHTTPFailureFromResponse("list issue", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -112,6 +138,14 @@ func ListMyIssue(ctx *command.Context, req *apistructs.IssuePagingRequest) (*api
 
 	}
 
+	return &resp, nil
+}
+
+func ListMyIssue(ctx *command.Context, req *apistructs.IssuePagingRequest) (*apistructs.IssuePagingResponseData, error) {
+	resp, err := ListMyIssueResponse(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 	return resp.Data, nil
 }
 
@@ -122,6 +156,7 @@ func ListState(ctx *command.Context, orgID uint64, req apistructs.IssueStateRela
 	response, err := ctx.Get().Path("/api/issues/actions/get-state-relations").
 		Param("org", strconv.FormatUint(orgID, 10)).
 		Param("projectID", strconv.FormatUint(req.ProjectID, 10)).
+		Param("issueType", string(req.IssueType)).
 		Do().Body(&b)
 
 	if err != nil {
@@ -131,10 +166,7 @@ func ListState(ctx *command.Context, orgID uint64, req apistructs.IssueStateRela
 	}
 
 	if !response.IsOK() {
-		return nil, fmt.Errorf("%s", utils.FormatErrMsg("get state-relations",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return nil, formatHTTPFailureFromResponse("get state-relations", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -151,6 +183,198 @@ func ListState(ctx *command.Context, orgID uint64, req apistructs.IssueStateRela
 	}
 
 	return resp.Data, nil
+}
+
+func ListIssueLabels(ctx *command.Context, projectID uint64) ([]apistructs.ProjectLabel, error) {
+	var resp apistructs.ProjectLabelListResponse
+	var b bytes.Buffer
+
+	response, err := ctx.Get().Path("/api/labels").
+		Param("projectID", strconv.FormatUint(projectID, 10)).
+		Param("type", string(apistructs.LabelTypeIssue)).
+		Param("pageNo", "1").
+		Param("pageSize", "1000").
+		Do().Body(&b)
+	if err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg(
+			"list issue labels", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return nil, formatHTTPFailureFromResponse("list issue labels", response, b.Bytes())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue labels",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue labels",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	if resp.Data == nil {
+		return nil, nil
+	}
+	return resp.Data.List, nil
+}
+
+func ListIssueProperties(ctx *command.Context, orgID uint64, projectID uint64, issueType apistructs.IssueType) ([]apistructs.IssuePropertyIndex, error) {
+	var resp apistructs.IssuePropertiesResponse
+	var b bytes.Buffer
+
+	response, err := ctx.Get().Path("/api/issues/actions/get-properties").
+		Param("orgID", strconv.FormatUint(orgID, 10)).
+		Param("scopeID", strconv.FormatUint(projectID, 10)).
+		Param("propertyIssueType", string(issueType)).
+		Do().Body(&b)
+	if err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg(
+			"list issue properties", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return nil, formatHTTPFailureFromResponse("list issue properties", response, b.Bytes())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue properties",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue properties",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return resp.Data, nil
+}
+
+func ListIssueStages(ctx *command.Context, orgID uint64, issueType apistructs.IssueType) ([]apistructs.IssueStage, error) {
+	var resp apistructs.IssueStageResponse
+	var b bytes.Buffer
+
+	response, err := ctx.Get().Path("/api/issues/action/get-stage").
+		Param("orgID", strconv.FormatUint(orgID, 10)).
+		Param("issueType", string(issueType)).
+		Do().Body(&b)
+	if err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg(
+			"list issue stages", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return nil, formatHTTPFailureFromResponse("list issue stages", response, b.Bytes())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue stages",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list issue stages",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return resp.Data, nil
+}
+
+type IssuePropertyInstanceCreateRequest struct {
+	OrgID     int64                   `json:"orgID"`
+	ProjectID int64                   `json:"projectID"`
+	IssueID   int64                   `json:"issueID"`
+	Property  []IssuePropertyInstance `json:"property"`
+}
+
+type IssuePropertyInstance struct {
+	PropertyID        int64                        `json:"propertyID"`
+	ScopeID           int64                        `json:"scopeID"`
+	ScopeType         apistructs.ScopeType         `json:"scopeType"`
+	OrgID             int64                        `json:"orgID"`
+	PropertyName      string                       `json:"propertyName"`
+	DisplayName       string                       `json:"displayName"`
+	PropertyType      apistructs.PropertyType      `json:"propertyType"`
+	Required          bool                         `json:"required"`
+	PropertyIssueType apistructs.PropertyIssueType `json:"propertyIssueType"`
+	Relation          int64                        `json:"relation"`
+	Index             int64                        `json:"index"`
+	EnumeratedValues  []apistructs.Enumerate       `json:"enumeratedValues"`
+	Values            []int64                      `json:"values,omitempty"`
+	ArbitraryValue    interface{}                  `json:"arbitraryValue,omitempty"`
+}
+
+type issuePropertyInstanceCreateResponse struct {
+	apistructs.Header
+	Data int64 `json:"data"`
+}
+
+func CreateIssuePropertyInstance(ctx *command.Context, request *IssuePropertyInstanceCreateRequest) error {
+	var resp issuePropertyInstanceCreateResponse
+	var b bytes.Buffer
+
+	response, err := ctx.Post().Path("/api/issues/actions/create-property-instance").JSONBody(request).
+		Header("org", strconv.FormatInt(request.OrgID, 10)).
+		Do().Body(&b)
+	if err != nil {
+		return fmt.Errorf("%s", utils.FormatErrMsg(
+			"create issue property instance", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return formatHTTPFailureFromResponse("create issue property instance", response, b.Bytes())
+	}
+
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return fmt.Errorf("%s", utils.FormatErrMsg("create issue property instance",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("%s", utils.FormatErrMsg("create issue property instance",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return nil
+}
+
+func CreateIssueRelation(ctx *command.Context, orgID uint64, parentID uint64, request *apistructs.IssueRelationCreateRequest) error {
+	var resp apistructs.Header
+	var b bytes.Buffer
+
+	response, err := ctx.Post().Path(fmt.Sprintf("/api/issues/%d/relations", parentID)).
+		JSONBody(request).
+		Header("org", strconv.FormatUint(orgID, 10)).
+		Do().Body(&b)
+	if err != nil {
+		return fmt.Errorf("%s", utils.FormatErrMsg(
+			"create issue relation", "failed to request ("+err.Error()+")", false))
+	}
+
+	if !response.IsOK() {
+		return formatHTTPFailureFromResponse("create issue relation", response, b.Bytes())
+	}
+
+	if len(b.Bytes()) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
+		return fmt.Errorf("%s", utils.FormatErrMsg("create issue relation",
+			"failed to unmarshal response ("+err.Error()+")", false))
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("%s", utils.FormatErrMsg("create issue relation",
+			fmt.Sprintf("failed to request, error code: %s, error message: %s",
+				resp.Error.Code, resp.Error.Msg), false))
+	}
+
+	return nil
 }
 
 func GetTodoStateIds(states []apistructs.IssueStateRelation) ([]int64, error) {
@@ -190,10 +414,7 @@ func CreateIssueComment(ctx *command.Context, orgID uint64, request *pb.CommentI
 	}
 
 	if !respponse.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("create issue comments",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				respponse.StatusCode(), respponse.ResponseHeader("Content-Type"), b.String()), false))
-
+		return formatHTTPFailureFromResponse("create issue comments", respponse, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -227,10 +448,7 @@ func UpdateIssue(ctx *command.Context, orgID uint64, request *apistructs.IssueUp
 	}
 
 	if !response.IsOK() {
-		return fmt.Errorf("%s", utils.FormatErrMsg("update issue",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return formatHTTPFailureFromResponse("update issue", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {

--- a/tools/cli/common/issue_test.go
+++ b/tools/cli/common/issue_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Terminus, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/erda-project/erda/apistructs"
+	"github.com/erda-project/erda/pkg/http/httpclient"
+	"github.com/erda-project/erda/tools/cli/command"
+	"github.com/erda-project/erda/tools/cli/status"
+)
+
+func TestListMyIssueIncludesOrgIDHeader(t *testing.T) {
+	client := httpclient.New()
+	client.BackendClient().Transport = issueRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if got := r.URL.Path; got != "/api/issues" {
+			t.Fatalf("request path = %q, want /api/issues", got)
+		}
+		if got := r.Header.Get("Org-ID"); got != "1" {
+			t.Fatalf("Org-ID header = %q, want 1", got)
+		}
+		if got := r.Header.Get("org"); got != "1" {
+			t.Fatalf("org header = %q, want 1", got)
+		}
+		if got := r.URL.Query().Get("orgID"); got != "1" {
+			t.Fatalf("orgID = %q, want 1", got)
+		}
+		if got := r.URL.Query().Get("projectID"); got != "2" {
+			t.Fatalf("projectID = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("type"); got != "TASK" {
+			t.Fatalf("type = %q, want TASK", got)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"success":true,"data":{"total":0,"list":[]},"err":{"code":"","msg":"","ctx":null}}`)),
+		}, nil
+	})
+
+	ctx := &command.Context{
+		CurrentHost: "http://127.0.0.1:12345",
+		Sessions:    map[string]status.StatusInfo{},
+		HttpClient:  client,
+	}
+
+	_, err := ListMyIssue(ctx, &apistructs.IssuePagingRequest{
+		OrgID:    1,
+		PageNo:   1,
+		PageSize: 20,
+		IssueListRequest: apistructs.IssueListRequest{
+			ProjectID: 2,
+			Type:      []apistructs.IssueType{apistructs.IssueTypeTask},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListMyIssue() error = %v", err)
+	}
+}
+
+type issueRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f issueRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/tools/cli/common/mr.go
+++ b/tools/cli/common/mr.go
@@ -44,10 +44,7 @@ func CreateMr(ctx *command.Context, orgID uint64, project, application string, r
 	}
 
 	if !respponse.IsOK() {
-		return nil, fmt.Errorf("%s", utils.FormatErrMsg("create mr",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				respponse.StatusCode(), respponse.ResponseHeader("Content-Type"), b.String()), false))
-
+		return nil, formatHTTPFailureFromResponse("create mr", respponse, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {

--- a/tools/cli/common/org.go
+++ b/tools/cli/common/org.go
@@ -44,10 +44,7 @@ func GetOrgDetail(ctx *command.Context, orgIDorName string) (apistructs.OrgDTO, 
 	}
 
 	if !response.IsOK() {
-		return apistructs.OrgDTO{}, fmt.Errorf("%s", utils.FormatErrMsg("get organization detail",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.OrgDTO{}, formatHTTPFailureFromResponse("get organization detail", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -76,8 +73,8 @@ func GetOrgID(ctx *command.Context, org string) (string, uint64, error) {
 		orgID = o.ID
 	}
 
-	if org == "" && ctx.CurrentOrg.Name == "" {
-		return org, orgID, errors.New("Invalid organization name. You may clone a project first.")
+	if org == "" && ctx.CurrentOrg.Name == "" && ctx.CurrentOrg.ID <= 0 {
+		return org, orgID, errors.New("invalid organization context, please provide --org or --org-id")
 	}
 
 	if org == "" && ctx.CurrentOrg.Name != "" {

--- a/tools/cli/common/project.go
+++ b/tools/cli/common/project.go
@@ -51,10 +51,7 @@ func GetProjectDetail(ctx *command.Context, orgID, projectID uint64) (apistructs
 	}
 
 	if !response.IsOK() {
-		return apistructs.ProjectDTO{}, fmt.Errorf("%s", utils.FormatErrMsg("get project detail",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.ProjectDTO{}, formatHTTPFailureFromResponse("get project detail", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -97,10 +94,7 @@ func CreateProject(ctx *command.Context, orgID uint64, name, desc string,
 	}
 
 	if !resp.IsOK() {
-		return response.Data, fmt.Errorf("%s", utils.FormatErrMsg("create",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				resp.StatusCode(), resp.ResponseHeader("Content-Type"), b.String()), false))
-
+		return response.Data, formatHTTPFailureFromResponse("create", resp, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &response); err != nil {
@@ -141,10 +135,7 @@ func CreateMSPProject(ctx *command.Context, projectID uint64, name string) (*pb.
 	}
 
 	if !resp.IsOK() {
-		return response.Data, fmt.Errorf("%s", utils.FormatErrMsg("create",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				resp.StatusCode(), resp.ResponseHeader("Content-Type"), b.String()), false))
-
+		return response.Data, formatHTTPFailureFromResponse("create", resp, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &response); err != nil {
@@ -186,10 +177,7 @@ func ImportPackage(ctx *command.Context, orgID, projectID uint64, pkg string) (u
 	}
 
 	if !resp.IsOK() {
-		return response.Data, fmt.Errorf("%s", utils.FormatErrMsg("import",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				resp.StatusCode(), resp.ResponseHeader("Content-Type"), b.String()), false))
-
+		return response.Data, formatHTTPFailureFromResponse("import", resp, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &response); err != nil {
@@ -219,10 +207,7 @@ func ListMyProjectInOrg(ctx *command.Context, orgId string, projectName string) 
 	}
 
 	if !response.IsOK() {
-		return nil, fmt.Errorf("%s", utils.FormatErrMsg("list",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return nil, formatHTTPFailureFromResponse("list", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {
@@ -298,8 +283,8 @@ func GetProjectID(ctx *command.Context, orgID uint64, project string) (string, u
 		projectID = pId
 	}
 
-	if project == "" && ctx.CurrentProject.Project == "" {
-		return project, projectID, errors.New("Invalid project name")
+	if project == "" && ctx.CurrentProject.Project == "" && ctx.CurrentProject.ProjectID <= 0 {
+		return project, projectID, errors.New("invalid project context, please provide --project or --project-id")
 	}
 
 	if project == "" && ctx.CurrentProject.Project != "" {
@@ -387,10 +372,7 @@ func GetPagingProjects(ctx *command.Context, orgId uint64, pageNo, pageSize int)
 	}
 
 	if !response.IsOK() {
-		return apistructs.PagingProjectDTO{}, fmt.Errorf("%s", utils.FormatErrMsg("list",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.PagingProjectDTO{}, formatHTTPFailureFromResponse("list", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {

--- a/tools/cli/common/record.go
+++ b/tools/cli/common/record.go
@@ -40,10 +40,7 @@ func GetRecord(ctx *command.Context, orgID, id uint64) (apistructs.TestFileRecor
 	}
 
 	if !response.IsOK() {
-		return apistructs.TestFileRecord{}, fmt.Errorf("%s", utils.FormatErrMsg("get record",
-			fmt.Sprintf("failed to request, status-code: %d, content-type: %s, raw bod: %s",
-				response.StatusCode(), response.ResponseHeader("Content-Type"), b.String()), false))
-
+		return apistructs.TestFileRecord{}, formatHTTPFailureFromResponse("get record", response, b.Bytes())
 	}
 
 	if err := json.Unmarshal(b.Bytes(), &resp); err != nil {

--- a/tools/cli/common/repo.go
+++ b/tools/cli/common/repo.go
@@ -51,7 +51,7 @@ func GetWorkspaceRepoStats(ctx *command.Context, orgID uint64, projectName, appl
 //  1. current project config/context IDs when names match
 //  2. repo stats by org/repo
 //  3. return an explicit error without falling back to high-permission list APIs
-func ResolveWorkspaceApplication(ctx *command.Context, orgID uint64, projectName, applicationName string) (projectID uint64, applicationID int64, err error) {
+func ResolveWorkspaceApplication(ctx *command.Context, orgID uint64, orgName, projectName, applicationName string) (projectID uint64, applicationID int64, err error) {
 	if ctx != nil &&
 		ctx.CurrentProject.ProjectID > 0 &&
 		ctx.CurrentApplication.ApplicationID > 0 &&

--- a/tools/cli/common/repo_test.go
+++ b/tools/cli/common/repo_test.go
@@ -45,7 +45,7 @@ func TestResolveWorkspaceApplicationPrefersContextIDs(t *testing.T) {
 		},
 	}
 
-	projectID, applicationID, err := ResolveWorkspaceApplication(ctx, 1001, "demo-project", "demo-app")
+	projectID, applicationID, err := ResolveWorkspaceApplication(ctx, 1001, "demo-org", "demo-project", "demo-app")
 	if err != nil {
 		t.Fatalf("ResolveWorkspaceApplication() error = %v", err)
 	}
@@ -70,7 +70,7 @@ func TestResolveWorkspaceApplicationFallsBackToRepoStatsWhenContextMissingIDs(t 
 		}, nil
 	}
 
-	projectID, applicationID, err := ResolveWorkspaceApplication(&command.Context{}, 1001, "demo-project", "demo-app")
+	projectID, applicationID, err := ResolveWorkspaceApplication(&command.Context{}, 1001, "demo-org", "demo-project", "demo-app")
 	if err != nil {
 		t.Fatalf("ResolveWorkspaceApplication() error = %v", err)
 	}
@@ -106,7 +106,7 @@ func TestResolveWorkspaceApplicationFallsBackToRepoStatsWhenNamesDoNotMatch(t *t
 		},
 	}
 
-	projectID, applicationID, err := ResolveWorkspaceApplication(ctx, 1001, "target-project", "target-app")
+	projectID, applicationID, err := ResolveWorkspaceApplication(ctx, 1001, "demo-org", "target-project", "target-app")
 	if err != nil {
 		t.Fatalf("ResolveWorkspaceApplication() error = %v", err)
 	}
@@ -125,7 +125,7 @@ func TestResolveWorkspaceApplicationReturnsExplicitErrorWhenRepoStatsFails(t *te
 		return apistructs.GittarStatsData{}, errors.New("repo not found")
 	}
 
-	_, _, err := ResolveWorkspaceApplication(&command.Context{}, 1001, "demo-project", "demo-app")
+	_, _, err := ResolveWorkspaceApplication(&command.Context{}, 1001, "demo-org", "demo-project", "demo-app")
 	if err == nil {
 		t.Fatal("expected error when repo stats cannot resolve workspace")
 	}

--- a/tools/release-cli/main_test.go
+++ b/tools/release-cli/main_test.go
@@ -85,8 +85,11 @@ func TestResolvePublishReleasesUsesEmbeddedArtifacts(t *testing.T) {
 	if releases[0].goos != "darwin" || releases[0].goarch != "arm64" {
 		t.Fatalf("unexpected first release target: %+v", releases[0])
 	}
-	if releases[1].goos != "linux" || releases[1].goarch != "amd64" {
+	if releases[1].goos != "darwin" || releases[1].goarch != "amd64" {
 		t.Fatalf("unexpected second release target: %+v", releases[1])
+	}
+	if releases[2].goos != "linux" || releases[2].goarch != "amd64" {
+		t.Fatalf("unexpected third release target: %+v", releases[2])
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
- Squash-merge CLI and DOP issue provider changes onto upstream master.
- Align release-cli publish tests with multi-arch artifact layout (darwin arm64/amd64, linux amd64/arm64).
- Resolve workspace application with org name; scoped workspace info respects global org/project flags.
- Prefer workspace API host via cobra annotations and codegen (PreferWorkspaceHost) instead of string switches.
- Harden self-update default channel when global config is nil.

#### Which issue(s) this PR fixes:

- Fixes #your-issue_number
- [Erda Cloud Issue Link](paste your link here)


#### Specified Reviewers:

/assign @luobily 


#### ChangeLog
<!--
Describe the specific changes from the user's perspective, as well as possible Breaking Change and other risks.
Common Format：
Bugfix： Fix the bug that ... in xxx platform （修复了 xxx 平台的 ...）
Feature: Support/Optimize ... in xxx platform （实现/优化了 xxx 平台的 ...）

`xxx` is one of DevOps/Micro Service/Cloud Management
-->

| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |    add issue and iteration commands with workspace-aware host          |
| 🇨🇳 中文    |   增加项目协同以及迭代的能力           |


#### Need cherry-pick to release versions?

Add comment like `/cherry-pick release/1.0` when this PR is merged.

> For details on the cherry pick process, see the [cherry pick requests](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md#how-to-cherry-pick-a-merged-pr) section under [CONTRIBUTING.md](https://github.com/erda-project/erda/blob/master/CONTRIBUTING.md).
