### PR TITLE
fix(hepa): strip path from Kong service URL in BuildKongServiceReq

### DIFF
--- a/internal/tools/orchestrator/hepa/gateway/assembler/gateway_kong_assembler.go
+++ b/internal/tools/orchestrator/hepa/gateway/assembler/gateway_kong_assembler.go
@@ -16,6 +16,7 @@ package assembler
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -37,6 +38,12 @@ func (GatewayKongAssemblerImpl) BuildKongServiceReq(serviceId string, dto *gw.Ap
 	}
 	req := &providerDto.ServiceReqDto{}
 	req.Url = dto.RedirectAddr
+	if u, err := url.Parse(dto.RedirectAddr); err == nil && u.Host != "" {
+		u.Path = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		req.Url = u.String()
+	}
 	req.ConnectTimeout = 5000
 	req.ReadTimeout = 600000
 	req.WriteTimeout = 600000


### PR DESCRIPTION
When SDK re-registers APIs after service redeployment, the RedirectAddr contains both host and path (e.g. http://host:8080/retail-mall/acl-web). This path was being set as Kong service.path, causing Kong to prepend it to upstream requests, resulting in 404 errors.

Strip the path unconditionally so Kong service.path is always "/". This does not affect the "流量入口" (endpoint API) flow which uses its own createKongServiceReq function with AdjustRedirectAddr.

#### What this PR does / why we need it:


#### Which issue(s) this PR fixes:


#### Specified Reviewers:

#### ChangeLog
| Language | Changelog |
| --------- | ------------ |
| 🇺🇸 English |      fix(hepa): strip path from Kong service URL in BuildKongServiceReq        |
| 🇨🇳 中文    |      修复创建 kong service 时，去掉 path 的设置        |


#### Need cherry-pick to release versions?